### PR TITLE
Reject unrecognized parameters in set_configuration instead of reporting success

### DIFF
--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -746,8 +746,7 @@ function lookupConfigParam(arg: string): string | undefined {
 
 /**
  * Component entries (`my-component_package`, `my-component_port`) are operator-named, so they
- * cannot be enumerated in CONFIG_PARAM_MAP and bypass it. Case-sensitive, matching the existing
- * behavior of the write loop this rule was factored out of.
+ * cannot be enumerated in CONFIG_PARAM_MAP and bypass it.
  */
 function isSuffixEscapedParam(arg: string): boolean {
 	return arg.endsWith('_package') || arg.endsWith('_port');
@@ -1108,8 +1107,8 @@ export async function setConfiguration(setConfigJson) {
 		);
 	}
 	// Before any local write: the writer skips names it cannot resolve, so a request mixing
-	// recognized and unrecognized names would otherwise apply the recognized half and report plain
-	// success. Local only — the fan-out below is a separate step and is not made atomic by this.
+	// recognized and unrecognized names would otherwise apply the recognized half and still report
+	// success.
 	const unrecognized = findUnrecognizedParams(configFields);
 	if (unrecognized.length > 0) {
 		throw handleHDBError(

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -273,7 +273,7 @@ export function getDefaultConfig(param: string) {
 		flatDefaultConfigObj = flattenConfig(configDoc.toJSON());
 	}
 
-	const paramMap = CONFIG_PARAM_MAP[param.toLowerCase()];
+	const paramMap = lookupConfigParam(param);
 	if (paramMap === undefined) return undefined;
 
 	return flatDefaultConfigObj[paramMap.toLowerCase()];
@@ -297,7 +297,7 @@ export function getConfigValue(param: string | null | undefined) {
 		return undefined;
 	}
 
-	const paramMap = CONFIG_PARAM_MAP[param.toLowerCase()];
+	const paramMap = lookupConfigParam(param);
 	if (paramMap === undefined) return undefined;
 
 	return flatConfigObj[paramMap.toLowerCase()];
@@ -690,7 +690,7 @@ export function updateConfigObject(param: string, value: any) {
 		flatConfigObj = {};
 	}
 
-	const configObjKey = CONFIG_PARAM_MAP[param.toLowerCase()];
+	const configObjKey = lookupConfigParam(param);
 	if (configObjKey === undefined) {
 		logger.trace(`Unable to update config object because config param '${param}' does not exist`);
 		return;
@@ -735,19 +735,9 @@ export function updateConfigObject(param: string, value: any) {
 }
 
 /**
- * Updates and validates a config value in config file. Can also create a backup of config before updating.
- * @param param - the config value to update
- * @param value - the value to set the config to
- * @param parsedArgs - an object of param/values to update
- * @param createBackup - if true backup file is created
- * @param update_config_obj - if true updates the in memory flattened config object
- */
-/**
  * Canonical config param for an arg name, or `undefined` when the name is not a config param.
- * `Object.hasOwn` keeps inherited names (`constructor`) from resolving to an `Object.prototype`
- * member that later fails a `.split('_')` — unreachable over HTTP today, where a body-property
- * guard rejects `constructor` and the lowercased lookup misses every other inherited name, but
- * direct callers have no such guard.
+ * `Object.hasOwn` because a bare lookup resolves inherited names: `constructor` yields an
+ * `Object.prototype` member that then fails `.split('_')` or `.toLowerCase()`.
  */
 function lookupConfigParam(arg: string): string | undefined {
 	const name = arg.toLowerCase();
@@ -755,15 +745,14 @@ function lookupConfigParam(arg: string): string | undefined {
 }
 
 /**
- * Component entries (`my-component_package`, `my-component_port`) are named by the operator, so
- * they cannot be enumerated in CONFIG_PARAM_MAP and bypass it. Deliberately case-sensitive:
- * matching a lowercased name would newly accept `TYPO_PORT`, widening the accepted surface.
+ * Component entries (`my-component_package`, `my-component_port`) are operator-named, so they
+ * cannot be enumerated in CONFIG_PARAM_MAP and bypass it. Case-sensitive, matching the existing
+ * behavior of the write loop this rule was factored out of.
  */
 function isSuffixEscapedParam(arg: string): boolean {
 	return arg.endsWith('_package') || arg.endsWith('_port');
 }
 
-/** Every arg name in `args` that is neither a known config param nor a suffix-escaped one. */
 function findUnrecognizedParams(args: object): string[] {
 	let unrecognized;
 	for (const arg in args) {
@@ -772,6 +761,14 @@ function findUnrecognizedParams(args: object): string[] {
 	return unrecognized ?? [];
 }
 
+/**
+ * Updates and validates a config value in config file. Can also create a backup of config before updating.
+ * @param param - the config value to update
+ * @param value - the value to set the config to
+ * @param parsedArgs - an object of param/values to update
+ * @param createBackup - if true backup file is created
+ * @param update_config_obj - if true updates the in memory flattened config object
+ */
 export function updateConfigValue(
 	param: string,
 	value: any,
@@ -1075,11 +1072,11 @@ export function getConfiguration() {
 
  */
 export async function setConfiguration(setConfigJson) {
-	// `hdb_auth_header` is the legacy spelling of the same internal auth artifact as `hdbAuthHeader`
-	// (still attached to operation objects on the 4.x line); it is a control field, never a config
-	// param, so it is stripped rather than reported as unrecognized below.
+	// `hdb_auth_header` is the 4.x spelling of `hdbAuthHeader`, and `impersonate` is a generic
+	// operation-body field (server/operationsServer.ts): control fields, never config params.
 	// eslint-disable-next-line no-unused-vars
-	const { operation, hdb_user, hdbAuthHeader, hdb_auth_header, replicated, ...configFields } = setConfigJson;
+	const { operation, hdb_user, hdbAuthHeader, hdb_auth_header, impersonate, replicated, ...configFields } =
+		setConfigJson;
 	// Operation-control field, not a config param: enforce boolean (matching other
 	// `replicated` surfaces, e.g. analyticsValidator) before any local write so a
 	// malformed value like the string "false" — which is truthy — can't apply config
@@ -1094,10 +1091,9 @@ export async function setConfiguration(setConfigJson) {
 			true
 		);
 	}
-	// Reject the whole request before writing anything locally: the writer skips param names it
-	// cannot resolve, so without this a request mixing recognized and unrecognized names applies
-	// the recognized half and still reports plain success (#2266). Local only — the fan-out below
-	// is a separate step, so this says nothing about cluster-wide atomicity.
+	// Before any local write: the writer skips names it cannot resolve, so a request mixing
+	// recognized and unrecognized names would otherwise apply the recognized half and report plain
+	// success. Local only — the fan-out below is a separate step and is not made atomic by this.
 	const unrecognized = findUnrecognizedParams(configFields);
 	if (unrecognized.length > 0) {
 		throw handleHDBError(

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -740,6 +740,7 @@ export function updateConfigObject(param: string, value: any) {
  * `Object.prototype` member that then fails `.split('_')` or `.toLowerCase()`.
  */
 function lookupConfigParam(arg: string): string | undefined {
+	if (typeof arg !== 'string') return undefined;
 	const name = arg.toLowerCase();
 	return Object.hasOwn(CONFIG_PARAM_MAP, name) ? CONFIG_PARAM_MAP[name] : undefined;
 }
@@ -749,7 +750,7 @@ function lookupConfigParam(arg: string): string | undefined {
  * cannot be enumerated in CONFIG_PARAM_MAP and bypass it.
  */
 function isSuffixEscapedParam(arg: string): boolean {
-	return arg.endsWith('_package') || arg.endsWith('_port');
+	return typeof arg === 'string' && (arg.endsWith('_package') || arg.endsWith('_port'));
 }
 
 const MAX_REPORTED_UNRECOGNIZED = 10;

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -753,6 +753,22 @@ function isSuffixEscapedParam(arg: string): boolean {
 	return arg.endsWith('_package') || arg.endsWith('_port');
 }
 
+const MAX_REPORTED_UNRECOGNIZED = 10;
+
+/**
+ * Render unrecognized names for an error that also reaches the operations log: control characters
+ * are stripped so a name containing a newline cannot forge a log line, and the list is capped so a
+ * body carrying thousands of unknown keys cannot produce an unbounded message.
+ */
+function describeUnrecognized(names: string[]): string {
+	const shown = names
+		.slice(0, MAX_REPORTED_UNRECOGNIZED)
+		// eslint-disable-next-line no-control-regex
+		.map((name) => name.replace(/[\u0000-\u001f\u007f]/g, '?'));
+	const remaining = names.length - shown.length;
+	return remaining > 0 ? `${shown.join(', ')} (and ${remaining} more)` : shown.join(', ');
+}
+
 function findUnrecognizedParams(args: object): string[] {
 	let unrecognized;
 	for (const arg in args) {
@@ -1098,7 +1114,7 @@ export async function setConfiguration(setConfigJson) {
 	if (unrecognized.length > 0) {
 		throw handleHDBError(
 			new Error(),
-			`Unable to update config, unrecognized config parameter${unrecognized.length > 1 ? 's' : ''}: ${unrecognized.join(', ')}`,
+			`Unable to update config, unrecognized config parameter${unrecognized.length > 1 ? 's' : ''}: ${describeUnrecognized(unrecognized)}`,
 			HTTP_STATUS_CODES.BAD_REQUEST,
 			undefined,
 			undefined,

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -154,7 +154,7 @@ export function createConfigFile(args, skipFsValidation = false) {
 	// Loop through the user inputted args. Match them to a parameter in the default config file and update value.
 	let schemasArgs;
 	for (const arg in args) {
-		let configParam = CONFIG_PARAM_MAP[arg.toLowerCase()];
+		let configParam = lookupConfigParam(arg);
 
 		// Schemas config args are handled differently, so if they exist set them to var that will be used by setSchemasConfig
 		if (configParam === CONFIG_PARAMS.DATABASES) {
@@ -169,7 +169,7 @@ export function createConfigFile(args, skipFsValidation = false) {
 			continue;
 		}
 
-		if (!configParam && (arg.endsWith('_package') || arg.endsWith('_port'))) {
+		if (!configParam && isSuffixEscapedParam(arg)) {
 			configParam = arg;
 		}
 
@@ -742,6 +742,36 @@ export function updateConfigObject(param: string, value: any) {
  * @param createBackup - if true backup file is created
  * @param update_config_obj - if true updates the in memory flattened config object
  */
+/**
+ * Canonical config param for an arg name, or `undefined` when the name is not a config param.
+ * `Object.hasOwn` keeps inherited names (`constructor`) from resolving to an `Object.prototype`
+ * member that later fails a `.split('_')` — unreachable over HTTP today, where a body-property
+ * guard rejects `constructor` and the lowercased lookup misses every other inherited name, but
+ * direct callers have no such guard.
+ */
+function lookupConfigParam(arg: string): string | undefined {
+	const name = arg.toLowerCase();
+	return Object.hasOwn(CONFIG_PARAM_MAP, name) ? CONFIG_PARAM_MAP[name] : undefined;
+}
+
+/**
+ * Component entries (`my-component_package`, `my-component_port`) are named by the operator, so
+ * they cannot be enumerated in CONFIG_PARAM_MAP and bypass it. Deliberately case-sensitive:
+ * matching a lowercased name would newly accept `TYPO_PORT`, widening the accepted surface.
+ */
+function isSuffixEscapedParam(arg: string): boolean {
+	return arg.endsWith('_package') || arg.endsWith('_port');
+}
+
+/** Every arg name in `args` that is neither a known config param nor a suffix-escaped one. */
+function findUnrecognizedParams(args: object): string[] {
+	let unrecognized;
+	for (const arg in args) {
+		if (lookupConfigParam(arg) === undefined && !isSuffixEscapedParam(arg)) (unrecognized ??= []).push(arg);
+	}
+	return unrecognized ?? [];
+}
+
 export function updateConfigValue(
 	param: string,
 	value: any,
@@ -794,7 +824,7 @@ export function updateConfigValue(
 		if (skipParamMap) {
 			configParam = param;
 		} else {
-			configParam = CONFIG_PARAM_MAP[param.toLowerCase()];
+			configParam = lookupConfigParam(param);
 			if (configParam === undefined) {
 				throw handleHDBError(
 					new Error(),
@@ -813,7 +843,7 @@ export function updateConfigValue(
 	} else {
 		// Loop through the user inputted args. Match them to a parameter in the default config file and update value.
 		for (const arg in parsedArgs) {
-			let configParam = CONFIG_PARAM_MAP[arg.toLowerCase()];
+			let configParam = lookupConfigParam(arg);
 
 			// If setting http.securePort to the same value as http.port, set http.port to null to avoid clashing ports
 			if (
@@ -845,7 +875,7 @@ export function updateConfigValue(
 				}
 			}
 
-			if (!configParam && (arg.endsWith('_package') || arg.endsWith('_port'))) {
+			if (!configParam && isSuffixEscapedParam(arg)) {
 				configParam = arg;
 			}
 
@@ -1045,8 +1075,11 @@ export function getConfiguration() {
 
  */
 export async function setConfiguration(setConfigJson) {
+	// `hdb_auth_header` is the legacy spelling of the same internal auth artifact as `hdbAuthHeader`
+	// (still attached to operation objects on the 4.x line); it is a control field, never a config
+	// param, so it is stripped rather than reported as unrecognized below.
 	// eslint-disable-next-line no-unused-vars
-	const { operation, hdb_user, hdbAuthHeader, replicated, ...configFields } = setConfigJson;
+	const { operation, hdb_user, hdbAuthHeader, hdb_auth_header, replicated, ...configFields } = setConfigJson;
 	// Operation-control field, not a config param: enforce boolean (matching other
 	// `replicated` surfaces, e.g. analyticsValidator) before any local write so a
 	// malformed value like the string "false" — which is truthy — can't apply config
@@ -1055,6 +1088,21 @@ export async function setConfiguration(setConfigJson) {
 		throw handleHDBError(
 			new Error(),
 			`'replicated' must be a boolean`,
+			HTTP_STATUS_CODES.BAD_REQUEST,
+			undefined,
+			undefined,
+			true
+		);
+	}
+	// Reject the whole request before writing anything locally: the writer skips param names it
+	// cannot resolve, so without this a request mixing recognized and unrecognized names applies
+	// the recognized half and still reports plain success (#2266). Local only — the fan-out below
+	// is a separate step, so this says nothing about cluster-wide atomicity.
+	const unrecognized = findUnrecognizedParams(configFields);
+	if (unrecognized.length > 0) {
+		throw handleHDBError(
+			new Error(),
+			`Unable to update config, unrecognized config parameter${unrecognized.length > 1 ? 's' : ''}: ${unrecognized.join(', ')}`,
 			HTTP_STATUS_CODES.BAD_REQUEST,
 			undefined,
 			undefined,

--- a/integrationTests/apiTests/configuration.test.mjs
+++ b/integrationTests/apiTests/configuration.test.mjs
@@ -273,16 +273,26 @@ suite('Configuration', (ctx) => {
 	});
 
 	test('set_configuration writes nothing when a request mixes recognized and unrecognized params', async () => {
+		// Read the current value rather than assuming what an earlier test left behind, so this is
+		// self-contained under isolation or reordering.
+		let before;
+		await client
+			.req()
+			.send({ operation: 'get_configuration' })
+			.expect((r) => {
+				before = r.body.logging.rotation.maxSize;
+			})
+			.expect(200);
 		await client
 			.req()
 			.send({ operation: 'set_configuration', logging_rotation_maxSize: '99M', bogus_param: true })
 			.expect((r) => assert.match(r.body.error, /bogus_param/, r.text))
 			.expect(400);
-		// The recognized half of the rejected request must not have landed: still the value set above.
+		// The recognized half of the rejected request must not have landed.
 		await client
 			.req()
 			.send({ operation: 'get_configuration' })
-			.expect((r) => assert.equal(r.body.logging.rotation.maxSize, '12M', r.text))
+			.expect((r) => assert.equal(r.body.logging.rotation.maxSize, before, r.text))
 			.expect(200);
 	});
 

--- a/integrationTests/apiTests/configuration.test.mjs
+++ b/integrationTests/apiTests/configuration.test.mjs
@@ -286,11 +286,19 @@ suite('Configuration', (ctx) => {
 			.expect(200);
 	});
 
-	test('set_configuration still accepts an operator-named component _package entry', async () => {
+	test('set_configuration still writes an operator-named component _package entry', async () => {
 		await client
 			.req()
 			.send({ 'operation': 'set_configuration', 'integration-probe_package': 'file:./nowhere' })
 			.expect(200);
+		// Status alone would pass even if preflight accepted the name and the write loop dropped it.
+		await client
+			.req()
+			.send({ operation: 'get_configuration' })
+			.expect((r) => assert.equal(r.body['integration-probe'].package, 'file:./nowhere', r.text))
+			.expect(200);
+		// Leave no component entry behind for the rest of the suite, or a later restart, to load.
+		await client.req().send({ 'operation': 'set_configuration', 'integration-probe_package': null }).expect(200);
 	});
 
 	// ── set_configuration + replicated (#660) ───────────────────────────────

--- a/integrationTests/apiTests/configuration.test.mjs
+++ b/integrationTests/apiTests/configuration.test.mjs
@@ -273,8 +273,6 @@ suite('Configuration', (ctx) => {
 	});
 
 	test('set_configuration writes nothing when a request mixes recognized and unrecognized params', async () => {
-		// Read the current value rather than assuming what an earlier test left behind, so this is
-		// self-contained under isolation or reordering.
 		let before;
 		await client
 			.req()

--- a/integrationTests/apiTests/configuration.test.mjs
+++ b/integrationTests/apiTests/configuration.test.mjs
@@ -281,6 +281,9 @@ suite('Configuration', (ctx) => {
 				before = r?.body?.logging?.rotation?.maxSize;
 			})
 			.expect(200);
+		// Without this the optional chaining below turns an unexpected response shape into
+		// `undefined === undefined`, and the atomicity assertion passes having proved nothing.
+		assert.ok(before !== undefined, 'precondition: logging.rotation.maxSize is readable');
 		await client
 			.req()
 			.send({ operation: 'set_configuration', logging_rotation_maxSize: '99M', bogus_param: true })

--- a/integrationTests/apiTests/configuration.test.mjs
+++ b/integrationTests/apiTests/configuration.test.mjs
@@ -260,7 +260,7 @@ suite('Configuration', (ctx) => {
 		await client
 			.req()
 			.send({ operation: 'set_configuration', not_a_real_param: 1 })
-			.expect((r) => assert.match(r.body.error, /unrecognized config parameter: not_a_real_param/, r.text))
+			.expect((r) => assert.match(r?.body?.error ?? '', /unrecognized config parameter: not_a_real_param/, r?.text))
 			.expect(400);
 	});
 
@@ -268,7 +268,7 @@ suite('Configuration', (ctx) => {
 		await client
 			.req()
 			.send({ operation: 'set_configuration', nope_one: 1, nope_two: 2 })
-			.expect((r) => assert.match(r.body.error, /unrecognized config parameters: nope_one, nope_two/, r.text))
+			.expect((r) => assert.match(r?.body?.error ?? '', /unrecognized config parameters: nope_one, nope_two/, r?.text))
 			.expect(400);
 	});
 
@@ -278,19 +278,19 @@ suite('Configuration', (ctx) => {
 			.req()
 			.send({ operation: 'get_configuration' })
 			.expect((r) => {
-				before = r.body.logging.rotation.maxSize;
+				before = r?.body?.logging?.rotation?.maxSize;
 			})
 			.expect(200);
 		await client
 			.req()
 			.send({ operation: 'set_configuration', logging_rotation_maxSize: '99M', bogus_param: true })
-			.expect((r) => assert.match(r.body.error, /bogus_param/, r.text))
+			.expect((r) => assert.match(r?.body?.error ?? '', /bogus_param/, r?.text))
 			.expect(400);
 		// The recognized half of the rejected request must not have landed.
 		await client
 			.req()
 			.send({ operation: 'get_configuration' })
-			.expect((r) => assert.equal(r.body.logging.rotation.maxSize, before, r.text))
+			.expect((r) => assert.strictEqual(r?.body?.logging?.rotation?.maxSize, before, r?.text))
 			.expect(200);
 	});
 
@@ -303,7 +303,7 @@ suite('Configuration', (ctx) => {
 		await client
 			.req()
 			.send({ operation: 'get_configuration' })
-			.expect((r) => assert.equal(r.body['integration-probe'].package, 'file:./nowhere', r.text))
+			.expect((r) => assert.strictEqual(r?.body?.['integration-probe']?.package, 'file:./nowhere', r?.text))
 			.expect(200);
 		// Neutralize rather than remove: set_configuration has no delete, so the entry stays with a
 		// null package, which componentLoader then treats as an application-only entry and skips.
@@ -311,7 +311,7 @@ suite('Configuration', (ctx) => {
 		await client
 			.req()
 			.send({ operation: 'get_configuration' })
-			.expect((r) => assert.equal(r.body['integration-probe'].package, null, r.text))
+			.expect((r) => assert.strictEqual(r?.body?.['integration-probe']?.package, null, r?.text))
 			.expect(200);
 	});
 

--- a/integrationTests/apiTests/configuration.test.mjs
+++ b/integrationTests/apiTests/configuration.test.mjs
@@ -256,6 +256,43 @@ suite('Configuration', (ctx) => {
 			.expect(400);
 	});
 
+	test('set_configuration rejects an unrecognized param with 400 instead of reporting success', async () => {
+		await client
+			.req()
+			.send({ operation: 'set_configuration', not_a_real_param: 1 })
+			.expect((r) => assert.match(r.body.error, /unrecognized config parameter: not_a_real_param/, r.text))
+			.expect(400);
+	});
+
+	test('set_configuration names every unrecognized param in one 400', async () => {
+		await client
+			.req()
+			.send({ operation: 'set_configuration', nope_one: 1, nope_two: 2 })
+			.expect((r) => assert.match(r.body.error, /unrecognized config parameters: nope_one, nope_two/, r.text))
+			.expect(400);
+	});
+
+	test('set_configuration writes nothing when a request mixes recognized and unrecognized params', async () => {
+		await client
+			.req()
+			.send({ operation: 'set_configuration', logging_rotation_maxSize: '99M', bogus_param: true })
+			.expect((r) => assert.match(r.body.error, /bogus_param/, r.text))
+			.expect(400);
+		// The recognized half of the rejected request must not have landed: still the value set above.
+		await client
+			.req()
+			.send({ operation: 'get_configuration' })
+			.expect((r) => assert.equal(r.body.logging.rotation.maxSize, '12M', r.text))
+			.expect(200);
+	});
+
+	test('set_configuration still accepts an operator-named component _package entry', async () => {
+		await client
+			.req()
+			.send({ 'operation': 'set_configuration', 'integration-probe_package': 'file:./nowhere' })
+			.expect(200);
+	});
+
 	// ── set_configuration + replicated (#660) ───────────────────────────────
 	// Real cluster fan-out lives in harper-pro; without it, the base server's
 	// replication stub rejects a truthy `replicated`. These tests pin the

--- a/integrationTests/apiTests/configuration.test.mjs
+++ b/integrationTests/apiTests/configuration.test.mjs
@@ -297,8 +297,14 @@ suite('Configuration', (ctx) => {
 			.send({ operation: 'get_configuration' })
 			.expect((r) => assert.equal(r.body['integration-probe'].package, 'file:./nowhere', r.text))
 			.expect(200);
-		// Leave no component entry behind for the rest of the suite, or a later restart, to load.
+		// Neutralize rather than remove: set_configuration has no delete, so the entry stays with a
+		// null package, which componentLoader then treats as an application-only entry and skips.
 		await client.req().send({ 'operation': 'set_configuration', 'integration-probe_package': null }).expect(200);
+		await client
+			.req()
+			.send({ operation: 'get_configuration' })
+			.expect((r) => assert.equal(r.body['integration-probe'].package, null, r.text))
+			.expect(200);
 	});
 
 	// ── set_configuration + replicated (#660) ───────────────────────────────

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -1390,7 +1390,7 @@ describe('Test configUtils module', () => {
 		it('Test happy path success response returned', async () => {
 			const test_set_config_json = {
 				operation: 'set_configuration',
-				operationsApi_processes: 18,
+				threads_count: 18,
 				hdb_user: {},
 				hdb_auth_header: 'test_header',
 			};
@@ -1418,6 +1418,55 @@ describe('Test configUtils module', () => {
 			}
 
 			expect(error.name).to.equal(STRING_ERROR);
+		});
+
+		describe('unrecognized config params (#2266)', () => {
+			async function rejection(body) {
+				try {
+					await config_utils_rw.setConfiguration({ operation: 'set_configuration', ...body });
+				} catch (err) {
+					return err.http_resp_msg ?? err.message;
+				}
+				return undefined;
+			}
+
+			it('rejects an unrecognized param instead of reporting success', async () => {
+				const message = await rejection({ not_a_real_param: 1 });
+				expect(message).to.include('unrecognized config parameter: not_a_real_param');
+			});
+
+			it('names every unrecognized param in one error', async () => {
+				const message = await rejection({ nope_one: 1, nope_two: 2 });
+				expect(message).to.include('unrecognized config parameters: nope_one, nope_two');
+			});
+
+			it('writes nothing when a request mixes recognized and unrecognized params', async () => {
+				const message = await rejection({ logging_level: 'debug', not_a_real_param: 1 });
+				expect(message).to.include('not_a_real_param');
+				expect(update_config_value_stub.called).to.equal(false);
+			});
+
+			it('still accepts recognized params', async () => {
+				expect(await rejection({ logging_level: 'debug' })).to.equal(undefined);
+				expect(update_config_value_stub.called).to.equal(true);
+			});
+
+			it('preserves the operator-named _package and _port escape hatch', async () => {
+				expect(await rejection({ 'my-component_package': 'x', 'my-component_port': 1 })).to.equal(undefined);
+			});
+
+			it('treats the escape hatch as case-sensitive, so an uppercase typo is still rejected', async () => {
+				expect(await rejection({ TYPO_PORT: 1 })).to.include('TYPO_PORT');
+			});
+
+			it('does not mistake control fields for config params', async () => {
+				const message = await rejection({ hdb_user: {}, hdbAuthHeader: 'h', hdb_auth_header: 'h', replicated: false });
+				expect(message).to.equal(undefined);
+			});
+
+			it('rejects an inherited Object.prototype name rather than resolving it', async () => {
+				expect(await rejection({ toString: 'x' })).to.include('toString');
+			});
 		});
 
 		describe('replicated: true', () => {
@@ -1470,14 +1519,13 @@ describe('Test configUtils module', () => {
 				const config_fields = update_config_value_stub.firstCall.args[2];
 				expect(config_fields).to.eql({
 					http_corsAccessList: ['harper.fast'],
-					hdb_auth_header: 'test_header',
 				});
 			});
 
 			it('Test no replicated flag does not fan out', async () => {
 				const test_set_config_json = {
 					operation: 'set_configuration',
-					operationsApi_processes: 18,
+					threads_count: 18,
 					hdb_user: {},
 					hdb_auth_header: 'test_header',
 				};

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -1467,6 +1467,21 @@ describe('Test configUtils module', () => {
 			it('rejects an inherited Object.prototype name rather than resolving it', async () => {
 				expect(await rejection({ toString: 'x' })).to.include('toString');
 			});
+
+			it('replaces control characters in reported names so a name cannot forge a log line', async () => {
+				const message = await rejection({ 'bad\nname': 1 });
+				expect(message).to.include('bad?name');
+				expect(message).to.not.include('\n');
+			});
+
+			it('caps the reported names so a body full of unknown keys cannot make the message unbounded', async () => {
+				const body = {};
+				for (let i = 0; i < 25; i++) body[`nope_${i}`] = i;
+				const message = await rejection(body);
+				expect(message).to.include('(and 15 more)');
+				expect(message).to.include('nope_0');
+				expect(message).to.not.include('nope_10,');
+			});
 		});
 
 		describe('replicated: true', () => {


### PR DESCRIPTION
`set_configuration` resolved each request key through `CONFIG_PARAM_MAP` and, on a miss, ended the loop iteration with no error and no log — then returned `Configuration successfully set`. A typo, or a config block Harper does not expose as a param, was accepted with HTTP 200 and never written. The operation now preflights every request key and rejects the whole request with a 400 naming each unrecognized param, before anything is written locally.

Verified live on 5.2.4 before the fix: a `models` block and `logging_levl` both returned success and changed nothing.

## For the human reviewer

1. **Which layer enforces this.** The preflight sits in `setConfiguration`, not in `updateConfigValue`'s bulk loop, and not as a Joi schema in `operationsValidation.js` like most operations. The writer must stay permissive: `createConfigFile` merges `installParams` carrying install-only keys (`INSTALL_PROMPTS.DEFAULTS_MODE`, `HDB_CONFIG`) at `utility/install/installer.ts:617`, so strictness there aborts install. A Joi schema would also cover future bulk writers and match how every other operation validates — but it would have to duplicate the dynamic alias table and the `_package`/`_port` rule outside the config subsystem. Cheap to move later, except that the error text and status become API surface the moment this ships.
2. **This is a breaking change; it is milestoned v5.3 (Kris's call, 2026-08-22).** `set_configuration` has tolerated extra keys for years. Any client that sends one — Studio spreads arbitrary `...changes` from its config UI — starts failing on upgrade, and the failure is total rather than partial, so it holds for a minor rather than riding a 5.2.x patch.

   The scope question behind that call, for the record: **no request that previously succeeded *and applied its changes* behaves differently.** The only changes outside new error responses run the other way — `getConfigValue`/`createConfigFile` previously threw a `TypeError` on an inherited or non-string param name and now return `undefined`/skip, which removes a crash rather than adding one. Everything else is a 200-that-silently-discarded becoming a 400.
3. **Typo-shaped names are still accepted.** The preflight reuses the `_package`/`_port` escape hatch verbatim, so `logging_port` or `htpp_port` passes validation and is written as a component entry. That is arguably the larger half of #2266 for a real operator. Tightening it (requiring the prefix to look like a component name) is a follow-up, not a revert.
4. **`hdb_auth_header` is stripped silently, where `registryAuth` is rejected with a rename message** (`components/operationsValidation.js:525`). I chose stripping because it is the 4.x spelling of an internal auth artifact that clients never typed, so a 400 would break legacy-shaped callers for no benefit. A reviewer may want consistency with the `registryAuth` precedent instead.
5. **Escape-hatch case sensitivity is now pinned by a test.** `_package`/`_port` match case-sensitively while every mapped param matches case-insensitively, so `TYPO_PORT` is rejected. That asymmetry is pre-existing behavior I preserved rather than a decision I made — but the test now encodes it, so a reviewer reading it as a bug will find a test asserting it is intended.

6. **Open reviewer question: should there be an opt-in that allows unrecognized params?** Raised by @dawsontoth on `config/configUtils.ts:1114`, on the grounds that components read this config too, so an operator might want a component's entry staged before rolling the component out — or a param staged ahead of a breaking Harper config change. I checked both against the writer rather than reasoning about them, and neither works today, with or without this change: `set_configuration` only ever wrote a name resolvable through `CONFIG_PARAM_MAP` or ending in `_package`/`_port` (`config/configUtils.ts:891-895`; the same resolution on `main` at `configUtils.ts:848`), so `myComponent_urlPath`, a nested `myComponent: {...}` block, and a param from a newer version were all dropped with no write and no log. Staging a component *does* still work through `<name>_package`/`<name>_port`, which the preflight passes through and an integration case asserts lands. The reason a bypass flag is the wrong shape for the opt-in: skipping only the preflight restores "200 and nothing written" — the #2266 behavior — because the writer still drops the name. The real gap is writer-side (`set_configuration` cannot reach anything but `_package`/`_port` on a component entry) and is independent of whether unknown names 400. **Left open for a human call**; the thread is unresolved and the full trace is in the [PR comment](https://github.com/HarperFast/harper/pull/2272#issuecomment-5396737527).

Round-3 review added two hardening nits, both applied: the error message now strips control characters and caps the number of names it lists (a key containing a newline could otherwise forge a line in the operations log, and a body with thousands of unknown keys produced an unbounded message), and the atomicity integration case now reads the current value rather than assuming what an earlier test left behind, so it holds under isolation or reordering.

One nit is knowingly carried: the new unit cases sit inside the file's existing Sinon/rewire describe block rather than a real-module seam. The rejection cases need no stub at all — they throw before the writer is reached — but the atomicity assertion has to observe that the writer was *not* called, and reusing the harness that already exists beat introducing a second one.

Two findings from the review are real, pre-existing, and deliberately **not** fixed here — both are the same false-success family and are filed: **#2269** (a resolved param whose `configDoc.setIn` throws is caught, logged, and still reported as success) and **#2270** (on a `replicated: true` fan-out the origin overwrites the per-node response with the success string). #2270 matters more *because* of this PR: a peer that used to silently ignore an unknown name now 400s the whole request, so during a mixed-version window older peers apply neither param where they previously applied the recognized one. That widens divergence, and it is only visible in `response.replicated`. Worth deciding alongside decision 2 below.

## Verification

- **Route (a) — extended the existing integration suite.** `integrationTests/apiTests/configuration.test.mjs` gains four HTTP-level cases: single unknown name 400s naming it; several unknown names produce one 400 naming each; a mixed recognized/unrecognized request 400s and a follow-up `get_configuration` proves the recognized half did not land; a `_package` entry still writes (asserted via `get_configuration`, then removed so it does not leak into later tests).
- **Unit:** `npx mocha --conditions=typestrip unitTests/config/configUtils.test.js` → 89 passing (87 at the time of the original run; two cases were added by the later hardening commits).
- **Fails-on-base:** restored `config/configUtils.ts` from `origin/main`, deleted `dist/config/configUtils.js` and the tsbuildinfo, rebuilt, re-ran → **6 failing** (the five rejection cases plus the control-field expectation). Three control cases pass on either side. Restored and rebuilt → 87 passing.
- **Live:** the `models` and `logging_levl` payloads from #2266 reproduced on a 5.2.4 instance; also confirmed `toString`/`hasOwnProperty`/`valueOf` take the same silent-success path, while `constructor` is already blocked upstream by a body-property guard — which is why the `Object.hasOwn` guard is described as defense-in-depth for direct callers rather than a reachable HTTP fix.

Fixes #2266

Complexity: medium

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=6 @ c98b40eb2db9</sub>

<sub>Human-Review-Need: 3 @ c98b40eb2db9</sub>
