### PR TITLE
Deflake the unit-test cluster: seed HNSW routing, signal-based waits, quarantine two unreproduced hangs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1094,6 +1094,12 @@ graphs being identical, though equal metrics do not prove it. It is the expected
 the upper layers are sparse enough that a greedy walk reaches the same entry point, which is why
 standard HNSW descends this way.
 
+Greedy-equals-full is statistical, not per-graph: rare level layouts route to a different layer-0
+entry point and displace the tail of the top-k (~2-3% of random 600-node graphs in the unit test's
+corpus). Tests that assert exact result-set equality across search strategies must therefore pin the
+graph: level assignment draws from the instance's `random` property (a test seam defaulting to
+`Math.random`), which the routing test replaces with a seeded PRNG.
+
 ## `efConstruction` and the search-`ef` ceiling both auto-scale with the graph
 
 The connection-building pass selects each node's stored edges from a candidate list of

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1098,7 +1098,10 @@ Greedy-equals-full is statistical, not per-graph: rare level layouts route to a 
 entry point and displace the tail of the top-k (~2-3% of random 600-node graphs in the unit test's
 corpus). Tests that assert exact result-set equality across search strategies must therefore pin the
 graph: level assignment draws from the instance's `random` property (a test seam defaulting to
-`Math.random`), which the routing test replaces with a seeded PRNG.
+`Math.random`), which the routing test replaces with a seeded PRNG. One pinned graph samples the
+property once, so that test sweeps a fixed list of seeds, each verified non-divergent when the list
+was written — a seed that starts diverging after an intentional index change is a re-pin, not
+necessarily a routing regression.
 
 ## `efConstruction` and the search-`ef` ceiling both auto-scale with the graph
 

--- a/integrationTests/components/risk-query.test.ts
+++ b/integrationTests/components/risk-query.test.ts
@@ -13,7 +13,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 import { startHarper, teardownHarper, sendOperation, type ContextWithHarper } from '@harperfast/integration-testing';
 
-suite('Component: risk-query', (ctx: ContextWithHarper) => {
+// Quarantined on Windows: deploy_component (restart:true) hangs server-side after npm pack, which
+// stalls before() on undici's 300s headers timeout and cancels every child test. See
+// https://github.com/HarperFast/harper/issues/2273 — remove the skip when the deploy hang is fixed.
+const skipSuite = process.platform === 'win32';
+
+suite('Component: risk-query', { skip: skipSuite }, (ctx: ContextWithHarper) => {
 	before(async () => {
 		await startHarper(ctx);
 
@@ -27,11 +32,13 @@ suite('Component: risk-query', (ctx: ContextWithHarper) => {
 		strictEqual(body.message, 'Successfully deployed: risk-query, restarting Harper');
 		ok(typeof body.deployment_id === 'string', `expected deployment_id in deploy response, got ${body.deployment_id}`);
 
-		// Poll until the component is ready
+		// Poll until the component is ready. Each probe carries its own abort timeout: without it, a
+		// connection that opens but never sends headers holds fetch for undici's 300s default and
+		// blows past the deadline check (issue #2273's client-side half).
 		const deadline = Date.now() + 30_000;
 		while (true) {
 			try {
-				const check = await fetch(`${ctx.harper.httpURL}/RisqTable/`);
+				const check = await fetch(`${ctx.harper.httpURL}/RisqTable/`, { signal: AbortSignal.timeout(5_000) });
 				if (check.status === 200) break;
 			} catch {
 				// server not yet accepting connections

--- a/resources/indexes/HierarchicalNavigableSmallWorld.ts
+++ b/resources/indexes/HierarchicalNavigableSmallWorld.ts
@@ -209,6 +209,10 @@ export class HierarchicalNavigableSmallWorld {
 	// a value of 1 is extremely aggressive.
 	optimizeRouting = 0.5;
 	nodesVisitedCount = 0;
+	// Test seam: source of randomness for level assignment. Tests that assert exact result-set
+	// equality across search strategies replace this with a seeded PRNG so the graph shape is
+	// reproducible; greedy routing legitimately diverges on rare unlucky graphs otherwise.
+	random: () => number = Math.random;
 	// Visit-budget multiplier for predicate-aware traversal (#1241). Under-filled filtered searches
 	// stop after the resolved budget ef * filterExpansion visits; automatic search ef contributes at
 	// most AUTO_EF_MAX, while explicit schema/query ef remains authoritative. A filter that fills its
@@ -337,7 +341,7 @@ export class HierarchicalNavigableSmallWorld {
 			const storedScale = q ? q.scale : undefined;
 			let entryPoint = entryPointId && this.safeGetSync(entryPointId, options);
 			if (entryPoint == null) {
-				const level = Math.floor(-Math.log(Math.random()) * this.mL);
+				const level = Math.min(Math.floor(-Math.log(this.random()) * this.mL), MAX_LEVEL);
 				const node = {
 					vector: storedVector,
 					scale: storedScale,
@@ -358,7 +362,7 @@ export class HierarchicalNavigableSmallWorld {
 			}
 
 			// Generate random level for this new element
-			const level = oldNode.level ?? Math.min(Math.floor(-Math.log(Math.random()) * this.mL), MAX_LEVEL);
+			const level = oldNode.level ?? Math.min(Math.floor(-Math.log(this.random()) * this.mL), MAX_LEVEL);
 			let currentLevel = entryPoint.level;
 			if (level > currentLevel) {
 				// if we are at a higher level, make this the new entry point

--- a/unitTests/apiTests/mqtt-test.mjs
+++ b/unitTests/apiTests/mqtt-test.mjs
@@ -890,7 +890,11 @@ describe('test MQTT connections and commands', function () {
 		const granted = await subscribeAllowingSubackError(clientV5, '+/SimpleRecord/test');
 		assert.equal(granted[0].qos, 0x8f); // assert that the subscription was rejected
 	});
-	it('subscribe with QoS=1 and reconnect with non-clean session', async function () {
+	// Quarantined: hung silently to its 20s timeout on CI main (lmdb pass, Node 26) with no
+	// server-side log output; not reproduced in 30 contended local runs. Evidence, hypotheses,
+	// and the reinstatement path (bounded per-step waits) are in
+	// https://github.com/HarperFast/harper/issues/2274 — unskip once the hang is localized.
+	it.skip('subscribe with QoS=1 and reconnect with non-clean session', async function () {
 		this.timeout(20000); // needs more than the suite-level 10 s on loaded runners
 		// this first connection is a tear down to remove any previous durable session with this id
 		let client = await connectAsync(mqttUrl, {

--- a/unitTests/apiTests/mqtt-test.mjs
+++ b/unitTests/apiTests/mqtt-test.mjs
@@ -890,112 +890,117 @@ describe('test MQTT connections and commands', function () {
 		const granted = await subscribeAllowingSubackError(clientV5, '+/SimpleRecord/test');
 		assert.equal(granted[0].qos, 0x8f); // assert that the subscription was rejected
 	});
-	// Quarantined: hung silently to its 20s timeout on CI main (lmdb pass, Node 26) with no
-	// server-side log output; not reproduced in 30 contended local runs. Evidence, hypotheses,
-	// and the reinstatement path (bounded per-step waits) are in
-	// https://github.com/HarperFast/harper/issues/2274 — unskip once the hang is localized.
-	it.skip('subscribe with QoS=1 and reconnect with non-clean session', async function () {
-		this.timeout(20000); // needs more than the suite-level 10 s on loaded runners
-		// this first connection is a tear down to remove any previous durable session with this id
-		let client = await connectAsync(mqttUrl, {
-			clean: true,
-			clientId: 'test-client1',
-			protocolVersion: 4,
-		});
-		await endDurableSession(client, 'test-client1');
-		client = await connectAsync(mqttUrl, {
-			clean: false,
-			clientId: 'test-client1',
-			protocolVersion: 4,
-		});
-		await client.subscribeAsync(['SimpleRecord/41', 'SimpleRecord/42'], { qos: 1 });
-		await endDurableSession(client, 'test-client1');
-		client = await connectAsync(mqttUrl, {
-			clean: false,
-			clientId: 'test-client1',
-			protocolVersion: 4,
-		});
-		await new Promise((resolve) => {
-			// Wait for the broker to finish processing (and durably persisting) our ack of this
-			// message, not just for the client to have sent it — see `session.acknowledge()`.
-			const acknowledged = waitForMqttSessionEvent('acknowledged', 'test-client1');
-			client.on('message', (topic, payload) => {
-				JSON.parse(payload);
-				resolve(acknowledged);
+	// Quarantined on lmdb only: hung silently to its 20s timeout on CI main (lmdb pass, Node 26)
+	// with no server-side log output; not reproduced in 30 contended local runs. The rocksdb pass
+	// keeps this durable-session coverage. Evidence, hypotheses, and the reinstatement path
+	// (bounded per-step waits) are in https://github.com/HarperFast/harper/issues/2274.
+	(process.env.HARPER_STORAGE_ENGINE === 'lmdb' ? it.skip : it)(
+		'subscribe with QoS=1 and reconnect with non-clean session',
+		async function () {
+			this.timeout(20000); // needs more than the suite-level 10 s on loaded runners
+			// this first connection is a tear down to remove any previous durable session with this id
+			let client = await connectAsync(mqttUrl, {
+				clean: true,
+				clientId: 'test-client1',
+				protocolVersion: 4,
 			});
+			await endDurableSession(client, 'test-client1');
+			client = await connectAsync(mqttUrl, {
+				clean: false,
+				clientId: 'test-client1',
+				protocolVersion: 4,
+			});
+			await client.subscribeAsync(['SimpleRecord/41', 'SimpleRecord/42'], { qos: 1 });
+			await endDurableSession(client, 'test-client1');
+			client = await connectAsync(mqttUrl, {
+				clean: false,
+				clientId: 'test-client1',
+				protocolVersion: 4,
+			});
+			await new Promise((resolve) => {
+				// Wait for the broker to finish processing (and durably persisting) our ack of this
+				// message, not just for the client to have sent it — see `session.acknowledge()`.
+				const acknowledged = waitForMqttSessionEvent('acknowledged', 'test-client1');
+				client.on('message', (topic, payload) => {
+					JSON.parse(payload);
+					resolve(acknowledged);
+				});
 
-			client.publish(
+				client.publish(
+					'SimpleRecord/41',
+					JSON.stringify({
+						name: 'This is a test of durable session with subscriptions restarting',
+					}),
+					{
+						qos: 1,
+					}
+				);
+			});
+			await endDurableSession(client, 'test-client1');
+			await clientV5.publishAsync(
 				'SimpleRecord/41',
 				JSON.stringify({
-					name: 'This is a test of durable session with subscriptions restarting',
+					name: 'This is a test of publishing to a disconnected durable session',
 				}),
 				{
 					qos: 1,
 				}
 			);
-		});
-		await endDurableSession(client, 'test-client1');
-		await clientV5.publishAsync(
-			'SimpleRecord/41',
-			JSON.stringify({
-				name: 'This is a test of publishing to a disconnected durable session',
-			}),
-			{
-				qos: 1,
-			}
-		);
-		await clientV5.publishAsync(
-			'SimpleRecord/42',
-			JSON.stringify({
-				name: 'This is a test of publishing to a disconnected durable session 2',
-			}),
-			{
-				qos: 1,
-			}
-		);
-		await clientV5.publishAsync(
-			'SimpleRecord/42',
-			JSON.stringify({
-				name: 'This is a test of publishing to a disconnected durable session 3',
-			}),
-			{
-				qos: 1,
-			}
-		);
-		let messages = [];
-		client = await connectWithMessageListener(
-			mqttUrl,
-			{
-				clean: false,
-				clientId: 'test-client1',
-				protocolVersion: 5,
-				properties: {
-					sessionExpiryInterval: 3600,
-				},
-			},
-			(topic, message) => {
-				messages.push(message.toString());
-			}
-		);
-		await new Promise((resolve, reject) => {
-			const interval = setInterval(() => {
-				if (messages.length === 3) {
-					clearInterval(interval);
-					resolve();
+			await clientV5.publishAsync(
+				'SimpleRecord/42',
+				JSON.stringify({
+					name: 'This is a test of publishing to a disconnected durable session 2',
+				}),
+				{
+					qos: 1,
 				}
-			}, 1);
-			setTimeout(() => {
-				clearInterval(interval);
-				reject(
-					new Error(`Expected 3 queued messages to be delivered to reconnected durable session, got ${messages.length}`)
-				);
-			}, 15000);
-		});
-		await delay(50);
-		await client.endAsync();
-		if (messages.length !== 3) console.error('Incorrect messages', { messages });
-		assert(messages.length === 3);
-	});
+			);
+			await clientV5.publishAsync(
+				'SimpleRecord/42',
+				JSON.stringify({
+					name: 'This is a test of publishing to a disconnected durable session 3',
+				}),
+				{
+					qos: 1,
+				}
+			);
+			let messages = [];
+			client = await connectWithMessageListener(
+				mqttUrl,
+				{
+					clean: false,
+					clientId: 'test-client1',
+					protocolVersion: 5,
+					properties: {
+						sessionExpiryInterval: 3600,
+					},
+				},
+				(topic, message) => {
+					messages.push(message.toString());
+				}
+			);
+			await new Promise((resolve, reject) => {
+				const interval = setInterval(() => {
+					if (messages.length === 3) {
+						clearInterval(interval);
+						resolve();
+					}
+				}, 1);
+				setTimeout(() => {
+					clearInterval(interval);
+					reject(
+						new Error(
+							`Expected 3 queued messages to be delivered to reconnected durable session, got ${messages.length}`
+						)
+					);
+				}, 15000);
+			});
+			await delay(50);
+			await client.endAsync();
+			if (messages.length !== 3) console.error('Incorrect messages', { messages });
+			assert(messages.length === 3);
+		}
+	);
 	it('subscribe with QoS=2', async function () {
 		// this first connection is a tear down to remove any previous durable session with this id
 		let client = await connectAsync(mqttUrl, {

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -577,8 +577,6 @@ describe('Subscription replay', () => {
 				inFlight.push(CurrentStateTable.put(14000 + i, { name: 'inflight' + i }));
 			}
 			const subscription = await CurrentStateTable.subscribe({ isCollection: true });
-			// collect()'s quiet window can expire while the 200 puts are still committing; wait for
-			// the commits, then for every key's delivery.
 			const events = [];
 			subscription.on('data', (e) => events.push(e));
 			await Promise.all(inFlight);
@@ -646,8 +644,19 @@ describe('Subscription replay', () => {
 				inFlight.push(CountTable.put(17000 + i, { name: 'count_race_inflight' + i }));
 			}
 			const subscription = await CountTable.subscribe({ previousCount: 10, isCollection: true });
-			const events = await collect(subscription, 250);
+			// The duplicate check below is only sound once every in-flight write's delivery has had
+			// the chance to arrive — collect()'s quiet window returning early made it vacuous.
+			const events = [];
+			subscription.on('data', (e) => events.push(e));
 			await Promise.all(inFlight);
+			await waitFor(
+				() => {
+					const seen = new Set(events.map((e) => e.id));
+					for (let i = 0; i < 30; i++) if (!seen.has(17000 + i)) return false;
+					return true;
+				},
+				{ timeout: 5000 }
+			).catch(() => {});
 			subscription.return?.();
 
 			// the regression we want to catch: a record landing in BOTH history (from cursor's
@@ -669,8 +678,13 @@ describe('Subscription replay', () => {
 				inFlight.push(RecordTable.put(15000, { name: 'inflight_v' + i }));
 			}
 			const subscription = await RecordTable.subscribe({ id: 15000, startTime: startTime - 1 });
-			const events = await collect(subscription, 250);
+			// Same soundness requirement as the count test above, but rapid same-record versions can
+			// legitimately coalesce, so the only guaranteed delivery is the final version — wait for
+			// it (any cursor/listener duplicate of an earlier version travels with its original).
+			const events = [];
+			subscription.on('data', (e) => events.push(e));
 			await Promise.all(inFlight);
+			await waitFor(() => events.some((e) => e.value?.name === 'inflight_v49'), { timeout: 5000 }).catch(() => {});
 			subscription.return?.();
 
 			const pairs = events.map((e) => `${e.id}:${e.version}`);

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -370,10 +370,11 @@ describe('Subscription replay', () => {
 			const events = [];
 			subscription.on('data', (e) => events.push(e));
 			await Promise.all(inFlight);
-			// Wait for every in-flight write to be delivered rather than guessing a fixed
-			// duration — the fixed wait raced loaded runners and was the source of the
-			// intermittent "missing id" failures. The timeout falls through so the per-id
-			// asserts below name whichever write was lost instead of reporting a bare timeout.
+			// Wait on the deliveries themselves rather than a fixed duration, and let the timeout
+			// fall through so the per-id asserts below name whichever write was lost. A
+			// `missing in-flight id N` failure here is not a test-timing problem: it is the lost
+			// delivery in https://github.com/HarperFast/harper/issues/2311 — the startTime replay
+			// branch drops live events committed after its audit cursor has terminated.
 			await waitFor(
 				() => {
 					const seen = new Set(events.map((e) => e.id));

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -372,12 +372,16 @@ describe('Subscription replay', () => {
 			await Promise.all(inFlight);
 			// Wait for every in-flight write to be delivered rather than guessing a fixed
 			// duration — the fixed wait raced loaded runners and was the source of the
-			// intermittent "missing id" failures.
-			await waitFor(() => {
-				const seen = new Set(events.map((e) => e.id));
-				for (let i = 0; i < 200; i++) if (!seen.has(20000 + i)) return false;
-				return true;
-			});
+			// intermittent "missing id" failures. The timeout falls through so the per-id
+			// asserts below name whichever write was lost instead of reporting a bare timeout.
+			await waitFor(
+				() => {
+					const seen = new Set(events.map((e) => e.id));
+					for (let i = 0; i < 200; i++) if (!seen.has(20000 + i)) return false;
+					return true;
+				},
+				{ timeout: 5000 }
+			).catch(() => {});
 			subscription.return?.();
 
 			const ids = new Set(events.map((e) => e.id));

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -657,6 +657,9 @@ describe('Subscription replay', () => {
 				},
 				{ timeout: 5000 }
 			).catch(() => {});
+			// additive settle: a duplicate trailing the last expected delivery can still land; this
+			// can only catch more, never lose events
+			await delay(100);
 			subscription.return?.();
 
 			// the regression we want to catch: a record landing in BOTH history (from cursor's
@@ -685,6 +688,8 @@ describe('Subscription replay', () => {
 			subscription.on('data', (e) => events.push(e));
 			await Promise.all(inFlight);
 			await waitFor(() => events.some((e) => e.value?.name === 'inflight_v49'), { timeout: 5000 }).catch(() => {});
+			// additive settle so a duplicate trailing the final version can still surface
+			await delay(100);
 			subscription.return?.();
 
 			const pairs = events.map((e) => `${e.id}:${e.version}`);

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -418,8 +418,25 @@ describe('Subscription replay', () => {
 					await CurrentStateTable.put(7000 + i, { name: 'pp_updated' + i });
 				}
 			})();
-			const events = await collect(subscription, 250);
+			// Attach a listener and wait for every key's final value rather than using collect()'s
+			// quiet-period timer — on a loaded runner the subscription can go quiet longer than the
+			// window while queued updates are still in flight (the same race the two tests above
+			// already moved off of). The timeout path falls through so the per-key asserts below
+			// report exactly which key was stale.
+			const events = [];
+			subscription.on('data', (e) => events.push(e));
 			await concurrentWrites;
+			await waitFor(
+				() => {
+					const finals = new Map();
+					for (const e of events) finals.set(e.id, e);
+					for (let i = 0; i < 50; i++) {
+						if (finals.get(7000 + i)?.value?.name !== 'pp_updated' + i) return false;
+					}
+					return true;
+				},
+				{ timeout: 5000 }
+			).catch(() => {});
 			subscription.return?.();
 
 			// every key 7000..7049 must end up at the updated value as its final delivery

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -131,18 +131,29 @@ describe('Subscription replay', () => {
 				await StartTimeTable.put(1000 + i, { name: 'pre' + i });
 			}
 			const subscription = await StartTimeTable.subscribe({ startTime: startTime - 1, isCollection: true });
+			const events = [];
+			subscription.on('data', (e) => events.push(e));
 			// fire writes concurrently with the replay loop
 			const concurrentWrites = (async () => {
 				for (let i = 0; i < 30; i++) {
 					await StartTimeTable.put(2000 + i, { name: 'post' + i });
 				}
 			})();
-			const events = await collect(subscription, 100);
 			await concurrentWrites;
-			// All writes have committed; wait for any pending subscription events to flush
-			// before closing. Without this, the last write's event can be queued but not
-			// yet delivered when return() closes the stream.
-			await delay(200);
+			// Wait for every expected id rather than for the stream to go quiet: under contention
+			// the gap between two deliveries can exceed any fixed window, and the per-id asserts
+			// below then name whichever one went missing.
+			await waitFor(
+				() => {
+					const ids = new Set(events.map((e) => e.id));
+					for (let i = 0; i < 150; i++) if (!ids.has(1000 + i)) return false;
+					for (let i = 0; i < 30; i++) if (!ids.has(2000 + i)) return false;
+					return true;
+				},
+				{ timeout: 5000 }
+			).catch(() => {});
+			// additive settle: a duplicate trailing the last expected delivery can still land
+			await delay(100);
 			subscription.return?.();
 
 			const ids = new Set(events.map((e) => e.id));
@@ -188,15 +199,25 @@ describe('Subscription replay', () => {
 				await CountTable.put(3000 + i, { name: 'count_pre' + i });
 			}
 			const subscription = await CountTable.subscribe({ previousCount: 5, isCollection: true });
+			const events = [];
+			subscription.on('data', (e) => events.push(e));
 			// fire writes after subscribe returns but while replay loop is still running
 			const concurrentWrites = (async () => {
 				for (let i = 0; i < 20; i++) {
 					await CountTable.put(4000 + i, { name: 'count_post' + i });
 				}
 			})();
-			const events = await collect(subscription, 150);
 			await concurrentWrites;
-			await delay(200);
+			await waitFor(
+				() => {
+					const ids = new Set(events.map((e) => e.id));
+					for (let i = 0; i < 20; i++) if (!ids.has(4000 + i)) return false;
+					return true;
+				},
+				{ timeout: 5000 }
+			).catch(() => {});
+			// additive settle: a duplicate trailing the last expected delivery can still land
+			await delay(100);
 			subscription.return?.();
 
 			// concurrent writes should arrive
@@ -245,15 +266,27 @@ describe('Subscription replay', () => {
 				await CurrentStateTable.put(5000 + i, { name: 'dedupe_pre' + i });
 			}
 			const subscription = await CurrentStateTable.subscribe({ isCollection: true });
+			const events = [];
+			subscription.on('data', (e) => events.push(e));
 			// concurrent writes that may be observed by both cursor (snapshot:false) and the listener
 			const concurrentWrites = (async () => {
 				for (let i = 0; i < 30; i++) {
 					await CurrentStateTable.put(5000 + i, { name: 'dedupe_updated' + i });
 				}
 			})();
-			const events = await collect(subscription, 150);
 			await concurrentWrites;
-			await delay(200);
+			await waitFor(
+				() => {
+					const lastByKey = new Map();
+					for (const e of events) lastByKey.set(e.id, e);
+					for (let i = 0; i < 30; i++) {
+						if (lastByKey.get(5000 + i)?.value?.name !== 'dedupe_updated' + i) return false;
+					}
+					return true;
+				},
+				{ timeout: 5000 }
+			).catch(() => {});
+			await delay(100);
 			subscription.return?.();
 
 			// every updated key MUST be delivered with its final value at least once, even if
@@ -644,21 +677,21 @@ describe('Subscription replay', () => {
 				inFlight.push(CountTable.put(17000 + i, { name: 'count_race_inflight' + i }));
 			}
 			const subscription = await CountTable.subscribe({ previousCount: 10, isCollection: true });
-			// The duplicate check below is only sound once every in-flight write's delivery has had
-			// the chance to arrive — collect()'s quiet window returning early made it vacuous.
 			const events = [];
 			subscription.on('data', (e) => events.push(e));
 			await Promise.all(inFlight);
-			await waitFor(
-				() => {
-					const seen = new Set(events.map((e) => e.id));
-					for (let i = 0; i < 30; i++) if (!seen.has(17000 + i)) return false;
-					return true;
-				},
-				{ timeout: 5000 }
-			).catch(() => {});
-			// additive settle: a duplicate trailing the last expected delivery can still land; this
-			// can only catch more, never lose events
+			// The duplicate check below is only sound once every delivery that is coming has come.
+			// It cannot wait for all 30 in-flight ids: one that commits before the cursor's snapshot
+			// and falls outside previousCount is legitimately never delivered (running this test
+			// alone, 17000-17002 never arrive). Deliveries follow commit order, so a record written
+			// after the in-flight writes settle bounds them — once it arrives, they have all arrived.
+			await CountTable.put(17999, { name: 'count_race_sentinel' });
+			await waitFor(() => events.some((e) => e.id === 17999), {
+				timeout: 5000,
+				message: 'sentinel written after the in-flight writes was never delivered',
+			});
+			// additive settle: a duplicate trailing the sentinel can still land; this can only
+			// catch more, never lose events
 			await delay(100);
 			subscription.return?.();
 
@@ -681,14 +714,19 @@ describe('Subscription replay', () => {
 				inFlight.push(RecordTable.put(15000, { name: 'inflight_v' + i }));
 			}
 			const subscription = await RecordTable.subscribe({ id: 15000, startTime: startTime - 1 });
-			// Same soundness requirement as the count test above, but rapid same-record versions can
-			// legitimately coalesce, so the only guaranteed delivery is the final version — wait for
-			// it (any cursor/listener duplicate of an earlier version travels with its original).
 			const events = [];
 			subscription.on('data', (e) => events.push(e));
 			await Promise.all(inFlight);
-			await waitFor(() => events.some((e) => e.value?.name === 'inflight_v49'), { timeout: 5000 }).catch(() => {});
-			// additive settle so a duplicate trailing the final version can still surface
+			// Same soundness requirement as the count test above. Rapid same-record versions can
+			// legitimately coalesce, so no in-flight version is guaranteed to be delivered on its
+			// own; a version written after they all settle is (any cursor/listener duplicate of an
+			// earlier version travels with its original, so it precedes the sentinel).
+			await RecordTable.put(15000, { name: 'inflight_sentinel' });
+			await waitFor(() => events.some((e) => e.value?.name === 'inflight_sentinel'), {
+				timeout: 5000,
+				message: 'sentinel version written after the in-flight writes was never delivered',
+			});
+			// additive settle so a duplicate trailing the sentinel can still surface
 			await delay(100);
 			subscription.return?.();
 
@@ -1035,7 +1073,21 @@ describe('Subscription replay', () => {
 			for (let i = 0; i < N; i++) {
 				await T.put(20000 + i, { name: 'burst' + i });
 			}
-			const events = await collect(subscription, 300);
+			const events = [];
+			subscription.on('data', (e) => events.push(e));
+			// Every write is committed and awaited before this point, so all N must be delivered —
+			// wait for that rather than for a quiet window, which a mid-drain stall longer than the
+			// window ends early (measured: 1 failure in 32 lmdb runs, "missing 7 of 600").
+			await waitFor(
+				() => {
+					const seen = new Set(events.map((e) => e.id));
+					for (let i = 0; i < N; i++) if (!seen.has(20000 + i)) return false;
+					return true;
+				},
+				{ timeout: 10000 }
+			).catch(() => {});
+			// additive settle: a duplicate trailing the last delivery can still land
+			await delay(100);
 			subscription.return?.();
 
 			const ids = new Set(events.map((e) => e.id));

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -216,7 +216,6 @@ describe('Subscription replay', () => {
 				},
 				{ timeout: 5000 }
 			).catch(() => {});
-			// additive settle: a duplicate trailing the last expected delivery can still land
 			await delay(100);
 			subscription.return?.();
 
@@ -683,8 +682,10 @@ describe('Subscription replay', () => {
 			// The duplicate check below is only sound once every delivery that is coming has come.
 			// It cannot wait for all 30 in-flight ids: one that commits before the cursor's snapshot
 			// and falls outside previousCount is legitimately never delivered (running this test
-			// alone, 17000-17002 never arrive). Deliveries follow commit order, so a record written
-			// after the in-flight writes settle bounds them — once it arrives, they have all arrived.
+			// alone, 17000-17002 never arrive). A record written after they settle bounds them
+			// instead: the previousCount cursor collects its history from a snapshot taken before
+			// subscribe() resolves, so it cannot deliver this record, and the queue that will is
+			// drained in commit order.
 			await CountTable.put(17999, { name: 'count_race_sentinel' });
 			await waitFor(() => events.some((e) => e.id === 17999), {
 				timeout: 5000,
@@ -719,8 +720,9 @@ describe('Subscription replay', () => {
 			await Promise.all(inFlight);
 			// Same soundness requirement as the count test above. Rapid same-record versions can
 			// legitimately coalesce, so no in-flight version is guaranteed to be delivered on its
-			// own; a version written after they all settle is (any cursor/listener duplicate of an
-			// earlier version travels with its original, so it precedes the sentinel).
+			// own; a version written after they all settle is. The cursor captures this record's
+			// entry before subscribe() resolves, so it cannot deliver that later version — it
+			// arrives through the commit-ordered queue, after every in-flight delivery.
 			await RecordTable.put(15000, { name: 'inflight_sentinel' });
 			await waitFor(() => events.some((e) => e.value?.name === 'inflight_sentinel'), {
 				timeout: 5000,
@@ -1086,7 +1088,6 @@ describe('Subscription replay', () => {
 				},
 				{ timeout: 10000 }
 			).catch(() => {});
-			// additive settle: a duplicate trailing the last delivery can still land
 			await delay(100);
 			subscription.return?.();
 

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -381,7 +381,19 @@ describe('Subscription replay', () => {
 			const events = [];
 			subscription.on('data', (e) => events.push(e));
 			await concurrentWrites;
-			await delay(200);
+			// wait for every hammered key's final (round-2) value instead of a fixed 200ms — the
+			// queued deliveries can trail the commits on a loaded runner
+			await waitFor(
+				() => {
+					const lastSeen = new Map();
+					for (const e of events) lastSeen.set(e.id, e);
+					for (let i = 100; i < 200; i++) {
+						if (lastSeen.get(6000 + i)?.value?.name !== `rc_v2_${i}`) return false;
+					}
+					return true;
+				},
+				{ timeout: 5000 }
+			).catch(() => {});
 			subscription.return?.();
 
 			// every key in 6000..6199 must appear at least once
@@ -418,11 +430,9 @@ describe('Subscription replay', () => {
 					await CurrentStateTable.put(7000 + i, { name: 'pp_updated' + i });
 				}
 			})();
-			// Attach a listener and wait for every key's final value rather than using collect()'s
-			// quiet-period timer — on a loaded runner the subscription can go quiet longer than the
-			// window while queued updates are still in flight (the same race the two tests above
-			// already moved off of). The timeout path falls through so the per-key asserts below
-			// report exactly which key was stale.
+			// Queued deliveries can trail the commits by more than any quiet window on a loaded
+			// runner, so wait for every key's final value. The timeout falls through so the per-key
+			// asserts below report exactly which key was stale.
 			const events = [];
 			subscription.on('data', (e) => events.push(e));
 			await concurrentWrites;
@@ -567,8 +577,19 @@ describe('Subscription replay', () => {
 				inFlight.push(CurrentStateTable.put(14000 + i, { name: 'inflight' + i }));
 			}
 			const subscription = await CurrentStateTable.subscribe({ isCollection: true });
-			const events = await collect(subscription, 250);
+			// collect()'s quiet window can expire while the 200 puts are still committing; wait for
+			// the commits, then for every key's delivery.
+			const events = [];
+			subscription.on('data', (e) => events.push(e));
 			await Promise.all(inFlight);
+			await waitFor(
+				() => {
+					const seen = new Set(events.map((e) => e.id));
+					for (let i = 0; i < 200; i++) if (!seen.has(14000 + i)) return false;
+					return true;
+				},
+				{ timeout: 5000 }
+			).catch(() => {});
 			subscription.return?.();
 
 			// every in-flight key must be delivered at least once (duplicates allowed under

--- a/unitTests/resources/txn-tracking.test.js
+++ b/unitTests/resources/txn-tracking.test.js
@@ -102,7 +102,10 @@ describe('Txn Expiration', () => {
 		}
 	});
 	after(function () {
+		// the 20ms limit above went to whichever engine is active; both module globals are
+		// process-wide, so both are restored rather than leaking 20ms into the rest of the run
 		setTxnExpiration(30000);
+		setLMDBTxnExpiration(30000);
 	});
 });
 

--- a/unitTests/resources/txn-tracking.test.js
+++ b/unitTests/resources/txn-tracking.test.js
@@ -73,11 +73,8 @@ describe('Txn Expiration', () => {
 			assert.equal(lastTxn.startedFrom.method, 'get');
 			assert.equal(lastTxn.timeout, 20);
 		}
-		// Wait on the actual signals instead of racing a fixed 50ms window: under CI contention
-		// the 40ms sleep inside get() overruns the window before the follow-up read/write lands,
-		// and the expiry sweep needs two ~20ms monitor ticks that can also land late. The 500ms
-		// tail inside get() keeps `result` pending, so observing expiry before `result` settles
-		// still proves the txn was expired mid-flight rather than removed by normal completion.
+		// The 500ms tail inside get() keeps `result` pending, so observing expiry before `result`
+		// settles proves the txn was expired mid-flight rather than removed by normal completion.
 		let resultSettled = false;
 		result.then(
 			() => (resultSettled = true),
@@ -95,6 +92,14 @@ describe('Txn Expiration', () => {
 			'expired',
 			'expected the slow transaction to have been expired and removed from trackedTxns before get() completed'
 		);
+		// Drain the slow get() so its 500ms tail and final read cannot run into the next
+		// describe's expiration settings and freshly re-pathed test DB. On rocksdb the aborted
+		// outer transaction must also surface to the caller.
+		if (SlowResource.primaryStore instanceof RocksDatabase) {
+			await assert.rejects(result, /aborted after exceeding the maximum open-transaction time/);
+		} else {
+			await result.catch(() => {});
+		}
 	});
 	after(function () {
 		setTxnExpiration(30000);

--- a/unitTests/resources/txn-tracking.test.js
+++ b/unitTests/resources/txn-tracking.test.js
@@ -102,8 +102,8 @@ describe('Txn Expiration', () => {
 		}
 	});
 	after(function () {
-		// the 20ms limit above went to whichever engine is active; both module globals are
-		// process-wide, so both are restored rather than leaking 20ms into the rest of the run
+		// both expiration globals are process-wide, and the 20ms above went to whichever engine
+		// is active, so restoring only one leaks it into every later test on the other pass
 		setTxnExpiration(30000);
 		setLMDBTxnExpiration(30000);
 	});

--- a/unitTests/resources/txn-tracking.test.js
+++ b/unitTests/resources/txn-tracking.test.js
@@ -73,14 +73,27 @@ describe('Txn Expiration', () => {
 			assert.equal(lastTxn.startedFrom.method, 'get');
 			assert.equal(lastTxn.timeout, 20);
 		}
-		await Promise.race([delay(50), result]);
-		assert(performedDBInteractions);
+		// Wait on the actual signals instead of racing a fixed 50ms window: under CI contention
+		// the 40ms sleep inside get() overruns the window before the follow-up read/write lands,
+		// and the expiry sweep needs two ~20ms monitor ticks that can also land late. The 500ms
+		// tail inside get() keeps `result` pending, so observing expiry before `result` settles
+		// still proves the txn was expired mid-flight rather than removed by normal completion.
+		let resultSettled = false;
+		result.then(
+			() => (resultSettled = true),
+			() => (resultSettled = true)
+		);
+		await waitFor(() => performedDBInteractions, { message: 'read/write after expiry never completed' });
 		// Check the specific txn we started was expired and removed. Counting against
 		// existingTxns is unreliable: other tests' transactions can expire concurrently and
-		// shift the count underneath us during the 50ms window.
-		assert.ok(
-			!trackedTxns.has(lastTxn),
-			'expected the slow transaction to have been expired and removed from trackedTxns'
+		// shift the count underneath us.
+		const outcome = await waitFor(() => (!trackedTxns.has(lastTxn) ? 'expired' : resultSettled && 'settled'), {
+			message: 'the slow transaction was neither expired nor completed',
+		});
+		assert.equal(
+			outcome,
+			'expired',
+			'expected the slow transaction to have been expired and removed from trackedTxns before get() completed'
 		);
 	});
 	after(function () {

--- a/unitTests/resources/vectorIndex.test.js
+++ b/unitTests/resources/vectorIndex.test.js
@@ -1044,11 +1044,13 @@ describe('HNSW entry-point level clamp', () => {
 		T.dropTable();
 	});
 
-	it('caps the first node of an empty index at MAX_LEVEL even when random() returns 0', async () => {
+	it('caps the first node of an empty index at MAX_LEVEL', async () => {
 		const customIndex = T.indices.vector.customIndex;
-		// -Math.log(0) is Infinity; unclamped, the entry-point path would loop forever
-		// initializing per-level connection arrays.
-		customIndex.random = () => 0;
+		// Number.MIN_VALUE draws an unclamped level of ~268 (-ln(5e-324) * mL). A finite draw keeps
+		// a clamp regression a fast assertion failure — random() === 0 (Infinity) would instead wedge
+		// the runner in the synchronous per-level init loop, which is worse than the flake this
+		// branch removes.
+		customIndex.random = () => Number.MIN_VALUE;
 		try {
 			await T.put(1, { vector: [1, 0, 0] });
 		} finally {

--- a/unitTests/resources/vectorIndex.test.js
+++ b/unitTests/resources/vectorIndex.test.js
@@ -934,25 +934,37 @@ describe('HNSW construction ef auto-scale (#2180)', () => {
 
 describe('HNSW greedy routing above layer 0 (ROUTING_EF)', () => {
 	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
-	let T;
 	const N = 600;
+	// Each graph's level assignment is pinned with a seeded PRNG (mulberry32) so a run is
+	// reproducible: greedy-vs-full equality is only statistically true over random graphs — ~2-3%
+	// of random 600-node graphs legitimately route to a different entry point and change the
+	// top-10 tail, which is what flaked on CI. One pinned graph samples that property once, so the
+	// assertion sweeps several: all of these are non-divergent at this head (measured over 40
+	// arbitrary seeds, 4 diverged, so a divergent seed here after an intentional index change is a
+	// re-pin rather than necessarily a regression — see DESIGN.md).
+	const SEEDS = [0x9e3779b9, 0x85ebca6b, 0xc2b2ae35, 0x27d4eb2f, 0x165667b1, 0x7feb352d, 0x846ca68b, 0xff51afd7];
+	const targets = [
+		[1, 0, 0, 0],
+		[0, 1, 0.5, 0.2],
+		[-0.6, 0.3, 0.9, 0.4],
+		[0.2, -0.8, 0.1, 0.7],
+	];
 
-	before(async () => {
+	before(() => {
 		setupTestDBPath();
 		setMainIsWorker(true);
-		T = table({
-			table: 'HNSWRoutingTest',
+	});
+
+	async function buildGraph(seed) {
+		const T = table({
+			table: 'HNSWRoutingTest' + (seed >>> 0).toString(16),
 			database: 'test',
 			attributes: [
 				{ name: 'id', isPrimaryKey: true },
 				{ name: 'vector', indexed: { type: 'HNSW', distance: 'cosine' }, type: 'Array' },
 			],
 		});
-		// Seed level assignment (mulberry32) so the graph is identical every run. The greedy-vs-full
-		// equality below is only statistically true over random graphs — rare level layouts
-		// legitimately route to a different entry point and change the top-10 tail (flaked ~2-3% of
-		// runs on CI). Pinning the graph keeps the assertion exact without weakening it.
-		let seedState = 0x9e3779b9;
+		let seedState = seed;
 		T.indices.vector.customIndex.random = () => {
 			seedState = (seedState + 0x6d2b79f5) | 0;
 			let t = Math.imul(seedState ^ (seedState >>> 15), 1 | seedState);
@@ -964,63 +976,57 @@ describe('HNSW greedy routing above layer 0 (ROUTING_EF)', () => {
 			const b = ((i * 7) % N) / N;
 			await T.put(i, { vector: [Math.cos(a), Math.sin(a), b, (i % 11) / 11] });
 		}
-	});
+		return T;
+	}
 
-	after(() => {
-		T.dropTable();
-	});
+	async function topTenIds(T, target) {
+		return (
+			await fromAsync(
+				T.search({ sort: { attribute: 'vector', target, distance: 'cosine' }, select: ['id'], limit: 10 })
+			)
+		)
+			.map((r) => r.id)
+			.join(',');
+	}
 
 	// Layers above 0 only supply the next layer's entry point, so descending greedily must not cost
 	// accuracy. Compare against the same graph searched with the full ef at every layer — the
 	// pre-change behaviour — rather than against a fixed expectation.
 	it('returns the same neighbours as searching every layer at the full ef', async () => {
-		const customIndex = T.indices.vector.customIndex;
-		const originalSearchLayer = customIndex.searchLayer;
-		const targets = [
-			[1, 0, 0, 0],
-			[0, 1, 0.5, 0.2],
-			[-0.6, 0.3, 0.9, 0.4],
-			[0.2, -0.8, 0.1, 0.7],
-		];
+		for (const seed of SEEDS) {
+			const label = '0x' + (seed >>> 0).toString(16);
+			const T = await buildGraph(seed);
+			try {
+				const customIndex = T.indices.vector.customIndex;
+				const greedy = [];
+				for (const target of targets) {
+					greedy.push(await topTenIds(T, target));
+				}
 
-		const greedy = [];
-		for (const target of targets) {
-			greedy.push(
-				(
-					await fromAsync(
-						T.search({ sort: { attribute: 'vector', target, distance: 'cosine' }, select: ['id'], limit: 10 })
-					)
-				)
-					.map((r) => r.id)
-					.join(',')
-			);
-		}
-
-		// Every layer at the ef layer 0 actually resolves to — what search() passed down before greedy
-		// descent. Read it from a real query rather than efConstructionSearch, which is only the
-		// pre-change value when a schema configures one; this index takes the auto-scaled path.
-		const resolvedLayer0Ef = await captureLayer0Ef(T, { limit: 10 });
-		assert(resolvedLayer0Ef > 1, `expected an auto-scaled layer-0 ef, got ${resolvedLayer0Ef}`);
-		customIndex.searchLayer = function (v, epId, ep, ef, level, ...rest) {
-			return originalSearchLayer.call(this, v, epId, ep, level > 0 ? resolvedLayer0Ef : ef, level, ...rest);
-		};
-		try {
-			for (let i = 0; i < targets.length; i++) {
-				const full = (
-					await fromAsync(
-						T.search({
-							sort: { attribute: 'vector', target: targets[i], distance: 'cosine' },
-							select: ['id'],
-							limit: 10,
-						})
-					)
-				)
-					.map((r) => r.id)
-					.join(',');
-				assert.strictEqual(greedy[i], full, `greedy descent changed the result set for target ${i}`);
+				// Every layer at the ef layer 0 actually resolves to — what search() passed down before
+				// greedy descent. Read it from a real query rather than efConstructionSearch, which is
+				// only the pre-change value when a schema configures one; this index takes the
+				// auto-scaled path.
+				const resolvedLayer0Ef = await captureLayer0Ef(T, { limit: 10 });
+				assert(resolvedLayer0Ef > 1, `expected an auto-scaled layer-0 ef, got ${resolvedLayer0Ef} (seed ${label})`);
+				const originalSearchLayer = customIndex.searchLayer;
+				customIndex.searchLayer = function (v, epId, ep, ef, level, ...rest) {
+					return originalSearchLayer.call(this, v, epId, ep, level > 0 ? resolvedLayer0Ef : ef, level, ...rest);
+				};
+				try {
+					for (let i = 0; i < targets.length; i++) {
+						assert.strictEqual(
+							greedy[i],
+							await topTenIds(T, targets[i]),
+							`greedy descent changed the result set for target ${i} (seed ${label})`
+						);
+					}
+				} finally {
+					customIndex.searchLayer = originalSearchLayer;
+				}
+			} finally {
+				T.dropTable();
 			}
-		} finally {
-			customIndex.searchLayer = originalSearchLayer;
 		}
 	});
 });

--- a/unitTests/resources/vectorIndex.test.js
+++ b/unitTests/resources/vectorIndex.test.js
@@ -1025,7 +1025,7 @@ describe('HNSW greedy routing above layer 0 (ROUTING_EF)', () => {
 					customIndex.searchLayer = originalSearchLayer;
 				}
 			} finally {
-				T.dropTable();
+				await T.dropTable();
 			}
 		}
 	});

--- a/unitTests/resources/vectorIndex.test.js
+++ b/unitTests/resources/vectorIndex.test.js
@@ -1025,6 +1025,43 @@ describe('HNSW greedy routing above layer 0 (ROUTING_EF)', () => {
 	});
 });
 
+describe('HNSW entry-point level clamp', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+	let T;
+	before(() => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		T = table({
+			table: 'HNSWClampTest',
+			database: 'test',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'vector', indexed: { type: 'HNSW', distance: 'cosine' }, type: 'Array' },
+			],
+		});
+	});
+	after(() => {
+		T.dropTable();
+	});
+
+	it('caps the first node of an empty index at MAX_LEVEL even when random() returns 0', async () => {
+		const customIndex = T.indices.vector.customIndex;
+		// -Math.log(0) is Infinity; unclamped, the entry-point path would loop forever
+		// initializing per-level connection arrays.
+		customIndex.random = () => 0;
+		try {
+			await T.put(1, { vector: [1, 0, 0] });
+		} finally {
+			customIndex.random = Math.random;
+		}
+		let entryLevel;
+		for (const { value } of customIndex.indexStore.getRange({ start: 0, end: Infinity })) {
+			if (value?.level !== undefined) entryLevel = value.level;
+		}
+		assert.strictEqual(entryLevel, 10, `expected the entry point level to be clamped to MAX_LEVEL, got ${entryLevel}`);
+	});
+});
+
 describe('HNSW limit above the resolved search ef', () => {
 	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
 	let T;

--- a/unitTests/resources/vectorIndex.test.js
+++ b/unitTests/resources/vectorIndex.test.js
@@ -948,6 +948,17 @@ describe('HNSW greedy routing above layer 0 (ROUTING_EF)', () => {
 				{ name: 'vector', indexed: { type: 'HNSW', distance: 'cosine' }, type: 'Array' },
 			],
 		});
+		// Seed level assignment (mulberry32) so the graph is identical every run. The greedy-vs-full
+		// equality below is only statistically true over random graphs — rare level layouts
+		// legitimately route to a different entry point and change the top-10 tail (flaked ~2-3% of
+		// runs on CI). Pinning the graph keeps the assertion exact without weakening it.
+		let seedState = 0x9e3779b9;
+		T.indices.vector.customIndex.random = () => {
+			seedState = (seedState + 0x6d2b79f5) | 0;
+			let t = Math.imul(seedState ^ (seedState >>> 15), 1 | seedState);
+			t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+			return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+		};
 		for (let i = 0; i < N; i++) {
 			const a = (i / N) * Math.PI * 2;
 			const b = ((i * 7) % N) / N;


### PR DESCRIPTION
Deflakes the cluster of unit-test failures that took the Unit Test workflow red on 7 of its last 30 main runs (four distinct tests across 2026-08-21 alone), plus the Windows-only risk-query integration failure. Three tests are fixed with demonstrated root causes; two could not be root-caused within this round and are quarantined, each behind a filed, prioritized issue under epic [[Epic] CI test flakiness (#1655)](https://github.com/HarperFast/harper/issues/1655). No product behavior changes beyond a test seam (details below).

## What changed

**Fixed (root cause demonstrated):**

1. **HNSW greedy routing** (`unitTests/resources/vectorIndex.test.js`, `resources/indexes/HierarchicalNavigableSmallWorld.ts`) — graph levels were drawn from unseeded `Math.random()`, and greedy-vs-full-ef result equality is only *statistically* true across random graphs: ~2-3% of random 600-node graphs legitimately route to a different layer-0 entry point and displace the top-10 tail. Added a `random` property to `HierarchicalNavigableSmallWorld` (test seam, defaults to `Math.random`) and the test now pins the graph with a seeded PRNG. One pinned graph samples that statistical property exactly once, so the test [sweeps eight fixed seeds](https://github.com/HarperFast/harper/pull/2276/changes?w=1#diff-cad9073daf8c1f98872bbf9e6517826faa9fcc099c2010ba808180e42ff5ca9aR945), each asserted for exact equality — measured over 40 arbitrary seeds, 4 produce a graph that legitimately diverges, and all eight in `SEEDS` are non-divergent at this head. Product-side this also clamps the entry-point-creation level to `MAX_LEVEL`, matching the other assignment site — previously `-Math.log(random())` at that one site was unclamped, and a `random()` returning exactly 0 (possible for both `Math.random` and any test PRNG) would produce `level = Infinity` and an infinite loop in the node-initialization `for` loop; a high finite draw persists an entry point dozens of empty layers above the graph for the life of the index. And it is not just a lottery ticket: with a schema-configured `mL` (e.g. `mL: 5`, which the constructor accepts), **13.5% of first-node draws exceed MAX_LEVEL** — every such index got a permanently over-tall entry point while later nodes were clamped. The clamp now has its own regression test (`HNSW entry-point level clamp`), driven with a finite pathological draw so a clamp regression fails fast instead of wedging the runner. The statistical nature of greedy-equals-full, and the seed-sweep contract, are recorded in `DESIGN.md`.
2. **Txn expiration** (`unitTests/resources/txn-tracking.test.js`) — the test raced a fixed 50ms window (`Promise.race([delay(50), result])`) against a 40ms sleep + two real DB operations + an expiry that structurally needs *two* ~20ms monitor ticks. Ten milliseconds of slack loses on a contended runner. Now waits on the actual signals (`waitFor`), and proves the transaction left `trackedTxns` **while the slow `get()` was still pending** — so removal-by-expiry can't be confused with removal-by-completion. The suite's teardown also [restores both engines' expiration globals](https://github.com/HarperFast/harper/pull/2276/changes?w=1#diff-5256529b9bab4e434c486e2097f5cda53ac099dd1e34f88e5113e036808c31e3R93): it set 20ms through whichever engine is active but restored only the rocksdb one, so on the lmdb pass a 20ms open-transaction limit leaked into every later test in the `unitTests/resources` process.
3. **Subscription replay** (`unitTests/resources/subscriptionReplay.test.js`) — `!omitCurrent: updates to passed keys arrive via queue` still used `collect()`'s quiet-period timer, the exact race its two sibling tests were already migrated off (their in-file comments document it). Under contention the subscription can go quiet longer than the window while queued updates are in flight, so the final-value assertion reads stale values. Nine tests in this file are now converted to condition waits: the five caught in the first review round, the 600-id notify-batch burst test (still on a 300ms quiet window and still flaking — 1 failure in 32 lmdb runs, `missing 7 of 600`), and the three remaining tests that write *after* subscribe and then assert completeness. `collect()`'s quiet window remains only where a quiet window is the semantically right tool — asserting that *no* events arrive, and history-replay tests whose writes all precede `subscribe()`.
4. **Vacuous duplicate checks** (`unitTests/resources/subscriptionReplay.test.js`) — the two in-flight duplicate-detection tests swallowed their `waitFor` timeout, leaving `no duplicate (id,version)` as the only assertion, which is trivially true over a partial event set. Run alone, the count test timed out on **every** run and went green in 5.3s. Waiting for all 30 in-flight ids is not the fix: an in-flight write that commits before the cursor's snapshot and falls outside `previousCount` is legitimately never delivered (measured: 17000-17002 never arrive in an isolated run). Both tests now [write a record after the in-flight writes settle and wait for it](https://github.com/HarperFast/harper/pull/2276/changes?w=1#diff-5bbee047cb24c2c491077195b51dec92b3ccd4c564827396e44c68f8a5e795a3R691) with a terminal timeout. The ordering that makes this sound is code-traced, not assumed: the `previousCount` cursor collects its history from a reverse audit `getRange` under the default snapshot, bounded by `count = 10` well under `REPLAY_YIELD_INTERVAL = 100`, so it completes in the subscribe IIFE's first synchronous segment — before `subscribe()` resolves and long before the sentinel commits; the [non-collection shape](https://github.com/HarperFast/harper/pull/2276/changes?w=1#diff-5bbee047cb24c2c491077195b51dec92b3ccd4c564827396e44c68f8a5e795a3R724) captures `entry` in that same segment and never re-reads it. Neither cursor can deliver the sentinel, so it can only arrive through `pendingRealTimeQueue`, which drains in commit order after every in-flight delivery.

**Quarantined (issue filed, skip links to it):**

5. **risk-query on Windows** (`integrationTests/components/risk-query.test.ts`) — [#2273](https://github.com/HarperFast/harper/issues/2273): `deploy_component` (restart:true) hung server-side after `npm pack` on Windows CI — the instance log goes silent and the client fetch dies on undici's 300s headers timeout, cancelling all 9 children at 319s. This is a hang, not runner slowness (npm pack itself finished in <1s; then 5+ minutes of zero log output), so a timeout bump would not help — the suite is skipped on `win32` until the deploy hang is fixed. The readiness poll also now carries `AbortSignal.timeout(5s)` per probe so one hung fetch can't consume the whole budget. Suite verified green on Linux.
6. **MQTT non-clean session** (`unitTests/apiTests/mqtt-test.mjs`) — [#2274](https://github.com/HarperFast/harper/issues/2274): silent 20s mocha timeout on CI (lmdb pass, Node 26), zero server-side log output, and the hang is provably in one of the steps with no individual timeout (the test's own bounded 15s wait never fired). Not reproduced in 30 contended local full-file runs. Skipped **on the lmdb pass only** — where the hang was observed — so the rocksdb pass keeps this durable-session coverage. Hypotheses and a reinstatement path are in the issue. Most of this file's diff is indentation from wrapping the test in the conditional skip; the body is unchanged.

**Found but not touched (out of scope):** the repro loops surfaced a sixth flaky test, `MQTT subscribe to retained record with patch operations` — ~10% failure rate under 2-core contention, duplicate retained/live delivery asserted as an uncaught exception. Filed as [#2275](https://github.com/HarperFast/harper/issues/2275) with mechanism and repro instructions.

## For the human reviewer

- **The red check is not this branch.** `Integration Tests 2/6 (Windows, Node.js v24)` fails at `integrationTests/apiTests/describe-metadata-upgrade.test.ts:62` with `Probe /SeoPageCache/ did not become ready within 120000ms (ECONNREFUSED) after restart_service`, and phase 2 then cascades. This branch touches no integration file in that shard, no test util and no restart path. `main` run [32812674585](https://github.com/HarperFast/harper/actions/runs/32812674585) (05:23 UTC, 2026-08-25) fails identically; `main` run [32820775289](https://github.com/HarperFast/harper/actions/runs/32820775289) (07:16) passes. [#2309](https://github.com/HarperFast/harper/pull/2309) is the fix and names the mechanism: libuv's `fs-event` callback asserts that the `GetLongPathNameW` expansion of an event path still starts with the directory stored when the watch was armed, and the Windows runner's `os.tmpdir()` (`C:\Users\RUNNER~1\AppData\Local\Temp`) never satisfies it, so libuv **aborts the process** with no JS-observable seam. The instance logs from both failed attempts here match that exactly and rule out the "120s probe budget is too tight after a slow npm install" reading recorded on [#2273](https://github.com/HarperFast/harper/issues/2273): the restarted http worker resolves its middleware chains (attempt 1 at 06:49:17.3, attempt 2 at 07:19:42.6) and then logs **nothing at all** for the full 120s while every connection is refused — a dead process, not a slow one — and phase 2 boots a fresh process on the same runner, against the same component directory and its 541-package `node_modules`, fully up with both tables initialized **2.5s** later. Attempt 1 also died after a 3-minute `npm install`, not a 10-minute one. No test change was made here for it, deliberately: the fix belongs in #2309, and quarantining the suite would cost Windows coverage of the #1245 metadata-upgrade regression for a defect that is already understood.
- **The one product-source file touched is `HierarchicalNavigableSmallWorld.ts`**, and the judgment call is the `random` instance property as a test seam plus the `MAX_LEVEL` clamp on the entry-point site. The seam is inert in production (`this.random` defaults to `Math.random`; both call sites previously called `Math.random()` directly). The clamp changes behavior only for `random() === 0` or graphs demanding level > 10, i.e. probability ~2^-32 per insert — but the unclamped site could infinite-loop, so it is a genuine (if theoretical) hardening, called out here rather than buried.
- **Two review suggestions were implemented differently than proposed, both because the proposed form would have failed or flaked** — worth a look because the alternatives are still live:
  - *Duplicate-detection tests*: the suggested fix was to make the "all 30 in-flight ids arrived" wait terminal (`assert.fail` on timeout). That completeness condition is unreachable by design — `previousCount: 10` means an in-flight write committed before the cursor snapshot is legitimately never delivered — so it would have failed on every isolated run. The sentinel wait is terminal instead, on a condition that must hold.
  - *Routing seed*: the suggested fix was to sweep ~20 seeds and assert at most one diverges. At the measured divergence rate (4 of 40 arbitrary seeds) that bound fails ~20% of the time — a worse flake than the one being removed. Eight non-divergent seeds asserted exactly keeps determinism and still samples the property eight times instead of once. The cost is that an intentional index change can force a seed re-pin; `DESIGN.md` says so.
- **The txn test's new "expired-before-settled" outcome check** is deliberately stricter than the old assertion: it fails with a distinct message if the slow `get()` completes before expiry is observed, which would indicate the timing assumption broke in a new way rather than passing vacuously.
- The subscription-replay conversions keep `.catch(() => {})` on waits whose *own* completeness assert follows immediately (the per-key/per-id asserts report exactly which key went stale). The two sentinel waits do **not** swallow: there the wait is the only thing standing between a slow runner and a vacuous pass.
- Windows quarantine means Windows loses risk-query coverage entirely until #2273 is fixed; that felt better than a suite that red-flags the whole Integration workflow on a 300s hang, but it is a coverage regression on that platform. Same shape for the lmdb MQTT durable-session skip: engine-specific offline-queue persistence is exactly the code path most likely to differ per engine, and it is unguarded on lmdb until #2274 is closed.
- **Round-7 review threads (Barber AI), both declined — the evidence is here because the alternatives are still live:**
  - *Quarantine `FIRST-subscription-on-fresh-DB while writes are in flight` on lmdb.* Declined. That test is byte-identical at the merge base and does not reproduce on this box: **0 failures in 46 lmdb runs at this head** — 12 sequential full-file, 24 six-way-contended full-file, 10 grep-isolated under 16 busy cores — and it prints `✔` in every recent `main` unit-test run on CI, including the seven that failed for other reasons. Skipping it would drop the only coverage of a claimed lost delivery on the one backend where it is claimed to happen, for a failure CI has never observed. What *was* applied is the thread's "at minimum": an explicit 5000 ms timeout plus `.catch(() => {})`, so a genuine loss now fails as `missing in-flight id N` rather than a bare `Timed out after 2000ms` (verified by widening the wait to an id that can never arrive). If it reproduces for you, the quarantine is one line — and the trace worth starting from is that the `startTime` collection branch nulls `pendingRealTimeQueue` and sets `dropDuringReplay = true` (`resources/Table.ts:4151`), so that branch depends entirely on the forward `snapshot: false` audit cursor never being overtaken by a commit that lands during replay.
  - *Assert a divergence bound over a larger fixed seed list instead of curating eight non-divergent ones.* Declined as yours to call, not a bot-driven redesign. One correction to the bullet above, in fairness to the suggestion: over a **fixed** seed list the divergence count is deterministic, so a bound would not flake the way the arbitrary-seed version would — the reviewer is right that it measures the property while exact equality only samples it. The reasons to keep the current form are cost (40 seeds is ~5× the 600-node graph builds, roughly +12s on a rocksdb-only suite) and that the baseline count then has to hold across machines and index versions. Cheap to switch if you want the measured form.
- **Round-8 (this push): the lost delivery is root-caused and filed as [#2311](https://github.com/HarperFast/harper/issues/2311)** — P1 Bug under [[Epic] Audit-log subsystem hardening (#1651)](https://github.com/HarperFast/harper/issues/1651). The review thread's remaining ask was a ticket for the lost delivery itself rather than a quarantine, and the mechanism turned out to be demonstrable, not just a hypothesis. `Table.ts:4149-4188`'s `startTime` collection branch is the one replay branch that *discards* live events (`pendingRealTimeQueue = null`) instead of buffering them, on the assumption that its `snapshot: false` cursor picks up the tail — but `getRange()` returns a terminating iterator, so the window between *cursor exhausted* and `dropDuringReplay = false` is covered by neither path. Forced by inserting a 100 ms delay between the replay loop and its `finally` (in `dist` only, nothing else changed): **200 of 200** in-flight events hit the `dropDuringReplay` early return, the cursor recovered none, and the test failed with `missing in-flight id 20000` — the reviewer's exact signature. The mid-replay portion of the window is genuinely covered and a fix should not over-correct there: with the artificial delay at the `await rest()` yield instead, 200 events were dropped by the listener and all 200 were then delivered by the cursor. A second, narrower hole is code-traced but unreproduced: replay advances `subscription.startTime` to the last record it saw (`Table.ts:4184`), and `transactionBroadcast.ts:202` skips any live event with `subscription.startTime >= timestamp`. **The test is still not quarantined** — same reasoning as round 7, now with a linked issue so a `missing in-flight id N` failure reads as #2311 rather than as runner slowness.
  - *One correction to round 7's non-repro, and to the reviewer's explanation of it.* The suggestion was that the grep-isolated leg had silently run on the default engine. It had not: probing the store path shows `test2.mdb` (lmdb) on exactly the command in question, and lmdb is the *faster* pass here (80 ms vs 143 ms on rocksdb), not the slower one. This head is now 41/41 green on lmdb on this box (15 sequential grep-isolated, 18 six-way contended, 8 pinned to a single core). The real difference is which side of the window the writes land on: instrumented here, the replay cursor sees an **empty** audit range and there are **zero** listener drops, so the uncovered window is never entered at all. On a box where the in-flight writes straddle the end of replay it is deterministic. Both results are correct and #2311 explains the gap between them.

- **Review decision ledger, left as author calls for you to override**: pin-the-graph vs a tolerance assertion on random graphs (pinned, now eight of them); the `random` seam as a public field vs threading through schema `options` (field — options are persisted schema config, a function doesn't round-trip); MAX_LEVEL clamp bundled here vs its own PR (bundled — one line, named in the commit body, now with its own regression test); quarantine now vs holding for root cause (quarantine — greening main is the task); converting the three unflagged same-class `collect()` tests vs leaving them (converted — the PR's claim about the idiom is only true if the class is gone).

## Verification

- HNSW: pre-fix 1/40 sequential failures; post-fix **0/120** (4-way parallel) on the single-seed form, and the eight-seed sweep passes at 3.9s for the suite (up from 0.9s; ~0.47s per 600-node graph). Intermediate result worth knowing: seeding alone appeared to still fail 5/100 — because unit tests load `dist/`, and the seam wasn't built yet; after `npm run build`, graph state (level histograms) is byte-identical across runs.
- Seed divergence measured directly: a 40-seed sweep at this head diverges on 4 (`[1, 4, 6, 33]` of an `imul(s+1, 0x9e3779b9)` series), i.e. 4 of 160 target-graph pairs — matching the ~2-3% the `DESIGN.md` note records.
- Txn expiration: pre-fix **2/80** failures with 8 workers pinned to 2 cores (same assertion family as CI); post-fix **0/160** under the identical harness.
- Subscription replay: **0 failures in 24 contended full-file lmdb runs** (4-way parallel pinned to 2 cores) after the conversions, plus 0 in isolated single-test runs. The count in-flight test went from a 5.3s vacuous pass in isolation to a 0.25s real one. Sentinel ordering was instrumented over those runs: the sentinel was the last event delivered every time, with zero in-flight events after it.
- Gates: `npm run test:unit:resources` on **both** engines — rocksdb 1672 passing / 3 failing, lmdb 1423 passing / 2 failing, where every failure is a pre-existing `randomAccessFields` / `replayStructures` failure that reproduces standalone in a fresh mocha process on files this branch does not touch. `lint:required` and prettier clean. `npm run test:unit:main` could not be run on this box: a stale local Harper install (`~/.harperdb/hdb_boot_properties.file` pointing at another checkout) makes `security/auth.ts` fail at module load, before any test runs. That gate `--exclude`s `unitTests/resources/**`, which is the only area this round touches; forced onto a synthesized clean root it reports 4840 passing with 14 failures, all in `cliOperations` / `Login` / `configValidator`, i.e. artifacts of the synthesized root.
- Round-7 follow-up, at `510058687`: the fresh-DB in-flight test was run **46 times on lmdb** at this head with zero failures (12 sequential full-file, 24 six-way-contended full-file, 10 grep-isolated under 16 busy cores). The new failure message was proved rather than assumed — widening the wait to an id that can never arrive produces `AssertionError: missing in-flight id 20200` after 5s instead of the old bare timeout. `test:unit:resources` re-run on both engines at this head (rocksdb 1672 passing / 3 failing, lmdb 1423 passing / 2 failing — the same pre-existing `randomAccessFields` / `replayStructures` failures on files this branch does not touch), plus `lint:required` and prettier clean.
- Round-8 follow-up, at `47f9b8993`: the change itself is a five-line comment, so the gates re-run rather than expanded — `test:unit:resources` on **both** engines at this head (rocksdb 1672 passing / 3 failing, lmdb 1423 passing / 2 failing — the same pre-existing `randomAccessFields` / `replayStructures` failures on files this branch does not touch), `lint:required` and prettier clean. The #2311 mechanism was established by direct instrumentation of `dist/resources/Table.js` and `dist/resources/transactionBroadcast.js` (drop counter, replay start/end markers, and the `startTime >= timestamp` skip counter), each reverted and `dist` rebuilt afterwards; the counts quoted above are from those runs.

- `test:integration:all` not run in full: this branch touches a single integration file (`integrationTests/components/risk-query.test.ts`, run individually, 9/9 on Linux) and the Integration workflow on main is currently failing for unrelated reasons (17 of its last 30 main runs), so a full local run has no usable baseline.
- Round-9 (rebase onto `main`@`df5355aaa`, at `56e544505`): no conflicts — the branch's 7 changed files did not overlap anything new on `main`, so the rebase replayed cleanly. `npm run build` clean; `npx mocha unitTests/resources/vectorIndex.test.js unitTests/resources/subscriptionReplay.test.js unitTests/resources/txn-tracking.test.js` — 153 passing / 11 pending (pending are the pre-existing `Read Txn Expiration` and count-branch skips, unrelated to this rebase). `unitTests/apiTests/**` could not be run in this worktree (no installed Harper system database at `HDB_ROOT`, an environment gap unrelated to the diff). A full independent pre-push re-review ran (force-push breaks the ancestor chain the delta mode needs) and raised nothing not already covered above — the two Harper-domain findings it surfaced (a timing-dependent branch in the txn-tracking `assert.rejects`, and the lmdb MQTT quarantine's coverage cost) restate the "txn test's stricter outcome check" and "MQTT durable-session skip" points already called out in this section, so no code changed.

Refs [[Epic] CI test flakiness (#1655)](https://github.com/HarperFast/harper/issues/1655)

Complexity: low — test-only changes plus one inert test seam and a theoretical-edge clamp in HNSW level assignment.

— Claude Opus 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=claude; ran=gemini,codex; adjudicated=domain; declined=cursor-grok,cursor-composer; rounds=10 @ d894e40ef64a</sub>

<sub>Human-Review-Need: 3 (decisions: test-seam-on-production-class, pinned-seed-sweep-vs-recall-tolerance, known-defect-test-left-red, windows-skip-whole-suite, lmdb-mqtt-quarantine-before-root-cause) @ d894e40ef64a</sub>
