### PR TITLE
Let a database be opened into a caller-owned table graph instead of the global map

### DIFF
--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1055,6 +1055,10 @@ export function openBranchDatabase(path: string, databaseName: string, storeName
 	// The guards below compare against keys in the env map, so two spellings of one directory must
 	// not read as two directories.
 	path = realpathSync(path);
+	// Load the registry FIRST: the guards below read it, and loading is itself what populates
+	// `rocksdbDatabaseEnvs` — running the path guard before the scan would let this branch adopt a
+	// database that the scan then opened at the same path.
+	getDatabases();
 	// A second open would hand back a rival table graph over one shared root store, and the two
 	// callers would disagree about who may close it.
 	if (openBranches.has(path)) throw new Error(`Branch database at ${path} is already open`);
@@ -1076,11 +1080,8 @@ export function openBranchDatabase(path: string, databaseName: string, storeName
 		// in the env map with no handle able to close it.
 		const stranded = rocksdbDatabaseEnvs.get(path);
 		rocksdbDatabaseEnvs.delete(path);
-		try {
-			stranded?.close();
-		} catch (closeError) {
-			logger.warn?.(`Error closing partially opened branch database at ${path}`, closeError);
-		}
+		// `tables` holds whatever initStores managed to build before it threw.
+		closeBranchHandles(path, stranded, tables);
 		throw error;
 	}
 	const branch: BranchDatabase = {
@@ -1089,24 +1090,38 @@ export function openBranchDatabase(path: string, databaseName: string, storeName
 		close() {
 			if (!openBranches.delete(path)) return; // already closed; closing a store twice is not safe
 			rocksdbDatabaseEnvs.delete(path);
-			// The column families opened for the tables and the audit store hold their own handles, and
-			// closing only the root leaves them behind.
-			for (const store of [(rootStore as any).dbisDb, (rootStore as any).auditStore]) {
-				try {
-					store?.close?.();
-				} catch (error) {
-					logger.warn?.(`Error closing branch column family at ${path}`, error);
-				}
-			}
-			try {
-				rootStore.close();
-			} catch (error) {
-				logger.warn?.(`Error closing branch database at ${path}`, error);
-			}
+			closeBranchHandles(path, rootStore, tables);
 		},
 	};
 	openBranches.set(path, branch);
 	return branch;
+}
+
+/**
+ * Release every RocksDB handle a branch open created. `initStores` opens a column family per table
+ * primary store and per index, on top of the internal-dbis and audit families, so closing only the
+ * root leaves all of them behind — which is why `closeDatabase` walks them individually for a real
+ * database. Shared by `close()` and the partial-open cleanup, so a failure part-way through
+ * `initStores` releases exactly what a success would.
+ */
+function closeBranchHandles(path: string, rootStore?: RootDatabaseKind, tables?: Tables): void {
+	const closeStore = (store: any, description: string) => {
+		try {
+			store?.close?.();
+		} catch (error) {
+			logger.warn?.(`Error closing ${description} for branch database at ${path}`, error);
+		}
+	};
+	for (const tableName in tables ?? {}) {
+		const table: any = (tables as any)[tableName];
+		if (!table?.primaryStore) continue;
+		for (const indexName in table.indices || {})
+			closeStore(table.indices[indexName], `index ${tableName}.${indexName}`);
+		closeStore(table.primaryStore, `table ${tableName}`);
+	}
+	closeStore((rootStore as any)?.dbisDb, 'attributes store');
+	closeStore((rootStore as any)?.auditStore, 'audit store');
+	closeStore(rootStore, 'root store');
 }
 
 /** Close every open branch. Branches are process-local, so this is shutdown, not a data operation. */

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -30,7 +30,9 @@ const { forComponent } = harperLogger;
 import * as manageThreads from '../server/threads/manageThreads.js';
 import { openAuditStore, readAuditEntry, createAuditEntry, type AuditRecord } from './auditStore.ts';
 import { handleLocalTimeForGets } from './RecordEncoder.ts';
-import { deleteRootBlobPathsForDB } from './blob.ts';
+import { databasePaths, deleteRootBlobPathsForDB } from './blob.ts';
+import { removeStorageReclamation } from '../server/storageReclamation.ts';
+import { schemaRegex } from '../validation/common_validators.ts';
 import { CUSTOM_INDEXES } from './indexes/customIndexes.ts';
 import { OpenDBIObject } from '../utility/lmdb/OpenDBIObject.ts';
 import { RocksDatabase, supportedCompression, type RocksDatabaseOptions } from '@harperfast/rocksdb-js';
@@ -454,6 +456,7 @@ export function getDatabases(): Databases {
 			const dbName = basename(databaseEntry.name, '.mdb');
 			const dbPath = join(databasePath, databaseEntry.name);
 			if (blockedByRestore.has(dbName)) continue;
+			if (isOpenBranchPath(dbPath)) continue;
 
 			if (
 				databaseEntry.isFile() &&
@@ -516,6 +519,7 @@ export function getDatabases(): Databases {
 					if (databaseEntry.name.endsWith(MIGRATING_DIR_SUFFIX)) continue; // migration staging dir
 					if (databaseEntry.name === RESTORE_META_DIR) continue; // reserved restore-metadata dir
 					if (blockedByRestore.has(basename(databaseEntry.name, '.mdb'))) continue;
+					if (isOpenBranchPath(join(databasePath, databaseEntry.name))) continue;
 					if (databaseEntry.isFile() && extname(databaseEntry.name).toLowerCase() === '.mdb') {
 						readMetaDb(join(databasePath, databaseEntry.name), basename(databaseEntry.name, '.mdb'), dbName);
 					} else {
@@ -1032,6 +1036,33 @@ export interface BranchDatabase {
 const openBranches = new Map<string, BranchDatabase>();
 
 /**
+ * True when `dbPath` is a directory an open branch owns. The database scan opens any directory that
+ * holds CURRENT + MANIFEST-*, and harper#643 places a branch inside the directory it walks, so
+ * without this the first `resetDatabases()` after a branch is open would rebuild that branch's tables
+ * into the global map, overwrite the store identity its blob roots resolve from, and hand its store
+ * to `closeLoadedDatabases`.
+ */
+function isOpenBranchPath(dbPath: string): boolean {
+	if (openBranches.size === 0) return false;
+	try {
+		return openBranches.has(realpathSync(dbPath));
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * A branch identity resolves its blob roots through `join(…, 'blobs', storeName)`, so it must be a
+ * single path segment: `schemaRegex`, which every other database name is validated against, plus the
+ * dot segments and backslash that regex permits but a path component must not be.
+ */
+function assertLegalBranchName(name: string, description: string): void {
+	if (!name || !schemaRegex.test(name) || name.includes('\\') || name === '.' || name === '..') {
+		throw new Error(`Cannot use '${name}' as a branch ${description}: it is not a legal database name`);
+	}
+}
+
+/**
  * Open a RocksDB directory as a **scope-private** database: its Table classes are built into an
  * object the caller owns and nothing is registered in the global `databases` map, so no enumerator
  * of that map — analytics, `describe_all`, worker teardown, replication — can observe it.
@@ -1041,8 +1072,10 @@ const openBranches = new Map<string, BranchDatabase>();
  * blob directories from, which is how a branch gets its own blob roots rather than writing into the
  * base's.
  *
- * The caller owns the returned handle. `closeLoadedDatabases` walks `databases` and therefore cannot
- * see a branch, so nothing else will close it.
+ * The caller owns the returned handle: no enumerator of `databases` can reach a branch, so nothing
+ * closes it on the caller's behalf except `closeBranchDatabases`, which `closeLoadedDatabases` runs
+ * at thread teardown so a branch left open on an exiting worker does not leak its process-global
+ * RocksDB handles.
  *
  * NOT YET SAFE FOR SCHEMA MUTATION. A branch's Table classes carry the base's logical name, so a
  * `dropTable()` or equivalent through one resolves against the global schema and would delete the
@@ -1051,6 +1084,8 @@ const openBranches = new Map<string, BranchDatabase>();
  * (harper#643).
  */
 export function openBranchDatabase(path: string, databaseName: string, storeName: string): BranchDatabase {
+	assertLegalBranchName(databaseName, 'logical database name');
+	assertLegalBranchName(storeName, 'store identity');
 	if (!existsSync(path)) throw new Error(`Cannot open branch database: no directory at ${path}`);
 	// The guards below compare against keys in the env map, so two spellings of one directory must
 	// not read as two directories.
@@ -1098,14 +1133,20 @@ export function openBranchDatabase(path: string, databaseName: string, storeName
 }
 
 /**
- * Release every RocksDB handle a branch open created. `initStores` opens a column family per table
- * primary store and per index, on top of the internal-dbis and audit families, so closing only the
- * root leaves all of them behind — which is why `closeDatabase` walks them individually for a real
- * database. Shared by `close()` and the partial-open cleanup, so a failure part-way through
+ * Release everything a branch open created. `initStores` opens a column family per table primary
+ * store and per index, on top of the internal-dbis and audit families, so closing only the root
+ * leaves all of them behind — which is why `closeDatabase` walks them individually for a real
+ * database. It also leaves two process-global registrations behind the stores it closes, neither of
+ * which has a lifetime of its own: a storage-reclamation handler per store path, whose closure pins
+ * the now-closed store, and the memoized blob roots in `databasePaths`. A real database is opened
+ * once per thread, but harper#643 makes branch open/close routine, so both would grow with branch
+ * churn. Shared by `close()` and the partial-open cleanup, so a failure part-way through
  * `initStores` releases exactly what a success would.
  */
 function closeBranchHandles(path: string, rootStore?: RootDatabaseKind, tables?: Tables): void {
+	const reclamationPaths = new Set<string>([path]);
 	const closeStore = (store: any, description: string) => {
+		if (store?.path) reclamationPaths.add(store.path);
 		try {
 			store?.close?.();
 		} catch (error) {
@@ -1122,6 +1163,8 @@ function closeBranchHandles(path: string, rootStore?: RootDatabaseKind, tables?:
 	closeStore((rootStore as any)?.dbisDb, 'attributes store');
 	closeStore((rootStore as any)?.auditStore, 'audit store');
 	closeStore(rootStore, 'root store');
+	if (rootStore) databasePaths.delete(rootStore as RootDatabase);
+	for (const reclamationPath of reclamationPaths) removeStorageReclamation(reclamationPath);
 }
 
 /** Close every open branch. Branches are process-local, so this is shutdown, not a data operation. */
@@ -1474,8 +1517,13 @@ export function closeDatabase(databaseName: string): boolean {
  * database is closed). The `system` database is intentionally left open: it is non-enumerable here
  * (skipped by the loop), is never restored online, and the exiting worker may still touch the job
  * table during teardown. Best-effort: closing failures are swallowed inside `closeDatabase`.
+ *
+ * Branches are not in `databases` and so are invisible to the loop below, but they hold handles from
+ * the same process-global registry — this is the thread's one teardown entry point, so it closes
+ * them too rather than leaving a rule for the next exit path to remember.
  */
 export function closeLoadedDatabases(): void {
+	closeBranchDatabases();
 	// snapshot the names first: closeDatabase() deletes from `databases` as it goes
 	for (const databaseName of Object.keys(databases)) {
 		const dbTables = databases[databaseName];

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -652,8 +652,7 @@ function readRocksMetaDb(
 	path: string,
 	defaultTable?: string,
 	databaseName: string = DEFAULT_DATABASE_NAME,
-	destination?: Tables,
-	storeName?: string
+	{ destination, storeName, openedStores }: Pick<InitStoresOptions, 'destination' | 'storeName' | 'openedStores'> = {}
 ) {
 	try {
 		logger.trace(`loading rocksdb database: ${path}`);
@@ -667,14 +666,13 @@ function readRocksMetaDb(
 
 		let rootStore: RocksRootDatabase | undefined = rocksdbDatabaseEnvs.get(path);
 		if (rootStore) {
-			initStores(path, rootStore, databaseName, { defaultTable, destination, storeName });
+			initStores(path, rootStore, databaseName, { defaultTable, destination, storeName, openedStores });
 		} else {
 			rootStore = openRocksDatabase(path, { disableWAL: false, enableStats: true }) as any;
 			rocksdbDatabaseEnvs.set(path, rootStore);
-			initStores(path, rootStore, databaseName, { defaultTable, destination, storeName });
-			// Replay into whichever graph this open owns. Skipping it for a caller-owned graph would
-			// leave any tail the checkpoint captured permanently invisible in that graph, since nothing
-			// else will ever replay this store.
+			initStores(path, rootStore, databaseName, { defaultTable, destination, storeName, openedStores });
+			// a caller-owned graph is replayed into as well: nothing else will ever replay this store,
+			// so skipping it would leave the tail the checkpoint captured permanently invisible there
 			if (!isReadOnlyMode()) {
 				replayLogs(rootStore, destination ?? databases[databaseName]);
 			}
@@ -694,19 +692,24 @@ interface InitStoresOptions {
 	destination?: Tables;
 	/**
 	 * Identity stamped on the root store, when it must differ from the logical `databaseName` the
-	 * Table classes carry. `getRootBlobPathsForDB` resolves a database's blob directories from it, so
-	 * a branch sets it to the branch's own name to get its own blob roots while its tables keep the
-	 * name the application's code and schema already use.
+	 * Table classes carry. `getRootBlobPathsForDB` resolves blob directories from it.
 	 */
 	storeName?: string;
+	/**
+	 * Every column family opened here is appended, so a caller can release the ones a failure left
+	 * unreachable — a table's stores are opened well before `setTable` publishes it into the graph.
+	 */
+	openedStores?: any[];
 }
 
 function initStores(
 	path: string,
 	rootStore: RootDatabaseKind,
 	databaseName: string,
-	{ defaultTable, auditPath, isLegacy, destination, storeName }: InitStoresOptions = {}
+	{ defaultTable, auditPath, isLegacy, destination, storeName, openedStores }: InitStoresOptions = {}
 ) {
+	// a store with no tables never reaches the per-table loop below, and blob roots resolve from this
+	rootStore.databaseName = storeName ?? databaseName;
 	const envInit = new OpenEnvironmentObject(path, isReadOnlyMode());
 	const internalDbiInit = createOpenDBIObject(false);
 	let attributesDbi = rootStore.dbisDb;
@@ -908,7 +911,7 @@ function initStores(
 					rootStore
 				);
 			}
-			rootStore.databaseName = storeName ?? databaseName;
+			openedStores?.push(primaryStore);
 			primaryStore.tableId = tableId;
 		}
 		let attributesUpdated: boolean;
@@ -919,6 +922,7 @@ function initStores(
 				if (!attribute.isPrimaryKey && (attribute.indexed || (attribute.attribute && !attribute.name))) {
 					if (!indices[attribute.name]) {
 						const dbi = openIndex(attribute.key, rootStore, attribute);
+						openedStores?.push(dbi);
 						indices[attribute.name] = dbi;
 						indices[attribute.name].indexNulls = attribute.indexNulls;
 					}
@@ -1032,15 +1036,15 @@ export interface BranchDatabase {
 	close(): void;
 }
 
-/** Open branches by directory, so teardown has something to walk and a repeat open is detectable. */
 const openBranches = new Map<string, BranchDatabase>();
+/** Store identities in use, so two branches cannot resolve one set of blob roots. */
+const openBranchIdentities = new Set<string>();
 
 /**
  * True when `dbPath` is a directory an open branch owns. The database scan opens any directory that
  * holds CURRENT + MANIFEST-*, and harper#643 places a branch inside the directory it walks, so
- * without this the first `resetDatabases()` after a branch is open would rebuild that branch's tables
- * into the global map, overwrite the store identity its blob roots resolve from, and hand its store
- * to `closeLoadedDatabases`.
+ * without this a rescan would rebuild the branch's tables into the global map, overwrite the store
+ * identity its blob roots resolve from, and hand its store to `closeLoadedDatabases`.
  */
 function isOpenBranchPath(dbPath: string): boolean {
 	if (openBranches.size === 0) return false;
@@ -1072,51 +1076,52 @@ function assertLegalBranchName(name: string, description: string): void {
  * blob directories from, which is how a branch gets its own blob roots rather than writing into the
  * base's.
  *
- * The caller owns the returned handle: no enumerator of `databases` can reach a branch, so nothing
- * closes it on the caller's behalf except `closeBranchDatabases`, which `closeLoadedDatabases` runs
- * at thread teardown so a branch left open on an exiting worker does not leak its process-global
- * RocksDB handles.
+ * The caller owns the returned handle; the only thing that closes it on the caller's behalf is
+ * `closeBranchDatabases`, which `closeLoadedDatabases` runs at thread teardown so a branch left open
+ * on an exiting worker does not leak its handles into the process-global RocksDB registry.
  *
  * NOT YET SAFE FOR SCHEMA MUTATION. A branch's Table classes carry the base's logical name, so a
  * `dropTable()` or equivalent through one resolves against the global schema and would delete the
- * live base Table class. Row reads and writes are fine. Nothing calls this yet; the scope wiring
- * that first exposes a branch to application code must gate schema operations before it does
- * (harper#643).
+ * live base Table class. Nothing calls this yet; the scope wiring that first exposes a branch to
+ * application code must gate schema operations before it does (harper#643).
+ *
+ * A branch's blob roots start empty, so a row whose blob was written before the checkpoint reads
+ * back as a missing file until harper#644 links the base's blob tree into them. Non-blob rows are
+ * unaffected, for reads and writes alike.
  */
 export function openBranchDatabase(path: string, databaseName: string, storeName: string): BranchDatabase {
 	assertLegalBranchName(databaseName, 'logical database name');
 	assertLegalBranchName(storeName, 'store identity');
 	if (!existsSync(path)) throw new Error(`Cannot open branch database: no directory at ${path}`);
-	// The guards below compare against keys in the env map, so two spellings of one directory must
-	// not read as two directories.
+	// the guards compare against env-map keys, so two spellings of one directory must not read as two
 	path = realpathSync(path);
-	// Load the registry FIRST: the guards below read it, and loading is itself what populates
-	// `rocksdbDatabaseEnvs` — running the path guard before the scan would let this branch adopt a
-	// database that the scan then opened at the same path.
+	// FIRST: loading is itself what populates `rocksdbDatabaseEnvs`, so a path guard ahead of the
+	// scan could adopt a database that the scan then opens at this path
 	getDatabases();
-	// A second open would hand back a rival table graph over one shared root store, and the two
-	// callers would disagree about who may close it.
+	// a rival graph over one shared root store; the two callers would disagree about who may close it
 	if (openBranches.has(path)) throw new Error(`Branch database at ${path} is already open`);
-	// A globally-loaded database's store is shared and closed by `closeLoadedDatabases`; adopting it
-	// here would mean this handle's `close()` tears down a live database.
+	// a loaded database's store is closed by `closeLoadedDatabases`, so adopting it would mean this
+	// handle's `close()` tears down a live database
 	if (rocksdbDatabaseEnvs.has(path)) throw new Error(`Cannot branch ${path}: it is already open as a database`);
-	// `storeName` picks the blob roots. Letting it name a real database would point the branch's blob
-	// writes at that database's directory, which is the collision the separate identity exists to stop.
-	if (databases[storeName] || definedDatabases?.has(storeName)) {
-		throw new Error(`Cannot use '${storeName}' as a branch store identity: a database of that name exists`);
+	// `storeName` picks the blob roots, and blob file ids restart from each store's own checkpointed
+	// counter, so two holders of one identity write the same file paths and truncate each other
+	if (databases[storeName] || definedDatabases?.has(storeName) || openBranchIdentities.has(storeName)) {
+		throw new Error(`Cannot use '${storeName}' as a branch store identity: it is already in use`);
 	}
 
 	const tables: Tables = Object.create(null);
+	// initStores opens a table's column families well before `setTable` publishes it into `tables`,
+	// so the graph is not a complete record of what a failed open must release
+	const openedStores: any[] = [];
 	let rootStore: RootDatabaseKind;
 	try {
-		rootStore = readRocksMetaDb(path, null, databaseName, tables, storeName);
+		rootStore = readRocksMetaDb(path, null, databaseName, { destination: tables, storeName, openedStores });
 	} catch (error) {
 		// readRocksMetaDb registers the store before building tables, so a failure part-way leaves it
-		// in the env map with no handle able to close it.
+		// in the env map with no handle able to close it
 		const stranded = rocksdbDatabaseEnvs.get(path);
 		rocksdbDatabaseEnvs.delete(path);
-		// `tables` holds whatever initStores managed to build before it threw.
-		closeBranchHandles(path, stranded, tables);
+		closeBranchHandles(path, stranded, openedStores);
 		throw error;
 	}
 	let closed = false;
@@ -1124,32 +1129,31 @@ export function openBranchDatabase(path: string, databaseName: string, storeName
 		tables,
 		rootStore,
 		close() {
-			// Guard on this handle, not on the registrations: those are keyed by path, and once this
-			// branch has been closed the path is free to be opened again, so a stale handle closed a
-			// second time would deregister and half-tear-down whichever branch owns the path now.
-			if (closed) return; // closing a store twice is not safe
+			// guard on the handle, not on the registrations: those are keyed by path, and a closed
+			// branch frees its path, so a stale handle would otherwise tear down its successor
+			if (closed) return;
 			closed = true;
 			openBranches.delete(path);
+			openBranchIdentities.delete(storeName);
 			rocksdbDatabaseEnvs.delete(path);
-			closeBranchHandles(path, rootStore, tables);
+			closeBranchHandles(path, rootStore, openedStores);
 		},
 	};
 	openBranches.set(path, branch);
+	openBranchIdentities.add(storeName);
 	return branch;
 }
 
 /**
- * Release everything a branch open created. `initStores` opens a column family per table primary
- * store and per index, on top of the internal-dbis and audit families, so closing only the root
- * leaves all of them behind — which is why `closeDatabase` walks them individually for a real
- * database. It also leaves two process-global registrations behind the stores it closes, neither of
- * which has a lifetime of its own: a storage-reclamation handler per store path, whose closure pins
- * the now-closed store, and the memoized blob roots in `databasePaths`. A real database is opened
- * once per thread, but harper#643 makes branch open/close routine, so both would grow with branch
- * churn. Shared by `close()` and the partial-open cleanup, so a failure part-way through
- * `initStores` releases exactly what a success would.
+ * Release everything a branch open created. Each table's primary store and each index is its own
+ * column family, on top of the internal-dbis and audit families, so closing the root alone leaves
+ * all of them behind — which is why `closeDatabase` walks them individually for a real database.
+ * Two process-global registrations outlive the stores as well, neither with a lifetime of its own:
+ * a storage-reclamation handler per store path, whose closure pins the now-closed store, and the
+ * memoized blob roots in `databasePaths`. A real database is opened once per thread; harper#643
+ * makes branch open/close routine, so both would grow with branch churn.
  */
-function closeBranchHandles(path: string, rootStore?: RootDatabaseKind, tables?: Tables): void {
+function closeBranchHandles(path: string, rootStore?: RootDatabaseKind, openedStores: any[] = []): void {
 	const reclamationPaths = new Set<string>([path]);
 	const closeStore = (store: any, description: string) => {
 		if (store?.path) reclamationPaths.add(store.path);
@@ -1159,13 +1163,7 @@ function closeBranchHandles(path: string, rootStore?: RootDatabaseKind, tables?:
 			logger.warn?.(`Error closing ${description} for branch database at ${path}`, error);
 		}
 	};
-	for (const tableName in tables ?? {}) {
-		const table: any = (tables as any)[tableName];
-		if (!table?.primaryStore) continue;
-		for (const indexName in table.indices || {})
-			closeStore(table.indices[indexName], `index ${tableName}.${indexName}`);
-		closeStore(table.primaryStore, `table ${tableName}`);
-	}
+	for (const store of openedStores) closeStore(store, 'column family');
 	closeStore((rootStore as any)?.dbisDb, 'attributes store');
 	closeStore((rootStore as any)?.auditStore, 'audit store');
 	closeStore(rootStore, 'root store');
@@ -1320,6 +1318,14 @@ export function database({ database: databaseName, table: tableName }) {
 	const useRocksdb = (process.env.HARPER_STORAGE_ENGINE || envGet(CONFIG_PARAMS.STORAGE_ENGINE)) !== 'lmdb';
 	if (useRocksdb) {
 		const path = join(databasePath, tablePath ? tableName : databaseName);
+		// the scan is not the only way to reach a branch's directory: a branch leaves its store in
+		// `rocksdbDatabaseEnvs`, so without this an on-demand open would staple it onto
+		// `definedDatabases` and the next `closeDatabase` would close it under the live handle
+		if (isOpenBranchPath(path)) {
+			const error: any = new Error(`Database '${databaseName}' is open as a scope-private branch`);
+			error.statusCode = 409;
+			throw error;
+		}
 		rootStore = rocksdbDatabaseEnvs.get(path);
 		if (!rootStore || rootStore.status === 'closed') {
 			// this on-demand open (create_table/create_database and friends) must not resurrect a
@@ -1524,9 +1530,8 @@ export function closeDatabase(databaseName: string): boolean {
  * (skipped by the loop), is never restored online, and the exiting worker may still touch the job
  * table during teardown. Best-effort: closing failures are swallowed inside `closeDatabase`.
  *
- * Branches are not in `databases` and so are invisible to the loop below, but they hold handles from
- * the same process-global registry — this is the thread's one teardown entry point, so it closes
- * them too rather than leaving a rule for the next exit path to remember.
+ * Branches are invisible to the loop below but hold handles from the same registry, so this — the
+ * thread's one teardown entry point — closes them too.
  */
 export function closeLoadedDatabases(): void {
 	closeBranchDatabases();

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -901,18 +901,14 @@ function initStores(
 			// per-table override of the storage.randomAccessFields default (see OpenDBIObject)
 			if (typeof primaryAttribute.randomAccessFields === 'boolean')
 				dbiInit.randomAccessStructure = primaryAttribute.randomAccessFields;
-			if (rootStore instanceof RocksDatabase) {
-				primaryStore = handleLocalTimeForGets(
-					openRocksDatabase(rootStore.path, { ...dbiInit, name: primaryAttribute.key, cache: true } as any),
-					rootStore
-				);
-			} else {
-				primaryStore = handleLocalTimeForGets(
-					(rootStore as any).openDB(primaryAttribute.key, dbiInit as any),
-					rootStore
-				);
-			}
-			openedStores?.push(primaryStore);
+			// recorded before the wrapper below, which is the only thing between the native open and
+			// the only list a failed open can release it from
+			const opened =
+				rootStore instanceof RocksDatabase
+					? openRocksDatabase(rootStore.path, { ...dbiInit, name: primaryAttribute.key, cache: true } as any)
+					: (rootStore as any).openDB(primaryAttribute.key, dbiInit as any);
+			openedStores?.push(opened);
+			primaryStore = handleLocalTimeForGets(opened, rootStore);
 			primaryStore.tableId = tableId;
 		}
 		let attributesUpdated: boolean;
@@ -1111,8 +1107,10 @@ export function openBranchDatabase(path: string, databaseName: string, storeName
 	if (!existsSync(path)) throw new Error(`Cannot open branch database: no directory at ${path}`);
 	// the guards compare against env-map keys, so two spellings of one directory must not read as two
 	path = realpathSync(path);
-	// FIRST: loading is itself what populates `rocksdbDatabaseEnvs`, so a path guard ahead of the
-	// scan could adopt a database that the scan then opens at this path
+	// FIRST: the guards below read the registry, and loading is itself what populates
+	// `rocksdbDatabaseEnvs`. Claiming the path ahead of this scan would make the scan skip it, which
+	// also means a directory that IS a real database no longer reads as one — so the pre-open window
+	// where the scan can adopt a branch directory stays open, by choice (harper#643).
 	getDatabases();
 	// a rival graph over one shared root store; the two callers would disagree about who may close it
 	if (openBranches.has(path)) throw new Error(`Branch database at ${path} is already open`);

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -3,7 +3,7 @@ import { initSync, getHdbBasePath, get as envGet } from '../utility/environment/
 import { INTERNAL_DBIS_NAME } from '../utility/lmdb/terms.ts';
 import { open, compareKeys, type Database, type RootDatabase } from 'lmdb';
 import { join, extname, basename } from 'path';
-import { existsSync, readdirSync, readFileSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, realpathSync } from 'node:fs';
 import { unlink } from 'node:fs/promises';
 import {
 	getBaseSchemaPath,
@@ -637,14 +637,20 @@ export function readMetaDb(
 			lmdbDatabaseEnvs.set(path, rootStore);
 		}
 
-		return initStores(path, rootStore, databaseName, defaultTable, auditPath, isLegacy);
+		return initStores(path, rootStore, databaseName, { defaultTable, auditPath, isLegacy });
 	} catch (error) {
 		error.message += ` opening database ${path}`;
 		throw error;
 	}
 }
 
-function readRocksMetaDb(path: string, defaultTable?: string, databaseName: string = DEFAULT_DATABASE_NAME) {
+function readRocksMetaDb(
+	path: string,
+	defaultTable?: string,
+	databaseName: string = DEFAULT_DATABASE_NAME,
+	destination?: Tables,
+	storeName?: string
+) {
 	try {
 		logger.trace(`loading rocksdb database: ${path}`);
 
@@ -657,14 +663,16 @@ function readRocksMetaDb(path: string, defaultTable?: string, databaseName: stri
 
 		let rootStore: RocksRootDatabase | undefined = rocksdbDatabaseEnvs.get(path);
 		if (rootStore) {
-			initStores(path, rootStore, databaseName, defaultTable);
+			initStores(path, rootStore, databaseName, { defaultTable, destination, storeName });
 		} else {
 			rootStore = openRocksDatabase(path, { disableWAL: false, enableStats: true }) as any;
 			rocksdbDatabaseEnvs.set(path, rootStore);
-			initStores(path, rootStore, databaseName, defaultTable);
-			// Skip transaction log replay in read-only mode
+			initStores(path, rootStore, databaseName, { defaultTable, destination, storeName });
+			// Replay into whichever graph this open owns. Skipping it for a caller-owned graph would
+			// leave any tail the checkpoint captured permanently invisible in that graph, since nothing
+			// else will ever replay this store.
 			if (!isReadOnlyMode()) {
-				replayLogs(rootStore, databases[databaseName]);
+				replayLogs(rootStore, destination ?? databases[databaseName]);
 			}
 		}
 		return rootStore;
@@ -674,13 +682,26 @@ function readRocksMetaDb(path: string, defaultTable?: string, databaseName: stri
 	}
 }
 
+interface InitStoresOptions {
+	defaultTable?: string;
+	auditPath?: string;
+	isLegacy?: boolean;
+	/** Build the Table classes here instead of the global `databases` map, and emit no global event. */
+	destination?: Tables;
+	/**
+	 * Identity stamped on the root store, when it must differ from the logical `databaseName` the
+	 * Table classes carry. `getRootBlobPathsForDB` resolves a database's blob directories from it, so
+	 * a branch sets it to the branch's own name to get its own blob roots while its tables keep the
+	 * name the application's code and schema already use.
+	 */
+	storeName?: string;
+}
+
 function initStores(
 	path: string,
 	rootStore: RootDatabaseKind,
 	databaseName: string,
-	defaultTable?: string,
-	auditPath?: string,
-	isLegacy?: boolean
+	{ defaultTable, auditPath, isLegacy, destination, storeName }: InitStoresOptions = {}
 ) {
 	const envInit = new OpenEnvironmentObject(path, isReadOnlyMode());
 	const internalDbiInit = createOpenDBIObject(false);
@@ -721,7 +742,8 @@ function initStores(
 		}
 	}
 
-	const tables = ensureDB(databaseName);
+	const tables = destination ?? ensureDB(databaseName);
+	if (destination && !destination[DEFINED_TABLES]) destination[DEFINED_TABLES] = new Set<string>();
 	const definedTables = tables[DEFINED_TABLES];
 	(definedTables as any).rootStore = rootStore;
 	const tablesToLoad = new Map<string, any>();
@@ -882,7 +904,7 @@ function initStores(
 					rootStore
 				);
 			}
-			rootStore.databaseName = databaseName;
+			rootStore.databaseName = storeName ?? databaseName;
 			primaryStore.tableId = tableId;
 		}
 		let attributesUpdated: boolean;
@@ -993,10 +1015,103 @@ function initStores(
 				})
 			);
 			table.schemaVersion = 1;
-			databaseEventsEmitter.emit('updateTable', table);
+			if (!destination) databaseEventsEmitter.emit('updateTable', table);
 		}
 	}
 	return rootStore;
+}
+
+/** A branch's private table graph plus the handle needed to tear it down. */
+export interface BranchDatabase {
+	tables: Tables;
+	rootStore: RootDatabaseKind;
+	close(): void;
+}
+
+/** Open branches by directory, so teardown has something to walk and a repeat open is detectable. */
+const openBranches = new Map<string, BranchDatabase>();
+
+/**
+ * Open a RocksDB directory as a **scope-private** database: its Table classes are built into an
+ * object the caller owns and nothing is registered in the global `databases` map, so no enumerator
+ * of that map — analytics, `describe_all`, worker teardown, replication — can observe it.
+ *
+ * `databaseName` is the *logical* name the application knows (`data`), so its schema and code need
+ * no changes. `storeName` is the branch's own identity and is what `getRootBlobPathsForDB` resolves
+ * blob directories from, which is how a branch gets its own blob roots rather than writing into the
+ * base's.
+ *
+ * The caller owns the returned handle. `closeLoadedDatabases` walks `databases` and therefore cannot
+ * see a branch, so nothing else will close it.
+ *
+ * NOT YET SAFE FOR SCHEMA MUTATION. A branch's Table classes carry the base's logical name, so a
+ * `dropTable()` or equivalent through one resolves against the global schema and would delete the
+ * live base Table class. Row reads and writes are fine. Nothing calls this yet; the scope wiring
+ * that first exposes a branch to application code must gate schema operations before it does
+ * (harper#643).
+ */
+export function openBranchDatabase(path: string, databaseName: string, storeName: string): BranchDatabase {
+	if (!existsSync(path)) throw new Error(`Cannot open branch database: no directory at ${path}`);
+	// The guards below compare against keys in the env map, so two spellings of one directory must
+	// not read as two directories.
+	path = realpathSync(path);
+	// A second open would hand back a rival table graph over one shared root store, and the two
+	// callers would disagree about who may close it.
+	if (openBranches.has(path)) throw new Error(`Branch database at ${path} is already open`);
+	// A globally-loaded database's store is shared and closed by `closeLoadedDatabases`; adopting it
+	// here would mean this handle's `close()` tears down a live database.
+	if (rocksdbDatabaseEnvs.has(path)) throw new Error(`Cannot branch ${path}: it is already open as a database`);
+	// `storeName` picks the blob roots. Letting it name a real database would point the branch's blob
+	// writes at that database's directory, which is the collision the separate identity exists to stop.
+	if (databases[storeName] || definedDatabases?.has(storeName)) {
+		throw new Error(`Cannot use '${storeName}' as a branch store identity: a database of that name exists`);
+	}
+
+	const tables: Tables = Object.create(null);
+	let rootStore: RootDatabaseKind;
+	try {
+		rootStore = readRocksMetaDb(path, null, databaseName, tables, storeName);
+	} catch (error) {
+		// readRocksMetaDb registers the store before building tables, so a failure part-way leaves it
+		// in the env map with no handle able to close it.
+		const stranded = rocksdbDatabaseEnvs.get(path);
+		rocksdbDatabaseEnvs.delete(path);
+		try {
+			stranded?.close();
+		} catch (closeError) {
+			logger.warn?.(`Error closing partially opened branch database at ${path}`, closeError);
+		}
+		throw error;
+	}
+	const branch: BranchDatabase = {
+		tables,
+		rootStore,
+		close() {
+			if (!openBranches.delete(path)) return; // already closed; closing a store twice is not safe
+			rocksdbDatabaseEnvs.delete(path);
+			// The column families opened for the tables and the audit store hold their own handles, and
+			// closing only the root leaves them behind.
+			for (const store of [(rootStore as any).dbisDb, (rootStore as any).auditStore]) {
+				try {
+					store?.close?.();
+				} catch (error) {
+					logger.warn?.(`Error closing branch column family at ${path}`, error);
+				}
+			}
+			try {
+				rootStore.close();
+			} catch (error) {
+				logger.warn?.(`Error closing branch database at ${path}`, error);
+			}
+		},
+	};
+	openBranches.set(path, branch);
+	return branch;
+}
+
+/** Close every open branch. Branches are process-local, so this is shutdown, not a data operation. */
+export function closeBranchDatabases(): void {
+	for (const branch of [...openBranches.values()]) branch.close();
 }
 
 export function resetDatabases() {

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1119,11 +1119,17 @@ export function openBranchDatabase(path: string, databaseName: string, storeName
 		closeBranchHandles(path, stranded, tables);
 		throw error;
 	}
+	let closed = false;
 	const branch: BranchDatabase = {
 		tables,
 		rootStore,
 		close() {
-			if (!openBranches.delete(path)) return; // already closed; closing a store twice is not safe
+			// Guard on this handle, not on the registrations: those are keyed by path, and once this
+			// branch has been closed the path is free to be opened again, so a stale handle closed a
+			// second time would deregister and half-tear-down whichever branch owns the path now.
+			if (closed) return; // closing a store twice is not safe
+			closed = true;
+			openBranches.delete(path);
 			rocksdbDatabaseEnvs.delete(path);
 			closeBranchHandles(path, rootStore, tables);
 		},

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -32,7 +32,7 @@ import { openAuditStore, readAuditEntry, createAuditEntry, type AuditRecord } fr
 import { handleLocalTimeForGets } from './RecordEncoder.ts';
 import { databasePaths, deleteRootBlobPathsForDB } from './blob.ts';
 import { removeStorageReclamation } from '../server/storageReclamation.ts';
-import { schemaRegex } from '../validation/common_validators.ts';
+import { commonValidators, schemaRegex } from '../validation/common_validators.ts';
 import { CUSTOM_INDEXES } from './indexes/customIndexes.ts';
 import { OpenDBIObject } from '../utility/lmdb/OpenDBIObject.ts';
 import { RocksDatabase, supportedCompression, type RocksDatabaseOptions } from '@harperfast/rocksdb-js';
@@ -671,8 +671,9 @@ function readRocksMetaDb(
 			rootStore = openRocksDatabase(path, { disableWAL: false, enableStats: true }) as any;
 			rocksdbDatabaseEnvs.set(path, rootStore);
 			initStores(path, rootStore, databaseName, { defaultTable, destination, storeName, openedStores });
-			// a caller-owned graph is replayed into as well: nothing else will ever replay this store,
-			// so skipping it would leave the tail the checkpoint captured permanently invisible there
+			// a caller-owned graph is replayed into as well: nothing else will ever replay this store.
+			// `replayLogs` is a no-op off the main thread, so a branch opened on a worker sees only
+			// what the checkpoint's SSTs hold — see the note on `openBranchDatabase`
 			if (!isReadOnlyMode()) {
 				replayLogs(rootStore, destination ?? databases[databaseName]);
 			}
@@ -1029,14 +1030,14 @@ function initStores(
 	return rootStore;
 }
 
-/** A branch's private table graph plus the handle needed to tear it down. */
 export interface BranchDatabase {
 	tables: Tables;
 	rootStore: RootDatabaseKind;
 	close(): void;
 }
 
-const openBranches = new Map<string, BranchDatabase>();
+/** `undefined` marks a path reserved by an open still in flight, which owns it just as firmly. */
+const openBranches = new Map<string, BranchDatabase | undefined>();
 /** Store identities in use, so two branches cannot resolve one set of blob roots. */
 const openBranchIdentities = new Set<string>();
 
@@ -1048,6 +1049,9 @@ const openBranchIdentities = new Set<string>();
  */
 function isOpenBranchPath(dbPath: string): boolean {
 	if (openBranches.size === 0) return false;
+	// the literal path first: `rocksdbDatabaseEnvs` is keyed by it too, so a directory unlinked under
+	// a live branch handle (realpathSync then throws) must not read as unowned
+	if (openBranches.has(dbPath)) return true;
 	try {
 		return openBranches.has(realpathSync(dbPath));
 	} catch {
@@ -1061,7 +1065,14 @@ function isOpenBranchPath(dbPath: string): boolean {
  * dot segments and backslash that regex permits but a path component must not be.
  */
 function assertLegalBranchName(name: string, description: string): void {
-	if (!name || !schemaRegex.test(name) || name.includes('\\') || name === '.' || name === '..') {
+	if (
+		!name ||
+		name.length > commonValidators.schema_length.maximum ||
+		!schemaRegex.test(name) ||
+		name.includes('\\') ||
+		name === '.' ||
+		name === '..'
+	) {
 		throw new Error(`Cannot use '${name}' as a branch ${description}: it is not a legal database name`);
 	}
 }
@@ -1088,6 +1099,11 @@ function assertLegalBranchName(name: string, description: string): void {
  * A branch's blob roots start empty, so a row whose blob was written before the checkpoint reads
  * back as a missing file until harper#644 links the base's blob tree into them. Non-blob rows are
  * unaffected, for reads and writes alike.
+ *
+ * A branch is the checkpoint's SST content plus, on the main thread only, its transaction-log tail:
+ * `replayLogs` is a no-op off the main thread and nothing else will ever replay a private store. It
+ * is also not awaited, so `close()` can race a replay still writing — neither is a problem while
+ * nothing calls this, and both are decisions the scope wiring has to settle (harper#643).
  */
 export function openBranchDatabase(path: string, databaseName: string, storeName: string): BranchDatabase {
 	assertLegalBranchName(databaseName, 'logical database name');
@@ -1114,11 +1130,16 @@ export function openBranchDatabase(path: string, databaseName: string, storeName
 	// so the graph is not a complete record of what a failed open must release
 	const openedStores: any[] = [];
 	let rootStore: RootDatabaseKind;
+	// claim the path before the open, not after: readRocksMetaDb registers the store in
+	// `rocksdbDatabaseEnvs` partway through, so anything re-entering `database()` during initStores
+	// would otherwise find the branch's store on an unowned path
+	openBranches.set(path, undefined);
+	openBranchIdentities.add(storeName);
 	try {
 		rootStore = readRocksMetaDb(path, null, databaseName, { destination: tables, storeName, openedStores });
 	} catch (error) {
-		// readRocksMetaDb registers the store before building tables, so a failure part-way leaves it
-		// in the env map with no handle able to close it
+		openBranches.delete(path);
+		openBranchIdentities.delete(storeName);
 		const stranded = rocksdbDatabaseEnvs.get(path);
 		rocksdbDatabaseEnvs.delete(path);
 		closeBranchHandles(path, stranded, openedStores);
@@ -1140,7 +1161,6 @@ export function openBranchDatabase(path: string, databaseName: string, storeName
 		},
 	};
 	openBranches.set(path, branch);
-	openBranchIdentities.add(storeName);
 	return branch;
 }
 
@@ -1160,7 +1180,7 @@ function closeBranchHandles(path: string, rootStore?: RootDatabaseKind, openedSt
 		try {
 			store?.close?.();
 		} catch (error) {
-			logger.warn?.(`Error closing ${description} for branch database at ${path}`, error);
+			logger.warn(`Error closing ${description} for branch database at ${path}`, error);
 		}
 	};
 	for (const store of openedStores) closeStore(store, 'column family');
@@ -1171,9 +1191,9 @@ function closeBranchHandles(path: string, rootStore?: RootDatabaseKind, openedSt
 	for (const reclamationPath of reclamationPaths) removeStorageReclamation(reclamationPath);
 }
 
-/** Close every open branch. Branches are process-local, so this is shutdown, not a data operation. */
+/** Branches are process-local, so this is shutdown, not a data operation. */
 export function closeBranchDatabases(): void {
-	for (const branch of [...openBranches.values()]) branch.close();
+	for (const branch of [...openBranches.values()]) branch?.close();
 }
 
 export function resetDatabases() {

--- a/server/storageReclamation.ts
+++ b/server/storageReclamation.ts
@@ -118,6 +118,16 @@ export function onStorageReclamation(
 		if (!reclamationTimer) reclamationTimer = setTimeout(runReclamationHandlers, RECLAMATION_INTERVAL).unref();
 	}
 }
+
+/**
+ * Drop every reclamation handler registered for `path`. Registration is process-global and keyed by
+ * storage path with no lifetime of its own, so a store that is closed and discarded leaves both its
+ * handler and the closure holding the closed store alive for the life of the process, and every
+ * re-open of the same path appends another.
+ */
+export function removeStorageReclamation(path: string): boolean {
+	return reclamationHandlers.delete(path);
+}
 let reclamationTimer: NodeJS.Timeout;
 
 export type StorageSpaceStats = {

--- a/unitTests/resources/closeLoadedDatabases.test.js
+++ b/unitTests/resources/closeLoadedDatabases.test.js
@@ -9,7 +9,18 @@
 require('../testUtils');
 const assert = require('node:assert');
 const { setupTestDBPath } = require('../testUtils');
-const { table, database, getDatabases, closeDatabase, closeLoadedDatabases } = require('#src/resources/databases');
+const { mkdtempSync, rmSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const {
+	table,
+	database,
+	getDatabases,
+	closeDatabase,
+	closeLoadedDatabases,
+	openBranchDatabase,
+	closeBranchDatabases,
+} = require('#src/resources/databases');
 const { registryStatus, RocksDatabase } = require('@harperfast/rocksdb-js');
 
 describe('RocksDB handle release', function () {
@@ -54,6 +65,28 @@ describe('RocksDB handle release', function () {
 
 		assert.strictEqual(refCountFor(a.path), 0, 'database a should be released');
 		assert.strictEqual(refCountFor(b.path), 0, 'database b should be released');
+	});
+
+	it('closeLoadedDatabases releases a branch database (invisible to the databases map it walks)', async function () {
+		this.timeout(30000);
+		const rootStore = openRocksDb('closerelease4');
+		if (!(rootStore instanceof RocksDatabase)) return this.skip();
+		const scratchRoot = mkdtempSync(join(tmpdir(), 'harper.unit-test.branch-close-'));
+		const checkpointDir = join(scratchRoot, 'checkpoint');
+		try {
+			await rootStore.createCheckpoint(checkpointDir);
+			const branch = openBranchDatabase(checkpointDir, 'closerelease4', 'appA__closerelease4');
+			assert.ok(refCountFor(branch.rootStore.path) > 0, 'branch should be open');
+
+			closeLoadedDatabases();
+
+			// a branch is not in `databases`, so the walk below cannot reach it — an exiting job worker
+			// would leak its handles process-wide unless this is the single teardown entry point
+			assert.strictEqual(refCountFor(checkpointDir), 0, 'branch should be released on thread teardown');
+		} finally {
+			closeBranchDatabases();
+			rmSync(scratchRoot, { recursive: true, force: true });
+		}
 	});
 
 	it('closeLoadedDatabases releases a tableless database (root store not reachable via any table)', async function () {

--- a/unitTests/resources/databases.test.js
+++ b/unitTests/resources/databases.test.js
@@ -178,7 +178,7 @@ describe('dropDatabase restore serialization', () => {
 
 describe('openBranchDatabase (scope-private graph, harper#643)', () => {
 	const { openBranchDatabase, closeBranchDatabases, databases } = require('#src/resources/databases');
-	const { mkdtempSync, rmSync } = require('node:fs');
+	const { cpSync, mkdtempSync, rmSync } = require('node:fs');
 	const { tmpdir } = require('node:os');
 	const { registryStatus } = require('@harperfast/rocksdb-js');
 
@@ -268,10 +268,50 @@ describe('openBranchDatabase (scope-private graph, harper#643)', () => {
 	});
 
 	it('refuses a store identity that names a real database, which would steal its blob roots', function () {
-		assert.throws(
-			() => openBranchDatabase(checkpointDir, 'branchbase', 'branchbase'),
-			/a database of that name exists/
+		assert.throws(() => openBranchDatabase(checkpointDir, 'branchbase', 'branchbase'), /already in use/);
+	});
+
+	it('refuses a store identity another open branch already holds', async function () {
+		this.timeout(30000);
+		const secondDir = join(scratchRoot, 'checkpoint2');
+		await databases.branchbase.BranchSource.primaryStore.rootStore.createCheckpoint(secondDir);
+		openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
+
+		// blob file ids restart from each store's own checkpointed counter, so a shared identity is
+		// not merely a shared directory: the two branches generate the same paths and truncate each other
+		assert.throws(() => openBranchDatabase(secondDir, 'branchbase', 'appA__branchbase'), /already in use/);
+	});
+
+	it('writes through the branch without touching the base table', async function () {
+		const branch = openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
+
+		await branch.tables.BranchSource.put({ id: 'branch-only', note: 'written through the branch' });
+
+		assert.strictEqual((await branch.tables.BranchSource.get('branch-only'))?.note, 'written through the branch');
+		assert.ok(
+			!(await databases.branchbase.BranchSource.get('branch-only')),
+			'a branch write must not reach the base table it shares a logical name with'
 		);
+	});
+
+	it('refuses an on-demand database() open of a directory a branch owns', function () {
+		const { database } = require('#src/resources/databases');
+		// database() resolves an unconfigured name against the same root the base database sits in
+		const probeDir = join(dirname(databases.branchbase.BranchSource.primaryStore.rootStore.path), 'branchdbprobe');
+		rmSync(probeDir, { recursive: true, force: true });
+		let branch;
+		try {
+			// the scan guards are not the only route to the directory: database() looks the resolved
+			// path up in the shared env map, where a branch leaves its store for its whole lifetime
+			cpSync(checkpointDir, probeDir, { recursive: true });
+			branch = openBranchDatabase(probeDir, 'branchbase', 'appA__dbprobe');
+
+			assert.throws(() => database({ database: 'branchdbprobe' }), /scope-private branch/);
+			assert.strictEqual(branch.rootStore.status, 'open', 'the branch store must survive the refused open');
+		} finally {
+			branch?.close();
+			rmSync(probeDir, { recursive: true, force: true });
+		}
 	});
 
 	it('releases every native handle it opened, not just the root', function () {

--- a/unitTests/resources/databases.test.js
+++ b/unitTests/resources/databases.test.js
@@ -293,6 +293,36 @@ describe('openBranchDatabase (scope-private graph, harper#643)', () => {
 		assert.strictEqual(refCountFor(branch.rootStore.path), 0, 'a second close must not double-release');
 	});
 
+	it('a stale handle closed twice does not tear down a later open of the same directory', function () {
+		// the point of the re-close guard is not that closing twice throws — it is that the second
+		// call is keyed by path, so without it a discarded handle deregisters whoever holds the path now
+		const stale = openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
+		stale.close();
+		const live = openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
+
+		stale.close();
+
+		assert.throws(
+			() => openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase'),
+			/already open/,
+			'the live branch must still own the directory'
+		);
+		assert.ok(refCountFor(live.rootStore.path) > 0, 'the live branch must still hold its handles');
+	});
+
+	it('drops the memoized blob roots pinning the store', function () {
+		const { databasePaths, getRootBlobPathsForDB } = require('#src/resources/blob');
+		const branch = openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
+		getRootBlobPathsForDB(branch.rootStore);
+		assert.ok(databasePaths.has(branch.rootStore), 'resolving blob roots memoizes them against the store');
+
+		branch.close();
+
+		// databasePaths is a strong Map keyed by the store, so an entry left behind pins the closed
+		// store for the life of the process and grows with branch churn
+		assert.ok(!databasePaths.has(branch.rootStore), 'close() must drop the memoized blob roots');
+	});
+
 	it('is not adopted back into the global map when the database scan reruns', async function () {
 		this.timeout(30000);
 		// harper#643 puts a branch directory inside the directory getDatabases() walks, so the first

--- a/unitTests/resources/databases.test.js
+++ b/unitTests/resources/databases.test.js
@@ -180,12 +180,18 @@ describe('openBranchDatabase (scope-private graph, harper#643)', () => {
 	const { openBranchDatabase, closeBranchDatabases, databases } = require('#src/resources/databases');
 	const { mkdtempSync, rmSync } = require('node:fs');
 	const { tmpdir } = require('node:os');
+	const { registryStatus } = require('@harperfast/rocksdb-js');
+
+	// the real observable for a released handle: rocksdb-js's registry is process-global and its
+	// refCount only drops to zero once every column family opened under a path has been closed
+	const refCountFor = (dbPath) => registryStatus().find((entry) => entry.path === dbPath)?.refCount ?? 0;
 
 	let checkpointDir;
 	let scratchRoot;
+	let databasesDir;
 	before(async function () {
 		this.timeout(30000);
-		setupTestDBPath();
+		databasesDir = setupTestDBPath();
 		setMainIsWorker(true);
 		const BranchSource = table({
 			table: 'BranchSource',
@@ -268,10 +274,87 @@ describe('openBranchDatabase (scope-private graph, harper#643)', () => {
 		);
 	});
 
+	it('releases every native handle it opened, not just the root', function () {
+		const branch = openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
+		const branchPath = branch.rootStore.path;
+		assert.ok(refCountFor(branchPath) > 0, 'the branch should hold native handles while open');
+
+		branch.close();
+
+		// a per-table column family left open keeps the process-global refCount above zero, which is
+		// what distinguishes a released handle from a leaked one
+		assert.strictEqual(refCountFor(branchPath), 0, 'close() must release every column family it opened');
+	});
+
 	it('tolerates a repeated close', function () {
 		const branch = openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
 		branch.close();
 		assert.doesNotThrow(() => branch.close(), 'a second close must not close the store twice');
+		assert.strictEqual(refCountFor(branch.rootStore.path), 0, 'a second close must not double-release');
+	});
+
+	it('is not adopted back into the global map when the database scan reruns', async function () {
+		this.timeout(30000);
+		// harper#643 puts a branch directory inside the directory getDatabases() walks, so the first
+		// resetDatabases() after a branch opens is the case that would rebuild it globally
+		const probeDir = join(databasesDir, 'branchscanprobe');
+		rmSync(probeDir, { recursive: true, force: true });
+		let branch;
+		try {
+			await databases.branchbase.BranchSource.primaryStore.rootStore.createCheckpoint(probeDir);
+			branch = openBranchDatabase(probeDir, 'branchbase', 'appA__scanprobe');
+
+			resetDatabases();
+
+			for (const [name, dbTables] of Object.entries(databases)) {
+				for (const tableName in dbTables) {
+					assert.notStrictEqual(
+						dbTables[tableName]?.primaryStore?.rootStore,
+						branch.rootStore,
+						`the rescan adopted the branch store as databases.${name}.${tableName}`
+					);
+				}
+			}
+			assert.strictEqual(
+				branch.rootStore.databaseName,
+				'appA__scanprobe',
+				'adoption would overwrite the store identity the branch blob roots resolve from'
+			);
+		} finally {
+			branch?.close();
+			rmSync(probeDir, { recursive: true, force: true });
+		}
+	});
+
+	it('deregisters the storage-reclamation handler its stores registered', async function () {
+		const { runReclamationHandlers, setAvailableSpaceRatioGetter } = require('#src/server/storageReclamation');
+		const queried = [];
+		setAvailableSpaceRatioGetter(async (path) => {
+			queried.push(path);
+			return 1;
+		});
+		try {
+			const branch = openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
+			const branchPath = branch.rootStore.path;
+			await runReclamationHandlers();
+			assert.ok(queried.includes(branchPath), 'opening a branch registers a reclamation handler for its path');
+
+			branch.close();
+			queried.length = 0;
+			await runReclamationHandlers();
+
+			// registration is process-global and keyed by path, and its closure pins the closed store,
+			// so an open/close cycle that leaves it behind grows unboundedly with branch churn
+			assert.ok(!queried.includes(branchPath), 'close() must drop the handler pinning the closed store');
+		} finally {
+			setAvailableSpaceRatioGetter();
+		}
+	});
+
+	it('rejects a store identity that would resolve blob roots outside the blobs directory', function () {
+		assert.throws(() => openBranchDatabase(checkpointDir, 'branchbase', '..'), /not a legal database name/);
+		assert.throws(() => openBranchDatabase(checkpointDir, 'branchbase', 'a/b'), /not a legal database name/);
+		assert.throws(() => openBranchDatabase(checkpointDir, 'branchbase', ''), /not a legal database name/);
 	});
 
 	it('rejects a path that is not there rather than registering an empty database', function () {

--- a/unitTests/resources/databases.test.js
+++ b/unitTests/resources/databases.test.js
@@ -192,6 +192,7 @@ describe('openBranchDatabase (scope-private graph, harper#643)', () => {
 			database: 'branchbase',
 			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'note' }],
 		});
+		if (!(BranchSource.primaryStore.rootStore instanceof RocksDatabase)) return this.skip();
 		await BranchSource.put({ id: 'a', note: 'base' });
 		scratchRoot = mkdtempSync(join(tmpdir(), 'harper.unit-test.branch-'));
 		checkpointDir = join(scratchRoot, 'checkpoint');

--- a/unitTests/resources/databases.test.js
+++ b/unitTests/resources/databases.test.js
@@ -175,3 +175,107 @@ describe('dropDatabase restore serialization', () => {
 		assert.ok(existsSync(reservedDir), 'the reserved dir itself is left in place (used for lifecycle metadata)');
 	});
 });
+
+describe('openBranchDatabase (scope-private graph, harper#643)', () => {
+	const { openBranchDatabase, closeBranchDatabases, databases } = require('#src/resources/databases');
+	const { mkdtempSync, rmSync } = require('node:fs');
+	const { tmpdir } = require('node:os');
+
+	let checkpointDir;
+	let scratchRoot;
+	before(async function () {
+		this.timeout(30000);
+		setupTestDBPath();
+		setMainIsWorker(true);
+		const BranchSource = table({
+			table: 'BranchSource',
+			database: 'branchbase',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'note' }],
+		});
+		await BranchSource.put({ id: 'a', note: 'base' });
+		scratchRoot = mkdtempSync(join(tmpdir(), 'harper.unit-test.branch-'));
+		checkpointDir = join(scratchRoot, 'checkpoint');
+		await BranchSource.primaryStore.rootStore.createCheckpoint(checkpointDir);
+	});
+
+	afterEach(function () {
+		closeBranchDatabases();
+	});
+
+	after(function () {
+		if (scratchRoot) rmSync(scratchRoot, { recursive: true, force: true });
+	});
+
+	it('serves the base rows under the logical table name', async function () {
+		const branch = openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
+
+		assert.ok(branch.tables.BranchSource);
+		const row = await branch.tables.BranchSource.get('a');
+		assert.strictEqual(row?.note, 'base', 'the branch reads the rows the checkpoint captured');
+	});
+
+	it('is invisible to every enumerator of the global databases map', function () {
+		const baseTableClass = databases.branchbase.BranchSource;
+		const globalKeysBefore = Object.keys(databases).length;
+
+		const branch = openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
+
+		for (const [name, dbTables] of Object.entries(databases)) {
+			assert.notStrictEqual(dbTables, branch.tables, `branch graph reachable as databases.${name}`);
+		}
+		assert.strictEqual(databases.branchbase.BranchSource, baseTableClass);
+		assert.strictEqual(Object.keys(databases).length, globalKeysBefore);
+	});
+
+	it('stamps the branch identity on the store so blob roots do not resolve to the base', function () {
+		const branch = openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
+
+		assert.strictEqual(branch.rootStore.databaseName, 'appA__branchbase');
+		assert.notStrictEqual(
+			branch.rootStore.databaseName,
+			'branchbase',
+			'sharing the base name would resolve the branch blob roots onto the base directory'
+		);
+	});
+
+	it('refuses a second open of the same directory rather than handing out a rival graph', function () {
+		openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
+		assert.throws(() => openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase'), /already open/);
+	});
+
+	it('closes what nothing else can: the store is gone from the env map after close', function () {
+		const branch = openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
+		branch.close();
+
+		assert.doesNotThrow(
+			() => openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase'),
+			'after close the directory can be opened again'
+		);
+	});
+
+	it('refuses to adopt a directory that is already open as a real database', function () {
+		const basePath = databases.branchbase.BranchSource.primaryStore.rootStore.path;
+		// Its store is shared and closed by closeLoadedDatabases; adopting it would make this handle's
+		// close() tear down a live database.
+		assert.throws(() => openBranchDatabase(basePath, 'branchbase', 'appB__branchbase'), /already open as a database/);
+	});
+
+	it('refuses a store identity that names a real database, which would steal its blob roots', function () {
+		assert.throws(
+			() => openBranchDatabase(checkpointDir, 'branchbase', 'branchbase'),
+			/a database of that name exists/
+		);
+	});
+
+	it('tolerates a repeated close', function () {
+		const branch = openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
+		branch.close();
+		assert.doesNotThrow(() => branch.close(), 'a second close must not close the store twice');
+	});
+
+	it('rejects a path that is not there rather than registering an empty database', function () {
+		const before = Object.keys(databases).length;
+		assert.throws(() => openBranchDatabase(join(checkpointDir, 'nope'), 'branchbase', 'x'), /no directory at/);
+		assert.strictEqual(Object.keys(databases).length, before);
+	});
+});

--- a/unitTests/resources/databases.test.js
+++ b/unitTests/resources/databases.test.js
@@ -262,8 +262,6 @@ describe('openBranchDatabase (scope-private graph, harper#643)', () => {
 
 	it('refuses to adopt a directory that is already open as a real database', function () {
 		const basePath = databases.branchbase.BranchSource.primaryStore.rootStore.path;
-		// Its store is shared and closed by closeLoadedDatabases; adopting it would make this handle's
-		// close() tear down a live database.
 		assert.throws(() => openBranchDatabase(basePath, 'branchbase', 'appB__branchbase'), /already open as a database/);
 	});
 
@@ -277,8 +275,6 @@ describe('openBranchDatabase (scope-private graph, harper#643)', () => {
 		await databases.branchbase.BranchSource.primaryStore.rootStore.createCheckpoint(secondDir);
 		openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
 
-		// blob file ids restart from each store's own checkpointed counter, so a shared identity is
-		// not merely a shared directory: the two branches generate the same paths and truncate each other
 		assert.throws(() => openBranchDatabase(secondDir, 'branchbase', 'appA__branchbase'), /already in use/);
 	});
 
@@ -321,8 +317,6 @@ describe('openBranchDatabase (scope-private graph, harper#643)', () => {
 
 		branch.close();
 
-		// a per-table column family left open keeps the process-global refCount above zero, which is
-		// what distinguishes a released handle from a leaked one
 		assert.strictEqual(refCountFor(branchPath), 0, 'close() must release every column family it opened');
 	});
 
@@ -334,8 +328,6 @@ describe('openBranchDatabase (scope-private graph, harper#643)', () => {
 	});
 
 	it('a stale handle closed twice does not tear down a later open of the same directory', function () {
-		// the point of the re-close guard is not that closing twice throws — it is that the second
-		// call is keyed by path, so without it a discarded handle deregisters whoever holds the path now
 		const stale = openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
 		stale.close();
 		const live = openBranchDatabase(checkpointDir, 'branchbase', 'appA__branchbase');
@@ -358,8 +350,6 @@ describe('openBranchDatabase (scope-private graph, harper#643)', () => {
 
 		branch.close();
 
-		// databasePaths is a strong Map keyed by the store, so an entry left behind pins the closed
-		// store for the life of the process and grows with branch churn
 		assert.ok(!databasePaths.has(branch.rootStore), 'close() must drop the memoized blob roots');
 	});
 
@@ -413,8 +403,6 @@ describe('openBranchDatabase (scope-private graph, harper#643)', () => {
 			queried.length = 0;
 			await runReclamationHandlers();
 
-			// registration is process-global and keyed by path, and its closure pins the closed store,
-			// so an open/close cycle that leaves it behind grows unboundedly with branch churn
 			assert.ok(!queried.includes(branchPath), 'close() must drop the handler pinning the closed store');
 		} finally {
 			setAvailableSpaceRatioGetter();
@@ -425,6 +413,8 @@ describe('openBranchDatabase (scope-private graph, harper#643)', () => {
 		assert.throws(() => openBranchDatabase(checkpointDir, 'branchbase', '..'), /not a legal database name/);
 		assert.throws(() => openBranchDatabase(checkpointDir, 'branchbase', 'a/b'), /not a legal database name/);
 		assert.throws(() => openBranchDatabase(checkpointDir, 'branchbase', ''), /not a legal database name/);
+		// otherwise this surfaces as ENAMETOOLONG from a blob write, far from the call that caused it
+		assert.throws(() => openBranchDatabase(checkpointDir, 'branchbase', 'x'.repeat(251)), /not a legal database name/);
 	});
 
 	it('rejects a path that is not there rather than registering an empty database', function () {


### PR DESCRIPTION
Branched databases (#642) need a database whose Table classes are reachable **only** through the application scope that asked for it. Registering one in the process-global `databases` map and asking every consumer to skip it does not work: that map is walked by analytics (`storeDBSizeMetrics`), by `describe_all` (`schemaDescribe`), and by worker teardown (`closeLoadedDatabases`), and Pro walks it too. A skip list is a rule each future enumerator has to remember, and the one that forgets leaks a branch into a customer's metrics or a describe response.

So [`initStores` takes a **destination**](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R713) instead. With one it builds into the caller's object, seeds that object's defined-tables bookkeeping, emits no global `updateTable`, and replays the transaction log into that same graph. Without one, every existing path behaves exactly as before. `openBranchDatabase(path, databaseName, storeName)` is the narrow entry point on top, returning a closeable handle.

This is the storage-side opener only — **nothing calls it yet.** The config, scope wiring, and lifecycle that expose a branch to application code are the rest of #643.

Refs #643.

## For the human reviewer

Reviewing this at the level of "is the mechanism sound" is the right frame; there is no consumer to judge it against. The three items below are open decisions, not defects I chose not to fix — each is a #643 layout or contract question rather than a local edit, and each is stated in the opener's docstring so a first caller cannot miss it.

1. **Branch ownership is process-local, so the scan window is not fully closed** (`persistent-branch-ownership`). [`isOpenBranchPath`](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1046) keeps `getDatabases()` out of a branch **while a handle is open**, and the same guard now covers the [on-demand `database()` open](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1342). It does not cover the before-first-open or after-crash cases: a branch directory left inside the scanned root by a SIGKILLed worker loads as an ordinary, globally-enumerated database at the next boot. I tried moving the ownership claim ahead of the `getDatabases()` inside the open, which closes that window — and reverted it, because a claim taken before the scan also means a directory that genuinely **is** a real database stops reading as one, so `openBranchDatabase` would succeed over it and that database would vanish from the thread. The durable fix is an on-disk marker (the way the scan already skips `MIGRATING_DIR_SUFFIX` and `RESTORE_META_DIR`) or a branch path outside the scanned root — both are #643 §3 layout decisions. The reasoning is [recorded at the guard it constrains](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1108).
2. **What a branch is, exactly** (`branch-replay-contract`). `replayLogs` returns immediately off the main thread, so a branch opened on a worker — the intended consumer — is the checkpoint's SST content and nothing more; its transaction-log tail is silently absent. It is also not awaited, so a `close()` shortly after an open can race a replay still writing. Neither can bite while nothing calls this, and both are contracts callers will build on, so they are stated on the opener rather than papered over. Forcing replay for branches regardless of thread is the alternative and it is a behavior change to a boot-critical routine.
3. **Ships with schema mutation unsafe** (`schema-mutation-exposure`). A branch's Table classes carry the base's logical name, so a `dropTable()` through one resolves against the global schema and would delete the live base Table class. Kris's call was to gate it in the scope-wiring PR *before any caller exists*; it is in the docstring and on #643. If you would rather see a branch flag rejecting DDL here, that is cheaper now than after callers exist.

Two smaller judgment calls, for completeness: `removeStorageReclamation(path)` drops every handler registered for a path, which is safe only because the guards keep a branch path from also being a loaded database; and `closeDatabase` has the same reclamation/`databasePaths` pins that `closeBranchHandles` now releases, left alone as pre-existing and out of this diff's scope.

## What changed since the first review round

Four rounds of independent review (Codex, Gemini, Cursor Composer, Harper domain) plus the CI bots landed these:

- **Two branches could claim one store identity.** `storeName` was checked against real database names only. Blob file ids restart from each store's own checkpointed counter, so two branches sharing an identity do not merely share a directory — they generate identical file paths and truncate each other. [Live identities are now reserved](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1038).
- **A stale handle's second `close()` tore down its successor.** The re-close guard was `if (!openBranches.delete(path)) return` — keyed by path, and a closed branch frees its path, so a discarded handle deregistered whichever branch owned the path by then, dropping the live one out of `rocksdbDatabaseEnvs` and removing its reclamation handler while its RocksDB handles stayed open. [Now keyed to the handle](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1134). Found by writing the mutation-killing teardown test the review asked for.
- **The partial-open leak this PR previously recorded as a residual is closed.** `initStores` opens a table's column families well before `setTable` publishes it, so cleanup that walked the graph could not see them. It now [appends every column family it opens](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R910) to a caller-supplied list — recorded before the wrapper that could throw — and the branch [releases that list](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1184) on failure and on close, replacing the graph walk entirely.
- **`close()` left two process-global registrations behind:** a storage-reclamation handler pinning the closed store, and the memoized blob roots in `blob.ts`'s `databasePaths`. `onStorageReclamation` gains `removeStorageReclamation`, and both are released.
- **`closeBranchDatabases()` had no caller,** so a branch open on a job worker leaked process-wide on exit. [`closeLoadedDatabases` runs it](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1555).
- **A tableless branch never got its identity stamped,** so its blob roots resolved through `join(undefined, …)`. The stamp [moved to the top of `initStores`](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R713), which fixes it for a tableless real database too.
- **`storeName` lands in a filesystem path** and was unvalidated; it is now checked for shape and [length](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1066) against the same rules every other database name obeys.
- **`isOpenBranchPath` resolved the realpath before consulting the map** and returned false when that threw, so a directory unlinked under a live handle read as unowned while `rocksdbDatabaseEnvs` still held the branch store under that literal key.
- **The doc claimed "row reads and writes are fine".** Not true of a row whose blob predates the checkpoint: a branch's blob roots start empty until #644 links the base tree in.

## Verification

Suites: `databases.test.js`, `closeLoadedDatabases.test.js`, `caching-rocks-database.test.js`. Full `test:unit:resources` gate: **1690 passing, 16 pending, 3 failing** — the three failures (`randomAccessFields` ×2, `replayStructures`) reproduce unchanged on `origin/main`'s own copies of those files and are untouched by this diff. `test:unit:main` cannot complete on this machine: it dies at load reading a stale `system.mdb` in a shared local hdb root, identically with and without this change. `tsc --noEmit`, `lint:required`, prettier clean. Relying on CI for both full gates.

Teardown claims are proved against `registryStatus().refCount` — the process-global count only drops to zero once every column family under a path is closed — and each new case was mutation-checked: [column-family release](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-d89a878c46959d4e1a9364b6009ecf89d8ca08cc125e71357911283edce9b0ef R313), [`databasePaths` cleanup](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-d89a878c46959d4e1a9364b6009ecf89d8ca08cc125e71357911283edce9b0efR345), reclamation deregistration, the scan skip, the [identity collision](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-d89a878c46959d4e1a9364b6009ecf89d8ca08cc125e71357911283edce9b0efR272), the [`database()` refusal](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-d89a878c46959d4e1a9364b6009ecf89d8ca08cc125e71357911283edce9b0efR293), and the [stale-handle re-close](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-d89a878c46959d4e1a9364b6009ecf89d8ca08cc125e71357911283edce9b0efR330) each fail with their behavior removed. A [write through the branch](https://github.com/HarperFast/harper/pull/2285/changes?w=1#diff-d89a878c46959d4e1a9364b6009ecf89d8ca08cc125e71357911283edce9b0efR281) is now asserted not to reach the base table.

The partial-open release has **no permanent test**: `initStores` has no fault-injection seam. It was verified with a throw injected immediately after a primary store opens — the registry refCount for the branch path returns to 0 with the release and stays at 2 without it — and the injection removed rather than shipped as a stub.

End-to-end route: **not observable end-to-end in this PR** — nothing calls the opener, so the integration proof lands with the scope wiring in #643.

Complexity: medium

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=4 @ 08e0674331ca</sub>

<sub>Human-Review-Need: 4 @ 08e0674331ca</sub>
