### PR TITLE
Keep a node bootable when threads.maxHeapMemory is set below what a worker can start on

### DIFF
--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -25,6 +25,7 @@ import { PACKAGE_ROOT } from '../utility/packageUtils.js';
 import * as env from '../utility/environment/environmentManager.ts';
 import { applyRuntimeEnvConfig, hasPersistedEnvConfigState } from './harperConfigEnvVars.ts';
 import { warnComponentEnvConfigVars, resolveConfiguredPath } from './componentEnvPrepass.ts';
+import { isStartableThreadHeapMemory } from '../server/threads/threadHeapMemory.ts';
 
 const { DATABASES_PARAM_CONFIG, CONFIG_PARAMS, CONFIG_PARAM_MAP } = hdbTerms;
 const UNINIT_GET_CONFIG_ERR = 'Unable to get config value because config is uninitialized';
@@ -1082,6 +1083,43 @@ export function getConfiguration() {
 	return configDoc.toJSON();
 }
 
+// `set_configuration` is the one config writer that also fans out (`replicated: true`), so a value
+// accepted here lands on every peer at once and the next rolling restart takes the whole cluster
+// down together (harper-pro#558). Boot-time writers are deliberately not gated the same way: config
+// that already exists has to stay bootable, so it is recovered at the point of use instead
+// (server/threads/threadHeapMemory.ts).
+function assertThreadHeapMemoryStartable(configFields) {
+	for (const field in configFields) {
+		const configParam = CONFIG_PARAM_MAP[field.toLowerCase()];
+		let configured;
+		if (configParam === CONFIG_PARAMS.THREADS_MAXHEAPMEMORY) configured = configFields[field];
+		else if (configParam === CONFIG_PARAMS.THREADS) configured = readSectionHeapMemory(configFields[field]);
+		else continue;
+		const value = castConfigValue(CONFIG_PARAMS.THREADS_MAXHEAPMEMORY, configured);
+		if (typeof value !== 'number' || isStartableThreadHeapMemory(value)) continue;
+		throw handleHDBError(
+			new Error(),
+			HDB_ERROR_MSGS.CONFIG_VALIDATION(
+				`'threads.maxHeapMemory' must be greater than or equal to ${hdbTerms.MIN_THREAD_HEAP_MEMORY_MB}`
+			),
+			HTTP_STATUS_CODES.BAD_REQUEST,
+			undefined,
+			undefined,
+			true
+		);
+	}
+}
+
+// A whole `threads` section reaches the same config key, and `threads` canonicalizes to itself
+// rather than to `threads_count`. It arrives either as an object or as the JSON string
+// castConfigValue parses, and flattenConfig lowercases every key on the way back out, so the nested
+// name has to be matched the same way the top-level one is.
+function readSectionHeapMemory(section) {
+	const parsed = castConfigValue(CONFIG_PARAMS.THREADS, section);
+	if (!hdbUtils.isObject(parsed)) return undefined;
+	for (const key in parsed) if (key.toLowerCase() === 'maxheapmemory') return parsed[key];
+}
+
 /**
  * Set Configuration - this function sets new configuration
  * @param setConfigJson
@@ -1121,6 +1159,7 @@ export async function setConfiguration(setConfigJson) {
 			true
 		);
 	}
+	assertThreadHeapMemoryStartable(configFields);
 	try {
 		updateConfigValue(undefined, undefined, configFields, true);
 		if (replicated) {

--- a/integrationTests/apiTests/configuration.test.mjs
+++ b/integrationTests/apiTests/configuration.test.mjs
@@ -6,6 +6,7 @@
  * - `get_configuration` shape (key sections present)
  * - `read_log` shape
  * - `set_configuration` round-trip and bad-data rejection
+ * - `set_configuration` rejects a `threads.maxHeapMemory` no worker thread could start on
  * - Non-superuser role cannot call `get_configuration` (403)
  *
  * Self-contained setup: creates the `dev` schema and an `AttributeDropTest`
@@ -18,11 +19,16 @@ import assert from 'node:assert';
 import request from 'supertest';
 import { startHarper, teardownHarper } from '@harperfast/integration-testing';
 import { createApiClient } from './utils/client.mjs';
+import { MIN_THREAD_HEAP_MEMORY_MB } from '../../utility/hdbTerms.ts';
 
 const SCHEMA = 'dev';
 const ATTR_TEST_TABLE = 'create_attr_test';
 const DROP_ATTR_TABLE = 'AttributeDropTest';
 const SCHEMALESS_TABLE = 'MqttRetained';
+
+const MIN_HEAP_ERROR = new RegExp(
+	`'threads\\.maxHeapMemory' must be greater than or equal to ${MIN_THREAD_HEAP_MEMORY_MB}`
+);
 
 const TEST_ROLE = 'test_dev_role';
 const TEST_USER = 'test_user';
@@ -375,6 +381,51 @@ suite('Configuration', (ctx) => {
 				assert.equal(r.body.logging.rotation.maxSize, '14M', r.text);
 				assert.equal(r.body.replicated, undefined, r.text);
 			})
+			.expect(200);
+	});
+
+	// ── boot-critical values (harper-pro#558) ───────────────────────────────
+
+	test('set_configuration rejects an unstartable threads.maxHeapMemory with 400', async () => {
+		await client
+			.req()
+			.send({ operation: 'set_configuration', threads_maxHeapMemory: 1 })
+			.expect((r) => assert.match(r.body.error ?? '', MIN_HEAP_ERROR, r.text))
+			.expect(400);
+	});
+
+	test('the rejected threads.maxHeapMemory never reaches configuration', async () => {
+		await client
+			.req()
+			.send({ operation: 'get_configuration' })
+			.expect((r) => assert.notEqual(r.body.threads?.maxHeapMemory, 1, r.text))
+			.expect(200);
+	});
+
+	test('set_configuration rejects the whole-section spellings of the same write', async () => {
+		for (const threads of [{ count: 4, maxHeapMemory: 1 }, { maxheapmemory: 8 }, '{"maxHeapMemory":8}']) {
+			await client
+				.req()
+				.send({ operation: 'set_configuration', threads })
+				.expect((r) => assert.match(r.body.error ?? '', MIN_HEAP_ERROR, r.text))
+				.expect(400);
+		}
+		await client
+			.req()
+			.send({ operation: 'get_configuration' })
+			.expect((r) => assert.equal(r.body.threads.maxHeapMemory, undefined, r.text))
+			.expect(200);
+	});
+
+	test('set_configuration accepts threads.maxHeapMemory at the minimum', async () => {
+		await client
+			.req()
+			.send({ operation: 'set_configuration', threads_maxHeapMemory: MIN_THREAD_HEAP_MEMORY_MB })
+			.expect(200);
+		await client
+			.req()
+			.send({ operation: 'get_configuration' })
+			.expect((r) => assert.equal(r.body.threads.maxHeapMemory, MIN_THREAD_HEAP_MEMORY_MB, r.text))
 			.expect(200);
 	});
 

--- a/integrationTests/server/thread-heap-memory-recovery.test.ts
+++ b/integrationTests/server/thread-heap-memory-recovery.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression test for harper-pro#558.
+ *
+ * `threads.maxHeapMemory` is passed straight to `worker_threads` as `maxOldGenerationSizeMb`.
+ * A value of 1 passes config validation (`number.min(0)`) but leaves V8 unable to finish snapshot
+ * deserialization, and Node aborts the whole process from `v8::Isolate::Initialize` — an
+ * uncatchable native abort, not a JS error, so no restart or error handler can contain it. Because
+ * `set_configuration` fans that value out to every peer with `replicated: true`, one accepted write
+ * bricked every node in the cluster on the next rolling restart, with no healthy peer to recover
+ * from.
+ *
+ * Config already on disk is an untrusted boot input, so Harper must start on it anyway. This test
+ * boots with the poisoned value persisted and asserts Harper comes up and serves the operations
+ * API. It has to run in its own process: on the unfixed code the failure kills the parent.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { startHarper, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+import { MIN_THREAD_HEAP_MEMORY_MB } from '../../utility/hdbTerms.ts';
+
+const RECOVERY_LOG = /Ignoring threads\.maxHeapMemory/;
+
+async function waitForLogMatch(logDir: string, pattern: RegExp, timeoutMs = 15_000): Promise<string> {
+	const logFile = join(logDir, 'hdb.log');
+	const deadline = Date.now() + timeoutMs;
+	let contents = '';
+	while (Date.now() < deadline) {
+		try {
+			contents = await readFile(logFile, 'utf8');
+			if (pattern.test(contents)) return contents;
+		} catch {
+			/* not written yet */
+		}
+		await sleep(200);
+	}
+	return contents;
+}
+
+suite('Harper boots on a threads.maxHeapMemory no worker thread could start on', (ctx: ContextWithHarper) => {
+	before(async () => {
+		await startHarper(ctx, { config: { threads: { count: 1, maxHeapMemory: 1 } }, env: {} });
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('the process survives worker startup', () => {
+		ok(ctx.harper.process && ctx.harper.process.exitCode === null, 'Harper process should be running');
+	});
+
+	test('the operations API serves traffic', async () => {
+		const res = await fetch(`${ctx.harper.operationsAPIURL}/health`);
+		strictEqual(res.status, 200);
+	});
+
+	test('the displaced value is reported', async () => {
+		const logDir = ctx.harper.logDir ?? join(ctx.harper.dataRootDir, 'log');
+		const contents = await waitForLogMatch(logDir, RECOVERY_LOG);
+		ok(RECOVERY_LOG.test(contents), `expected a recovery warning; got:\n${contents.slice(-2000)}`);
+	});
+});
+
+// The accepted boundary is the one number the guard hinges on, so prove a worker actually completes
+// startup there rather than only that an isolate initializes. Measured floor for a bare worker is
+// between 48 (fails) and 56 (serves).
+suite('Harper boots at the accepted threads.maxHeapMemory minimum', (ctx: ContextWithHarper) => {
+	before(async () => {
+		await startHarper(ctx, {
+			config: { threads: { count: 1, maxHeapMemory: MIN_THREAD_HEAP_MEMORY_MB } },
+			env: {},
+		});
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('the operations API serves traffic on the configured minimum', async () => {
+		const res = await fetch(`${ctx.harper.operationsAPIURL}/health`);
+		strictEqual(res.status, 200);
+	});
+
+	test('the configured minimum is honored, not displaced', async () => {
+		const logDir = ctx.harper.logDir ?? join(ctx.harper.dataRootDir, 'log');
+		const contents = await waitForLogMatch(logDir, RECOVERY_LOG, 2000);
+		ok(!RECOVERY_LOG.test(contents), 'a value at the minimum must not trigger recovery');
+	});
+});

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -21,6 +21,7 @@ const { randomBytes } = require('crypto');
 const { _assignPackageExport } = require('../../globals.js');
 const { PACKAGE_ROOT } = require('../../utility/packageUtils.js');
 const { resolvePreloadModules } = require('./resolvePreload.ts');
+const { resolveThreadHeapMemoryMb } = require('./threadHeapMemory.ts');
 const { getConfigPath } = require('../../config/configUtils.ts');
 let importModules;
 function getImportModules() {
@@ -338,7 +339,7 @@ function startWorker(path, options = {}) {
 	// and lower than total memory
 	availableMemory = Math.min(availableMemory, totalmem(), 20000 * MB);
 	const maxOldMemory =
-		envMgr.get(hdbTerms.CONFIG_PARAMS.THREADS_MAXHEAPMEMORY) ??
+		resolveThreadHeapMemoryMb(envMgr.get(hdbTerms.CONFIG_PARAMS.THREADS_MAXHEAPMEMORY)) ??
 		Math.max(Math.floor(availableMemory / MB / (10 + (options.threadCount || 1) / 4)), 512);
 	// Max young memory space (semi-space for scavenger) is 1/128 of max memory (limited to 16-64). For most of our m5
 	// machines this will be 64MB (less for t3's). This is based on recommendations from:

--- a/server/threads/threadHeapMemory.ts
+++ b/server/threads/threadHeapMemory.ts
@@ -18,7 +18,7 @@ export function resolveThreadHeapMemoryMb(configured: unknown): number | undefin
 	if (isStartableThreadHeapMemory(configuredMb)) return configuredMb;
 	if (!recoveryWarned) {
 		recoveryWarned = true;
-		harperLogger.warn(
+		harperLogger.error(
 			`Ignoring threads.maxHeapMemory: ${JSON.stringify(configured)} is below the ${MIN_THREAD_HEAP_MEMORY_MB}MB a worker thread can start on. Using the default instead; replace the configured value before downgrading.`
 		);
 	}

--- a/server/threads/threadHeapMemory.ts
+++ b/server/threads/threadHeapMemory.ts
@@ -1,0 +1,26 @@
+import harperLogger from '../../utility/logging/harper_logger.ts';
+import { MIN_THREAD_HEAP_MEMORY_MB } from '../../utility/hdbTerms.ts';
+
+let recoveryWarned = false;
+
+export function isStartableThreadHeapMemory(configuredMb: unknown): boolean {
+	return Number.isFinite(configuredMb) && (configuredMb as number) >= MIN_THREAD_HEAP_MEMORY_MB;
+}
+
+// Below the minimum, Node aborts the whole process from v8::Isolate::Initialize before any
+// JavaScript runs, so this has to be caught ahead of startWorker — no error handler downstream can
+// contain it. The value on disk is an untrusted boot input (replicated, env var, hand edit, older
+// peer), so an unstartable one falls back to the caller's computed default rather than stopping the
+// node.
+export function resolveThreadHeapMemoryMb(configured: unknown): number | undefined {
+	if (configured == null) return undefined;
+	const configuredMb = Number(configured);
+	if (isStartableThreadHeapMemory(configuredMb)) return configuredMb;
+	if (!recoveryWarned) {
+		recoveryWarned = true;
+		harperLogger.warn(
+			`Ignoring threads.maxHeapMemory: ${JSON.stringify(configured)} is below the ${MIN_THREAD_HEAP_MEMORY_MB}MB a worker thread can start on. Using the default instead; replace the configured value before downgrading.`
+		);
+	}
+	return undefined;
+}

--- a/unitTests/config/setConfigurationThreadHeap.test.js
+++ b/unitTests/config/setConfigurationThreadHeap.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const assert = require('node:assert');
+
+const { setConfiguration } = require('#src/config/configUtils');
+const { MIN_THREAD_HEAP_MEMORY_MB } = require('#src/utility/hdbTerms');
+const { server } = require('#src/server/Server');
+
+describe('set_configuration threads.maxHeapMemory rejection', () => {
+	const EXPECTED = new RegExp(
+		`'threads\\.maxHeapMemory' must be greater than or equal to ${MIN_THREAD_HEAP_MEMORY_MB}`
+	);
+	let fanOutCalls;
+	let originalReplicateOperation;
+
+	// Recording the fan-out is what makes these ordering assertions rather than error assertions:
+	// moving the guard below the local write would still throw, but would already have persisted
+	// the value and pushed it to every peer.
+	beforeEach(() => {
+		fanOutCalls = 0;
+		originalReplicateOperation = server.replication?.replicateOperation;
+		if (server.replication)
+			server.replication.replicateOperation = async () => {
+				fanOutCalls++;
+				return { message: '' };
+			};
+	});
+
+	afterEach(() => {
+		if (server.replication) server.replication.replicateOperation = originalReplicateOperation;
+	});
+
+	it('rejects a below-minimum value with a 400', async () => {
+		await assert.rejects(setConfiguration({ operation: 'set_configuration', threads_maxHeapMemory: 1 }), (error) => {
+			assert.match(error.message, EXPECTED);
+			assert.strictEqual(error.statusCode ?? error.status, 400);
+			return true;
+		});
+	});
+
+	it('rejects the numeric-string spelling after casting', async () => {
+		await assert.rejects(setConfiguration({ operation: 'set_configuration', threads_maxHeapMemory: '8' }), EXPECTED);
+	});
+
+	it('rejects zero, which V8 normalizes to an unstartable limit rather than treating as unset', async () => {
+		await assert.rejects(setConfiguration({ operation: 'set_configuration', threads_maxHeapMemory: 0 }), EXPECTED);
+	});
+
+	it('rejects the whole-section spelling, which reaches the same config key', async () => {
+		await assert.rejects(
+			setConfiguration({ operation: 'set_configuration', threads: { count: 4, maxHeapMemory: 1 } }),
+			EXPECTED
+		);
+	});
+
+	it('rejects the section spelling with a lower-cased nested key', async () => {
+		await assert.rejects(setConfiguration({ operation: 'set_configuration', threads: { maxheapmemory: 8 } }), EXPECTED);
+	});
+
+	it('rejects the section spelling sent as a JSON string', async () => {
+		await assert.rejects(
+			setConfiguration({ operation: 'set_configuration', threads: '{"maxHeapMemory":8}' }),
+			EXPECTED
+		);
+	});
+
+	it('rejects before fan-out, so no peer ever receives the value', async () => {
+		await assert.rejects(
+			setConfiguration({ operation: 'set_configuration', threads_maxHeapMemory: 1, replicated: true }),
+			EXPECTED
+		);
+		assert.strictEqual(fanOutCalls, 0);
+	});
+
+	it('rejects the replicated whole-section spelling before fan-out too', async () => {
+		await assert.rejects(
+			setConfiguration({ operation: 'set_configuration', threads: { maxHeapMemory: 0 }, replicated: true }),
+			EXPECTED
+		);
+		assert.strictEqual(fanOutCalls, 0);
+	});
+});

--- a/unitTests/server/threads/threadHeapMemory.test.js
+++ b/unitTests/server/threads/threadHeapMemory.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const assert = require('node:assert');
+
+const { resolveThreadHeapMemoryMb, isStartableThreadHeapMemory } = require('#src/server/threads/threadHeapMemory');
+const { MIN_THREAD_HEAP_MEMORY_MB } = require('#src/utility/hdbTerms');
+
+describe('resolveThreadHeapMemoryMb', () => {
+	it('returns undefined when unconfigured, so the caller computes its default', () => {
+		assert.strictEqual(resolveThreadHeapMemoryMb(undefined), undefined);
+		assert.strictEqual(resolveThreadHeapMemoryMb(null), undefined);
+	});
+
+	it('honors a configured value at or above the minimum', () => {
+		assert.strictEqual(resolveThreadHeapMemoryMb(MIN_THREAD_HEAP_MEMORY_MB), MIN_THREAD_HEAP_MEMORY_MB);
+		assert.strictEqual(resolveThreadHeapMemoryMb(300), 300);
+		assert.strictEqual(resolveThreadHeapMemoryMb('300'), 300);
+	});
+
+	it('recovers to the computed default for a value below the minimum', () => {
+		assert.strictEqual(resolveThreadHeapMemoryMb(1), undefined);
+		assert.strictEqual(resolveThreadHeapMemoryMb(0), undefined);
+		assert.strictEqual(resolveThreadHeapMemoryMb(-1), undefined);
+		assert.strictEqual(resolveThreadHeapMemoryMb(MIN_THREAD_HEAP_MEMORY_MB - 1), undefined);
+		assert.strictEqual(resolveThreadHeapMemoryMb('1'), undefined);
+	});
+
+	it('recovers to the computed default for a non-numeric value', () => {
+		assert.strictEqual(resolveThreadHeapMemoryMb('lots'), undefined);
+		assert.strictEqual(resolveThreadHeapMemoryMb({}), undefined);
+		assert.strictEqual(resolveThreadHeapMemoryMb(NaN), undefined);
+		assert.strictEqual(resolveThreadHeapMemoryMb(Infinity), undefined);
+	});
+});
+
+describe('isStartableThreadHeapMemory', () => {
+	it('accepts only finite numbers at or above the minimum', () => {
+		assert.strictEqual(isStartableThreadHeapMemory(MIN_THREAD_HEAP_MEMORY_MB), true);
+		assert.strictEqual(isStartableThreadHeapMemory(MIN_THREAD_HEAP_MEMORY_MB - 1), false);
+		assert.strictEqual(isStartableThreadHeapMemory(0), false);
+		assert.strictEqual(isStartableThreadHeapMemory(-1), false);
+		assert.strictEqual(isStartableThreadHeapMemory(Infinity), false);
+		assert.strictEqual(isStartableThreadHeapMemory(NaN), false);
+		assert.strictEqual(isStartableThreadHeapMemory('300'), false);
+	});
+});

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -155,6 +155,9 @@ export const MAX_SET_TIMEOUT_MS = 2147483647;
 /** Harper File Permissions Mode */
 export const HDB_FILE_PERMISSIONS = 0o700;
 
+/** Smallest `threads.maxHeapMemory` (MB) a worker thread is accepted on — see server/threads/threadHeapMemory.ts */
+export const MIN_THREAD_HEAP_MEMORY_MB = 64;
+
 /** Database directory */
 export const DATABASES_DIR_NAME = 'database';
 /** Suffix for in-progress LMDB→RocksDB migration staging directories: excluded from database


### PR DESCRIPTION
`set_configuration { threads_maxHeapMemory: 1, replicated: true }` returned 200 and fanned that
value out to every peer. `threads.maxHeapMemory` becomes a worker's `maxOldGenerationSizeMb`, and a
few MB below the minimum leaves V8 unable to finish deserializing its startup snapshot — Node
aborts the whole process from `v8::Isolate::Initialize`, an uncatchable native abort rather than a
JS error, so no restart path or error handler can contain it. The next rolling restart therefore
took down every node in the cluster at once, with no healthy peer to recover from. Reported as
HarperFast/harper-pro#558.

The only validation in the path was Joi's `number.min(0)`, and origin and every peer run the
identical validator, so whatever passed locally passed everywhere.

Measured on Node 26.2.0, one worker per row, with `maxYoungGenerationSizeMb` derived exactly as
`startWorker` derives it:

| `maxOldGenerationSizeMb` | outcome |
| --- | --- |
| 0, 1, 2 | process-level fatal abort — the brick |
| 3–8 | catchable `Worker terminated due to reaching memory limit` |
| 16+ | isolate initializes; loads a four-module graph with ~14MB used |

## The change

**Boot recovers where an administrative write rejects.**

Config already on disk is an untrusted boot input — it arrives from a replicated
`set_configuration`, an env var, a hand-edited `harperdb-config.yaml`, or an older peer in a
mixed-version cluster — so refusing to start on it just trades one cluster-wide outage for another.
`resolveThreadHeapMemoryMb` resolves an unstartable value to the caller's computed default and
warns once per process. Explicit `0` is included: V8 normalizes it to a ~2MB limit and aborts, so it
is not a harmless "unset" sentinel here.

The 64MB minimum is measured, not assumed. Booting a real Harper (`threads.count: 1`, no components)
through the integration harness:

| `threads.maxHeapMemory` | outcome |
| --- | --- |
| 32, 40, 48 | worker never completes startup |
| 56, 64, 96, 128, 192, 256 | boots; ops API serves |

So the floor sits just above where a worker can actually *run*, not merely where an isolate
initializes — an "isolate-initializes" floor around 16 would still have accepted values like 20 that
kill every worker in a bounded restart loop and leave the node workerless, which is the same outage
by a slower route. Values at or above the floor are honored exactly, so a deliberately memory-capped
deployment keeps the ceiling it configured.

`set_configuration` is the one writer that also fans out, so it rejects a below-minimum value with a
400 *before* the local write and before `replicateOperation` — the value never persists and no peer
is contacted. Every accepted spelling is covered: the flat `threads_maxHeapMemory` key, and the whole-section
`threads` object — which canonicalizes to itself rather than to `threads_count`, arrives either as an
object or as the JSON string `castConfigValue` parses, and has its keys lowercased by
`flattenConfig`, so the nested name is matched the same way the top-level one is.

Boot-time writers deliberately do not share that gate: `bin/run.ts` feeds env/CLI overrides through
`updateConfigValue` during startup, where a throw reaches `main`'s catch and `process.exit(1)`
before threads ever start.

## Verification

Route (b), a new integration test, plus a route (a) extension of the existing one.

- `integrationTests/server/thread-heap-memory-recovery.test.ts` — two cold boots. With
  `threads.maxHeapMemory: 1` persisted: the process survives worker startup, `/health` answers 200,
  and the recovery warning is logged. At the accepted minimum: `/health` answers 200 and no recovery
  warning fires, so the boundary itself is proven end-to-end rather than assumed. Process-isolated
  because on base the failure kills the parent. **5/5 pass.**
- `integrationTests/apiTests/configuration.test.mjs` — both spellings rejected with 400, the value
  never reaches `get_configuration`, and the configured minimum is accepted. **30/30 pass.**
- `unitTests/server/threads/threadHeapMemory.test.js` — boundaries: absent, 0, 1, floor−1, floor,
  above, numeric-string, non-numeric, Infinity.
- `unitTests/config/setConfigurationThreadHeap.test.js` — rejection with a 400, the numeric-string
  spelling, explicit 0, all three whole-section spellings (object, lower-cased nested key, JSON
  string), and — by recording `server.replication.replicateOperation` — that fan-out is never
  reached. The API integration test's non-persistence check proves the guard also precedes the local write.
- Full unit gate (`test:unit:main` equivalent): **4792 passing**, 25 failing — the identical 25 fail
  on `origin/main` in this worktree (logging/componentLoader/spawn-isolation tests that need a real
  local install). Base run for comparison: 4779 passing, same 25 failing.
- fails-on-base: the new unit tests were run against the base commit and fail there with the
  expected signatures — `resolveThreadHeapMemoryMb` absent, and `setConfiguration` accepting
  `threads_maxHeapMemory: 1` past the guard.

## For the human reviewer

Three review rounds; the first two changed the design. The framing that shipped is the reviewers', not
my original note's.

**Planning review** returned `better-alternative-exists`, adopted before any code was written: the
rejection moved out of `updateConfigValue` (its `bin/run.ts` boot caller would have turned an
env-configured bad value into a permanent startup failure — the exact outage this prevents);
recovery targets the computed default rather than the floor; and a generic `param → floor` table was
dropped as premature.

**Code review**, three rounds. The first two ran codex + gemini + cursor-composer + harper-domain;
the current-head receipt reran codex + gemini + harper-domain after the Cursor round cap. Round 1
raised two majors, both real:
- the whole-section `threads` write walked past the guard — `CONFIG_PARAM_MAP['threads']` resolves to
  `'threads'`, because the dynamic loop in `hdbTerms.ts` overwrites the `threads → threads_count`
  alias. Verified directly against the built terms before fixing.
- a floor of 64 was said to silently replace deliberate 4–63MB settings with ≥512MB. I lowered it to
  16 on that basis.

Round 2 then found the 16MB floor still accepted worker-killing values (`maxHeapMemory: 20` boots an
isolate but no worker), and that the boundary had no evidence behind it. Rather than pick a third
number, I measured it — the table above. That refutes round 1's premise as well: there is no working
4–63MB deployment to displace, because a Harper worker cannot start below ~56MB. Round 2's remaining
minors are fixed too: the case-insensitive and JSON-string section spellings, a non-persistence
assertion for the section path, and the hardcoded floor in the API tests now deriving from the
constant.

Round 3 found no production correctness, performance, crash-safety, or security defect. It noted
that the unit fan-out spy alone would not catch a guard moved between persistence and replication;
the integration non-persistence assertion is the actual ordering proof. It also kept the 64MB floor
as a human judgment because it is platform-measured rather than failure-detected. No code was changed
for those non-blocking observations during the CI-fix dispatch.

Open decisions worth a human call:
- `heap-floor-value` — 64 is the measured floor for a *bare* worker on this runtime. An app with
  large components or an APM preload needs more; the floor is an anti-brick guard, not a sizing
  recommendation.
- `recover-vs-refuse-at-boot` — recovery does not rewrite the poisoned value, so `get_configuration`
  keeps reporting a number no worker is using. The warning says to replace it. Rewriting operator
  config at boot seemed worse than reporting it.
- `guard-layer` — Joi still accepts ≥0 so that existing on-disk config boots; the API floor is 64.
  The layers disagree on "valid" by design, and that gap is what allowed the section-shape bypass.
  Consolidating means giving the schema a boot-path exemption — worth a second opinion.
- Not covered: the boot proof was not run across the Node 22/24/26 matrix or Bun. It runs on CI's
  runtime only.

Rollout: `set_configuration` writes from 0 through 63 change from 200 to 400. An existing config
file holding such a value stays readable and now boots, but the value is still on disk — replace it
before downgrading to a release without this recovery.

<sub>Review-Coverage: authored=claude; ran=gemini,codex; adjudicated=domain; declined=cursor-grok,cursor-composer; rounds=3 @ 1aca47829784</sub>

<sub>Human-Review-Need: 3 (decisions: min-heap-floor-value, reject-vs-clamp-on-set-configuration, boot-fallback-target, guard-layer, replicated-write-guard-scope) @ 1aca47829784</sub>
