### PR TITLE
Assign dependency-bot PRs to a single reviewer

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -24,7 +24,11 @@ jobs:
           reviewers=$(echo "$REVIEWERS_JSON" | jq 'length')
           teams=$(echo "$TEAMS_JSON" | jq 'length')
           if [ "$reviewers" -eq 0 ] && [ "$teams" -eq 0 ]; then
-            echo '["cb1kenobi","heskew","Ethan-Arrowood","kriszyp"]' \
+            case "$PR_AUTHOR" in
+              'renovate[bot]' | 'dependabot[bot]') default_reviewers='["kriszyp"]' ;;
+              *) default_reviewers='["cb1kenobi","heskew","Ethan-Arrowood","kriszyp"]' ;;
+            esac
+            echo "$default_reviewers" \
               | jq --arg author "$PR_AUTHOR" '{"reviewers": [.[] | select(. != $author)]}' \
               | gh api "repos/$REPO/pulls/$PR_NUMBER/requested_reviewers" \
                 --method POST \


### PR DESCRIPTION
Renovate and Dependabot PRs get the same four default reviewers as a feature PR, so a lockfile bump costs four review requests. Bot-authored PRs now default to a single reviewer; human PRs keep the existing set unchanged.

## For the human reviewer

1. **Bot PRs default to @kriszyp alone** (his request — he owns Harper's storage/serialization dependencies), which takes @cb1kenobi, @heskew and @Ethan-Arrowood off dependency PRs. Note these PRs already automerge on green (`"automerge": true` in `renovate.json`), so the request has always been notification rather than a gate. Reversible in one line.
2. **Done in this workflow rather than CODEOWNERS, on purpose.** A `package.json @kriszyp` rule would have GitHub auto-request Kris on *any* PR touching a manifest, and this workflow only posts its defaults when the request list is empty — so a human PR that bumped a dependency alongside source changes would silently get Kris as its only reviewer. The other four repos in this set use CODEOWNERS because they have no such workflow.
3. **`dependabot[bot]` is included though only Renovate runs here**, so a future Dependabot alert PR routes the same way. Drop it if you'd rather not encode a bot that isn't configured.

## Verification

Not observable end-to-end without opening a bot PR, so the branch logic was executed directly against the same shell and `jq` pipeline the workflow runs:

```
renovate[bot]      -> {"reviewers":["kriszyp"]}
dependabot[bot]    -> {"reviewers":["kriszyp"]}
kriszyp            -> {"reviewers":["cb1kenobi","heskew","Ethan-Arrowood"]}
heskew             -> {"reviewers":["cb1kenobi","Ethan-Arrowood","kriszyp"]}
```

The last two confirm human behavior is byte-identical to today, including the existing self-request filter. The file parses as YAML (`yq '.jobs.assign.steps[0].name'` resolves), and the guard, trigger (`pull_request_target` on `opened`/`ready_for_review`) and permissions are untouched.

Complexity: easy

<sub>Review-Coverage: authored=unknown; ran=none; rounds=1 @ baff4e66f58c</sub>

<sub>Human-Review-Need: 4 @ baff4e66f58c</sub>
