### PR TITLE
chore(ci): match main's ai-review-prompts pin on v5.2 so the review gate can run

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@224c2adcfdb408d68c7ca48eb618623c990a96ad # main 2026-07-28 (#80 week-of-07-20 calibration: producing-side guard verification; on 82c9484)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@4b59dc0ddb15aff517884127b58204f79193b4f2 # main 2026-08-20 (#86 reliable review evidence, context, and run binding)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -60,7 +60,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 224c2adcfdb408d68c7ca48eb618623c990a96ad
+      ai-review-prompts-ref: 4b59dc0ddb15aff517884127b58204f79193b4f2
       # CANARY (2026-07-11): run this repo's Claude reviews on Sonnet 5
       # while the fleet default stays claude-sonnet-4-6. Every ai-review-log
       # entry records `Model:`, so calibration can compare sonnet-5 vs

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -52,7 +52,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@224c2adcfdb408d68c7ca48eb618623c990a96ad # main 2026-07-28 (#80 week-of-07-20 calibration: producing-side guard verification; on 82c9484)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@4b59dc0ddb15aff517884127b58204f79193b4f2 # main 2026-08-20 (#86 reliable review evidence, context, and run binding)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -70,7 +70,7 @@ jobs:
       # duplication is unavoidable: reusable workflows can't introspect
       # their own ref (`github.workflow_ref` resolves to the CALLER's
       # ref in workflow_call context), and `uses: …@<ref>` is literal.
-      ai-review-prompts-ref: 224c2adcfdb408d68c7ca48eb618623c990a96ad
+      ai-review-prompts-ref: 4b59dc0ddb15aff517884127b58204f79193b4f2
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -27,9 +27,9 @@ on:
 
 jobs:
   validate:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@224c2adcfdb408d68c7ca48eb618623c990a96ad # main 2026-07-28 (#80 week-of-07-20 calibration: producing-side guard verification; on 82c9484)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@4b59dc0ddb15aff517884127b58204f79193b4f2 # main 2026-08-20 (#86 reliable review evidence, context, and run binding)
     with:
       # Same SHA as the `uses:` ref above — the reusable uses this
       # to check out the validator script at the matching version.
       # Same SHA-twice pattern as the other caller workflows.
-      ai-review-prompts-ref: 224c2adcfdb408d68c7ca48eb618623c990a96ad
+      ai-review-prompts-ref: 4b59dc0ddb15aff517884127b58204f79193b4f2


### PR DESCRIPTION
Restores AI review coverage on the `v5.2` release branch, which has had none since the branch was cut.

## The defect

The Claude GitHub App only exchanges its token when the caller workflow file on the PR's head is **byte-identical** to the copy on the repository's default branch. `v5.2` still pins `ai-review-prompts@224c2ad` (main 2026-07-28) while `main` moved to `@4b59dc0` in [Canary reliable AI review evidence in Harper](https://github.com/HarperFast/harper/pull/2256) on 2026-08-21 — after the `v5.2` cut, and the release branches weren't included in that rollout.

So **every** PR targeting `v5.2` fails token exchange and gets no Claude review. From the `review / review` job on [#2307](https://github.com/HarperFast/harper/pull/2307) ([run 32804942131](https://github.com/HarperFast/harper/actions/runs/32804942131)):

```
App token exchange failed: 401 Unauthorized - Workflow validation failed.
The workflow file must exist and have identical content to the version on
the repository's default branch.
```

Two retries, same 401, then the job failed at 41s having posted nothing — so the red check isn't a verdict, it's the gate never running. The `Log review to ai-review-log` step then recorded `No marker'd review surface found (review_status=failure); skipping log`, meaning these non-reviews aren't showing up in calibration data either.

That check failure was the only non-green one on #2307 (all 30 others — build, format, integration 1–6 across Node/Bun/Windows/uWS — passed), which is what surfaced this.

## The change

All three ai-review-prompts callers move to `4b59dc0` together, exactly as #2256 did on `main`: the #86 delta changes the workflow contract the validator checks callers against, so `claude-review`, `gemini-review`, and `validate-caller-workflows` share one pin. Six lines, all of them the pin (each file carries the SHA twice — once in `uses:`, once in `ai-review-prompts-ref:`, since a reusable workflow can't introspect its own ref).

No other change: triggers, `permissions:`, secrets, `if:` conditions, review layers, and the Sonnet 5 model canary are untouched.

## Verification

- **Byte-identity, which is the actual fix.** Each of the three files now hashes identically to `origin/main`'s copy (`sha256`, verified per file), so the App's validation compares equal rather than approximately equal.
- **Pin provenance.** `4b59dc0ddb15aff517884127b58204f79193b4f2` is GitHub-reported as **verified** (signed) and is the merge commit of [Make AI review calibration evidence reliable](https://github.com/HarperFast/ai-review-prompts/pull/86), committed 2026-08-21 — the same commit `main`, harper-pro#748, and oauth#210 already run.
- **YAML parses** for all three files; `git diff --check` clean.
- **This PR is its own smoke test.** Its head carries the new content, which now matches `main`, so its own `review / review` check exercises exactly the path that 401'd on #2307 — if the gate runs here, the fix holds. (Note that Claude correctly *declines* self-modifying caller-workflow diffs, as it did on #2256; the signal to look for is token exchange succeeding and the job reaching a decline, not a verdict.)
- **Scope check.** `git diff origin/main origin/v5.2 -- .github/workflows/` reports these three files and nothing else, so this closes the entire workflow drift between the branches. harper-pro's `v5.2` has no ai-review-prompts drift — this is harper-only.

Complexity: easy
