### PR TITLE
Canonicalize watch paths so a Windows 8.3 short path cannot abort the process

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1213,3 +1213,35 @@ An `{}` in the config system is context-dependent, and conflating the contexts i
 Removal therefore prunes: `deleteNestedValue` removes ancestors the deletion emptied, only when it actually deleted an existing leaf, and reports what it pruned. The overlap case — a file-declared empty scope an env layer temporarily populated — is tracked in the state file's `emptyScopeOriginals` (separate from `originalValues` so a marker can never mask or be consumed as a real leaf original at the same path; older state files lacking the field are defaulted). Restore consumes a marker only for a path the prune actually removed, so a scalar overwrite or an absent-leaf no-op can never resurrect a scope over live env-layer content. Note there are two coexisting mechanisms for "file `{}` is user content": `restoreBaseEmptyObjects` on the stateless compose path and the marker pair on the stateful removal path — if you touch one, check the other.
 
 Two durable limitations of the marker mechanism, both with user config-file content as the blast radius: markers can only be recorded at populate time, so a scope an env layer populated _before_ `emptyScopeOriginals` existed (any pre-upgrade boot) has no marker and prunes away on its first post-upgrade vacate; and a corrupt config-state file resets to fresh state — dropping `originalValues` and `emptyScopeOriginals` for every tracked path — after which the next removal prunes those scopes for good; `saveConfigState` writes via temp+rename precisely so a torn write cannot be the trigger, leaving genuine corruption (disk faults, hand edits) as the remaining path.
+
+## Every path handed to a native file watch must be canonicalized (`utility/watchPath.ts`)
+
+libuv's Windows fs-event callback rebuilds each event's absolute path, expands it with
+`GetLongPathNameW`, and asserts the expansion still starts with the directory it stored when the
+watch was armed. An 8.3 short directory (`C:\Users\RUNNER~1\...`) never survives that comparison,
+and libuv **aborts the process** rather than failing the watch — there is no JS-observable seam, so
+`isWatcherExhaustionError`/polling recovery never runs (harper#2234).
+
+The trap is that libuv only stores that directory for **file** targets, which reads as a narrow
+surface until you follow chokidar: v4 opens a per-file `fs.watch` for every file it discovers inside
+a watched tree, so one directory watch arms hundreds of file watches.
+
+So `canonicalizeWatchPath` runs on every path before it reaches `fs.watch` (directly or through
+chokidar). It only touches a path that actually carries an 8.3 component — everything else is
+returned as given, which keeps `realpathSync.native`'s symlink resolution off every path that cannot
+abort. It returns `undefined` when it cannot prove the long form, _including when the resolved path
+is still short_; `resolveWatchTarget` turns that into `mustPoll`, and polling stats the file instead
+of arming a native watch. Plain `realpathSync` is not a substitute: it resolves symlinks but leaves
+8.3 names intact.
+
+New watch sites must go through it. As of this writing the sites are `components/EntryHandler.ts`,
+`components/OptionsWatcher.ts`, `config/RootConfigWatcher.ts`, `security/keys.ts`,
+`server/threads/manageThreads.js`, and `resources/blob.ts`. `fs.watchFile` (`utility/logging/readLog.ts`)
+is stat polling with no fs-event handle and is outside this invariant.
+
+Two consequences worth knowing before adding a caller. `EntryHandler` is the one place where the
+canonical path is load-bearing past the `fs.watch` call: chokidar's `ignored` predicate receives
+absolute paths built from `cwd`, so its bases must be derived from the same spelling, while event
+paths are relative to `cwd` and reads stay on the configured `component.directory`. And a watcher
+that degrades to polling stays there for its lifetime, so a caller with no polling story of its own
+(`resources/blob.ts`) needs one — there it polls `readMore` on the existing no-progress deadline.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1227,12 +1227,15 @@ surface until you follow chokidar: v4 opens a per-file `fs.watch` for every file
 a watched tree, so one directory watch arms hundreds of file watches.
 
 So `canonicalizeWatchPath` runs on every path before it reaches `fs.watch` (directly or through
-chokidar). It only touches a path that actually carries an 8.3 component — everything else is
-returned as given, which keeps `realpathSync.native`'s symlink resolution off every path that cannot
-abort. It returns `undefined` when it cannot prove the long form, _including when the resolved path
-is still short_; `resolveWatchTarget` turns that into `mustPoll`, and polling stats the file instead
-of arming a native watch. Plain `realpathSync` is not a substitute: it resolves symlinks but leaves
-8.3 names intact.
+chokidar), and returns `undefined` when it cannot establish the long form; `resolveWatchTarget` turns
+that into `mustPoll`, and polling stats the file instead of arming a native watch. It resolves every
+Windows path rather than only the ones that look short: `GetLongPathNameW`'s documentation is
+explicit that a short name need not contain a tilde, so any spelling test leaves the abort reachable.
+Plain `realpathSync` is not a substitute for the `.native` variant: it resolves symlinks but leaves
+8.3 names intact — which also means Windows watch paths are symlink-resolved, matching what
+`fs.watch` already does elsewhere by following a symlinked file to its target inode. A leaf that does
+not exist yet resolves through its directory, because libuv stores and compares only the parent
+directory of a file target.
 
 New watch sites must go through it. As of this writing the sites are `components/EntryHandler.ts`,
 `components/OptionsWatcher.ts`, `config/RootConfigWatcher.ts`, `security/keys.ts`,

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -537,8 +537,8 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			readFailures: new Map(),
 		};
 
-		// chokidar reports every path — to `ignored` and to the event handlers — relative to `cwd`,
-		// so the predicate's bases must be derived from the same canonicalized directory.
+		// `ignored` receives absolute paths built from `cwd`, so its bases must come from the same
+		// directory spelling. Event paths are relative to `cwd`, so reads below stay on `this.directory`.
 		const watchTarget = resolveWatchTarget(this.#component.directory);
 		const watchDirectory = watchTarget.path;
 		const normalizedDirectory = watchDirectory.replace(/\\/g, '/');

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -5,7 +5,7 @@ import type { Stats } from 'node:fs';
 import { EventEmitter } from 'node:events';
 import { Component, FileAndURLPathConfig } from './Component.ts';
 import chokidar, { FSWatcher, FSWatcherEventMap } from 'chokidar';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import { readFile } from 'node:fs/promises';
 import { FilesOption } from './deriveGlobOptions.ts';
 import { deriveURLPath } from './deriveURLPath.ts';
@@ -545,9 +545,18 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		const normalizedDirectory = watchDirectory.replace(/\\/g, '/');
 		const normalizedBases = this.#component.patternBases.map((base) => join(watchDirectory, base).replace(/\\/g, '/'));
 
+		// chokidar resolves a relative pattern base against `cwd`, but an absolute one reaches the
+		// native watch as spelled, bypassing the canonicalized `cwd` above.
+		let watchPattern = this.#component.commonPatternBase;
+		if (isAbsolute(watchPattern)) {
+			const patternTarget = resolveWatchTarget(watchPattern);
+			if (patternTarget.mustPoll) this.#usingPolling = true;
+			watchPattern = patternTarget.path;
+		}
+
 		this.#openCount++;
 		const watcher = (this.#watcher = chokidar
-			.watch(this.#component.commonPatternBase, {
+			.watch(watchPattern, {
 				cwd: watchDirectory,
 				persistent: false,
 				followSymlinks: false,

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -540,7 +540,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		// `ignored` receives absolute paths built from `cwd`, so its bases must come from the same
 		// directory spelling. Event paths are relative to `cwd`, so reads below stay on `this.directory`.
 		const watchTarget = resolveWatchTarget(this.#component.directory);
-		// Latched, not assigned: a reinstall must not clear an exhaustion fallback.
+		// Latched: a reinstall must not clear an exhaustion fallback.
 		if (watchTarget.mustPoll) this.#usingPolling = true;
 		const watchDirectory = watchTarget.path;
 		const normalizedDirectory = watchDirectory.replace(/\\/g, '/');

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -540,7 +540,6 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		// `ignored` receives absolute paths built from `cwd`, so its bases must come from the same
 		// directory spelling. Event paths are relative to `cwd`, so reads below stay on `this.directory`.
 		const watchTarget = resolveWatchTarget(this.#component.directory);
-		// Latched: a reinstall must not clear an exhaustion fallback.
 		if (watchTarget.mustPoll) this.#usingPolling = true;
 		const watchDirectory = watchTarget.path;
 		const normalizedDirectory = watchDirectory.replace(/\\/g, '/');

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -540,8 +540,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		// `ignored` receives absolute paths built from `cwd`, so its bases must come from the same
 		// directory spelling. Event paths are relative to `cwd`, so reads below stay on `this.directory`.
 		const watchTarget = resolveWatchTarget(this.#component.directory);
-		// Latch rather than assign: an exhaustion fallback already set this, and a reinstall must not
-		// clear it.
+		// Latched, not assigned: a reinstall must not clear an exhaustion fallback.
 		if (watchTarget.mustPoll) this.#usingPolling = true;
 		const watchDirectory = watchTarget.path;
 		const normalizedDirectory = watchDirectory.replace(/\\/g, '/');

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -540,6 +540,9 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		// `ignored` receives absolute paths built from `cwd`, so its bases must come from the same
 		// directory spelling. Event paths are relative to `cwd`, so reads below stay on `this.directory`.
 		const watchTarget = resolveWatchTarget(this.#component.directory);
+		// Latch rather than assign: an exhaustion fallback already set this, and a reinstall must not
+		// clear it.
+		if (watchTarget.mustPoll) this.#usingPolling = true;
 		const watchDirectory = watchTarget.path;
 		const normalizedDirectory = watchDirectory.replace(/\\/g, '/');
 		const normalizedBases = this.#component.patternBases.map((base) => join(watchDirectory, base).replace(/\\/g, '/'));
@@ -550,7 +553,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 				cwd: watchDirectory,
 				persistent: false,
 				followSymlinks: false,
-				...(this.#usingPolling || watchTarget.mustPoll ? DIRECTORY_POLLING_FALLBACK_OPTIONS : {}),
+				...(this.#usingPolling ? DIRECTORY_POLLING_FALLBACK_OPTIONS : {}),
 				ignored: (path) => {
 					const normalizedPath = path.replace(/\\/g, '/');
 

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -15,6 +15,7 @@ import {
 	isWatcherExhaustionError,
 	warnWatcherFallback,
 } from '../utility/watcherFallback.ts';
+import { resolveWatchTarget } from '../utility/watchPath.ts';
 
 export interface BaseEntry {
 	stats?: Stats;
@@ -536,19 +537,22 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			readFailures: new Map(),
 		};
 
-		const allowedBases = this.#component.patternBases.map((base) => join(this.#component.directory, base));
+		// chokidar reports every path — to `ignored` and to the event handlers — relative to `cwd`,
+		// so the predicate's bases must be derived from the same canonicalized directory.
+		const watchTarget = resolveWatchTarget(this.#component.directory);
+		const watchDirectory = watchTarget.path;
+		const normalizedDirectory = watchDirectory.replace(/\\/g, '/');
+		const normalizedBases = this.#component.patternBases.map((base) => join(watchDirectory, base).replace(/\\/g, '/'));
 
 		this.#openCount++;
 		const watcher = (this.#watcher = chokidar
 			.watch(this.#component.commonPatternBase, {
-				cwd: this.#component.directory,
+				cwd: watchDirectory,
 				persistent: false,
 				followSymlinks: false,
-				...(this.#usingPolling ? DIRECTORY_POLLING_FALLBACK_OPTIONS : {}),
+				...(this.#usingPolling || watchTarget.mustPoll ? DIRECTORY_POLLING_FALLBACK_OPTIONS : {}),
 				ignored: (path) => {
 					const normalizedPath = path.replace(/\\/g, '/');
-					const normalizedBases = allowedBases.map((base) => base.replace(/\\/g, '/'));
-					const normalizedDirectory = this.#component.directory.replace(/\\/g, '/');
 
 					// Determine the path relative to the component directory. Leading '/' is preserved
 					// (or empty when the path *is* the component directory) so the regex anchors below

--- a/components/OptionsWatcher.ts
+++ b/components/OptionsWatcher.ts
@@ -8,6 +8,7 @@ import { isDeepStrictEqual } from 'util';
 import { DEFAULT_CONFIG } from './DEFAULT_CONFIG.ts';
 import { cloneDeep } from 'lodash';
 import { POLLING_FALLBACK_OPTIONS, isWatcherExhaustionError, warnWatcherFallback } from '../utility/watcherFallback.ts';
+import { resolveWatchTarget } from '../utility/watchPath.ts';
 import { overlayRootEnvConfig, isRootConfigFilename } from '../config/harperConfigEnvVars.ts';
 
 export interface Config {
@@ -84,6 +85,8 @@ export class CannotSetPropertyError extends Error {
  */
 export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 	#filePath: string;
+	#watchPath: string;
+	#watchPathRequiresPolling: boolean;
 	#watcher!: FSWatcher;
 	#scopedConfig?: ConfigValue;
 	#rootConfig?: Config;
@@ -100,6 +103,9 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 		super();
 		this.#name = name;
 		this.#filePath = filePath;
+		const watchTarget = resolveWatchTarget(filePath);
+		this.#watchPath = watchTarget.path;
+		this.#watchPathRequiresPolling = watchTarget.mustPoll;
 		// Root-config watchers must see runtime env config (HARPER_SET_CONFIG et al.)
 		// even when it hasn't been flushed to disk yet — see #handleChange (#1618).
 		// Application scopes watch their own config.yaml and are never overlaid.
@@ -114,9 +120,9 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 	#openWatcher() {
 		this.#openCount++;
 		this.#watcher = chokidar
-			.watch(this.#filePath, {
+			.watch(this.#watchPath, {
 				persistent: false,
-				...(this.#usingPolling ? POLLING_FALLBACK_OPTIONS : {}),
+				...(this.#usingPolling || this.#watchPathRequiresPolling ? POLLING_FALLBACK_OPTIONS : {}),
 			})
 			.on('add', this.#handleChange.bind(this))
 			.on('change', this.#handleChange.bind(this))

--- a/components/OptionsWatcher.ts
+++ b/components/OptionsWatcher.ts
@@ -203,18 +203,17 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 			if (!this.#usingPolling) {
 				warnWatcherFallback(this.#filePath);
 				this.#usingPolling = true;
-				// Close the failed native watcher and reopen with polling. Guard
-				// against reopen-after-close: the caller may have invoked close()
-				// while this teardown was in flight. The .catch is required because
-				// `finally` would re-raise a teardown rejection as an unhandled one.
-				this.#watcher
-					.close()
+				// Start close() from a microtask, not directly here, so a synchronous throw
+				// can't escape this 'error' listener as an uncaught exception.
+				Promise.resolve()
+					.then(() => this.#watcher.close())
 					.catch(() => {
 						// Teardown errors on an already-failed watcher are not actionable.
 					})
-					.finally(() => {
+					.then(() => {
 						if (!this.#closed) this.#openWatcher();
-					});
+					})
+					.catch((error) => this.#logger.error?.(`Could not reopen the ${this.#filePath} watch on polling:`, error));
 			}
 			return;
 		}

--- a/components/OptionsWatcher.ts
+++ b/components/OptionsWatcher.ts
@@ -86,7 +86,6 @@ export class CannotSetPropertyError extends Error {
 export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 	#filePath: string;
 	#watchPath: string;
-	#watchPathRequiresPolling: boolean;
 	#watcher!: FSWatcher;
 	#scopedConfig?: ConfigValue;
 	#rootConfig?: Config;
@@ -105,13 +104,12 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 		this.#filePath = filePath;
 		const watchTarget = resolveWatchTarget(filePath);
 		this.#watchPath = watchTarget.path;
-		this.#watchPathRequiresPolling = watchTarget.mustPoll;
 		// Root-config watchers must see runtime env config (HARPER_SET_CONFIG et al.)
 		// even when it hasn't been flushed to disk yet — see #handleChange (#1618).
 		// Application scopes watch their own config.yaml and are never overlaid.
 		this.#isRootConfig = isRootConfig ?? isRootConfigFilename(filePath);
 		this.#logger = logger || loggerWithTag(name);
-		this.#usingPolling = false;
+		this.#usingPolling = watchTarget.mustPoll;
 		this.#closed = false;
 		this.ready = once(this, 'ready');
 		this.#openWatcher();
@@ -122,7 +120,7 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 		this.#watcher = chokidar
 			.watch(this.#watchPath, {
 				persistent: false,
-				...(this.#usingPolling || this.#watchPathRequiresPolling ? POLLING_FALLBACK_OPTIONS : {}),
+				...(this.#usingPolling ? POLLING_FALLBACK_OPTIONS : {}),
 			})
 			.on('add', this.#handleChange.bind(this))
 			.on('change', this.#handleChange.bind(this))

--- a/config/RootConfigWatcher.ts
+++ b/config/RootConfigWatcher.ts
@@ -64,18 +64,17 @@ export class RootConfigWatcher extends EventEmitter {
 			if (!this.#usingPolling) {
 				warnWatcherFallback(this.#configFilePath);
 				this.#usingPolling = true;
-				// Guard against reopen-after-close: the caller may have invoked
-				// close() while this teardown was in flight. The .catch is required
-				// because `finally` would re-raise a teardown rejection as an
-				// unhandled one.
-				this.#watcher
-					.close()
+				// Start close() from a microtask, not directly here, so a synchronous throw
+				// can't escape this 'error' listener as an uncaught exception.
+				Promise.resolve()
+					.then(() => this.#watcher.close())
 					.catch(() => {
 						// Teardown errors on an already-failed watcher are not actionable.
 					})
-					.finally(() => {
+					.then(() => {
 						if (!this.#closed) this.#openWatcher();
-					});
+					})
+					.catch((error) => console.error(`Could not reopen the ${this.#configFilePath} watch on polling:`, error));
 			}
 			return;
 		}

--- a/config/RootConfigWatcher.ts
+++ b/config/RootConfigWatcher.ts
@@ -4,9 +4,12 @@ import { getConfigFilePath } from './configUtils.ts';
 import { EventEmitter, once } from 'node:events';
 import { parse } from 'yaml';
 import { POLLING_FALLBACK_OPTIONS, isWatcherExhaustionError, warnWatcherFallback } from '../utility/watcherFallback.ts';
+import { resolveWatchTarget } from '../utility/watchPath.ts';
 
 export class RootConfigWatcher extends EventEmitter {
 	#configFilePath: string;
+	#watchPath: string;
+	#watchPathRequiresPolling: boolean;
 	#watcher!: FSWatcher;
 	#config: any;
 	#usingPolling: boolean;
@@ -17,6 +20,9 @@ export class RootConfigWatcher extends EventEmitter {
 	constructor() {
 		super();
 		this.#configFilePath = getConfigFilePath();
+		const watchTarget = resolveWatchTarget(this.#configFilePath);
+		this.#watchPath = watchTarget.path;
+		this.#watchPathRequiresPolling = watchTarget.mustPoll;
 		this.#usingPolling = false;
 		this.#closed = false;
 		this.ready = once(this, 'ready');
@@ -26,9 +32,9 @@ export class RootConfigWatcher extends EventEmitter {
 	#openWatcher() {
 		this.#openCount++;
 		this.#watcher = chokidar
-			.watch(this.#configFilePath, {
+			.watch(this.#watchPath, {
 				persistent: false,
-				...(this.#usingPolling ? POLLING_FALLBACK_OPTIONS : {}),
+				...(this.#usingPolling || this.#watchPathRequiresPolling ? POLLING_FALLBACK_OPTIONS : {}),
 			})
 			.on('add', this.handleChange.bind(this))
 			.on('change', this.handleChange.bind(this))

--- a/config/RootConfigWatcher.ts
+++ b/config/RootConfigWatcher.ts
@@ -9,7 +9,6 @@ import { resolveWatchTarget } from '../utility/watchPath.ts';
 export class RootConfigWatcher extends EventEmitter {
 	#configFilePath: string;
 	#watchPath: string;
-	#watchPathRequiresPolling: boolean;
 	#watcher!: FSWatcher;
 	#config: any;
 	#usingPolling: boolean;
@@ -22,8 +21,7 @@ export class RootConfigWatcher extends EventEmitter {
 		this.#configFilePath = getConfigFilePath();
 		const watchTarget = resolveWatchTarget(this.#configFilePath);
 		this.#watchPath = watchTarget.path;
-		this.#watchPathRequiresPolling = watchTarget.mustPoll;
-		this.#usingPolling = false;
+		this.#usingPolling = watchTarget.mustPoll;
 		this.#closed = false;
 		this.ready = once(this, 'ready');
 		this.#openWatcher();
@@ -34,7 +32,7 @@ export class RootConfigWatcher extends EventEmitter {
 		this.#watcher = chokidar
 			.watch(this.#watchPath, {
 				persistent: false,
-				...(this.#usingPolling || this.#watchPathRequiresPolling ? POLLING_FALLBACK_OPTIONS : {}),
+				...(this.#usingPolling ? POLLING_FALLBACK_OPTIONS : {}),
 			})
 			.on('add', this.handleChange.bind(this))
 			.on('change', this.handleChange.bind(this))

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -807,8 +807,7 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 											readMore(resolve, reject);
 										} else if (!resumeIfWriterFinished()) {
 											if (!watcher) {
-												// No watcher could be armed, so nothing will wake this read. Poll on the same
-												// short backoff and the same no-progress deadline resumeIfWriterFinished uses,
+												// Nothing will wake this read, so poll on the deadline resumeIfWriterFinished uses
 												// rather than sitting out the full read timeout and 503-ing a healthy write.
 												if (Date.now() >= incompleteDeadline) {
 													onError(

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -535,7 +535,6 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 		let position = 0;
 		let totalContentRead = 0;
 		let watcher: FSWatcher;
-		// Resolved once per read: the stall path below re-arms the watcher on every retry.
 		let watchTarget: { path: string; mustPoll: boolean };
 		let timer: NodeJS.Timeout;
 		// The start() open-retry timer lives in a different scope/phase than pull()'s `timer`; track it

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -804,11 +804,15 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 											watcher = undefined;
 										}
 										// An FSWatcher that fails after registration emits 'error'; with no listener Node
-										// rethrows it out of the watcher callback. Drop to the same poll instead.
-										watcher?.on('error', (error) => {
+										// rethrows it out of the watcher callback. Drop to the same poll instead — but only
+										// while this watcher is still the live one, or a queued error from a superseded
+										// watcher would close its replacement and start a second read at the same position.
+										const installedWatcher = watcher;
+										installedWatcher?.once('error', (error) => {
+											if (watcher !== installedWatcher) return;
 											logger.debug?.(`Watch of ${filePath} failed, polling instead:`, error);
-											watcher?.close();
 											watcher = undefined;
+											installedWatcher.close();
 											clearTimeout(timer);
 											timer = setTimeout(() => readMore(resolve, reject), 20).unref();
 										});

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -801,6 +801,9 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 													});
 										} catch (error) {
 											logger.debug?.(`Could not watch ${filePath} for in-progress writes, polling instead:`, error);
+											// Latch on the stream-scoped target, or the 20 ms re-poll below re-enters here and
+											// re-attempts the same failing registration for the rest of the read.
+											watchTarget.mustPoll = true;
 											watcher = undefined;
 										}
 										// An FSWatcher that fails after registration emits 'error'; with no listener Node
@@ -811,6 +814,7 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 										installedWatcher?.once('error', (error) => {
 											if (watcher !== installedWatcher) return;
 											logger.debug?.(`Watch of ${filePath} failed, polling instead:`, error);
+											watchTarget.mustPoll = true;
 											watcher = undefined;
 											installedWatcher.close();
 											clearTimeout(timer);

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -51,7 +51,7 @@ import { get as envGet, getHdbBasePath } from '../utility/environment/environmen
 import { CONFIG_PARAMS, MAX_SET_TIMEOUT_MS } from '../utility/hdbTerms.ts';
 import { join, dirname } from 'path';
 import { logger } from '../utility/logging/logger.ts';
-import { canonicalizeWatchPath } from '../utility/watchPath.ts';
+import { resolveWatchTarget } from '../utility/watchPath.ts';
 import type { RootDatabase } from 'lmdb';
 import { asyncSerialization, hasAsyncSerialization } from '../server/serverHelpers/contentTypes.ts';
 import { getHeapStatistics } from 'node:v8';
@@ -536,8 +536,7 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 		let totalContentRead = 0;
 		let watcher: FSWatcher;
 		// Resolved once per read: the stall path below re-arms the watcher on every retry.
-		let watchPath: string | undefined;
-		let watchPathResolved = false;
+		let watchTarget: { path: string; mustPoll: boolean };
 		let timer: NodeJS.Timeout;
 		// The start() open-retry timer lives in a different scope/phase than pull()'s `timer`; track it
 		// separately so a cancel() during the file-creation wait clears it instead of leaking an fd (#1457).
@@ -787,20 +786,17 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 										};
 										// the file is not finished being written, watch the file for changes to resume reading
 										// set up a watcher to be notified of file changes
-										if (!watchPathResolved) {
-											watchPathResolved = true;
-											watchPath = canonicalizeWatchPath(filePath);
-										}
-										watcher =
-											watchPath &&
-											watch(watchPath, { persistent: false }, () => {
-												if (watcher) {
-													watcher.close();
-													watcher = null;
-													clearTimeout(timer); // clear it
-													readMore(resolve, reject);
-												}
-											});
+										watchTarget ??= resolveWatchTarget(filePath);
+										watcher = watchTarget.mustPoll
+											? undefined
+											: watch(watchTarget.path, { persistent: false }, () => {
+													if (watcher) {
+														watcher.close();
+														watcher = null;
+														clearTimeout(timer); // clear it
+														readMore(resolve, reject);
+													}
+												});
 										// immediately try to read again in case there was a change before we started watching,
 										// readSync should be fine here, the data should be in memory
 										if (readSync(fd, buffer, 0, buffer.length, position) > 0) {
@@ -811,6 +807,22 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 											}
 											readMore(resolve, reject);
 										} else if (!resumeIfWriterFinished()) {
+											if (!watcher) {
+												// No watcher could be armed, so nothing will wake this read. Poll on the same
+												// short backoff and the same no-progress deadline resumeIfWriterFinished uses,
+												// rather than sitting out the full read timeout and 503-ing a healthy write.
+												if (Date.now() >= incompleteDeadline) {
+													onError(
+														new BlobReadError(
+															`File read timed out reading from ${filePath}, read ${totalContentRead} bytes, but size is supposed to be ${size} bytes`,
+															BLOB_UNAVAILABLE_STATUS
+														)
+													);
+												} else {
+													timer = setTimeout(() => readMore(resolve, reject), 20).unref();
+												}
+												return;
+											}
 											// set a timer for the watcher too. A write that stalls past the bound returns a
 											// prompt 503 (retryable) instead of holding the connection for the full 60s (#1423).
 											timer = setTimeout(() => {

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -240,14 +240,12 @@ const BLOB_GONE_STATUS = 404;
 export const BLOB_UNAVAILABLE_STATUS = 503;
 const BLOB_CORRUPT_STATUS = 500;
 /**
- * Arm the one-shot watch that wakes an in-progress blob read, or report that the read must poll
- * instead. Exported (with an injectable `watchFile`) so the failure paths — a synchronous
- * registration throw, a post-registration `'error'`, and an `'error'` from a watcher the read has
- * already replaced — are directly testable; production never passes the last argument.
- *
- * `onFailure` runs only for a live watcher that fails after registration; a registration that
- * throws latches `mustPoll` and returns undefined, leaving the caller's own no-watcher branch to
- * schedule the poll.
+ * Arm the one-shot watch that wakes an in-progress blob read of `filePath`, or return `undefined`
+ * for a read that has to poll instead. `isLive` decides whether the read still owns a callback's
+ * watcher: a callback from one it has already replaced must not act, or it would close the live
+ * watcher and start a second read at the same position. `onFailure` runs only for a live watcher
+ * that fails after registration — a registration that throws latches `mustPoll` and leaves the
+ * caller in its own no-watcher branch. `watchFile` is injectable so those paths are testable.
  */
 export function watchInProgressFile(
 	filePath: string,
@@ -259,30 +257,27 @@ export function watchInProgressFile(
 	},
 	watchFile: typeof watch = watch
 ): FSWatcher | undefined {
+	if (watchTarget.mustPoll) return undefined;
 	let watcher: FSWatcher;
-	if (!watchTarget.mustPoll) {
-		try {
-			// fs.watch throws synchronously when the OS watcher pool is exhausted (EMFILE/ENOSPC); the
-			// caller's poll is the same recovery the unwatchable path already takes.
-			watcher = watchFile(watchTarget.path, { persistent: false }, () => handlers.onChange());
-		} catch (error) {
-			logger.debug?.(`Could not watch ${filePath} for in-progress writes, polling instead:`, error);
-			// Latch on the stream-scoped target, or the caller's 20 ms re-poll re-enters here and
-			// re-attempts the same failing registration for the rest of the read.
-			watchTarget.mustPoll = true;
-			return undefined;
-		}
+	try {
+		watcher = watchFile(watchTarget.path, { persistent: false }, () => {
+			if (handlers.isLive(watcher)) handlers.onChange();
+		});
+	} catch (error) {
+		// fs.watch throws synchronously when the OS watcher pool is exhausted (EMFILE/ENOSPC). Latch
+		// on the stream-scoped target, or the caller's re-poll re-enters here and re-attempts the same
+		// failing registration for the rest of the read.
+		logger.debug?.(`Could not watch ${filePath} for in-progress writes, polling instead:`, error);
+		watchTarget.mustPoll = true;
+		return undefined;
 	}
 	// An FSWatcher that fails after registration emits 'error'; with no listener Node rethrows it out
-	// of the watcher callback. Drop to the same poll instead — but only while this watcher is still
-	// the live one, or a queued error from a superseded watcher would close its replacement and start
-	// a second read at the same position.
-	const installedWatcher = watcher;
-	installedWatcher?.on('error', (error) => {
-		if (!handlers.isLive(installedWatcher)) return;
+	// of the watcher callback.
+	watcher.on('error', (error) => {
+		if (!handlers.isLive(watcher)) return;
 		logger.debug?.(`Watch of ${filePath} failed, polling instead:`, error);
 		watchTarget.mustPoll = true;
-		installedWatcher.close();
+		watcher.close();
 		handlers.onFailure();
 	});
 	return watcher;
@@ -839,12 +834,10 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 										watcher = watchInProgressFile(filePath, watchTarget, {
 											isLive: (candidate) => watcher === candidate,
 											onChange: () => {
-												if (watcher) {
-													watcher.close();
-													watcher = null;
-													clearTimeout(timer); // clear it
-													readMore(resolve, reject);
-												}
+												watcher.close();
+												watcher = null;
+												clearTimeout(timer); // clear it
+												readMore(resolve, reject);
 											},
 											onFailure: () => {
 												watcher = undefined;

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -239,6 +239,54 @@ const BLOB_GONE_STATUS = 404;
 // retryable class from the permanent ones without duplicating the status code.
 export const BLOB_UNAVAILABLE_STATUS = 503;
 const BLOB_CORRUPT_STATUS = 500;
+/**
+ * Arm the one-shot watch that wakes an in-progress blob read, or report that the read must poll
+ * instead. Exported (with an injectable `watchFile`) so the failure paths — a synchronous
+ * registration throw, a post-registration `'error'`, and an `'error'` from a watcher the read has
+ * already replaced — are directly testable; production never passes the last argument.
+ *
+ * `onFailure` runs only for a live watcher that fails after registration; a registration that
+ * throws latches `mustPoll` and returns undefined, leaving the caller's own no-watcher branch to
+ * schedule the poll.
+ */
+export function watchInProgressFile(
+	filePath: string,
+	watchTarget: { path: string; mustPoll: boolean },
+	handlers: {
+		isLive: (watcher: FSWatcher) => boolean;
+		onChange: () => void;
+		onFailure: () => void;
+	},
+	watchFile: typeof watch = watch
+): FSWatcher | undefined {
+	let watcher: FSWatcher;
+	if (!watchTarget.mustPoll) {
+		try {
+			// fs.watch throws synchronously when the OS watcher pool is exhausted (EMFILE/ENOSPC); the
+			// caller's poll is the same recovery the unwatchable path already takes.
+			watcher = watchFile(watchTarget.path, { persistent: false }, () => handlers.onChange());
+		} catch (error) {
+			logger.debug?.(`Could not watch ${filePath} for in-progress writes, polling instead:`, error);
+			// Latch on the stream-scoped target, or the caller's 20 ms re-poll re-enters here and
+			// re-attempts the same failing registration for the rest of the read.
+			watchTarget.mustPoll = true;
+			return undefined;
+		}
+	}
+	// An FSWatcher that fails after registration emits 'error'; with no listener Node rethrows it out
+	// of the watcher callback. Drop to the same poll instead — but only while this watcher is still
+	// the live one, or a queued error from a superseded watcher would close its replacement and start
+	// a second read at the same position.
+	const installedWatcher = watcher;
+	installedWatcher?.on('error', (error) => {
+		if (!handlers.isLive(installedWatcher)) return;
+		logger.debug?.(`Watch of ${filePath} failed, polling instead:`, error);
+		watchTarget.mustPoll = true;
+		installedWatcher.close();
+		handlers.onFailure();
+	});
+	return watcher;
+}
 class BlobReadError extends Error {
 	statusCode: number;
 	code?: string;
@@ -787,41 +835,22 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 											return true;
 										};
 										// the file is not finished being written, watch the file for changes to resume reading
-										// set up a watcher to be notified of file changes
 										watchTarget ??= resolveWatchTarget(filePath);
-										try {
-											// fs.watch throws synchronously when the OS watcher pool is exhausted (EMFILE/
-											// ENOSPC); the poll below is the same recovery the unwatchable path already takes.
-											watcher = watchTarget.mustPoll
-												? undefined
-												: watch(watchTarget.path, { persistent: false }, () => {
-														if (watcher) {
-															watcher.close();
-															watcher = null;
-															clearTimeout(timer); // clear it
-															readMore(resolve, reject);
-														}
-													});
-										} catch (error) {
-											logger.debug?.(`Could not watch ${filePath} for in-progress writes, polling instead:`, error);
-											// Latch on the stream-scoped target, or the 20 ms re-poll below re-enters here and
-											// re-attempts the same failing registration for the rest of the read.
-											watchTarget.mustPoll = true;
-											watcher = undefined;
-										}
-										// An FSWatcher that fails after registration emits 'error'; with no listener Node
-										// rethrows it out of the watcher callback. Drop to the same poll instead — but only
-										// while this watcher is still the live one, or a queued error from a superseded
-										// watcher would close its replacement and start a second read at the same position.
-										const installedWatcher = watcher;
-										installedWatcher?.on('error', (error) => {
-											if (watcher !== installedWatcher) return;
-											logger.debug?.(`Watch of ${filePath} failed, polling instead:`, error);
-											watchTarget.mustPoll = true;
-											watcher = undefined;
-											installedWatcher.close();
-											clearTimeout(timer);
-											timer = setTimeout(() => readMore(resolve, reject), 20).unref();
+										watcher = watchInProgressFile(filePath, watchTarget, {
+											isLive: (candidate) => watcher === candidate,
+											onChange: () => {
+												if (watcher) {
+													watcher.close();
+													watcher = null;
+													clearTimeout(timer); // clear it
+													readMore(resolve, reject);
+												}
+											},
+											onFailure: () => {
+												watcher = undefined;
+												clearTimeout(timer);
+												timer = setTimeout(() => readMore(resolve, reject), 20).unref();
+											},
 										});
 										// immediately try to read again in case there was a change before we started watching,
 										// readSync should be fine here, the data should be in memory

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -814,7 +814,7 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 										// while this watcher is still the live one, or a queued error from a superseded
 										// watcher would close its replacement and start a second read at the same position.
 										const installedWatcher = watcher;
-										installedWatcher?.once('error', (error) => {
+										installedWatcher?.on('error', (error) => {
 											if (watcher !== installedWatcher) return;
 											logger.debug?.(`Watch of ${filePath} failed, polling instead:`, error);
 											watchTarget.mustPoll = true;

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -803,6 +803,15 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 											logger.debug?.(`Could not watch ${filePath} for in-progress writes, polling instead:`, error);
 											watcher = undefined;
 										}
+										// An FSWatcher that fails after registration emits 'error'; with no listener Node
+										// rethrows it out of the watcher callback. Drop to the same poll instead.
+										watcher?.on('error', (error) => {
+											logger.debug?.(`Watch of ${filePath} failed, polling instead:`, error);
+											watcher?.close();
+											watcher = undefined;
+											clearTimeout(timer);
+											timer = setTimeout(() => readMore(resolve, reject), 20).unref();
+										});
 										// immediately try to read again in case there was a change before we started watching,
 										// readSync should be fine here, the data should be in memory
 										if (readSync(fd, buffer, 0, buffer.length, position) > 0) {

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -583,6 +583,18 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 		let position = 0;
 		let totalContentRead = 0;
 		let watcher: FSWatcher;
+		// Drop the live watcher before closing it, so a callback racing the close cannot pass its
+		// `isLive` check — and so a close() on an already-failed handle cannot abandon the teardown
+		// it was part of. Every site that retires this watcher goes through here.
+		const closeWatcher = () => {
+			const opened = watcher;
+			watcher = null;
+			try {
+				opened?.close();
+			} catch (error) {
+				logger.debug?.(`Could not close the in-progress watch of ${filePath}:`, error);
+			}
+		};
 		let watchTarget: { path: string; mustPoll: boolean };
 		let timer: NodeJS.Timeout;
 		// The start() open-retry timer lives in a different scope/phase than pull()'s `timer`; track it
@@ -684,10 +696,7 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 						settled = true;
 						closeFd();
 						clearTimeout(timer);
-						if (watcher) {
-							watcher.close();
-							watcher = null;
-						}
+						closeWatcher();
 						reject(error);
 						blob.#onError?.forEach((callback) => callback(error));
 					}
@@ -810,10 +819,7 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 											);
 											if (updatedSize === UNKNOWN_SIZE) return false;
 											size = updatedSize;
-											if (watcher) {
-												watcher.close();
-												watcher = null;
-											}
+											closeWatcher();
 											// The header reports a known final size but the bytes at `position` have not arrived.
 											// Re-entering readMore() synchronously here busy-spins the worker at ~100% CPU on a
 											// present-but-truncated blob (header rewritten to a self-consistent smaller size, lock
@@ -839,13 +845,12 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 										watcher = watchInProgressFile(filePath, watchTarget, {
 											isLive: (candidate) => watcher === candidate,
 											onChange: () => {
-												watcher.close();
-												watcher = null;
+												closeWatcher();
 												clearTimeout(timer); // clear it
 												readMore(resolve, reject);
 											},
 											onFailure: () => {
-												watcher = undefined;
+												watcher = null;
 												clearTimeout(timer);
 												timer = setTimeout(() => readMore(resolve, reject), 20).unref();
 											},
@@ -854,10 +859,7 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 										// readSync should be fine here, the data should be in memory
 										if (readSync(fd, buffer, 0, buffer.length, position) > 0) {
 											// never mind with the watcher, let's read more data
-											if (watcher) {
-												watcher.close();
-												watcher = null;
-											}
+											closeWatcher();
 											readMore(resolve, reject);
 										} else if (!resumeIfWriterFinished()) {
 											if (!watcher) {
@@ -964,10 +966,7 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 				closeFd(); // releases the hold, including when cancelled before any open succeeded
 				clearTimeout(timer);
 				clearTimeout(openTimer);
-				if (watcher) {
-					watcher.close();
-					watcher = null;
-				}
+				closeWatcher();
 			},
 		});
 		function checkIfIsBeingWritten() {

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -51,6 +51,7 @@ import { get as envGet, getHdbBasePath } from '../utility/environment/environmen
 import { CONFIG_PARAMS, MAX_SET_TIMEOUT_MS } from '../utility/hdbTerms.ts';
 import { join, dirname } from 'path';
 import { logger } from '../utility/logging/logger.ts';
+import { canonicalizeWatchPath } from '../utility/watchPath.ts';
 import type { RootDatabase } from 'lmdb';
 import { asyncSerialization, hasAsyncSerialization } from '../server/serverHelpers/contentTypes.ts';
 import { getHeapStatistics } from 'node:v8';
@@ -534,6 +535,9 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 		let position = 0;
 		let totalContentRead = 0;
 		let watcher: FSWatcher;
+		// Resolved once per read: the stall path below re-arms the watcher on every retry.
+		let watchPath: string | undefined;
+		let watchPathResolved = false;
 		let timer: NodeJS.Timeout;
 		// The start() open-retry timer lives in a different scope/phase than pull()'s `timer`; track it
 		// separately so a cancel() during the file-creation wait clears it instead of leaking an fd (#1457).
@@ -783,14 +787,20 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 										};
 										// the file is not finished being written, watch the file for changes to resume reading
 										// set up a watcher to be notified of file changes
-										watcher = watch(filePath, { persistent: false }, () => {
-											if (watcher) {
-												watcher.close();
-												watcher = null;
-												clearTimeout(timer); // clear it
-												readMore(resolve, reject);
-											}
-										});
+										if (!watchPathResolved) {
+											watchPathResolved = true;
+											watchPath = canonicalizeWatchPath(filePath);
+										}
+										watcher =
+											watchPath &&
+											watch(watchPath, { persistent: false }, () => {
+												if (watcher) {
+													watcher.close();
+													watcher = null;
+													clearTimeout(timer); // clear it
+													readMore(resolve, reject);
+												}
+											});
 										// immediately try to read again in case there was a change before we started watching,
 										// readSync should be fine here, the data should be in memory
 										if (readSync(fd, buffer, 0, buffer.length, position) > 0) {

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -786,16 +786,23 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 										// the file is not finished being written, watch the file for changes to resume reading
 										// set up a watcher to be notified of file changes
 										watchTarget ??= resolveWatchTarget(filePath);
-										watcher = watchTarget.mustPoll
-											? undefined
-											: watch(watchTarget.path, { persistent: false }, () => {
-													if (watcher) {
-														watcher.close();
-														watcher = null;
-														clearTimeout(timer); // clear it
-														readMore(resolve, reject);
-													}
-												});
+										try {
+											// fs.watch throws synchronously when the OS watcher pool is exhausted (EMFILE/
+											// ENOSPC); the poll below is the same recovery the unwatchable path already takes.
+											watcher = watchTarget.mustPoll
+												? undefined
+												: watch(watchTarget.path, { persistent: false }, () => {
+														if (watcher) {
+															watcher.close();
+															watcher = null;
+															clearTimeout(timer); // clear it
+															readMore(resolve, reject);
+														}
+													});
+										} catch (error) {
+											logger.debug?.(`Could not watch ${filePath} for in-progress writes, polling instead:`, error);
+											watcher = undefined;
+										}
 										// immediately try to read again in case there was a change before we started watching,
 										// readSync should be fine here, the data should be in memory
 										if (readSync(fd, buffer, 0, buffer.length, position) > 0) {

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -636,7 +636,10 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 						settled = true;
 						closeFd();
 						clearTimeout(timer);
-						if (watcher) watcher.close();
+						if (watcher) {
+							watcher.close();
+							watcher = null;
+						}
 						reject(error);
 						blob.#onError?.forEach((callback) => callback(error));
 					}
@@ -934,7 +937,10 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 				closeFd(); // releases the hold, including when cancelled before any open succeeded
 				clearTimeout(timer);
 				clearTimeout(openTimer);
-				if (watcher) watcher.close();
+				if (watcher) {
+					watcher.close();
+					watcher = null;
+				}
 			},
 		});
 		function checkIfIsBeingWritten() {

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -245,7 +245,7 @@ const BLOB_CORRUPT_STATUS = 500;
  * watcher: a callback from one it has already replaced must not act, or it would close the live
  * watcher and start a second read at the same position. `onFailure` runs only for a live watcher
  * that fails after registration — a registration that throws latches `mustPoll` and leaves the
- * caller in its own no-watcher branch. `watchFile` is injectable so those paths are testable.
+ * caller in its own no-watcher branch.
  */
 export function watchInProgressFile(
 	filePath: string,

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -277,7 +277,12 @@ export function watchInProgressFile(
 		if (!handlers.isLive(watcher)) return;
 		logger.debug?.(`Watch of ${filePath} failed, polling instead:`, error);
 		watchTarget.mustPoll = true;
-		watcher.close();
+		try {
+			watcher.close();
+		} catch {
+			// A close() that throws here must not skip onFailure — the poll fallback is what recovers
+			// the read, and the exception would otherwise escape this listener uncaught.
+		}
 		handlers.onFailure();
 	});
 	return watcher;

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -369,8 +369,7 @@ function loadAndWatch(path, loadCert, type) {
 			// The event carries the watched spelling, which is not the configured one once canonicalized;
 			// reload through the configured path so a retargeted link is followed.
 			.on('change', () => loadFile(path))
-			// chokidar emits 'error' unguarded for anything but ENOENT/ENOTDIR, so with no listener an
-			// ENOSPC here is an uncaughtException that leaves the cert fast path silently dead.
+			// chokidar emits 'error' unguarded for anything but ENOENT/ENOTDIR.
 			.on('error', (error) => {
 				if (isWatcherExhaustionError(error)) {
 					if (usingPolling || liveWatcher !== opened) return;

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -33,7 +33,7 @@ export const getPrivateKeys = () => privateKeys;
 import { readFileSync, statSync } from 'node:fs';
 import { getTicketKeys, onMessageFromWorkers } from '../server/threads/manageThreads.js';
 import { isMainThread } from 'worker_threads';
-import { POLLING_FALLBACK_OPTIONS } from '../utility/watcherFallback.ts';
+import { POLLING_FALLBACK_OPTIONS, isWatcherExhaustionError, warnWatcherFallback } from '../utility/watcherFallback.ts';
 import { resolveWatchTarget } from '../utility/watchPath.ts';
 import { TLSSocket } from 'node:tls';
 
@@ -358,12 +358,34 @@ function loadAndWatch(path, loadCert, type) {
 	if (fs.existsSync(path)) loadFile(path, statSync(path));
 	else logger.error?.(`${type} file not found:`, path);
 	const watchTarget = resolveWatchTarget(path);
-	watch(watchTarget.path, { persistent: false, ...(watchTarget.mustPoll ? POLLING_FALLBACK_OPTIONS : {}) }).on(
-		'change',
-		// The event carries the watched spelling, which is not the configured one once canonicalized;
-		// reload through the configured path so a retargeted link is followed.
-		() => loadFile(path)
-	);
+	let usingPolling = watchTarget.mustPoll;
+	let liveWatcher;
+	const openWatcher = () => {
+		const opened = (liveWatcher = watch(watchTarget.path, {
+			persistent: false,
+			...(usingPolling ? POLLING_FALLBACK_OPTIONS : {}),
+		}));
+		opened
+			// The event carries the watched spelling, which is not the configured one once canonicalized;
+			// reload through the configured path so a retargeted link is followed.
+			.on('change', () => loadFile(path))
+			.on('error', (error) => {
+				// chokidar rethrows an 'error' with no listener out of its own callback, which lands as
+				// an uncaughtException and leaves the fast path silently dead. Reopen on polling the way
+				// the other watch sites do; the periodic re-read below stays the backstop either way.
+				if (isWatcherExhaustionError(error)) {
+					if (usingPolling || liveWatcher !== opened) return;
+					warnWatcherFallback(path);
+					usingPolling = true;
+					Promise.resolve(opened.close())
+						.catch(() => {})
+						.then(openWatcher);
+					return;
+				}
+				logger.error?.(`Error watching ${type}:`, path, error);
+			});
+	};
+	openWatcher();
 
 	// Periodic re-read safety net. For certificates, this runs on the main thread only — workers
 	// receive cert updates via the hdb_certificate table subscription, so polling the cert file on

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -369,17 +369,17 @@ function loadAndWatch(path, loadCert, type) {
 			// The event carries the watched spelling, which is not the configured one once canonicalized;
 			// reload through the configured path so a retargeted link is followed.
 			.on('change', () => loadFile(path))
+			// chokidar emits 'error' unguarded for anything but ENOENT/ENOTDIR, so with no listener an
+			// ENOSPC here is an uncaughtException that leaves the cert fast path silently dead.
 			.on('error', (error) => {
-				// chokidar rethrows an 'error' with no listener out of its own callback, which lands as
-				// an uncaughtException and leaves the fast path silently dead. Reopen on polling the way
-				// the other watch sites do; the periodic re-read below stays the backstop either way.
 				if (isWatcherExhaustionError(error)) {
 					if (usingPolling || liveWatcher !== opened) return;
 					warnWatcherFallback(path);
 					usingPolling = true;
 					Promise.resolve(opened.close())
 						.catch(() => {})
-						.then(openWatcher);
+						.then(openWatcher)
+						.catch(() => {});
 					return;
 				}
 				logger.error?.(`Error watching ${type}:`, path, error);

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -340,7 +340,7 @@ const certificateWatchPollers = new Map<string, () => void>();
  */
 function loadAndWatch(path, loadCert, type) {
 	let lastModified;
-	const loadFile = (path, stats) => {
+	const loadFile = (path, stats?) => {
 		try {
 			// chokidar's 'change' event omits stats unless alwaysStat is set (default off in v4), so
 			// stat the file here when it's missing — otherwise the inotify fast path would throw and
@@ -360,7 +360,9 @@ function loadAndWatch(path, loadCert, type) {
 	const watchTarget = resolveWatchTarget(path);
 	watch(watchTarget.path, { persistent: false, ...(watchTarget.mustPoll ? POLLING_FALLBACK_OPTIONS : {}) }).on(
 		'change',
-		loadFile
+		// The event carries the watched spelling, which is not the configured one once canonicalized;
+		// reload through the configured path so a retargeted link is followed.
+		() => loadFile(path)
 	);
 
 	// Periodic re-read safety net. For certificates, this runs on the main thread only — workers

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -379,7 +379,7 @@ function loadAndWatch(path, loadCert, type) {
 						.then(() => opened.close())
 						.catch(() => {})
 						.then(openWatcher)
-						.catch(() => {});
+						.catch((error) => logger.error?.(`Could not reopen the ${type} watch on polling:`, path, error));
 					return;
 				}
 				logger.error?.(`Error watching ${type}:`, path, error);

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -33,6 +33,8 @@ export const getPrivateKeys = () => privateKeys;
 import { readFileSync, statSync } from 'node:fs';
 import { getTicketKeys, onMessageFromWorkers } from '../server/threads/manageThreads.js';
 import { isMainThread } from 'worker_threads';
+import { POLLING_FALLBACK_OPTIONS } from '../utility/watcherFallback.ts';
+import { resolveWatchTarget } from '../utility/watchPath.ts';
 import { TLSSocket } from 'node:tls';
 
 const CERT_VALIDITY_DAYS = 3650;
@@ -355,7 +357,11 @@ function loadAndWatch(path, loadCert, type) {
 	};
 	if (fs.existsSync(path)) loadFile(path, statSync(path));
 	else logger.error?.(`${type} file not found:`, path);
-	watch(path, { persistent: false }).on('change', loadFile);
+	const watchTarget = resolveWatchTarget(path);
+	watch(watchTarget.path, { persistent: false, ...(watchTarget.mustPoll ? POLLING_FALLBACK_OPTIONS : {}) }).on(
+		'change',
+		loadFile
+	);
 
 	// Periodic re-read safety net. For certificates, this runs on the main thread only — workers
 	// receive cert updates via the hdb_certificate table subscription, so polling the cert file on

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -375,7 +375,8 @@ function loadAndWatch(path, loadCert, type) {
 					if (usingPolling || liveWatcher !== opened) return;
 					warnWatcherFallback(path);
 					usingPolling = true;
-					Promise.resolve(opened.close())
+					Promise.resolve()
+						.then(() => opened.close())
 						.catch(() => {})
 						.then(openWatcher)
 						.catch(() => {});

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -24,7 +24,11 @@ const { resolvePreloadModules } = require('./resolvePreload.ts');
 const { resolveThreadHeapMemoryMb } = require('./threadHeapMemory.ts');
 const { getConfigPath } = require('../../config/configUtils.ts');
 const { resolveWatchTarget } = require('../../utility/watchPath.ts');
-const { DIRECTORY_POLLING_FALLBACK_OPTIONS } = require('../../utility/watcherFallback.ts');
+const {
+	DIRECTORY_POLLING_FALLBACK_OPTIONS,
+	isWatcherExhaustionError,
+	warnWatcherFallback,
+} = require('../../utility/watcherFallback.ts');
 let importModules;
 function getImportModules() {
 	if (importModules === undefined)
@@ -1255,24 +1259,43 @@ if (isMainThread) {
 	const watchDir = async (dir, beforeRestartCallback) => {
 		if (beforeRestartCallback) beforeRestart = beforeRestartCallback;
 		const watchTarget = resolveWatchTarget(dir);
-		chokidar
-			.watch(watchTarget.path, {
-				persistent: false,
-				...(watchTarget.mustPoll ? DIRECTORY_POLLING_FALLBACK_OPTIONS : {}),
-				ignored: (path) => {
-					return ignoredPaths.some((ignoredPath) => path.includes(ignoredPath));
-				},
-			})
-			.on('change', (path) => {
-				changedFiles.add(path);
-				if (queuedRestart) clearTimeout(queuedRestart);
-				queuedRestart = setTimeout(async () => {
-					if (beforeRestart) await beforeRestart();
-					await restartWorkers();
-					console.log('Reloaded Harper components, changed files:', Array.from(changedFiles));
-					changedFiles.clear();
-				}, 100);
-			});
+		let usingPolling = watchTarget.mustPoll;
+		const openWatcher = () => {
+			const opened = chokidar
+				.watch(watchTarget.path, {
+					persistent: false,
+					...(usingPolling ? DIRECTORY_POLLING_FALLBACK_OPTIONS : {}),
+					ignored: (path) => {
+						return ignoredPaths.some((ignoredPath) => path.includes(ignoredPath));
+					},
+				})
+				// chokidar emits 'error' unguarded for anything but ENOENT/ENOTDIR, and this runs on the
+				// thread that owns every worker, so without a listener an ENOSPC here is an
+				// uncaughtException on the main thread.
+				.on('error', (error) => {
+					if (isWatcherExhaustionError(error) && !usingPolling) {
+						warnWatcherFallback(dir);
+						usingPolling = true;
+						Promise.resolve(opened.close())
+							.catch(() => {})
+							.then(openWatcher)
+							.catch(() => {});
+						return;
+					}
+					console.error(`Error watching ${dir} for component reloads:`, error);
+				})
+				.on('change', (path) => {
+					changedFiles.add(path);
+					if (queuedRestart) clearTimeout(queuedRestart);
+					queuedRestart = setTimeout(async () => {
+						if (beforeRestart) await beforeRestart();
+						await restartWorkers();
+						console.log('Reloaded Harper components, changed files:', Array.from(changedFiles));
+						changedFiles.clear();
+					}, 100);
+				});
+		};
+		openWatcher();
 	};
 	module.exports.watchDir = watchDir;
 	if (process.env.WATCH_DIR) watchDir(process.env.WATCH_DIR);

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -23,6 +23,8 @@ const { PACKAGE_ROOT } = require('../../utility/packageUtils.js');
 const { resolvePreloadModules } = require('./resolvePreload.ts');
 const { resolveThreadHeapMemoryMb } = require('./threadHeapMemory.ts');
 const { getConfigPath } = require('../../config/configUtils.ts');
+const { resolveWatchTarget } = require('../../utility/watchPath.ts');
+const { DIRECTORY_POLLING_FALLBACK_OPTIONS } = require('../../utility/watcherFallback.ts');
 let importModules;
 function getImportModules() {
 	if (importModules === undefined)
@@ -1252,9 +1254,11 @@ if (isMainThread) {
 	const ignoredPaths = ['node_modules', '.git'];
 	const watchDir = async (dir, beforeRestartCallback) => {
 		if (beforeRestartCallback) beforeRestart = beforeRestartCallback;
+		const watchTarget = resolveWatchTarget(dir);
 		chokidar
-			.watch(dir, {
+			.watch(watchTarget.path, {
 				persistent: false,
+				...(watchTarget.mustPoll ? DIRECTORY_POLLING_FALLBACK_OPTIONS : {}),
 				ignored: (path) => {
 					return ignoredPaths.some((ignoredPath) => path.includes(ignoredPath));
 				},

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -1277,7 +1277,8 @@ if (isMainThread) {
 						if (usingPolling || liveWatcher !== opened) return;
 						warnWatcherFallback(dir);
 						usingPolling = true;
-						Promise.resolve(opened.close())
+						Promise.resolve()
+							.then(() => opened.close())
 							.catch(() => {})
 							.then(openWatcher)
 							.catch(() => {});

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -1260,20 +1260,21 @@ if (isMainThread) {
 		if (beforeRestartCallback) beforeRestart = beforeRestartCallback;
 		const watchTarget = resolveWatchTarget(dir);
 		let usingPolling = watchTarget.mustPoll;
+		let liveWatcher;
 		const openWatcher = () => {
-			const opened = chokidar
-				.watch(watchTarget.path, {
-					persistent: false,
-					...(usingPolling ? DIRECTORY_POLLING_FALLBACK_OPTIONS : {}),
-					ignored: (path) => {
-						return ignoredPaths.some((ignoredPath) => path.includes(ignoredPath));
-					},
-				})
-				// chokidar emits 'error' unguarded for anything but ENOENT/ENOTDIR, and this runs on the
-				// thread that owns every worker, so without a listener an ENOSPC here is an
-				// uncaughtException on the main thread.
+			const opened = (liveWatcher = chokidar.watch(watchTarget.path, {
+				persistent: false,
+				...(usingPolling ? DIRECTORY_POLLING_FALLBACK_OPTIONS : {}),
+				ignored: (path) => {
+					return ignoredPaths.some((ignoredPath) => path.includes(ignoredPath));
+				},
+			}));
+			opened
+				// This runs on the thread that owns every worker, and chokidar emits 'error' unguarded for
+				// anything but ENOENT/ENOTDIR.
 				.on('error', (error) => {
-					if (isWatcherExhaustionError(error) && !usingPolling) {
+					if (isWatcherExhaustionError(error)) {
+						if (usingPolling || liveWatcher !== opened) return;
 						warnWatcherFallback(dir);
 						usingPolling = true;
 						Promise.resolve(opened.close())

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -1281,7 +1281,9 @@ if (isMainThread) {
 							.then(() => opened.close())
 							.catch(() => {})
 							.then(openWatcher)
-							.catch(() => {});
+							.catch((reopenError) =>
+								console.error(`Could not reopen the ${dir} component-reload watch on polling:`, reopenError)
+							);
 						return;
 					}
 					console.error(`Error watching ${dir} for component reloads:`, error);

--- a/unitTests/components/OptionsWatcher.test.js
+++ b/unitTests/components/OptionsWatcher.test.js
@@ -8,6 +8,7 @@ const { mkdtempSync, writeFileSync, rmSync } = require('node:fs');
 const { writeFile, rm } = require('node:fs/promises');
 const { stringify } = require('yaml');
 const { spy } = require('sinon');
+const chokidar = require('chokidar');
 const { DEFAULT_CONFIG } = require('#src/components/DEFAULT_CONFIG');
 const { cloneDeep } = require('lodash');
 
@@ -711,6 +712,48 @@ describe('OptionsWatcher', () => {
 			assert.equal(errorSpy.callCount, 0, 'all exhaustion errors should be swallowed');
 
 			await teardown({ fixture, options });
+		});
+
+		it('a synchronous throw from close() stays inside the reopen chain', async () => {
+			// The reopen used to be spelled `Promise.resolve(this.#watcher.close())`, whose argument
+			// is evaluated eagerly: a close() that throws synchronously threw out of the 'error'
+			// listener itself, past the chained .catch(), and Node reported it as an uncaught
+			// exception instead of reopening on polling.
+			const realWatch = chokidar.default.watch;
+			const handlers = {};
+			const fakeWatcher = {
+				on(event, handler) {
+					handlers[event] = handler;
+					return fakeWatcher;
+				},
+				close() {
+					throw new Error('close failed synchronously');
+				},
+			};
+			chokidar.default.watch = () => fakeWatcher;
+
+			let options;
+			let fixture;
+			try {
+				const created = createFixture();
+				fixture = created.fixture;
+				options = new OptionsWatcher(NAME, created.configFilePath);
+				handlers.ready?.();
+				await options.ready;
+
+				assert.doesNotThrow(() => handlers.error(Object.assign(new Error('boom'), { code: 'ENOSPC' })));
+				await new Promise((resolve) => setImmediate(resolve));
+
+				assert.equal(options._usingPollingForTests, true, 'should have flipped to polling');
+				assert.equal(options._openCountForTests, 2, 'should have reopened after the failed close()');
+			} finally {
+				chokidar.default.watch = realWatch;
+				// The fake watcher's close() always throws; swap it for a real no-op before
+				// teardown so options.close() (unrelated to this test) doesn't also throw.
+				fakeWatcher.close = () => {};
+				await options?.close();
+				if (fixture) rmSync(fixture, { recursive: true, force: true });
+			}
 		});
 
 		it('does not reopen watcher if close() is called during recovery', async () => {

--- a/unitTests/config/rootConfigWatcher.test.js
+++ b/unitTests/config/rootConfigWatcher.test.js
@@ -6,6 +6,7 @@ const { join } = require('node:path');
 const { writeFileSync, mkdtempSync, rmSync, renameSync } = require('node:fs');
 const { writeFile } = require('node:fs/promises');
 const { replace, fake, restore, spy } = require('sinon');
+const chokidar = require('chokidar');
 const configUtils = require('#src/config/configUtils');
 const { stringify } = require('yaml');
 
@@ -144,6 +145,46 @@ describe('RootConfigWatcher', () => {
 			assert.equal(errorSpy.callCount, 0, 'all exhaustion errors should be swallowed');
 
 			configWatcher.close();
+		});
+
+		it('a synchronous throw from close() stays inside the reopen chain', async () => {
+			// The reopen used to be spelled `Promise.resolve(this.#watcher.close())`, whose argument
+			// is evaluated eagerly: a close() that throws synchronously threw out of the 'error'
+			// listener itself, past the chained .catch(), and Node reported it as an uncaught
+			// exception instead of reopening on polling.
+			writeFileSync(this.configFilePath, stringify({ foo: 'bar' }));
+
+			const realWatch = chokidar.default.watch;
+			const handlers = {};
+			const fakeWatcher = {
+				on(event, handler) {
+					handlers[event] = handler;
+					return fakeWatcher;
+				},
+				close() {
+					throw new Error('close failed synchronously');
+				},
+			};
+			chokidar.default.watch = () => fakeWatcher;
+
+			let configWatcher;
+			try {
+				configWatcher = new RootConfigWatcher();
+
+				assert.doesNotThrow(() =>
+					configWatcher._simulateWatcherErrorForTests(Object.assign(new Error('boom'), { code: 'ENOSPC' }))
+				);
+				await new Promise((resolve) => setImmediate(resolve));
+
+				assert.equal(configWatcher._usingPollingForTests, true, 'should have flipped to polling');
+				assert.equal(configWatcher._openCountForTests, 2, 'should have reopened after the failed close()');
+			} finally {
+				chokidar.default.watch = realWatch;
+				// The fake watcher's close() always throws; swap it for a real no-op before
+				// teardown so configWatcher.close() (unrelated to this test) doesn't also throw.
+				fakeWatcher.close = () => {};
+				configWatcher?.close();
+			}
 		});
 
 		it('does not reopen watcher if close() is called during recovery', async () => {

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -2286,8 +2286,6 @@ describe('backup of a blob root during a live write (harper#2262)', () => {
 	});
 });
 
-// A normal read cannot reach these paths — they need an exhausted OS watcher pool — so they are
-// driven through the injectable `watchFile` seam.
 describe('watchInProgressFile (in-progress read watcher fallback)', () => {
 	const ORIGINAL_PATH = '/blobs/RUNNER~1/00/01';
 	const CANONICAL_PATH = '/blobs/runneradmin/00/01';

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -2370,6 +2370,19 @@ describe('watchInProgressFile (in-progress read watcher fallback)', () => {
 		assert.deepStrictEqual(calls, { change: 0, failure: 1 });
 	});
 
+	it('still drops to polling when the failed watcher throws on close', () => {
+		const target = { path: CANONICAL_PATH, mustPoll: false };
+		const opened = fakeWatcher();
+		opened.close = () => {
+			throw new Error('close failed synchronously');
+		};
+		const { calls, handlers } = recordingHandlers((candidate) => candidate === opened);
+		assert.strictEqual(watchInProgressFile(ORIGINAL_PATH, target, handlers, opening(opened)), opened);
+		assert.doesNotThrow(() => opened.emit('error', exhaustion()));
+		assert.strictEqual(target.mustPoll, true);
+		assert.deepStrictEqual(calls, { change: 0, failure: 1 });
+	});
+
 	// Acting on either callback from a superseded watcher would close the live watcher and start a
 	// second read sharing the first one's fd and position.
 	describe('a watcher the read has already replaced', () => {

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -4,6 +4,7 @@ const { setupTestDBPath } = require('../testUtils');
 const { table, getDatabases } = require('#src/resources/databases');
 const { removeEntry } = require('#src/resources/RecordEncoder');
 const { Readable, PassThrough } = require('node:stream');
+const { EventEmitter } = require('node:events');
 const { setAuditRetention } = require('#src/resources/auditStore');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { transaction } = require('#src/resources/transaction');
@@ -33,6 +34,7 @@ const {
 	unregisterBlobReceiveInFlight,
 	isBlobReceiveInFlight,
 	createPendingMarkerBarrier,
+	watchInProgressFile,
 } = require('#src/resources/blob');
 const {
 	existsSync,
@@ -2281,5 +2283,111 @@ describe('backup of a blob root during a live write (harper#2262)', () => {
 
 		assert.strictEqual(readFileNow(livePath).length, 60000 + 8);
 		assert.deepStrictEqual(readFileNow(captured), capturedBytes, 'snapshot bytes changed after the write finished');
+	});
+});
+
+// The three recovery paths a read takes when its wake-up watcher cannot be relied on. All are
+// unreachable from a normal read — they need an exhausted OS watcher pool — so they are driven
+// through the injectable `watchFile` seam instead.
+describe('watchInProgressFile (in-progress read watcher fallback)', () => {
+	const ORIGINAL_PATH = '/blobs/RUNNER~1/00/01';
+	const CANONICAL_PATH = '/blobs/runneradmin/00/01';
+
+	function fakeWatcher() {
+		const watcher = new EventEmitter();
+		watcher.closeCount = 0;
+		watcher.close = () => watcher.closeCount++;
+		return watcher;
+	}
+
+	function exhaustion() {
+		return Object.assign(new Error('watcher pool exhausted'), { code: 'ENOSPC' });
+	}
+
+	function recordingHandlers(isLive = () => true) {
+		const calls = { change: 0, failure: 0 };
+		return { calls, handlers: { isLive, onChange: () => calls.change++, onFailure: () => calls.failure++ } };
+	}
+
+	it('arms nothing, and attempts no registration, for a target that must poll', () => {
+		const target = { path: ORIGINAL_PATH, mustPoll: true };
+		const { calls, handlers } = recordingHandlers();
+		let attempts = 0;
+		const watcher = watchInProgressFile(ORIGINAL_PATH, target, handlers, () => {
+			attempts++;
+			return fakeWatcher();
+		});
+		assert.strictEqual(watcher, undefined);
+		assert.strictEqual(attempts, 0);
+		assert.deepStrictEqual(calls, { change: 0, failure: 0 });
+	});
+
+	it('watches the canonical path, not the path the read reports', () => {
+		const target = { path: CANONICAL_PATH, mustPoll: false };
+		const { calls, handlers } = recordingHandlers();
+		const opened = fakeWatcher();
+		const seen = [];
+		const watcher = watchInProgressFile(ORIGINAL_PATH, target, handlers, (path, options, listener) => {
+			seen.push([path, options]);
+			opened.listener = listener;
+			return opened;
+		});
+		assert.strictEqual(watcher, opened);
+		assert.deepStrictEqual(seen, [[CANONICAL_PATH, { persistent: false }]]);
+		// Without a listener Node rethrows an emitted watcher error out of the watcher callback.
+		assert.strictEqual(opened.listenerCount('error'), 1);
+		opened.listener();
+		assert.strictEqual(calls.change, 1);
+	});
+
+	it('latches polling when registration throws, so the read stops re-attempting it', () => {
+		const target = { path: CANONICAL_PATH, mustPoll: false };
+		const { calls, handlers } = recordingHandlers();
+		let attempts = 0;
+		const throwOnRegistration = () => {
+			attempts++;
+			throw exhaustion();
+		};
+		assert.strictEqual(watchInProgressFile(ORIGINAL_PATH, target, handlers, throwOnRegistration), undefined);
+		assert.strictEqual(target.mustPoll, true);
+		// The caller schedules the poll for this case; a synchronous throw must not also drive onFailure.
+		assert.deepStrictEqual(calls, { change: 0, failure: 0 });
+		// Every 20 ms re-poll re-enters here for the rest of the read.
+		assert.strictEqual(watchInProgressFile(ORIGINAL_PATH, target, handlers, throwOnRegistration), undefined);
+		assert.strictEqual(attempts, 1);
+	});
+
+	it('drops a live watcher to polling when it fails after registration', () => {
+		const target = { path: CANONICAL_PATH, mustPoll: false };
+		const opened = fakeWatcher();
+		const { calls, handlers } = recordingHandlers((candidate) => candidate === opened);
+		assert.strictEqual(
+			watchInProgressFile(ORIGINAL_PATH, target, handlers, () => opened),
+			opened
+		);
+		opened.emit('error', exhaustion());
+		assert.strictEqual(target.mustPoll, true);
+		assert.strictEqual(opened.closeCount, 1);
+		assert.deepStrictEqual(calls, { change: 0, failure: 1 });
+	});
+
+	it('ignores an error from a watcher the read has already replaced', () => {
+		const target = { path: CANONICAL_PATH, mustPoll: false };
+		const superseded = fakeWatcher();
+		const live = fakeWatcher();
+		const pending = [superseded, live];
+		let current;
+		const { calls, handlers } = recordingHandlers((candidate) => candidate === current);
+		current = watchInProgressFile(ORIGINAL_PATH, target, handlers, () => pending.shift());
+		current = watchInProgressFile(ORIGINAL_PATH, target, handlers, () => pending.shift());
+		assert.strictEqual(current, live);
+
+		superseded.emit('error', exhaustion());
+
+		// Acting on it would close the live watcher and start a second read at the same position.
+		assert.deepStrictEqual(calls, { change: 0, failure: 0 });
+		assert.strictEqual(live.closeCount, 0);
+		assert.strictEqual(superseded.closeCount, 0);
+		assert.strictEqual(target.mustPoll, false);
 	});
 });

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -2301,8 +2301,6 @@ describe('watchInProgressFile (in-progress read watcher fallback)', () => {
 		return Object.assign(new Error('watcher pool exhausted'), { code: 'ENOSPC' });
 	}
 
-	// `opening` hands out the watchers a repeated registration returns, in order, and records the
-	// change listener each one was armed with so a test can deliver an event to a chosen watcher.
 	function opening(...watchers) {
 		const pending = [...watchers];
 		return (path, options, onChange) => {

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -2286,9 +2286,8 @@ describe('backup of a blob root during a live write (harper#2262)', () => {
 	});
 });
 
-// The three recovery paths a read takes when its wake-up watcher cannot be relied on. All are
-// unreachable from a normal read — they need an exhausted OS watcher pool — so they are driven
-// through the injectable `watchFile` seam instead.
+// A normal read cannot reach these paths — they need an exhausted OS watcher pool — so they are
+// driven through the injectable `watchFile` seam.
 describe('watchInProgressFile (in-progress read watcher fallback)', () => {
 	const ORIGINAL_PATH = '/blobs/RUNNER~1/00/01';
 	const CANONICAL_PATH = '/blobs/runneradmin/00/01';
@@ -2302,6 +2301,19 @@ describe('watchInProgressFile (in-progress read watcher fallback)', () => {
 
 	function exhaustion() {
 		return Object.assign(new Error('watcher pool exhausted'), { code: 'ENOSPC' });
+	}
+
+	// `opening` hands out the watchers a repeated registration returns, in order, and records the
+	// change listener each one was armed with so a test can deliver an event to a chosen watcher.
+	function opening(...watchers) {
+		const pending = [...watchers];
+		return (path, options, onChange) => {
+			const watcher = pending.shift();
+			watcher.path = path;
+			watcher.options = options;
+			watcher.change = onChange;
+			return watcher;
+		};
 	}
 
 	function recordingHandlers(isLive = () => true) {
@@ -2326,18 +2338,13 @@ describe('watchInProgressFile (in-progress read watcher fallback)', () => {
 		const target = { path: CANONICAL_PATH, mustPoll: false };
 		const { calls, handlers } = recordingHandlers();
 		const opened = fakeWatcher();
-		const seen = [];
-		const watcher = watchInProgressFile(ORIGINAL_PATH, target, handlers, (path, options, listener) => {
-			seen.push([path, options]);
-			opened.listener = listener;
-			return opened;
-		});
-		assert.strictEqual(watcher, opened);
-		assert.deepStrictEqual(seen, [[CANONICAL_PATH, { persistent: false }]]);
-		// Without a listener Node rethrows an emitted watcher error out of the watcher callback.
+		assert.strictEqual(watchInProgressFile(ORIGINAL_PATH, target, handlers, opening(opened)), opened);
+		assert.strictEqual(opened.path, CANONICAL_PATH);
+		assert.deepStrictEqual(opened.options, { persistent: false });
+		// Without this listener Node rethrows an emitted watcher error out of the watcher callback.
 		assert.strictEqual(opened.listenerCount('error'), 1);
-		opened.listener();
-		assert.strictEqual(calls.change, 1);
+		opened.change();
+		assert.deepStrictEqual(calls, { change: 1, failure: 0 });
 	});
 
 	it('latches polling when registration throws, so the read stops re-attempting it', () => {
@@ -2350,9 +2357,8 @@ describe('watchInProgressFile (in-progress read watcher fallback)', () => {
 		};
 		assert.strictEqual(watchInProgressFile(ORIGINAL_PATH, target, handlers, throwOnRegistration), undefined);
 		assert.strictEqual(target.mustPoll, true);
-		// The caller schedules the poll for this case; a synchronous throw must not also drive onFailure.
+		// The caller polls from its own no-watcher branch here, so a throw must not also drive onFailure.
 		assert.deepStrictEqual(calls, { change: 0, failure: 0 });
-		// Every 20 ms re-poll re-enters here for the rest of the read.
 		assert.strictEqual(watchInProgressFile(ORIGINAL_PATH, target, handlers, throwOnRegistration), undefined);
 		assert.strictEqual(attempts, 1);
 	});
@@ -2361,33 +2367,46 @@ describe('watchInProgressFile (in-progress read watcher fallback)', () => {
 		const target = { path: CANONICAL_PATH, mustPoll: false };
 		const opened = fakeWatcher();
 		const { calls, handlers } = recordingHandlers((candidate) => candidate === opened);
-		assert.strictEqual(
-			watchInProgressFile(ORIGINAL_PATH, target, handlers, () => opened),
-			opened
-		);
+		assert.strictEqual(watchInProgressFile(ORIGINAL_PATH, target, handlers, opening(opened)), opened);
 		opened.emit('error', exhaustion());
 		assert.strictEqual(target.mustPoll, true);
 		assert.strictEqual(opened.closeCount, 1);
 		assert.deepStrictEqual(calls, { change: 0, failure: 1 });
 	});
 
-	it('ignores an error from a watcher the read has already replaced', () => {
-		const target = { path: CANONICAL_PATH, mustPoll: false };
-		const superseded = fakeWatcher();
-		const live = fakeWatcher();
-		const pending = [superseded, live];
-		let current;
-		const { calls, handlers } = recordingHandlers((candidate) => candidate === current);
-		current = watchInProgressFile(ORIGINAL_PATH, target, handlers, () => pending.shift());
-		current = watchInProgressFile(ORIGINAL_PATH, target, handlers, () => pending.shift());
-		assert.strictEqual(current, live);
+	// Acting on either callback from a superseded watcher would close the live watcher and start a
+	// second read sharing the first one's fd and position.
+	describe('a watcher the read has already replaced', () => {
+		let superseded;
+		let live;
+		let target;
+		let recorded;
 
-		superseded.emit('error', exhaustion());
+		beforeEach(() => {
+			superseded = fakeWatcher();
+			live = fakeWatcher();
+			target = { path: CANONICAL_PATH, mustPoll: false };
+			let current;
+			recorded = recordingHandlers((candidate) => candidate === current);
+			const open = opening(superseded, live);
+			current = watchInProgressFile(ORIGINAL_PATH, target, recorded.handlers, open);
+			current = watchInProgressFile(ORIGINAL_PATH, target, recorded.handlers, open);
+			assert.strictEqual(current, live);
+		});
 
-		// Acting on it would close the live watcher and start a second read at the same position.
-		assert.deepStrictEqual(calls, { change: 0, failure: 0 });
-		assert.strictEqual(live.closeCount, 0);
-		assert.strictEqual(superseded.closeCount, 0);
-		assert.strictEqual(target.mustPoll, false);
+		afterEach(() => {
+			assert.deepStrictEqual(recorded.calls, { change: 0, failure: 0 });
+			assert.strictEqual(live.closeCount, 0);
+			assert.strictEqual(superseded.closeCount, 0);
+			assert.strictEqual(target.mustPoll, false);
+		});
+
+		it('cannot resume the read with a late change event', () => {
+			superseded.change();
+		});
+
+		it('cannot drop the read to polling with a late error', () => {
+			superseded.emit('error', exhaustion());
+		});
 	});
 });

--- a/unitTests/security/keys.test.js
+++ b/unitTests/security/keys.test.js
@@ -15,6 +15,7 @@ const mkcert = require('mkcert');
 const forge = require('node-forge');
 const pki = forge.pki;
 const { waitFor } = require('../waitFor.js');
+const { _resetForTests: resetWatcherFallbackWarning } = require('#src/utility/watcherFallback');
 
 describe('Test keys module', () => {
 	const sandbox = sinon.createSandbox();
@@ -1099,6 +1100,9 @@ describe('Test keys module', () => {
 
 		afterEach(() => {
 			localSandbox.restore();
+			// warnWatcherFallback's first-fallback gate is process-global; leaving it set would make a
+			// later suite's warning assertion silently observe nothing.
+			resetWatcherFallbackWarning();
 			const timer = watchTimers.get(watchPath);
 			if (timer) clearInterval(timer);
 			watchTimers.delete(watchPath);
@@ -1175,8 +1179,6 @@ describe('Test keys module', () => {
 			expect(openedOptions).to.have.lengthOf(2);
 			expect(openedOptions[1].usePolling).to.equal(true);
 
-			// chokidar can emit several exhaustion errors before the failed watcher closes; none of them
-			// may open a third.
 			errorHandlers[0](exhausted());
 			errorHandlers[1](exhausted());
 			await new Promise((resolve) => setImmediate(resolve));

--- a/unitTests/security/keys.test.js
+++ b/unitTests/security/keys.test.js
@@ -1077,7 +1077,6 @@ describe('Test keys module', () => {
 		const localSandbox = sinon.createSandbox();
 		let watchPath;
 
-		// A chokidar watcher is chainable and its `on` returns the watcher.
 		const fakeWatcher = (captureHandler) => {
 			const watcher = {
 				on: (event, handler) => {

--- a/unitTests/security/keys.test.js
+++ b/unitTests/security/keys.test.js
@@ -1077,11 +1077,23 @@ describe('Test keys module', () => {
 		const localSandbox = sinon.createSandbox();
 		let watchPath;
 
+		// A chokidar watcher is chainable and its `on` returns the watcher.
+		const fakeWatcher = (captureHandler) => {
+			const watcher = {
+				on: (event, handler) => {
+					captureHandler?.(event, handler);
+					return watcher;
+				},
+				close: () => Promise.resolve(),
+			};
+			return watcher;
+		};
+
 		beforeEach(() => {
 			// Stub chokidar's watch so these tests exercise only the poll path and never open a real
 			// FSWatcher (real watchers would leak fds and risk EMFILE across repeated runs).
 			const chokidar = require('chokidar');
-			localSandbox.stub(chokidar, 'watch').returns({ on: () => {} });
+			localSandbox.stub(chokidar, 'watch').returns(fakeWatcher());
 			watchPath = path.join(test_dir, `watch-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.pem`);
 			fs.writeFileSync(watchPath, 'PEM-V1');
 		});
@@ -1119,11 +1131,11 @@ describe('Test keys module', () => {
 			let changeHandler;
 			localSandbox.restore();
 			const chokidar = require('chokidar');
-			localSandbox.stub(chokidar, 'watch').returns({
-				on: (event, handler) => {
+			localSandbox.stub(chokidar, 'watch').returns(
+				fakeWatcher((event, handler) => {
 					if (event === 'change') changeHandler = handler;
-				},
-			});
+				})
+			);
 
 			const loaded = [];
 			loadAndWatch(watchPath, (pem) => loaded.push(pem), 'certificate');
@@ -1137,6 +1149,39 @@ describe('Test keys module', () => {
 			changeHandler(watchPath, undefined);
 
 			expect(loaded).to.eql(['PEM-V1', 'PEM-V2']);
+		});
+
+		it('reopens on polling when the watcher reports exhaustion', async () => {
+			// chokidar emits 'error' unguarded for any code other than ENOENT/ENOTDIR, so without a
+			// listener an ENOSPC here becomes an uncaughtException and the cert fast path dies silently.
+			localSandbox.restore();
+			const chokidar = require('chokidar');
+			const openedOptions = [];
+			const errorHandlers = [];
+			const exhausted = () => Object.assign(new Error('inotify watch limit reached'), { code: 'ENOSPC' });
+			localSandbox.stub(chokidar, 'watch').callsFake((_watchedPath, options) => {
+				openedOptions.push(options);
+				return fakeWatcher((event, handler) => {
+					if (event === 'error') errorHandlers.push(handler);
+				});
+			});
+
+			loadAndWatch(watchPath, () => {}, 'certificate');
+			expect(openedOptions).to.have.lengthOf(1);
+			expect(openedOptions[0].usePolling).to.equal(undefined);
+
+			errorHandlers[0](exhausted());
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(openedOptions).to.have.lengthOf(2);
+			expect(openedOptions[1].usePolling).to.equal(true);
+
+			// chokidar can emit several exhaustion errors before the failed watcher closes; none of them
+			// may open a third.
+			errorHandlers[0](exhausted());
+			errorHandlers[1](exhausted());
+			await new Promise((resolve) => setImmediate(resolve));
+			expect(openedOptions).to.have.lengthOf(2);
 		});
 
 		it('does not reload when the file is unchanged (mtime fingerprint dedup)', () => {

--- a/unitTests/security/keys.test.js
+++ b/unitTests/security/keys.test.js
@@ -1183,6 +1183,41 @@ describe('Test keys module', () => {
 			expect(openedOptions).to.have.lengthOf(2);
 		});
 
+		it('a synchronous throw from close() stays inside the reopen chain', async () => {
+			// The reopen used to be spelled `Promise.resolve(opened.close())`, whose argument is
+			// evaluated eagerly: a close() that throws synchronously threw out of the 'error' listener
+			// itself, past the chained .catch(), and Node reported it as an uncaught exception instead
+			// of reopening on polling.
+			localSandbox.restore();
+			const chokidar = require('chokidar');
+			const openedOptions = [];
+			const errorHandlers = [];
+			localSandbox.stub(chokidar, 'watch').callsFake((_watchedPath, options) => {
+				openedOptions.push(options);
+				const watcher = {
+					on: (event, handler) => {
+						if (event === 'error') errorHandlers.push(handler);
+						return watcher;
+					},
+					close: () => {
+						throw new Error('close failed synchronously');
+					},
+				};
+				return watcher;
+			});
+
+			loadAndWatch(watchPath, () => {}, 'certificate');
+			expect(openedOptions).to.have.lengthOf(1);
+
+			expect(() =>
+				errorHandlers[0](Object.assign(new Error('inotify watch limit reached'), { code: 'ENOSPC' }))
+			).to.not.throw();
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(openedOptions).to.have.lengthOf(2);
+			expect(openedOptions[1].usePolling).to.equal(true);
+		});
+
 		it('does not reload when the file is unchanged (mtime fingerprint dedup)', () => {
 			const loaded = [];
 			loadAndWatch(watchPath, (pem) => loaded.push(pem), 'certificate');

--- a/unitTests/security/keys.test.js
+++ b/unitTests/security/keys.test.js
@@ -1076,8 +1076,12 @@ describe('Test keys module', () => {
 		const watchTimers = keys.__get__('certificateWatchTimers');
 		const watchPollers = keys.__get__('certificateWatchPollers');
 		const localSandbox = sinon.createSandbox();
+		const chokidar = require('chokidar');
+		const realChokidarWatch = chokidar.watch;
 		let watchPath;
 
+		// Never open a real watcher here: these tests exercise only the poll/reopen paths, and real
+		// watchers would leak fds and risk EMFILE across repeated runs.
 		const fakeWatcher = (captureHandler) => {
 			const watcher = {
 				on: (event, handler) => {
@@ -1090,15 +1094,13 @@ describe('Test keys module', () => {
 		};
 
 		beforeEach(() => {
-			// Stub chokidar's watch so these tests exercise only the poll path and never open a real
-			// FSWatcher (real watchers would leak fds and risk EMFILE across repeated runs).
-			const chokidar = require('chokidar');
-			localSandbox.stub(chokidar, 'watch').returns(fakeWatcher());
+			chokidar.watch = () => fakeWatcher();
 			watchPath = path.join(test_dir, `watch-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.pem`);
 			fs.writeFileSync(watchPath, 'PEM-V1');
 		});
 
 		afterEach(() => {
+			chokidar.watch = realChokidarWatch;
 			localSandbox.restore();
 			// warnWatcherFallback's first-fallback gate is process-global; leaving it set would make a
 			// later suite's warning assertion silently observe nothing.
@@ -1132,13 +1134,10 @@ describe('Test keys module', () => {
 			// chokidar v4 defaults alwaysStat:false, so the 'change' handler is called with undefined
 			// stats; loadFile must stat the file itself rather than throw and silently skip the reload.
 			let changeHandler;
-			localSandbox.restore();
-			const chokidar = require('chokidar');
-			localSandbox.stub(chokidar, 'watch').returns(
+			chokidar.watch = () =>
 				fakeWatcher((event, handler) => {
 					if (event === 'change') changeHandler = handler;
-				})
-			);
+				});
 
 			const loaded = [];
 			loadAndWatch(watchPath, (pem) => loaded.push(pem), 'certificate');
@@ -1157,17 +1156,15 @@ describe('Test keys module', () => {
 		it('reopens on polling when the watcher reports exhaustion', async () => {
 			// chokidar emits 'error' unguarded for any code other than ENOENT/ENOTDIR, so without a
 			// listener an ENOSPC here becomes an uncaughtException and the cert fast path dies silently.
-			localSandbox.restore();
-			const chokidar = require('chokidar');
 			const openedOptions = [];
 			const errorHandlers = [];
 			const exhausted = () => Object.assign(new Error('inotify watch limit reached'), { code: 'ENOSPC' });
-			localSandbox.stub(chokidar, 'watch').callsFake((_watchedPath, options) => {
+			chokidar.watch = (_watchedPath, options) => {
 				openedOptions.push(options);
 				return fakeWatcher((event, handler) => {
 					if (event === 'error') errorHandlers.push(handler);
 				});
-			});
+			};
 
 			loadAndWatch(watchPath, () => {}, 'certificate');
 			expect(openedOptions).to.have.lengthOf(1);
@@ -1190,11 +1187,9 @@ describe('Test keys module', () => {
 			// evaluated eagerly: a close() that throws synchronously threw out of the 'error' listener
 			// itself, past the chained .catch(), and Node reported it as an uncaught exception instead
 			// of reopening on polling.
-			localSandbox.restore();
-			const chokidar = require('chokidar');
 			const openedOptions = [];
 			const errorHandlers = [];
-			localSandbox.stub(chokidar, 'watch').callsFake((_watchedPath, options) => {
+			chokidar.watch = (_watchedPath, options) => {
 				openedOptions.push(options);
 				const watcher = {
 					on: (event, handler) => {
@@ -1206,7 +1201,7 @@ describe('Test keys module', () => {
 					},
 				};
 				return watcher;
-			});
+			};
 
 			loadAndWatch(watchPath, () => {}, 'certificate');
 			expect(openedOptions).to.have.lengthOf(1);

--- a/unitTests/server/threads/watchDirFallback.test.js
+++ b/unitTests/server/threads/watchDirFallback.test.js
@@ -1,26 +1,29 @@
 'use strict';
 
-const { expect } = require('chai');
-const sinon = require('sinon');
+const assert = require('node:assert');
+const chokidar = require('chokidar');
 
 const { watchDir } = require('#src/server/threads/manageThreads');
+const { _resetForTests: resetWatcherFallbackWarning } = require('#src/utility/watcherFallback');
 
-// watchDir is the WATCH_DIR dev reloader's watch site. It runs on the thread that owns every
-// worker, and chokidar emits 'error' unguarded for anything but ENOENT/ENOTDIR, so an exhausted
-// watcher pool there would otherwise take the main thread down. These tests drive the listener
-// directly with a stubbed chokidar — no real watcher, no real reload.
 describe('watchDir watcher fallback', () => {
-	const sandbox = sinon.createSandbox();
+	const realWatch = chokidar.watch;
 
-	afterEach(() => sandbox.restore());
+	afterEach(() => {
+		chokidar.watch = realWatch;
+		// warnWatcherFallback's first-fallback gate is process-global; leaving it set would make a
+		// later suite's warning assertion silently observe nothing.
+		resetWatcherFallbackWarning();
+	});
 
 	const exhausted = () => Object.assign(new Error('inotify watch limit reached'), { code: 'ENOSPC' });
 
+	// Never open a real watcher here: these cases drive the 'error' listener directly, and real
+	// watchers would leak fds across repeated runs.
 	const stubChokidar = (close) => {
-		const chokidar = require('chokidar');
 		const openedOptions = [];
 		const errorHandlers = [];
-		sandbox.stub(chokidar, 'watch').callsFake((_watchedPath, options) => {
+		chokidar.watch = (_watchedPath, options) => {
 			openedOptions.push(options);
 			const watcher = {
 				on: (event, handler) => {
@@ -30,7 +33,7 @@ describe('watchDir watcher fallback', () => {
 				close,
 			};
 			return watcher;
-		});
+		};
 		return { openedOptions, errorHandlers };
 	};
 
@@ -38,21 +41,19 @@ describe('watchDir watcher fallback', () => {
 		const { openedOptions, errorHandlers } = stubChokidar(() => Promise.resolve());
 
 		await watchDir(__dirname);
-		expect(openedOptions).to.have.lengthOf(1);
-		expect(openedOptions[0].usePolling).to.equal(undefined);
+		assert.equal(openedOptions.length, 1);
+		assert.equal(openedOptions[0].usePolling, undefined);
 
 		errorHandlers[0](exhausted());
 		await new Promise((resolve) => setImmediate(resolve));
 
-		expect(openedOptions).to.have.lengthOf(2);
-		expect(openedOptions[1].usePolling).to.equal(true);
+		assert.equal(openedOptions.length, 2);
+		assert.equal(openedOptions[1].usePolling, true);
 
-		// Repeated exhaustion errors — from the failed watcher and the polling one — must not open a
-		// third watcher.
 		errorHandlers[0](exhausted());
 		errorHandlers[1](exhausted());
 		await new Promise((resolve) => setImmediate(resolve));
-		expect(openedOptions).to.have.lengthOf(2);
+		assert.equal(openedOptions.length, 2);
 	});
 
 	it('a synchronous throw from close() stays inside the reopen chain', async () => {
@@ -65,12 +66,12 @@ describe('watchDir watcher fallback', () => {
 		});
 
 		await watchDir(__dirname);
-		expect(openedOptions).to.have.lengthOf(1);
+		assert.equal(openedOptions.length, 1);
 
-		expect(() => errorHandlers[0](exhausted())).to.not.throw();
+		assert.doesNotThrow(() => errorHandlers[0](exhausted()));
 		await new Promise((resolve) => setImmediate(resolve));
 
-		expect(openedOptions).to.have.lengthOf(2);
-		expect(openedOptions[1].usePolling).to.equal(true);
+		assert.equal(openedOptions.length, 2);
+		assert.equal(openedOptions[1].usePolling, true);
 	});
 });

--- a/unitTests/server/threads/watchDirFallback.test.js
+++ b/unitTests/server/threads/watchDirFallback.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const { watchDir } = require('#src/server/threads/manageThreads');
+
+// watchDir is the WATCH_DIR dev reloader's watch site. It runs on the thread that owns every
+// worker, and chokidar emits 'error' unguarded for anything but ENOENT/ENOTDIR, so an exhausted
+// watcher pool there would otherwise take the main thread down. These tests drive the listener
+// directly with a stubbed chokidar — no real watcher, no real reload.
+describe('watchDir watcher fallback', () => {
+	const sandbox = sinon.createSandbox();
+
+	afterEach(() => sandbox.restore());
+
+	const exhausted = () => Object.assign(new Error('inotify watch limit reached'), { code: 'ENOSPC' });
+
+	const stubChokidar = (close) => {
+		const chokidar = require('chokidar');
+		const openedOptions = [];
+		const errorHandlers = [];
+		sandbox.stub(chokidar, 'watch').callsFake((_watchedPath, options) => {
+			openedOptions.push(options);
+			const watcher = {
+				on: (event, handler) => {
+					if (event === 'error') errorHandlers.push(handler);
+					return watcher;
+				},
+				close,
+			};
+			return watcher;
+		});
+		return { openedOptions, errorHandlers };
+	};
+
+	it('reopens on polling when the watcher reports exhaustion, and only once', async () => {
+		const { openedOptions, errorHandlers } = stubChokidar(() => Promise.resolve());
+
+		await watchDir(__dirname);
+		expect(openedOptions).to.have.lengthOf(1);
+		expect(openedOptions[0].usePolling).to.equal(undefined);
+
+		errorHandlers[0](exhausted());
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(openedOptions).to.have.lengthOf(2);
+		expect(openedOptions[1].usePolling).to.equal(true);
+
+		// Repeated exhaustion errors — from the failed watcher and the polling one — must not open a
+		// third watcher.
+		errorHandlers[0](exhausted());
+		errorHandlers[1](exhausted());
+		await new Promise((resolve) => setImmediate(resolve));
+		expect(openedOptions).to.have.lengthOf(2);
+	});
+
+	it('a synchronous throw from close() stays inside the reopen chain', async () => {
+		// The reopen used to be spelled `Promise.resolve(opened.close())`, whose argument is evaluated
+		// eagerly: a close() that throws synchronously threw out of the 'error' listener itself, past
+		// the chained .catch(), and Node reported it as an uncaught exception instead of reopening on
+		// polling.
+		const { openedOptions, errorHandlers } = stubChokidar(() => {
+			throw new Error('close failed synchronously');
+		});
+
+		await watchDir(__dirname);
+		expect(openedOptions).to.have.lengthOf(1);
+
+		expect(() => errorHandlers[0](exhausted())).to.not.throw();
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(openedOptions).to.have.lengthOf(2);
+		expect(openedOptions[1].usePolling).to.equal(true);
+	});
+});

--- a/unitTests/utility/watchPath.test.js
+++ b/unitTests/utility/watchPath.test.js
@@ -1,25 +1,25 @@
 const { canonicalizeWatchPath, resolveWatchTarget, _resetForTests } = require('#src/utility/watchPath');
 const assert = require('node:assert');
-const { mkdtempSync, mkdirSync, symlinkSync, realpathSync, rmSync } = require('node:fs');
+const { mkdtempSync, mkdirSync, symlinkSync, realpathSync, writeFileSync, rmSync } = require('node:fs');
 const { join } = require('node:path');
 const { tmpdir } = require('node:os');
 
-// On Windows the 8.3 alias `RUNNER~1` expands to a different long name; the closest host-independent
-// model of that is a symlink named with an 8.3-shaped component pointing at a long-named directory.
+// A symlink named `RUNNER~1` pointing at a long-named directory is the closest host-independent
+// model of the Windows 8.3 alias this exists for: `realpathSync.native` rewrites the component.
 describe('watchPath', () => {
 	let root;
 	let longDirectory;
 	let aliasLink;
-	let stubbornShortDirectory;
+	let longFile;
 
 	before(() => {
 		root = realpathSync.native(mkdtempSync(join(tmpdir(), 'watch-path-')));
 		longDirectory = join(root, 'runneradmin');
 		aliasLink = join(root, 'RUNNER~1');
-		stubbornShortDirectory = join(root, 'STILL~1');
+		longFile = join(longDirectory, 'config.yaml');
 		mkdirSync(longDirectory);
-		mkdirSync(stubbornShortDirectory);
 		symlinkSync(longDirectory, aliasLink, 'dir');
+		writeFileSync(longFile, 'x: 1');
 	});
 
 	after(() => {
@@ -34,47 +34,60 @@ describe('watchPath', () => {
 		it('leaves every path untouched off Windows', () => {
 			assert.strictEqual(canonicalizeWatchPath(aliasLink, 'linux'), aliasLink);
 			assert.strictEqual(canonicalizeWatchPath(aliasLink, 'darwin'), aliasLink);
+			assert.strictEqual(canonicalizeWatchPath(join(root, 'absent'), 'linux'), join(root, 'absent'));
 		});
 
-		it('leaves a path with no 8.3 component untouched, without hitting the filesystem', () => {
-			// Nothing here exists, so a resolution attempt would fail closed; getting the input back
-			// proves paths that cannot abort are never resolved (and never symlink-resolved).
-			const noSuchPath = join(root, 'absent', 'config.yaml');
-			assert.strictEqual(canonicalizeWatchPath(noSuchPath, 'win32'), noSuchPath);
-		});
-
-		it('expands an 8.3 component to its long form', () => {
+		it('resolves a directory to its long form', () => {
 			assert.strictEqual(canonicalizeWatchPath(aliasLink, 'win32'), longDirectory);
-			assert.strictEqual(canonicalizeWatchPath(join(aliasLink, 'config.yaml'), 'win32'), undefined);
 		});
 
-		it('fails closed when the resolved path is still short', () => {
-			// The abort needs only one surviving 8.3 component, so a resolution that did not expand it
-			// is not proof of anything.
-			assert.strictEqual(canonicalizeWatchPath(stubbornShortDirectory, 'win32'), undefined);
+		it('resolves a file reached through a short-form ancestor', () => {
+			assert.strictEqual(canonicalizeWatchPath(join(aliasLink, 'config.yaml'), 'win32'), longFile);
 		});
 
-		it('fails closed when a short path cannot be resolved at all', () => {
-			assert.strictEqual(canonicalizeWatchPath(join(root, 'GONE~1', 'config.yaml'), 'win32'), undefined);
+		it('resolves a leaf that does not exist yet through its directory', () => {
+			// libuv compares only the parent-directory prefix, so a watcher armed before its config file
+			// is written still gets a path that cannot trip the assertion.
+			assert.strictEqual(
+				canonicalizeWatchPath(join(aliasLink, 'not-written-yet.yaml'), 'win32'),
+				join(longDirectory, 'not-written-yet.yaml')
+			);
+		});
+
+		it('fails closed when not even the directory resolves', () => {
+			assert.strictEqual(canonicalizeWatchPath(join(root, 'absent', 'absent', 'config.yaml'), 'win32'), undefined);
 		});
 	});
 
 	describe('resolveWatchTarget', () => {
-		it('reports the path and no polling when nothing needs expanding', () => {
-			assert.deepStrictEqual(resolveWatchTarget(longDirectory), { path: longDirectory, mustPoll: false });
-		});
-
-		it('keeps the original path and demands polling when the long form cannot be established', () => {
+		const asWindows = (run) => {
 			const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
 			Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 			try {
-				assert.deepStrictEqual(resolveWatchTarget(stubbornShortDirectory), {
-					path: stubbornShortDirectory,
-					mustPoll: true,
-				});
+				run();
 			} finally {
 				Object.defineProperty(process, 'platform', originalPlatform);
 			}
+		};
+
+		it('reports the canonical path and no polling when it resolves', () => {
+			asWindows(() => {
+				assert.deepStrictEqual(resolveWatchTarget(aliasLink), { path: longDirectory, mustPoll: false });
+			});
+		});
+
+		it('keeps the original path and demands polling when it does not', () => {
+			asWindows(() => {
+				const unresolvable = join(root, 'absent', 'absent', 'config.yaml');
+				assert.deepStrictEqual(resolveWatchTarget(unresolvable), { path: unresolvable, mustPoll: true });
+			});
+		});
+
+		it('never demands polling off Windows', () => {
+			assert.deepStrictEqual(resolveWatchTarget(join(root, 'absent')), {
+				path: join(root, 'absent'),
+				mustPoll: false,
+			});
 		});
 	});
 });

--- a/unitTests/utility/watchPath.test.js
+++ b/unitTests/utility/watchPath.test.js
@@ -67,13 +67,13 @@ describe('watchPath', () => {
 
 		// The symlink model cannot separate `.native` from plain `realpathSync` — both resolve a
 		// symlink — but only `.native` expands an 8.3 name, so assert the call target itself.
-		const recordingNativeCalls = (run) => {
+		const recordingNativeCalls = (run, resolve) => {
 			const fs = require('node:fs');
 			const original = fs.realpathSync.native;
 			const resolved = [];
 			fs.realpathSync.native = (candidate) => {
 				resolved.push(candidate);
-				return original(candidate);
+				return resolve ? resolve(candidate, original) : original(candidate);
 			};
 			try {
 				run();
@@ -96,6 +96,16 @@ describe('watchPath', () => {
 				assert.strictEqual(canonicalizeWatchPath(absentLeaf, 'win32'), join(longDirectory, 'not-written-yet.yaml'))
 			);
 			assert.deepStrictEqual(resolved, [absentLeaf, aliasLink]);
+		});
+
+		it('fails closed without resolving the parent after a non-ENOENT failure', () => {
+			const resolved = recordingNativeCalls(
+				() => assert.strictEqual(canonicalizeWatchPath(aliasLink, 'win32'), undefined),
+				() => {
+					throw Object.assign(new Error('access denied'), { code: 'EACCES' });
+				}
+			);
+			assert.deepStrictEqual(resolved, [aliasLink]);
 		});
 	});
 

--- a/unitTests/utility/watchPath.test.js
+++ b/unitTests/utility/watchPath.test.js
@@ -4,8 +4,8 @@ const { mkdtempSync, mkdirSync, symlinkSync, realpathSync, writeFileSync, rmSync
 const { join } = require('node:path');
 const { tmpdir } = require('node:os');
 
-// A symlink named `RUNNER~1` pointing at a long-named directory is the closest host-independent
-// model of the Windows 8.3 alias this exists for: `realpathSync.native` rewrites the component.
+// A symlink named `RUNNER~1` pointing at a long-named directory models the Windows 8.3 alias this
+// exists for: `realpathSync.native` rewrites the component.
 describe('watchPath', () => {
 	let root;
 	let longDirectory;
@@ -46,8 +46,6 @@ describe('watchPath', () => {
 		});
 
 		it('resolves a leaf that does not exist yet through its directory', () => {
-			// libuv compares only the parent-directory prefix, so a watcher armed before its config file
-			// is written still gets a path that cannot trip the assertion.
 			assert.strictEqual(
 				canonicalizeWatchPath(join(aliasLink, 'not-written-yet.yaml'), 'win32'),
 				join(longDirectory, 'not-written-yet.yaml')

--- a/unitTests/utility/watchPath.test.js
+++ b/unitTests/utility/watchPath.test.js
@@ -1,0 +1,80 @@
+const { canonicalizeWatchPath, resolveWatchTarget, _resetForTests } = require('#src/utility/watchPath');
+const assert = require('node:assert');
+const { mkdtempSync, mkdirSync, symlinkSync, realpathSync, writeFileSync, rmSync } = require('node:fs');
+const { join } = require('node:path');
+const { tmpdir } = require('node:os');
+
+describe('watchPath', () => {
+	let root;
+	let realDirectory;
+	let linkedDirectory;
+	let regularFile;
+
+	before(() => {
+		root = realpathSync.native(mkdtempSync(join(tmpdir(), 'watch-path-')));
+		realDirectory = join(root, 'real');
+		linkedDirectory = join(root, 'link');
+		regularFile = join(root, 'file.txt');
+		mkdirSync(join(realDirectory, 'nested'), { recursive: true });
+		symlinkSync(realDirectory, linkedDirectory, 'dir');
+		writeFileSync(regularFile, 'contents');
+	});
+
+	after(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	beforeEach(() => {
+		_resetForTests();
+	});
+
+	describe('canonicalizeWatchPath', () => {
+		it('leaves the path untouched off Windows', () => {
+			// realpathSync.native would resolve symlinks here, which would change which tree an
+			// npm-linked component watches.
+			assert.strictEqual(canonicalizeWatchPath(linkedDirectory, 'linux'), linkedDirectory);
+			assert.strictEqual(canonicalizeWatchPath(linkedDirectory, 'darwin'), linkedDirectory);
+		});
+
+		it('canonicalizes an existing path on Windows', () => {
+			assert.strictEqual(canonicalizeWatchPath(linkedDirectory, 'win32'), realDirectory);
+		});
+
+		it('resolves a not-yet-created path through its deepest existing ancestor', () => {
+			assert.strictEqual(
+				canonicalizeWatchPath(join(linkedDirectory, 'nested', 'config.yaml'), 'win32'),
+				join(realDirectory, 'nested', 'config.yaml')
+			);
+		});
+
+		it('preserves every missing segment, not just the last one', () => {
+			assert.strictEqual(
+				canonicalizeWatchPath(join(linkedDirectory, 'later', 'deeper', 'config.yaml'), 'win32'),
+				join(realDirectory, 'later', 'deeper', 'config.yaml')
+			);
+		});
+
+		it('fails closed when the failure is not a missing leaf', () => {
+			// A regular file used as a directory yields ENOTDIR, not ENOENT: the long form cannot be
+			// established, so no path may be handed to a native watch.
+			assert.strictEqual(canonicalizeWatchPath(join(regularFile, 'child.yaml'), 'win32'), undefined);
+		});
+	});
+
+	describe('resolveWatchTarget', () => {
+		it('reports the canonical path and no polling when it resolves', () => {
+			assert.deepStrictEqual(resolveWatchTarget(realDirectory), { path: realDirectory, mustPoll: false });
+		});
+
+		it('keeps the original path and demands polling when canonicalization fails', () => {
+			const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+			Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+			try {
+				const unresolvable = join(regularFile, 'child.yaml');
+				assert.deepStrictEqual(resolveWatchTarget(unresolvable), { path: unresolvable, mustPoll: true });
+			} finally {
+				Object.defineProperty(process, 'platform', originalPlatform);
+			}
+		});
+	});
+});

--- a/unitTests/utility/watchPath.test.js
+++ b/unitTests/utility/watchPath.test.js
@@ -159,24 +159,27 @@ describe('watchPath', () => {
 		];
 
 		const repoRoot = join(__dirname, '..', '..');
-		const skippedDirectories = new Set([
+		// Anchored to repo-root children, so skipping generated output cannot also blind the scan to a
+		// nested `tmp/`, `docs/` or `coverage/` holding a real watch site.
+		const skippedRootEntries = new Set([
 			'.claude',
-			'.git',
 			'.nyc_output',
 			'coverage',
 			'dist',
 			'docs',
 			'integrationTests',
-			'node_modules',
 			'tmp',
 			'unitTests',
 		]);
+		const skippedAtAnyDepth = new Set(['.git', 'node_modules']);
 
-		const collectWatchSites = (directory, found = []) => {
+		const collectWatchSites = (directory, found = [], depth = 0) => {
 			for (const entry of readdirSync(directory, { withFileTypes: true })) {
 				const entryPath = join(directory, entry.name);
 				if (entry.isDirectory()) {
-					if (!skippedDirectories.has(entry.name)) collectWatchSites(entryPath, found);
+					if (skippedAtAnyDepth.has(entry.name)) continue;
+					if (depth === 0 && skippedRootEntries.has(entry.name)) continue;
+					collectWatchSites(entryPath, found, depth + 1);
 					continue;
 				}
 				if (!/\.(?:ts|js|mjs|cjs)$/.test(entry.name)) continue;

--- a/unitTests/utility/watchPath.test.js
+++ b/unitTests/utility/watchPath.test.js
@@ -1,23 +1,25 @@
 const { canonicalizeWatchPath, resolveWatchTarget, _resetForTests } = require('#src/utility/watchPath');
 const assert = require('node:assert');
-const { mkdtempSync, mkdirSync, symlinkSync, realpathSync, writeFileSync, rmSync } = require('node:fs');
+const { mkdtempSync, mkdirSync, symlinkSync, realpathSync, rmSync } = require('node:fs');
 const { join } = require('node:path');
 const { tmpdir } = require('node:os');
 
+// On Windows the 8.3 alias `RUNNER~1` expands to a different long name; the closest host-independent
+// model of that is a symlink named with an 8.3-shaped component pointing at a long-named directory.
 describe('watchPath', () => {
 	let root;
-	let realDirectory;
-	let linkedDirectory;
-	let regularFile;
+	let longDirectory;
+	let aliasLink;
+	let stubbornShortDirectory;
 
 	before(() => {
 		root = realpathSync.native(mkdtempSync(join(tmpdir(), 'watch-path-')));
-		realDirectory = join(root, 'real');
-		linkedDirectory = join(root, 'link');
-		regularFile = join(root, 'file.txt');
-		mkdirSync(join(realDirectory, 'nested'), { recursive: true });
-		symlinkSync(realDirectory, linkedDirectory, 'dir');
-		writeFileSync(regularFile, 'contents');
+		longDirectory = join(root, 'runneradmin');
+		aliasLink = join(root, 'RUNNER~1');
+		stubbornShortDirectory = join(root, 'STILL~1');
+		mkdirSync(longDirectory);
+		mkdirSync(stubbornShortDirectory);
+		symlinkSync(longDirectory, aliasLink, 'dir');
 	});
 
 	after(() => {
@@ -29,49 +31,47 @@ describe('watchPath', () => {
 	});
 
 	describe('canonicalizeWatchPath', () => {
-		it('leaves the path untouched off Windows', () => {
-			// realpathSync.native would resolve symlinks here, which would change which tree an
-			// npm-linked component watches.
-			assert.strictEqual(canonicalizeWatchPath(linkedDirectory, 'linux'), linkedDirectory);
-			assert.strictEqual(canonicalizeWatchPath(linkedDirectory, 'darwin'), linkedDirectory);
+		it('leaves every path untouched off Windows', () => {
+			assert.strictEqual(canonicalizeWatchPath(aliasLink, 'linux'), aliasLink);
+			assert.strictEqual(canonicalizeWatchPath(aliasLink, 'darwin'), aliasLink);
 		});
 
-		it('canonicalizes an existing path on Windows', () => {
-			assert.strictEqual(canonicalizeWatchPath(linkedDirectory, 'win32'), realDirectory);
+		it('leaves a path with no 8.3 component untouched, without hitting the filesystem', () => {
+			// Nothing here exists, so a resolution attempt would fail closed; getting the input back
+			// proves paths that cannot abort are never resolved (and never symlink-resolved).
+			const noSuchPath = join(root, 'absent', 'config.yaml');
+			assert.strictEqual(canonicalizeWatchPath(noSuchPath, 'win32'), noSuchPath);
 		});
 
-		it('resolves a not-yet-created path through its deepest existing ancestor', () => {
-			assert.strictEqual(
-				canonicalizeWatchPath(join(linkedDirectory, 'nested', 'config.yaml'), 'win32'),
-				join(realDirectory, 'nested', 'config.yaml')
-			);
+		it('expands an 8.3 component to its long form', () => {
+			assert.strictEqual(canonicalizeWatchPath(aliasLink, 'win32'), longDirectory);
+			assert.strictEqual(canonicalizeWatchPath(join(aliasLink, 'config.yaml'), 'win32'), undefined);
 		});
 
-		it('preserves every missing segment, not just the last one', () => {
-			assert.strictEqual(
-				canonicalizeWatchPath(join(linkedDirectory, 'later', 'deeper', 'config.yaml'), 'win32'),
-				join(realDirectory, 'later', 'deeper', 'config.yaml')
-			);
+		it('fails closed when the resolved path is still short', () => {
+			// The abort needs only one surviving 8.3 component, so a resolution that did not expand it
+			// is not proof of anything.
+			assert.strictEqual(canonicalizeWatchPath(stubbornShortDirectory, 'win32'), undefined);
 		});
 
-		it('fails closed when the failure is not a missing leaf', () => {
-			// A regular file used as a directory yields ENOTDIR, not ENOENT: the long form cannot be
-			// established, so no path may be handed to a native watch.
-			assert.strictEqual(canonicalizeWatchPath(join(regularFile, 'child.yaml'), 'win32'), undefined);
+		it('fails closed when a short path cannot be resolved at all', () => {
+			assert.strictEqual(canonicalizeWatchPath(join(root, 'GONE~1', 'config.yaml'), 'win32'), undefined);
 		});
 	});
 
 	describe('resolveWatchTarget', () => {
-		it('reports the canonical path and no polling when it resolves', () => {
-			assert.deepStrictEqual(resolveWatchTarget(realDirectory), { path: realDirectory, mustPoll: false });
+		it('reports the path and no polling when nothing needs expanding', () => {
+			assert.deepStrictEqual(resolveWatchTarget(longDirectory), { path: longDirectory, mustPoll: false });
 		});
 
-		it('keeps the original path and demands polling when canonicalization fails', () => {
+		it('keeps the original path and demands polling when the long form cannot be established', () => {
 			const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
 			Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 			try {
-				const unresolvable = join(regularFile, 'child.yaml');
-				assert.deepStrictEqual(resolveWatchTarget(unresolvable), { path: unresolvable, mustPoll: true });
+				assert.deepStrictEqual(resolveWatchTarget(stubbornShortDirectory), {
+					path: stubbornShortDirectory,
+					mustPoll: true,
+				});
 			} finally {
 				Object.defineProperty(process, 'platform', originalPlatform);
 			}

--- a/unitTests/utility/watchPath.test.js
+++ b/unitTests/utility/watchPath.test.js
@@ -65,10 +65,9 @@ describe('watchPath', () => {
 			assert.strictEqual(canonicalizeWatchPath(join(root, 'absent', 'absent', 'config.yaml'), 'win32'), undefined);
 		});
 
-		it('expands through realpathSync.native, not the symlink-only realpathSync', () => {
-			// The symlink model above cannot separate the two — plain `realpathSync` resolves a symlink
-			// as well — but only `.native` expands an 8.3 name, so assert the call target itself. A
-			// regression to the plain form would otherwise ship green and silently restore the abort.
+		// The symlink model cannot separate `.native` from plain `realpathSync` — both resolve a
+		// symlink — but only `.native` expands an 8.3 name, so assert the call target itself.
+		const recordingNativeCalls = (run) => {
 			const fs = require('node:fs');
 			const original = fs.realpathSync.native;
 			const resolved = [];
@@ -77,11 +76,28 @@ describe('watchPath', () => {
 				return original(candidate);
 			};
 			try {
-				assert.strictEqual(canonicalizeWatchPath(aliasLink, 'win32'), longDirectory);
+				run();
 			} finally {
 				fs.realpathSync.native = original;
 			}
+			return resolved;
+		};
+
+		it('expands an existing path through realpathSync.native', () => {
+			const resolved = recordingNativeCalls(() =>
+				assert.strictEqual(canonicalizeWatchPath(aliasLink, 'win32'), longDirectory)
+			);
 			assert.deepStrictEqual(resolved, [aliasLink]);
+		});
+
+		it('expands a not-yet-written leaf’s directory through realpathSync.native', () => {
+			// The install-window case from harper#2234: a config watcher armed before the file exists
+			// takes the fallback branch, so it needs the same guard as the primary one.
+			const absentLeaf = join(aliasLink, 'not-written-yet.yaml');
+			const resolved = recordingNativeCalls(() =>
+				assert.strictEqual(canonicalizeWatchPath(absentLeaf, 'win32'), join(longDirectory, 'not-written-yet.yaml'))
+			);
+			assert.deepStrictEqual(resolved, [absentLeaf, aliasLink]);
 		});
 	});
 
@@ -131,12 +147,18 @@ describe('watchPath', () => {
 			'server/threads/manageThreads.js',
 		];
 
-		const IMPORTS_CHOKIDAR = /from\s*['"]chokidar['"]|require\(\s*['"]chokidar['"]\s*\)/;
-		// `watch`, not `watchFile`: the latter is stat polling with no fs-event handle, so it is
-		// outside the invariant (`utility/logging/readLog.ts`).
-		const IMPORTS_FS_WATCH =
-			/import\s*\{[^}]*\bwatch\b[^}]*\}\s*from\s*['"](?:node:)?fs['"]|\{[^}]*\bwatch\b[^}]*\}\s*=\s*require\(\s*['"](?:node:)?fs['"]\s*\)/;
-		const CALLS_FS_WATCH = /\bfs\.watch\s*\(/;
+		// `watch`, not `watchFile`: the latter is stat polling with no fs-event handle, so it is outside
+		// the invariant (`utility/logging/readLog.ts`). `node:fs/promises` counts — its async iterator
+		// is a real fs-event watch.
+		const FS_MODULE = /(?:node:)?fs(?:\/promises)?/.source;
+		const WATCH_SPELLINGS = [
+			/from\s*['"]chokidar['"]/,
+			/require\(\s*['"]chokidar['"]\s*\)/,
+			new RegExp(`import\\s*\\{[^}]*\\bwatch\\b[^}]*\\}\\s*from\\s*['"]${FS_MODULE}['"]`),
+			new RegExp(`\\{[^}]*\\bwatch\\b[^}]*\\}\\s*=\\s*require\\(\\s*['"]${FS_MODULE}['"]\\s*\\)`),
+			new RegExp(`require\\(\\s*['"]${FS_MODULE}['"]\\s*\\)\\s*\\.watch\\s*\\(`),
+			/\bfs(?:Promises|p)?\.watch\s*\(/,
+		];
 
 		const repoRoot = join(__dirname, '..', '..');
 		const skippedDirectories = new Set([
@@ -158,7 +180,7 @@ describe('watchPath', () => {
 				}
 				if (!/\.(?:ts|js|mjs|cjs)$/.test(entry.name)) continue;
 				const source = readFileSync(entryPath, 'utf8');
-				if (IMPORTS_CHOKIDAR.test(source) || IMPORTS_FS_WATCH.test(source) || CALLS_FS_WATCH.test(source))
+				if (WATCH_SPELLINGS.some((spelling) => spelling.test(source)))
 					found.push(relative(repoRoot, entryPath).replace(/\\/g, '/'));
 			}
 			return found;
@@ -173,6 +195,8 @@ describe('watchPath', () => {
 			);
 		});
 
+		// File-level, so it catches a site that never canonicalizes at all, not a second raw watch
+		// added beside an existing canonicalized one.
 		it('all route their path through the canonicalization helper', () => {
 			for (const site of NATIVE_WATCH_SITES) {
 				const source = readFileSync(join(repoRoot, site), 'utf8');

--- a/unitTests/utility/watchPath.test.js
+++ b/unitTests/utility/watchPath.test.js
@@ -13,8 +13,10 @@ const {
 const { join, relative } = require('node:path');
 const { tmpdir } = require('node:os');
 
-// A symlink named `RUNNER~1` pointing at a long-named directory models the Windows 8.3 alias this
-// exists for: `realpathSync.native` rewrites the component.
+// A symlink pointing at a long-named directory models the Windows 8.3 alias this exists for:
+// `realpathSync.native` rewrites the component. The link must NOT be named after the alias NTFS
+// would itself generate for its sibling (`runneradmin` -> `RUNNER~1`): on a volume with 8.3 name
+// creation enabled that name is already taken, and symlinkSync fails EEXIST before any test runs.
 describe('watchPath', () => {
 	let root;
 	let longDirectory;
@@ -24,7 +26,7 @@ describe('watchPath', () => {
 	before(() => {
 		root = realpathSync.native(mkdtempSync(join(tmpdir(), 'watch-path-')));
 		longDirectory = join(root, 'runneradmin');
-		aliasLink = join(root, 'RUNNER~1');
+		aliasLink = join(root, 'WPLINK~1');
 		longFile = join(longDirectory, 'config.yaml');
 		mkdirSync(longDirectory);
 		symlinkSync(longDirectory, aliasLink, 'dir');

--- a/unitTests/utility/watchPath.test.js
+++ b/unitTests/utility/watchPath.test.js
@@ -91,8 +91,6 @@ describe('watchPath', () => {
 		});
 
 		it('expands a not-yet-written leaf’s directory through realpathSync.native', () => {
-			// The install-window case from harper#2234: a config watcher armed before the file exists
-			// takes the fallback branch, so it needs the same guard as the primary one.
 			const absentLeaf = join(aliasLink, 'not-written-yet.yaml');
 			const resolved = recordingNativeCalls(() =>
 				assert.strictEqual(canonicalizeWatchPath(absentLeaf, 'win32'), join(longDirectory, 'not-written-yet.yaml'))
@@ -164,10 +162,13 @@ describe('watchPath', () => {
 		const skippedDirectories = new Set([
 			'.claude',
 			'.git',
+			'.nyc_output',
+			'coverage',
 			'dist',
 			'docs',
 			'integrationTests',
 			'node_modules',
+			'tmp',
 			'unitTests',
 		]);
 
@@ -195,8 +196,8 @@ describe('watchPath', () => {
 			);
 		});
 
-		// File-level, so it catches a site that never canonicalizes at all, not a second raw watch
-		// added beside an existing canonicalized one.
+		// File-level: catches a site that never canonicalizes, not a second raw watch beside a
+		// canonicalized one.
 		it('all route their path through the canonicalization helper', () => {
 			for (const site of NATIVE_WATCH_SITES) {
 				const source = readFileSync(join(repoRoot, site), 'utf8');

--- a/unitTests/utility/watchPath.test.js
+++ b/unitTests/utility/watchPath.test.js
@@ -1,7 +1,16 @@
 const { canonicalizeWatchPath, resolveWatchTarget, _resetForTests } = require('#src/utility/watchPath');
 const assert = require('node:assert');
-const { mkdtempSync, mkdirSync, symlinkSync, realpathSync, writeFileSync, rmSync } = require('node:fs');
-const { join } = require('node:path');
+const {
+	mkdtempSync,
+	mkdirSync,
+	symlinkSync,
+	realpathSync,
+	writeFileSync,
+	rmSync,
+	readdirSync,
+	readFileSync,
+} = require('node:fs');
+const { join, relative } = require('node:path');
 const { tmpdir } = require('node:os');
 
 // A symlink named `RUNNER~1` pointing at a long-named directory models the Windows 8.3 alias this
@@ -55,6 +64,25 @@ describe('watchPath', () => {
 		it('fails closed when not even the directory resolves', () => {
 			assert.strictEqual(canonicalizeWatchPath(join(root, 'absent', 'absent', 'config.yaml'), 'win32'), undefined);
 		});
+
+		it('expands through realpathSync.native, not the symlink-only realpathSync', () => {
+			// The symlink model above cannot separate the two — plain `realpathSync` resolves a symlink
+			// as well — but only `.native` expands an 8.3 name, so assert the call target itself. A
+			// regression to the plain form would otherwise ship green and silently restore the abort.
+			const fs = require('node:fs');
+			const original = fs.realpathSync.native;
+			const resolved = [];
+			fs.realpathSync.native = (candidate) => {
+				resolved.push(candidate);
+				return original(candidate);
+			};
+			try {
+				assert.strictEqual(canonicalizeWatchPath(aliasLink, 'win32'), longDirectory);
+			} finally {
+				fs.realpathSync.native = original;
+			}
+			assert.deepStrictEqual(resolved, [aliasLink]);
+		});
 	});
 
 	describe('resolveWatchTarget', () => {
@@ -86,6 +114,73 @@ describe('watchPath', () => {
 				path: join(root, 'absent'),
 				mustPoll: false,
 			});
+		});
+	});
+
+	// The `platform !== 'win32'` early return makes every call site a provable no-op on the ubuntu
+	// and macOS runners this repo uses, so no test anywhere would notice a seventh watch site that
+	// skipped the helper — and what it produces is the unloggable process abort this exists to
+	// remove. This scan is the executable form of the DESIGN.md invariant.
+	describe('native watch sites', () => {
+		const NATIVE_WATCH_SITES = [
+			'components/EntryHandler.ts',
+			'components/OptionsWatcher.ts',
+			'config/RootConfigWatcher.ts',
+			'resources/blob.ts',
+			'security/keys.ts',
+			'server/threads/manageThreads.js',
+		];
+
+		const IMPORTS_CHOKIDAR = /from\s*['"]chokidar['"]|require\(\s*['"]chokidar['"]\s*\)/;
+		// `watch`, not `watchFile`: the latter is stat polling with no fs-event handle, so it is
+		// outside the invariant (`utility/logging/readLog.ts`).
+		const IMPORTS_FS_WATCH =
+			/import\s*\{[^}]*\bwatch\b[^}]*\}\s*from\s*['"](?:node:)?fs['"]|\{[^}]*\bwatch\b[^}]*\}\s*=\s*require\(\s*['"](?:node:)?fs['"]\s*\)/;
+		const CALLS_FS_WATCH = /\bfs\.watch\s*\(/;
+
+		const repoRoot = join(__dirname, '..', '..');
+		const skippedDirectories = new Set([
+			'.claude',
+			'.git',
+			'dist',
+			'docs',
+			'integrationTests',
+			'node_modules',
+			'unitTests',
+		]);
+
+		const collectWatchSites = (directory, found = []) => {
+			for (const entry of readdirSync(directory, { withFileTypes: true })) {
+				const entryPath = join(directory, entry.name);
+				if (entry.isDirectory()) {
+					if (!skippedDirectories.has(entry.name)) collectWatchSites(entryPath, found);
+					continue;
+				}
+				if (!/\.(?:ts|js|mjs|cjs)$/.test(entry.name)) continue;
+				const source = readFileSync(entryPath, 'utf8');
+				if (IMPORTS_CHOKIDAR.test(source) || IMPORTS_FS_WATCH.test(source) || CALLS_FS_WATCH.test(source))
+					found.push(relative(repoRoot, entryPath).replace(/\\/g, '/'));
+			}
+			return found;
+		};
+
+		it('are exactly the files that canonicalize their watch path', () => {
+			assert.deepStrictEqual(
+				collectWatchSites(repoRoot).sort(),
+				[...NATIVE_WATCH_SITES].sort(),
+				'A file that arms a native watch must canonicalize its path through utility/watchPath.ts ' +
+					'(see DESIGN.md) and then be listed here.'
+			);
+		});
+
+		it('all route their path through the canonicalization helper', () => {
+			for (const site of NATIVE_WATCH_SITES) {
+				const source = readFileSync(join(repoRoot, site), 'utf8');
+				assert.ok(
+					/\bresolveWatchTarget\b|\bcanonicalizeWatchPath\b/.test(source),
+					`${site} arms a native watch without going through utility/watchPath.ts`
+				);
+			}
 		});
 	});
 });

--- a/utility/watchPath.ts
+++ b/utility/watchPath.ts
@@ -1,13 +1,9 @@
 import { realpathSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
 import { loggerWithTag } from './logging/harper_logger.ts';
 
 const watchPathLogger = loggerWithTag('watcher');
 let canonicalizationWarned = false;
-
-// An 8.3 alias component (`RUNNER~1`) — the only form GetLongPathNameW rewrites, and so the only
-// one that can break the prefix comparison below. A long name that merely contains `~1` is a false
-// positive that costs one realpath.
-const SHORT_NAME_COMPONENT = /(?:^|[\\/])[^\\/]*~\d+[^\\/]*(?=[\\/]|$)/;
 
 /**
  * Canonicalize an absolute path before it is handed to a native file watch (`fs.watch`, directly or
@@ -19,24 +15,28 @@ const SHORT_NAME_COMPONENT = /(?:^|[\\/])[^\\/]*~\d+[^\\/]*(?=[\\/]|$)/;
  * comparison, and the assertion aborts the process rather than failing the watch, so a short path
  * reaching a native watch takes down the whole server (harper#2234).
  *
- * Only a path carrying an 8.3 component is touched at all: everything else is returned as given,
- * which keeps `realpathSync.native`'s symlink resolution — a behavior change of its own — off every
- * path that cannot abort. Plain `realpathSync` is not a substitute for it: that resolves symlinks
- * but leaves 8.3 names intact.
+ * Every Windows path is resolved rather than only the ones that look short: `GetLongPathNameW`'s
+ * documentation is explicit that a short name need not contain a tilde, and NTFS allows an
+ * explicitly assigned one, so any spelling test would leave the abort reachable. `realpathSync` is
+ * not a substitute for the `.native` variant — it resolves symlinks but leaves 8.3 names intact.
  *
- * Returns `undefined` when the long form cannot be established, including when the resolved path is
- * still short, because a path we cannot prove is expanded is exactly the one that must never reach a
- * native watch.
+ * Returns `undefined` when the long form cannot be established, because a path we cannot prove is
+ * expanded is exactly the one that must never reach a native watch.
  */
 export function canonicalizeWatchPath(watchPath: string, platform: string = process.platform): string | undefined {
-	if (platform !== 'win32' || !SHORT_NAME_COMPONENT.test(watchPath)) return watchPath;
-	let canonical: string;
+	if (platform !== 'win32') return watchPath;
 	try {
-		canonical = realpathSync.native(watchPath);
+		return realpathSync.native(watchPath);
 	} catch {
-		return undefined;
+		// libuv stores only the parent directory of a file target and compares only that prefix, so a
+		// leaf that does not exist yet — a config file whose watcher is armed during the install window
+		// — still yields a watch path that cannot trip the assertion.
+		try {
+			return join(realpathSync.native(dirname(watchPath)), basename(watchPath));
+		} catch {
+			return undefined;
+		}
 	}
-	return SHORT_NAME_COMPONENT.test(canonical) ? undefined : canonical;
 }
 
 /**

--- a/utility/watchPath.ts
+++ b/utility/watchPath.ts
@@ -27,7 +27,8 @@ export function canonicalizeWatchPath(watchPath: string, platform: string = proc
 	if (platform !== 'win32') return watchPath;
 	try {
 		return realpathSync.native(watchPath);
-	} catch {
+	} catch (error) {
+		if (!error || typeof error !== 'object' || !('code' in error) || error.code !== 'ENOENT') return undefined;
 		// libuv stores only the parent directory of a file target and compares only that prefix, so a
 		// leaf that does not exist yet — a config file whose watcher is armed during the install window
 		// — still yields a watch path that cannot trip the assertion.

--- a/utility/watchPath.ts
+++ b/utility/watchPath.ts
@@ -1,9 +1,13 @@
 import { realpathSync } from 'node:fs';
-import { basename, dirname, join } from 'node:path';
 import { loggerWithTag } from './logging/harper_logger.ts';
 
 const watchPathLogger = loggerWithTag('watcher');
 let canonicalizationWarned = false;
+
+// An 8.3 alias component (`RUNNER~1`) — the only form GetLongPathNameW rewrites, and so the only
+// one that can break the prefix comparison below. A long name that merely contains `~1` is a false
+// positive that costs one realpath.
+const SHORT_NAME_COMPONENT = /(?:^|[\\/])[^\\/]*~\d+[^\\/]*(?=[\\/]|$)/;
 
 /**
  * Canonicalize an absolute path before it is handed to a native file watch (`fs.watch`, directly or
@@ -15,37 +19,30 @@ let canonicalizationWarned = false;
  * comparison, and the assertion aborts the process rather than failing the watch, so a short path
  * reaching a native watch takes down the whole server (harper#2234).
  *
- * Returns `undefined` when the long form cannot be established, because a path we cannot prove is
- * canonical is exactly the one that must never reach a native watch. A leaf that does not exist yet
- * (a config file whose watcher is armed before it is written) resolves through its deepest existing
- * ancestor; any other failure fails closed.
+ * Only a path carrying an 8.3 component is touched at all: everything else is returned as given,
+ * which keeps `realpathSync.native`'s symlink resolution — a behavior change of its own — off every
+ * path that cannot abort. Plain `realpathSync` is not a substitute for it: that resolves symlinks
+ * but leaves 8.3 names intact.
  *
- * Windows-only: elsewhere `realpathSync.native` would additionally resolve symlinks, which changes
- * which tree an npm-linked component watches. Plain `realpathSync` is not a substitute — it resolves
- * symlinks but leaves 8.3 names intact.
+ * Returns `undefined` when the long form cannot be established, including when the resolved path is
+ * still short, because a path we cannot prove is expanded is exactly the one that must never reach a
+ * native watch.
  */
 export function canonicalizeWatchPath(watchPath: string, platform: string = process.platform): string | undefined {
-	if (platform !== 'win32') return watchPath;
-	let unresolvedSuffix = '';
-	let candidate = watchPath;
-	while (true) {
-		try {
-			const canonical = realpathSync.native(candidate);
-			return unresolvedSuffix ? join(canonical, unresolvedSuffix) : canonical;
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return undefined;
-			const parent = dirname(candidate);
-			if (parent === candidate) return undefined;
-			unresolvedSuffix = unresolvedSuffix ? join(basename(candidate), unresolvedSuffix) : basename(candidate);
-			candidate = parent;
-		}
+	if (platform !== 'win32' || !SHORT_NAME_COMPONENT.test(watchPath)) return watchPath;
+	let canonical: string;
+	try {
+		canonical = realpathSync.native(watchPath);
+	} catch {
+		return undefined;
 	}
+	return SHORT_NAME_COMPONENT.test(canonical) ? undefined : canonical;
 }
 
 /**
- * Watch target for a chokidar/`fs.watch` call: the canonical path when one could be established,
- * otherwise the original path with `mustPoll`, which callers turn into their polling options.
- * Polling never arms a native watch, so it cannot hit the abort.
+ * Watch target for a chokidar/`fs.watch` call: the canonical path, or the original path with
+ * `mustPoll`, which callers turn into their polling options. Polling stats the file instead of
+ * arming a native watch, so it cannot reach the abort.
  */
 export function resolveWatchTarget(watchPath: string): { path: string; mustPoll: boolean } {
 	const canonical = canonicalizeWatchPath(watchPath);
@@ -53,14 +50,13 @@ export function resolveWatchTarget(watchPath: string): { path: string; mustPoll:
 	if (!canonicalizationWarned) {
 		canonicalizationWarned = true;
 		watchPathLogger.warn?.(
-			`Could not resolve the canonical form of ${watchPath}. Falling back to polling-based watching ` +
-				'for affected watchers, because a non-canonical path handed to a native Windows watch aborts the process.'
+			`Could not resolve the long-path form of ${watchPath}. Falling back to polling-based watching for ` +
+				'affected watchers, because handing a Windows 8.3 short path to a native watch aborts the process.'
 		);
 	}
 	return { path: watchPath, mustPoll: true };
 }
 
-// Test-only hook to reset the one-time warning gate between cases.
 export function _resetForTests(): void {
 	canonicalizationWarned = false;
 }

--- a/utility/watchPath.ts
+++ b/utility/watchPath.ts
@@ -1,0 +1,66 @@
+import { realpathSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { loggerWithTag } from './logging/harper_logger.ts';
+
+const watchPathLogger = loggerWithTag('watcher');
+let canonicalizationWarned = false;
+
+/**
+ * Canonicalize an absolute path before it is handed to a native file watch (`fs.watch`, directly or
+ * through chokidar).
+ *
+ * libuv's Windows fs-event callback rebuilds each event's absolute path, expands it with
+ * `GetLongPathNameW`, and then asserts the expansion still starts with the directory it stored when
+ * the watch was armed. An 8.3 short directory (`C:\Users\RUNNER~1\...`) never survives that
+ * comparison, and the assertion aborts the process rather than failing the watch, so a short path
+ * reaching a native watch takes down the whole server (harper#2234).
+ *
+ * Returns `undefined` when the long form cannot be established, because a path we cannot prove is
+ * canonical is exactly the one that must never reach a native watch. A leaf that does not exist yet
+ * (a config file whose watcher is armed before it is written) resolves through its deepest existing
+ * ancestor; any other failure fails closed.
+ *
+ * Windows-only: elsewhere `realpathSync.native` would additionally resolve symlinks, which changes
+ * which tree an npm-linked component watches. Plain `realpathSync` is not a substitute — it resolves
+ * symlinks but leaves 8.3 names intact.
+ */
+export function canonicalizeWatchPath(watchPath: string, platform: string = process.platform): string | undefined {
+	if (platform !== 'win32') return watchPath;
+	let unresolvedSuffix = '';
+	let candidate = watchPath;
+	while (true) {
+		try {
+			const canonical = realpathSync.native(candidate);
+			return unresolvedSuffix ? join(canonical, unresolvedSuffix) : canonical;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return undefined;
+			const parent = dirname(candidate);
+			if (parent === candidate) return undefined;
+			unresolvedSuffix = unresolvedSuffix ? join(basename(candidate), unresolvedSuffix) : basename(candidate);
+			candidate = parent;
+		}
+	}
+}
+
+/**
+ * Watch target for a chokidar/`fs.watch` call: the canonical path when one could be established,
+ * otherwise the original path with `mustPoll`, which callers turn into their polling options.
+ * Polling never arms a native watch, so it cannot hit the abort.
+ */
+export function resolveWatchTarget(watchPath: string): { path: string; mustPoll: boolean } {
+	const canonical = canonicalizeWatchPath(watchPath);
+	if (canonical !== undefined) return { path: canonical, mustPoll: false };
+	if (!canonicalizationWarned) {
+		canonicalizationWarned = true;
+		watchPathLogger.warn?.(
+			`Could not resolve the canonical form of ${watchPath}. Falling back to polling-based watching ` +
+				'for affected watchers, because a non-canonical path handed to a native Windows watch aborts the process.'
+		);
+	}
+	return { path: watchPath, mustPoll: true };
+}
+
+// Test-only hook to reset the one-time warning gate between cases.
+export function _resetForTests(): void {
+	canonicalizationWarned = false;
+}


### PR DESCRIPTION
Refs #2234.

Harper aborts on Windows when a watched path carries an 8.3 short component. libuv's fs-event callback rebuilds each event's absolute path, expands it with `GetLongPathNameW`, and asserts the expansion still starts with the directory it stored when the watch was armed — `Assertion failed: !_wcsnicmp(filename, dir, dirlen), file src\win\fs-event.c, line 72`. A short directory (`C:\Users\RUNNER~1\...`) never survives that comparison, and libuv aborts the process rather than failing the watch. There is no JS-observable seam, so the existing `isWatcherExhaustionError` → polling recovery never runs and nothing is logged; the process is simply gone.

That is what has been failing `Integration Tests 2/6 (Windows, Node.js v24)` on roughly half of all runs since 2026-08-24, on every branch. The job only shows `Probe /SeoPageCache/ did not become ready within 120000ms (last error=ECONNREFUSED)` from `describe-metadata-upgrade.test.ts`; the assertion is only in the server-log artifact. On the GitHub Windows runner `os.tmpdir()` is `C:\Users\RUNNER~1\AppData\Local\Temp`, so every Harper instance in that shard runs with a short-path data root.

The surface is wider than "watches on a single file", which is the shape libuv needs: chokidar v4 opens a per-file `fs.watch` for every file it discovers inside a watched tree, so one component-directory watch arms hundreds of them. It is also not CI-only — the TLS certificate/private-key reload watcher is one of the six sites, and an abort there lands during automated renewal on a live node.

- [`canonicalizeWatchPath`](https://github.com/HarperFast/harper/pull/2309/changes?w=1#diff-1ddd8fe9d97134d7b3c50305fccb61ccf3b7f7dcf2b95614ca67b25fe137c513R26) resolves a path to its long form before it can reach a native watch, and returns `undefined` when it cannot — [`resolveWatchTarget`](https://github.com/HarperFast/harper/pull/2309/changes?w=1#diff-1ddd8fe9d97134d7b3c50305fccb61ccf3b7f7dcf2b95614ca67b25fe137c513R47) turns that into `mustPoll`, which each caller feeds into its existing polling options. Polling stats the file instead of arming a native watch, so it cannot reach the abort.
- **Every** Windows path is resolved, not only the ones that look short. An earlier revision gated on a `~<digits>` spelling test; `GetLongPathNameW`'s documentation is explicit that a short name need not contain a tilde, and NTFS allows an explicitly assigned one, so the test had false negatives that left the abort reachable — and false positives that would have pushed a genuine `archive~2024` install into permanent polling. `realpathSync` is not a substitute for the `.native` variant: it resolves symlinks but leaves 8.3 names intact.
- [A leaf that does not exist yet resolves through its directory](https://github.com/HarperFast/harper/pull/2309/changes?w=1#diff-1ddd8fe9d97134d7b3c50305fccb61ccf3b7f7dcf2b95614ca67b25fe137c513R31), because libuv stores and compares only the *parent directory* of a file target. Without that, a config watcher armed during the install window — the "file not written yet" case `OptionsWatcher` already documents — would fail closed to polling for the life of the process.
- Applied at all six sites: the [component tree](https://github.com/HarperFast/harper/pull/2309/changes?w=1#diff-c54fec2f7823e23c3a38c014bbc3721d06c5da4e83d3465dfe9bd2ede9152a05R542) and component config watchers, the root config watcher, the [TLS reload watcher](https://github.com/HarperFast/harper/pull/2309/changes?w=1#diff-ea5297f5d9097656312d08f0a1534f0426fb6ef893a2f5bf3a456b18f81a6841R360), the `WATCH_DIR` dev reloader, and the [incomplete-blob read watcher](https://github.com/HarperFast/harper/pull/2309/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR769). `fs.watchFile` (`utility/logging/readLog.ts`) is stat polling with no fs-event handle and is outside the invariant.
- `EntryHandler` is the one caller where the canonical path is load-bearing past the `fs.watch` call: chokidar's `ignored` predicate receives absolute paths built from `cwd`, so its bases are now derived from the same directory spelling (and hoisted out of the per-entry callback, where they were being rebuilt for every discovered path). Event paths are relative to `cwd`, so reads stay on the configured `component.directory`.
- `resources/blob.ts` had no polling story of its own, so [a degraded watch there polls `readMore`](https://github.com/HarperFast/harper/pull/2309/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR791) on the same 20 ms backoff and the same `incompleteDeadline` the in-progress-write stall already uses, rather than sitting out the full read timeout and returning a 503 on a healthy live upload.
- Two adjacent crash paths in that same call, both pre-existing on `main` and both surfaced by review: [`fs.watch` throws synchronously](https://github.com/HarperFast/harper/pull/2309/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR771) when the OS watcher pool is exhausted (EMFILE/ENOSPC), and [an `FSWatcher` that fails after registration emits `'error'`](https://github.com/HarperFast/harper/pull/2309/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR787) — with no listener Node rethrows it out of the watcher callback. Both now route into the same poll fallback.
- That whole block is [`watchInProgressFile()`](https://github.com/HarperFast/harper/pull/2309/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR231), exported with an injectable `watch`, so the paths a normal read cannot reach without an exhausted OS watcher pool are covered by [six focused unit tests](https://github.com/HarperFast/harper/pull/2309/changes?w=1#diff-9b125a1f520c4f030fa53590e672ec5278ebf46b2a2b78a9e6bbd70ea42b9382R2108). Extracting it also closed a hole: [both callbacks now go through the same `isLive` identity check](https://github.com/HarperFast/harper/pull/2309/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR234), where before only the `'error'` listener did — so neither a late error nor a [late change](https://github.com/HarperFast/harper/pull/2309/changes?w=1#diff-9b125a1f520c4f030fa53590e672ec5278ebf46b2a2b78a9e6bbd70ea42b9382R2196) from a watcher the read has already replaced can close the live watcher and start a second read sharing its fd and position.
- The two chokidar recovery sites [start their `close()` from a microtask](https://github.com/HarperFast/harper/pull/2309/changes?w=1#diff-ea5297f5d9097656312d08f0a1534f0426fb6ef893a2f5bf3a456b18f81a6841R378) rather than as the argument to `Promise.resolve(…)`, which evaluated it synchronously: a synchronous throw from `close()` escaped the chained `.catch()` and left the `'error'` listener as an uncaught exception. That ordering is now pinned by a test on each site — `unitTests/security/keys.test.js` and a new `unitTests/server/threads/watchDirFallback.test.js`, which is also the first coverage `watchDir` has had — and the reopen no longer swallows a synchronous `openWatcher` throw silently, so a permanently unwatched certificate or component directory is logged.
- `resources/blob.ts`'s `pull()` retired its in-progress watcher from five places, each hand-rolling close-then-null. They now share one `closeWatcher()` that drops the handle *before* closing it — so a callback racing the close fails its `isLive` check — and tolerates a throwing `close()`, so no teardown (`onError`, `resumeIfWriterFinished`, `onChange`, the `readSync` shortcut, `cancel()`) can be abandoned partway. Net fewer lines than the five copies.
- `EntryHandler` hands chokidar `component.commonPatternBase`. chokidar resolves a *relative* base against the canonicalized `cwd`, but an absolute one reaches the native watch as spelled, so an absolute base now goes through `resolveWatchTarget` as well.

## For the human reviewer

- **No Windows host was available, so nothing here has been executed against real 8.3 expansion or a real native watch.** The [unit tests](https://github.com/HarperFast/harper/pull/2309/changes?w=1#diff-fc5383f6c452b5a4fb9007116843d496dbc30dc836efc6a96f10bc66f80a0c1fR40) drive the branch logic with a symlink named `RUNNER~1` pointing at a long-named directory, which models what `realpathSync.native` does to an alias. That proves the algorithm, not libuv. The proof that matters is this PR's own `Integration Tests (Windows, Node.js v24)` matrix — please check whether all six Windows shards are green, and re-run once, because the failure it targets is ~50/50 per run. `Refs` rather than `Fixes` for exactly that reason.
- **Declined — a Windows-only regression test.** The strongest test would obtain a real 8.3 alias, arm both a chokidar file watch and a direct `fs.watch` under it in a child process, mutate the files, and assert both event delivery and child survival, isolated because unfixed it aborts the runner. I did not write it blind: unit tests are ubuntu-only in CI (`.github/workflows/unit-test.yml`), so it would never run there, and I cannot check it on the platform it exists for. @kriszyp has a Windows box for the follow-up.
- **Declined — a lint tripwire for the invariant.** "New watch sites must go through the helper" is enforced only by the DESIGN.md paragraph, and the failure it prevents is an unloggable process abort, so a reviewer suggested an oxlint `no-restricted-imports` rule with `utility/watchPath.ts` as the only allowed importer (`.oxlintrc.json` already bans `node:assert/strict` this way). It is a good idea and I'd support it as a follow-up; it needs a seven-file allowlist plus the test files that stub chokidar, which is scope growth on an already large change.
- **Done, after this was declined once — a test seam for the new `resources/blob.ts` watcher branches.** The earlier revision declined it on the grounds that a seam through the blob read path was a worse trade than the uncovered branch; @kriszyp chose the seam. It is one exported function with an injectable `watch` argument that production never passes, which is what the tests above drive. What it does *not* cover: the `mustPoll` decision inside `resolveWatchTarget` (win32-only), and the read loop's own no-watcher deadline branch, which still needs a `FileBackedBlob` stream to reach.
- **Not done — reopening a watcher after a *non-exhaustion* error.** A reviewer noted that chokidar can close the underlying watcher when it emits, so an `EACCES` on the TLS or dev-reload watcher logs and then silently never fires again. `security/keys.ts` is backstopped by its periodic re-read, and the dev reloader is `WATCH_DIR`-only, so this is a degraded fast path rather than a lost renewal — but re-arming on a delay after any error is a behavior decision I did not want to make inside a scoped follow-up.
- **Not done — the 20 ms poll re-allocates its read buffer.** Each re-entry into `readMore` allocates a fresh 256 KiB buffer before probing for data, so a read stuck in the fallback churns allocations on a host that is already under watcher pressure. The allocation is pre-existing and shared with the stall poll this fallback reuses; reusing a per-pull buffer is a separate change to that path.
- **Not done — direct coverage for `closeWatcher()`'s catch (raised by the review bot after the last push).** The `watchInProgressFile` tests drive that helper's own close-throw guard directly, but `pull()`'s `closeWatcher()` has no seam: `watchInProgressFile`'s injectable `watch` argument is a parameter of the *helper*, and production `pull()` calls it with the default. Reaching the catch from a real read means adding a second injection point to `pull()` itself — the same design question as the read loop's no-watcher deadline branch, which is the other known gap below.
- **Not done — a call-level watch-site tripwire.** The scan asserts each listed file *mentions* the canonicalization helper, so a second raw `fs.watch` beside a canonicalized one in an already-listed file stays green; making it call-level means parsing rather than grepping.
- **Not done — the dev reloader's queued restart is an `async` `setTimeout` callback.** A throw from `beforeRestart()` or `restartWorkers()` in `server/threads/manageThreads.js` becomes an unhandled rejection. It is byte-identical on `origin/main` — the block is only in this diff because the watch site around it moved — and it is `WATCH_DIR`-only, so it is recorded rather than absorbed; this PR has already taken on three pre-existing blob crash paths.
- **Considered and declined — `resolveWatchTarget` as synchronous I/O on the blob tail path.** A reviewer read `watchTarget ??= resolveWatchTarget(filePath)` as a per-read `realpathSync.native`. Off Windows `canonicalizeWatchPath` returns the path with no syscall at all, and on Windows it runs once per stream (the `??=` caches it) and only after a read has already stalled with no data to return.
- **Not done — an absolute component pattern base is separately broken.** `EntryHandler` now canonicalizes an absolute `commonPatternBase` too, so it cannot reach a native watch unexpanded. But such a component is already non-functional for a different reason: `join(watchDirectory, base)` in the `ignored` predicate produces garbage for an absolute base, so every discovered path is ignored. `Component` rejects a pattern that starts with `/`, which makes this unreachable on POSIX but leaves a Windows drive-letter pattern (`C:\...`) through. Rejecting absolute patterns outright is a user-facing validation change and belongs in its own PR.
- **Declined — extracting the reopen-on-exhaustion sequence into a shared helper.** `security/keys.ts` and `manageThreads.js`'s `watchDir` now hand-roll the same `usingPolling` / `liveWatcher !== opened` guard, `warnWatcherFallback`, close-and-reopen sequence that `EntryHandler`, `OptionsWatcher` and `RootConfigWatcher` already carry as private methods — five copies of one invariant, and a reviewer asked for a shared `utility/watcherFallback.ts` helper. It is the right end state and I'd support it as a follow-up alongside the lint tripwire above; @kriszyp confirmed the deferral when this follow-up was scoped. Three of the five copies predate this PR, and the two shapes differ (private class fields with a `#openWatcher` method vs. closure locals), so a common helper is a cross-cutting refactor of five files rather than part of this fix.
- **Symlink and junction resolution on Windows.** `realpathSync.native` also resolves reparse points, so a watched path that is a junction is now watched at its target on Windows; retargeting the junction without touching the target would not be seen. Two reviewers raised it and the adjudicating pass dropped it both rounds on the grounds that `fs.watch`/inotify already follow a symlinked file to its target inode, so the same retarget is already invisible on Linux and macOS — this makes Windows match, rather than diverge. `security/keys.ts` also keeps its periodic re-read as a backstop. Flagging it because it is the one deliberate platform-behavior change in the diff.
- **A watcher that degrades to polling stays there for its lifetime**, and the warning is one-shot process-wide, so a second, later degradation logs nothing. That matches how `#usingPolling` already latches for ENOSPC/EMFILE — it is now the same field, so `_usingPollingForTests` reports it — and it is a one-line change if you want it re-armed per watcher.
- **Rebased onto latest `main` (`760f5ffc9`) at `8d0c6ce45`, then two further review rounds fixed a config-watcher gap the rebase's wider CI surface exposed.** `OptionsWatcher`/`RootConfigWatcher` still called the failed watcher's `close()` directly inside the chokidar `'error'` listener — unlike `blob.ts`/`keys.ts`/`manageThreads.js`, hardened in earlier rounds — so a synchronous throw there would escape as an uncaught exception; fixed by starting `close()` from a microtask there too. The same round surfaced a second gap in the same two files: the reopen was chained via `.finally()` with no trailing `.catch()`, so a synchronous throw from `#openWatcher()` on reopen would become an unhandled rejection — added the same trailing `.catch()` pattern `keys.ts`/`manageThreads.js` already use. Both are now covered by a mirrored test in each file, using the sinon-free `chokidar.watch` reassignment pattern from `watchDirFallback.test.js` (per `AGENTS.md`'s no-new-sinon rule) — which also replaced this branch's own earlier `sinon.stub(chokidar, 'watch')` additions in `keys.test.js` with the same pattern.
- **CI at `8d0c6ce45`: all six Windows shards ran (after one re-run); `Integration Tests 2/6 (Windows)` — the shard this fix targets — passed, and `6/6` failed on its first two attempts for the same unrelated known reason as before, then passed on a third attempt.** Both failures were `set_configuration` tests hitting `EPERM: operation not permitted, rename ...harper-config.yaml.tmp -> harper-config.yaml` from `server/operationsServer.ts:345` — a *different* test each time (`replicated: true rejects explicitly`, then `writes an operator-named component _package entry`), matching the same flake documented independently on #2318, #2039, and #809 (all unrelated PRs, none touching watch paths or config writing) and tracked at #2313 with a fix already up in #2191. All other checks (Build, Unit Tests ×3 Node versions, Integration Tests 1–5/6 across Bun/Node/uWS/Windows, Next.js adapter, smoke, lint, format, coverage) passed on the first attempt.
- **CI at `485414892`: all six Windows shards ran; `Integration Tests 2/6 (Windows)` — the shard this fix targets — passed again, and `6/6` failed for the same unrelated known reason as before (`set_configuration` → `EPERM ... harper-config.yaml.tmp -> harper-config.yaml`).** All three `Unit Test` jobs failed on the first attempt and passed on re-run with no code change; the two failures were HNSW vector-index assertions (`greedy descent changed the result set`, `bulk delete severed survivors`) in `unitTests/resources/vectorIndex*`, on a code path this diff does not touch, and they pass locally at this head.
- **CI at the earlier head `31cfbbbe`: all six Windows shards ran; `Integration Tests 2/6 (Windows)` — the shard this fix targets — passed, and `6/6` failed for an unrelated known reason.** That failure is `Configuration` → `set_configuration` returning 500 from `EPERM: operation not permitted, rename ...harper-config.yaml.tmp -> harper-config.yaml`, which is [Windows: set_configuration returns 500 because the config write's rename retry blocks the thread that would release the handle](https://github.com/HarperFast/harper/issues/2313), already under fix in [fix(config): read root config synchronously and bound rename retries by wall clock](https://github.com/HarperFast/harper/pull/2191). It reproduces identically on `main` with no part of this diff present — same suite, same rename, same message — in [this `main` Integration Tests run](https://github.com/HarperFast/harper/actions/runs/32853337399). Nothing in this diff touches config writing.

## Verification

- Rebase round (`8d0c6ce45`, onto `main@760f5ffc9`): `npm run build`, `oxlint --deny-warnings` on all changed files, and every affected suite together — `unitTests/resources/blob.test.js`, `unitTests/utility/watchPath.test.js`, `unitTests/server/threads/watchDirFallback.test.js`, `unitTests/components/OptionsWatcher*.test.js`, `unitTests/config/rootConfigWatcher.test.js`, `unitTests/security/keys.test.js` — 234 passing, 0 failing, re-run after each of the two review-round fixes.
- Follow-up round (`485414892`): `npm run build`, changed-file prettier + oxlint clean, and each affected suite run on its own — `unitTests/resources/blob.test.js` 110 passing, `unitTests/security/keys.test.js` 62 passing, `unitTests/utility/watchPath.test.js` 13 passing, `unitTests/components/EntryHandler.test.js` 40 passing, `unitTests/server/threads/*.test.js` 36 passing. 0 failing.
- The synchronous-`close()`-throw fix is now mutation-pinned on both sites: reverting either reopen chain to `Promise.resolve(opened.close())` fails `unitTests/security/keys.test.js` and `unitTests/server/threads/watchDirFallback.test.js`, re-measured after the suites were rewritten to `node:assert`.
- Running `unitTests/resources` alongside `unitTests/security` in one mocha process reports 4 failures in two unrelated `createTLSSelector` cases, from an analytics-writer timer firing across suites. Identical, same two cases, on this branch's prior head `31cfbbbe2` with these files reverted — pre-existing cross-directory pollution, and not a shape CI runs (`test:unit:main` excludes `unitTests/resources`).

- Re-verified at the pushed head `31cfbbbe`: `npm run build`, then `unitTests/resources/blob.test.js` + `unitTests/utility/watchPath.test.js` + `unitTests/security/keys.test.js` — 183 passing, 0 failing.
- Follow-up review fix: non-`ENOENT` native realpath failures now fail closed to polling; `npm run build`, changed-file oxlint, and `unitTests/utility/watchPath.test.js` all pass (13 tests).
- `npm run test:integration:all` completed 1,816 passing and 20 skipped; 6 real-Ollama children were cancelled by an unrelated JSON import-attribute startup error in that optional suite.

- `npm run build`, `npm run lint:required`, `npm run test:types` — all pass.
- `unitTests/utility/watchPath.test.js` — 13 passing: the non-Windows identity return, directory and file resolution through a short-form ancestor, the not-yet-written leaf resolving through its directory, fail-closed when not even the directory resolves, and both `resolveWatchTarget` outcomes.
- Every suite covering a changed file — `unitTests/components`, `unitTests/config`, `unitTests/security`, `unitTests/utility`, `unitTests/resources/blob*` — 3195 passing, 44 pending, 0 failing. The two `resources/blob.ts` commits after that run were re-covered by `unitTests/resources/blob*` + `unitTests/utility/watchPath.test.js` (111 passing) and `unitTests/config/rootConfigWatcher.test.js` (6 passing).
- `npm run test:unit:resources` — 1684 passing, 16 pending, 3 failing; the three (`randomAccessFields` ×2, `replayStructures`) are this machine's pre-existing baseline failures.
- `npm run test:unit:main` cannot run on this machine: it aborts at module load against a stale local Harper install, **identically on a pristine `origin/main` checkout**, so it is environmental. The suites above cover its files for this diff.
- End-to-end route: this PR's own Windows CI matrix, as described above. Not reproducible locally — no Windows host.
- The watcher-seam follow-up: `unitTests/resources/blob.test.js` 109 passing, `unitTests/security` 664 passing, `unitTests/utility` 530 passing, `npm run build`, `npm run format:write` and `npm run lint:required` clean. `npm run test:unit:resources` — 1688 passing, 16 pending, 8 failing, and the same 8 fail identically on this branch's prior head with these files reverted, so they are this machine's baseline, not the change. `unitTests/components` and `unitTests/server` cannot start on this machine at all (they abort at module load resolving a storage root, on the unmodified tree too).
- Each of the five helper behaviors was mutation-checked rather than assumed: dropping the `isLive` guard from either callback, dropping the `mustPoll` latch, watching the uncanonicalized path, and registering unconditionally each fail at least one of the new tests.

Independent review: seventeen rounds (`prepush-review.mjs`, receipt count) — codex, Gemini, Cursor Grok and the Harper-domain adjudicator; the round numbers below are the substantive ones. The four rounds after `31cfbbbe` ran Gemini alone, which is why the receipt reads `declined=codex`: the adjudicating and codex legs had already covered this diff four times, and each of those rounds reviewed a small delta that came directly out of Gemini's own prior findings. Round 1: 5 findings, 5 fixed. Round 2 found the one that changed the design — an earlier `~<digits>` gate had false negatives, so the abort survived for a non-tilde alias — plus the `resources/blob.ts` fallback gap; both fixed. Rounds 4–6 each surfaced one further pre-existing crash path in the blob watcher call, all fixed above. Round 7 (the seam commit) raised the unguarded change callback as major — fixed in the next commit. Round 8 raised the synchronous `close()` throw — fixed. Round 9 is LGTM from the graded leg with one repeat comment-style nit. Round 10 (codex + Gemini, on the new regression coverage): 3 findings, 3 fixed — the new `watchDir` suite moved to bare `node:assert` per AGENTS.md, and both suites that fire an exhaustion error now reset `warnWatcherFallback`'s process-global one-time gate. Round 11 raised the uncanonicalized absolute `commonPatternBase` and the unguarded `close()` in `watchInProgressFile`'s error listener — both fixed. Round 12 raised the five hand-rolled blob teardowns and the two silently-swallowed reopen throws — both fixed. Round 13 produced no new actionable finding: one pre-existing `main` defect, one misreading of the lazy `??=` watch-target cache, and two repeats. After the rebase onto latest `main`, further rounds found and fixed the config-watcher microtask/reopen gap described above, plus a new-sinon house-style violation in the tests added to cover it; subsequent rounds converged with no further actionable findings beyond the pre-existing/deferred items already listed above. Everything raised and not taken is a `Not done` / `Declined` entry above.

Complexity: moderate — a small path-normalization helper, but it changes what every file watcher in the process is handed, and one caller (`resources/blob.ts`) needed a new fallback inside a delicate stall path.

— Claude Opus

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=23 @ 8d0c6ce4519d</sub>

<sub>Human-Review-Need: 4 @ 8d0c6ce4519d</sub>
