### PR TITLE
Add job and step timeouts to the integration-test workflows

### DIFF
--- a/.github/workflows/integration-tests-nextjs.yml
+++ b/.github/workflows/integration-tests-nextjs.yml
@@ -27,6 +27,7 @@ jobs:
   changes:
     name: Detect adapter-relevant changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,10 +25,14 @@ on:
 permissions:
   contents: read
 
+# Each shard job bounds its test step below its own job bound: a step timeout FAILS the step, so
+# the `if: failure()` Harper-log upload still runs, while a job timeout CANCELS it and skips the
+# upload.
 jobs:
   generate-node-version-matrix:
     name: Generate Node Version Matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       node-versions: ${{ steps.set-node-versions.outputs.node-versions }}
 
@@ -64,6 +68,7 @@ jobs:
     name: Build Harper (Node.js v${{ matrix.node-version }})
     needs: generate-node-version-matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false
@@ -106,6 +111,7 @@ jobs:
   run-integration-tests:
     name: Integration Tests ${{matrix.shard}}/6 (Node.js v${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     needs: [generate-node-version-matrix, build]
     strategy:
       fail-fast: false
@@ -148,6 +154,7 @@ jobs:
           npm install --ignore-scripts --prefix /tmp/harper-legacy-51 harper@5.1.22
 
       - name: Run Integration Test Shard ${{ matrix.shard }}
+        timeout-minutes: 15
         env:
           HARPER_INTEGRATION_TEST_LOG_DIR: /tmp/harper-integration-test-logs
           HARPER_LEGACY_VERSION_PATH: /tmp/harperdb-legacy/node_modules/harperdb
@@ -168,6 +175,7 @@ jobs:
   build-windows:
     name: Build Harper (Windows, Node.js v24)
     runs-on: windows-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -200,6 +208,7 @@ jobs:
   run-integration-tests-windows:
     name: Integration Tests ${{matrix.shard}}/6 (Windows, Node.js v24)
     runs-on: windows-latest
+    timeout-minutes: 30
     needs: [build-windows]
     strategy:
       fail-fast: false
@@ -228,6 +237,7 @@ jobs:
         run: npm install --ignore-scripts --prefix "${{ runner.temp }}/harperdb-legacy" harperdb@4
 
       - name: Run Integration Test Shard ${{ matrix.shard }}
+        timeout-minutes: 20
         env:
           HARPER_INTEGRATION_TEST_LOG_DIR: ${{ runner.temp }}/harper-integration-test-logs
           HARPER_LEGACY_VERSION_PATH: ${{ runner.temp }}/harperdb-legacy/node_modules/harperdb
@@ -246,6 +256,7 @@ jobs:
   run-integration-tests-bun:
     name: Integration Tests ${{matrix.shard}}/6 (Bun)
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     needs: [build]
     strategy:
       fail-fast: false
@@ -276,6 +287,7 @@ jobs:
         run: npm install --ignore-scripts
 
       - name: Run Integration Test Shard ${{ matrix.shard }}
+        timeout-minutes: 15
         env:
           HARPER_INTEGRATION_TEST_LOG_DIR: /tmp/harper-integration-test-logs
           HARPER_RUNTIME: bun
@@ -295,6 +307,7 @@ jobs:
   run-integration-tests-uws:
     name: Integration Tests ${{matrix.shard}}/6 (uWS HTTP)
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     needs: [build]
     strategy:
       fail-fast: false
@@ -334,6 +347,7 @@ jobs:
       # keep running on Node, so this exercises the uWS request/streaming/WS/GraphQL/Fastify-fallback
       # path against the full integration suite.
       - name: Run Integration Test Shard ${{ matrix.shard }}
+        timeout-minutes: 15
         env:
           HARPER_INTEGRATION_TEST_LOG_DIR: /tmp/harper-integration-test-logs
           HARPER_LEGACY_VERSION_PATH: /tmp/harperdb-legacy/node_modules/harperdb


### PR DESCRIPTION
No job in `integration-tests.yml` set `timeout-minutes`, so a hung shard ran against GitHub's 360-minute default: on [#2303](https://github.com/HarperFast/harper/pull/2303) (run 32776480248, attempt 2) `Integration Tests 6/6 (Windows, Node.js v24)` ran **106.8 minutes** before being cancelled by hand, while its five sibling shards on the same attempt finished in 2.7–8.5 minutes. This bounds every job in that workflow plus each shard's test step, and picks up the one remaining unbounded job in `integration-tests-nextjs.yml`.

[The step bound](https://github.com/HarperFast/harper/pull/2310/changes?w=1#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593R151) is the load-bearing half, not [the job bound](https://github.com/HarperFast/harper/pull/2310/changes?w=1#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593R108). A step timeout *fails* the step, so the existing `if: failure()` Harper-log upload still runs; a job-level timeout *cancels* the job and skips it, which would have left exactly the hang this change targets with zero diagnostics. `integration-tests-nextjs.yml` already uses this shape. Hang detection therefore lives in the step bound, and the job bound is only an outer backstop for a wedge outside the test step — so [its gap is a flat 10 minutes on every lane](https://github.com/HarperFast/harper/pull/2310/changes?w=1#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593R22), ample for setup (p95 0.7–2.0 min) and the log upload (p95 2 seconds over 32 real failure runs), rather than a per-lane figure someone has to re-derive whenever a setup step is added.

Bounds are measured, not guessed — from the last 25 completed `main` runs (1025 job records, 360 test-step records), in minutes:

| lane | step p95 / max | **step** | job p95 / max | **job** |
|---|---|---|---|---|
| Linux Node shards (required) | 4.3 / 4.9 | **15** | 5.5 / 6.0 | **25** |
| Bun shards | 4.1 / 4.7 | **15** | 4.5 / 5.2 | **25** |
| uWS shards | 5.4 / 6.0 | **15** | 6.4 / 7.1 | **25** |
| Windows shards | 9.7 / 12.8 | **20** | 11.4 / 15.5 | **30** |
| Build (Linux) | — | — | 1.6 / 1.8 | **10** |
| Build (Windows) | — | — | 2.8 / 3.0 | **10** |
| Generate matrix | — | — | 0.1 / 0.1 | **5** |
| nextjs paths-filter | — | — | 0.3 / 0.3 | **5** |

The three `ubuntu-latest` lanes run the same suite at statistically the same speed, so they share one 15-minute step bound (2.8–3.7× their p95, 2.5–3.2× their worst observed run). Windows is genuinely ~2.3× slower and [gets 20](https://github.com/HarperFast/harper/pull/2310/changes?w=1#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593R234) — the tightest multiple in the file at 2.1× p95 / 1.6× max. That is deliberate: per the repo ruleset only the six `Integration Tests N/6 (Node.js v24)` shards are required checks on `main`, so a spurious timeout on Windows costs a re-run, while a hang there is invisible to merge gating and only burns a runner. Short jobs are floored at 5–10m rather than 3× p95, because their risk is an npm or artifact stall, an absolute rather than proportional cost.

The other long-running workflows already set `timeout-minutes` (`docker-smoke` 30, `ycsb-nightly` 60, `perf-benchmarks-nightly` 120, `large-deploy-test` 60, `node26-canary` 45, `unit-test` 10, `npm-package-app-e2e` 20–30), so the gap was specific to these two files.

Two things found while measuring, deliberately left out of scope: `unit-test.yml`'s 10-minute bound is only **1.2× its observed max** (p95 7.0, max 8.2 over 59 runs) — the tightest in the repo and the one most likely to fire spuriously on a *required* check; and `nextjs-integration` carries a pre-existing 30-minute job bound over 25 minutes of step bounds, a 5-minute gap that must cover two `npm ci` runs, a harper build and fixture installs.

## For the human reviewer

1. **Step bound under job bound, vs job bounds alone.** Chosen because a job timeout cancels and skips the `if: failure()` log upload, so bounding only the job would fix the runner-burn and lose the diagnostics — the shape `integration-tests-nextjs.yml` already uses. Cost of the layering: the 10-minute gap is schedule headroom reserved on every lane. Saying no means accepting that a bounded hang produces no Harper server logs. One line per job to reverse.
2. **Windows gets [the tightest multiple](https://github.com/HarperFast/harper/pull/2310/changes?w=1#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593R234) (2.1× p95 / 1.6× max).** Justified by advisory status — a false red costs a re-run there, not a merge block. If Windows shards are ever promoted to required checks, this becomes the tightest bound in the file and should be revisited; that coupling lives only in this PR, not in the workflow. Alternative was applying the ubuntu lanes' ~3× uniformly, which would put Windows at 30/40.
3. **One 15-minute step bound shared by the required Node lane and the advisory Bun/uWS lanes.** They measure the same speed, so this treats them the same and lets a mis-sized bound land on a required check. The alternative — looser on the required lane — buys merge-block safety at the cost of a number with no measured basis. Reversible per number.
4. **`nextjs-integration`'s [`changes` job got a job bound](https://github.com/HarperFast/harper/pull/2310/changes?w=1#diff-7d35796e0cec9f05ff7ed8b28267e964a8937befa7e31bd9ca98fa1040457de5R30), not a step bound on the checkout.** A cancelled `changes` leaves `relevant` unset, so `nextjs-integration` skips and presents identically to the ordinary "no adapter-relevant paths changed" outcome — an invisible failure rather than a red one. Measured headroom is ~16× (0.3 min max against a 5-minute bound) on an advisory workflow, so I took the simpler shape. A step bound on the checkout would degrade to red instead; one-line move if you prefer that.
5. **Bounded these two workflows only, not a repo-wide sweep.** The 360-minute default still applies to `format-check`, `lint-code`, the claude/gemini review workflows and others. Additive to extend later; flagging so the scope is a decision rather than an oversight.

Unresolved from review: nothing above nit severity. The standing nit is that the three-line header comment is arguable against Harper's zero-new-comments default; I kept it because the step-fails-vs-job-cancels asymmetry is the one thing about this file a future editor cannot read off the YAML, and adding a shard job without it silently recreates the diagnostic loss.

## Verification

CI config only, so the end-to-end route is this PR's own Actions run — it executes the changed workflow directly. Local checks, all executed against `origin/main` as the base:

- **Purely additive, mechanically proven.** Parsed both workflows and recursively stripped every `timeout-minutes` key; the resulting structures are byte-identical to `origin/main`. No `runs-on`, `needs`, `strategy`, `steps` or `env` semantics changed. `git diff --stat` = 15 insertions, 0 deletions. This check caught a real defect mid-work: an earlier revision silently dropped `needs: [build-windows]` from the Windows shard job, which would have run the shards without their build artifact.
- **Every job bounded, every gap exact.** Enumerated all 9 jobs across both files: each has a job bound; all four shard jobs have a step bound; every gap in `integration-tests.yml` is exactly 10.
- **Bounds clear observed reality.** Every step and job bound exceeds its lane's observed maximum over the sampled window (multiples in the table above). Sourced from `gh api repos/HarperFast/harper/actions/runs/<id>/jobs` over the last 25 completed `main` runs.
- **Required-check claim verified**, not assumed — read from the repo ruleset: `validate / validate`, `runLinter`, `Format Check`, `Unit Test (Node.js v24)`, `Integration Tests 1..6/6 (Node.js v24)`. Windows, Bun and uWS are absent, hence advisory.
- **The motivating hang re-confirmed** from the API: run 32776480248 attempt 2, shard 6/6 Windows `21:19:44Z → 23:06:30Z` = 106.8 min, conclusion `cancelled`; siblings on the same attempt 2.7 / 3.5 / 4.4 / 5.3 / 8.5 min.
- `npx prettier --check` clean on both files; `git diff --check` clean.

**This PR's own CI run is the executed end-to-end check** (run 32810051890, all 40 checks green, 3 correctly skipped). Every lane finished with room to spare:

| lane | slowest step | step bound | slowest job | job bound |
|---|---|---|---|---|
| Linux Node | 4.2m | 15m (3.6×) | 5.2m | 25m (4.8×) |
| Bun | 4.1m | 15m (3.7×) | 4.5m | 25m (5.5×) |
| uWS | 5.3m | 15m (2.8×) | 6.3m | 25m (3.9×) |
| Windows | 7.5m | 20m (2.7×) | 9.1m | 30m (3.3×) |

`Integration Tests 6/6 (Windows, Node.js v24)` — the shard that burned 106.8 minutes on #2303 — finished here in 4m29s.

The ordering the design depends on was also observed live rather than only argued: on `Integration Tests 2/6 (Windows)` the job started 04:46:35Z and setup finished 04:48:05Z, so 1m30s of the 10-minute gap was consumed and its step timer (05:08:05Z) preceded its job timer (05:16:35Z) by 8.5 minutes. Had that shard hung, the step would have failed and the `if: failure()` log upload would have run.

`actionlint` is not installed on this machine, so the workflow was validated by YAML parse plus this live run rather than by a linter.

Complexity: medium

<sub>Review-Coverage: authored=codex; ran=gemini,claude,cursor-composer; adjudicated=domain; declined=cursor-grok; rounds=1 @ 567f954ded61</sub>

<sub>Human-Review-Need: 3 (decisions: timeout-budget-calibration, watchdog-scope) @ 567f954ded61</sub>
