### PR TITLE
Keep a pre-ready worker's event loop alive through startup (fixes the 'exited with code 0 before reporting ready' CI failure)

### DIFF
--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -387,22 +387,23 @@ export const getComponentName = () => compName;
  * every non-root component load and repaired if missing or pointing elsewhere.
  */
 function symlinkHarperModule(componentDirectory: string) {
-	return new Promise<void>((resolve, reject) => {
+	return new Promise<void>((resolve) => {
 		const store = Status.primaryStore;
-		// Create timeout to avoid deadlocks
-		const timeout = setTimeout(() => {
-			store.unlock(componentDirectory);
-			reject(new Error('symlinking harperdb module timed out'));
-		}, 10_000);
-
-		const callback = () => {
+		let timeout: NodeJS.Timeout;
+		const onUnlocked = () => {
 			clearTimeout(timeout);
 			resolve();
 		};
-		const lockAcquired = store.tryLock(componentDirectory, callback);
+		const lockAcquired = store.tryLock(componentDirectory, onUnlocked);
 
 		if (!lockAcquired) {
-			clearTimeout(timeout);
+			// The lock holder performs the fixup; just wait for its unlock. The timer both bounds
+			// the wait if the holder dies without unlocking and — because the unlock wake arrives
+			// via an unref'd threadsafe function — keeps this pre-ready worker's event loop alive
+			// so it cannot drain and cleanly exit (code 0) before the ready handshake. Timing out
+			// resolves rather than rejects: the fixup is idempotent maintenance another thread
+			// already ran or the next load re-runs, never worth failing the component load over.
+			timeout = setTimeout(resolve, 10_000);
 		} else {
 			try {
 				// validate node_modules directory exists

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -403,7 +403,12 @@ function symlinkHarperModule(componentDirectory: string) {
 			// so it cannot drain and cleanly exit (code 0) before the ready handshake. Timing out
 			// resolves rather than rejects: the fixup is idempotent maintenance another thread
 			// already ran or the next load re-runs, never worth failing the component load over.
-			timeout = setTimeout(resolve, 10_000);
+			timeout = setTimeout(() => {
+				harperLogger.warn(
+					`Timed out waiting for another thread to verify the harper module link in ${componentDirectory}; continuing with the link in its current state`
+				);
+				resolve();
+			}, 10_000);
 		} else {
 			try {
 				// validate node_modules directory exists
@@ -446,6 +451,9 @@ function symlinkHarperModule(componentDirectory: string) {
 		}
 	});
 }
+
+// Test-only: exercises the lock-wait branch directly (unitTests/components/symlinkHarperModuleLockWait.test.js).
+export const _symlinkHarperModuleForTests = symlinkHarperModule;
 
 /**
  * This function handles the `handleApplication` call for a plugin in a sequential manner.

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -451,6 +451,7 @@ function symlinkHarperModule(componentDirectory: string) {
 	});
 }
 
+// Direct access keeps lock timing deterministic without exposing a broader component-load seam.
 export const _symlinkHarperModuleForTests = symlinkHarperModule;
 
 /**

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -397,12 +397,11 @@ function symlinkHarperModule(componentDirectory: string) {
 		const lockAcquired = store.tryLock(componentDirectory, onUnlocked);
 
 		if (!lockAcquired) {
-			// The lock holder performs the fixup; just wait for its unlock. The timer both bounds
-			// the wait if the holder dies without unlocking and — because the unlock wake arrives
-			// via an unref'd threadsafe function — keeps this pre-ready worker's event loop alive
-			// so it cannot drain and cleanly exit (code 0) before the ready handshake. Timing out
-			// resolves rather than rejects: the fixup is idempotent maintenance another thread
-			// already ran or the next load re-runs, never worth failing the component load over.
+			// The lock holder performs the fixup; wait for its unlock. The timer bounds the wait if
+			// the holder dies without unlocking, and must stay ref'd: the unlock wake arrives via an
+			// unref'd threadsafe function (see the invariant comment in threadServer.startServers).
+			// Timing out resolves rather than rejects: the fixup is idempotent maintenance, never
+			// worth failing the component load over.
 			timeout = setTimeout(() => {
 				harperLogger.warn(
 					`Timed out waiting for another thread to verify the harper module link in ${componentDirectory}; continuing with the link in its current state`
@@ -452,7 +451,6 @@ function symlinkHarperModule(componentDirectory: string) {
 	});
 }
 
-// Test-only: exercises the lock-wait branch directly (unitTests/components/symlinkHarperModuleLockWait.test.js).
 export const _symlinkHarperModuleForTests = symlinkHarperModule;
 
 /**

--- a/integrationTests/server/fixtures/worker-startup-liveness/config.yaml
+++ b/integrationTests/server/fixtures/worker-startup-liveness/config.yaml
@@ -1,0 +1,3 @@
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/server/fixtures/worker-startup-liveness/package-lock.json
+++ b/integrationTests/server/fixtures/worker-startup-liveness/package-lock.json
@@ -1,0 +1,12 @@
+{
+	"name": "worker-startup-liveness",
+	"version": "1.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "worker-startup-liveness",
+			"version": "1.0.0"
+		}
+	}
+}

--- a/integrationTests/server/fixtures/worker-startup-liveness/package.json
+++ b/integrationTests/server/fixtures/worker-startup-liveness/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "worker-startup-liveness",
+	"version": "1.0.0",
+	"private": true
+}

--- a/integrationTests/server/fixtures/worker-startup-liveness/resources.js
+++ b/integrationTests/server/fixtures/worker-startup-liveness/resources.js
@@ -1,9 +1,6 @@
-// Component load in a worker awaits a completion that does not hold the event loop —
-// modeling a dependency wakeup delivered through an unref'd handle (the CI trigger is
-// rocksdb-js's cross-thread lock-release / parked-commit-retry wake, delivered through an
-// unref'd threadsafe function during concurrent multi-worker startup). A pre-ready worker
-// awaiting such a completion must stay alive until the ready handshake instead of
-// clean-exiting with code 0 when its ref'd-handle set drains.
+// In workers, load awaits a completion that does not hold the event loop — modeling the
+// unref'd-threadsafe-function wakes (rocksdb-js lock release / parked-commit retry) behind
+// harper#2312.
 import { isMainThread } from 'node:worker_threads';
 
 if (!isMainThread) {

--- a/integrationTests/server/fixtures/worker-startup-liveness/resources.js
+++ b/integrationTests/server/fixtures/worker-startup-liveness/resources.js
@@ -1,0 +1,17 @@
+// Component load in a worker awaits a completion that does not hold the event loop —
+// modeling a dependency wakeup delivered through an unref'd handle (the CI trigger is
+// rocksdb-js's cross-thread lock-release / parked-commit-retry wake, delivered through an
+// unref'd threadsafe function during concurrent multi-worker startup). A pre-ready worker
+// awaiting such a completion must stay alive until the ready handshake instead of
+// clean-exiting with code 0 when its ref'd-handle set drains.
+import { isMainThread } from 'node:worker_threads';
+
+if (!isMainThread) {
+	await new Promise((resolve) => setTimeout(resolve, 2500).unref());
+}
+
+export class LivenessProbe extends Resource {
+	async get() {
+		return { alive: true };
+	}
+}

--- a/integrationTests/server/fixtures/worker-startup-liveness/resources.js
+++ b/integrationTests/server/fixtures/worker-startup-liveness/resources.js
@@ -3,12 +3,14 @@
 // harper#2312.
 import { isMainThread } from 'node:worker_threads';
 
-if (!isMainThread) {
-	await new Promise((resolve) => setTimeout(resolve, 2500).unref());
-}
-
+// Declared before the await: Bun's loader reads the module namespace while evaluation is
+// suspended at the top-level await, and a class declared after it would still be in its TDZ.
 export class LivenessProbe extends Resource {
 	async get() {
 		return { alive: true };
 	}
+}
+
+if (!isMainThread) {
+	await new Promise((resolve) => setTimeout(resolve, 2500).unref());
 }

--- a/integrationTests/server/worker-startup-liveness.test.ts
+++ b/integrationTests/server/worker-startup-liveness.test.ts
@@ -7,7 +7,7 @@
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual } from 'node:assert';
 import { resolve, join } from 'node:path';
-import { readFile, mkdtemp, cp, rm } from 'node:fs/promises';
+import { mkdtemp, cp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 
@@ -46,19 +46,5 @@ suite('worker startup liveness (pre-ready event-loop drain)', (ctx: ContextWithH
 			headers: { Authorization: authorization },
 		});
 		strictEqual(response.status, 200, `expected the fixture resource to serve; got ${response.status}`);
-	});
-
-	test('no worker exited before reporting ready', async () => {
-		const logDir = ctx.harper.logDir ?? join(ctx.harper.dataRootDir, 'log');
-		let contents = '';
-		try {
-			contents = await readFile(join(logDir, 'hdb.log'), 'utf8');
-		} catch {
-			// no log file means nothing was logged — acceptable
-		}
-		ok(
-			!/exited with code \d+ before reporting ready/.test(contents),
-			`a worker exited before reporting ready:\n${contents.slice(-2000)}`
-		);
 	});
 });

--- a/integrationTests/server/worker-startup-liveness.test.ts
+++ b/integrationTests/server/worker-startup-liveness.test.ts
@@ -34,8 +34,11 @@ suite('worker startup liveness (pre-ready event-loop drain)', (ctx: ContextWithH
 	});
 
 	after(async () => {
-		await teardownHarper(ctx);
-		if (rootFixtureCopy) await rm(rootFixtureCopy, { recursive: true, force: true });
+		try {
+			await teardownHarper(ctx);
+		} finally {
+			if (rootFixtureCopy) await rm(rootFixtureCopy, { recursive: true, force: true });
+		}
 	});
 
 	test('workers survive a load-time await with no ref-holding completion source', async () => {

--- a/integrationTests/server/worker-startup-liveness.test.ts
+++ b/integrationTests/server/worker-startup-liveness.test.ts
@@ -1,21 +1,8 @@
 /**
- * Regression test for the pre-ready worker event-loop drain (the recurring CI failure
- * "Worker (index N) exited with code 0 before reporting ready" thrown from
- * socketRouter.ts's createWorkerReadyPromise).
- *
- * During loadRootComponents a worker's parentPort is unref'd (manageThreads.addPort) and is
- * only ref'd after component loading completes (threadServer.js). So if component load ever
- * awaits a completion that arrives via a non-ref'd source — an unref'd threadsafe function
- * (rocksdb-js parks an IsBusy commit on the conflicting worker's lock and wakes it through
- * one), a persistent:false watcher, an unref'd timer — the worker's ref'd-handle set can hit
- * zero, the event loop drains, and the worker cleanly exits before posting child_started.
- * Main then rejects startup and tears down stores while sibling workers are still loading
- * ("Database not open" cascade).
- *
- * The fixture component deterministically recreates that window: in workers its load awaits
- * a promise resolved only by an unref'd timer. Without the liveness guarantee the workers
- * exit 0 before ready and startup aborts; with it they stay alive, the timer fires, and the
- * instance becomes ready.
+ * Regression test for the pre-ready worker event-loop drain (harper#2312, "Worker (index N)
+ * exited with code 0 before reporting ready"): a worker whose component load awaits a
+ * completion delivered through a non-ref-holding source must stay alive until the ready
+ * handshake instead of clean-exiting when its ref'd-handle set drains.
  */
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual } from 'node:assert';

--- a/integrationTests/server/worker-startup-liveness.test.ts
+++ b/integrationTests/server/worker-startup-liveness.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression test for the pre-ready worker event-loop drain (the recurring CI failure
+ * "Worker (index N) exited with code 0 before reporting ready" thrown from
+ * socketRouter.ts's createWorkerReadyPromise).
+ *
+ * During loadRootComponents a worker's parentPort is unref'd (manageThreads.addPort) and is
+ * only ref'd after component loading completes (threadServer.js). So if component load ever
+ * awaits a completion that arrives via a non-ref'd source — an unref'd threadsafe function
+ * (rocksdb-js parks an IsBusy commit on the conflicting worker's lock and wakes it through
+ * one), a persistent:false watcher, an unref'd timer — the worker's ref'd-handle set can hit
+ * zero, the event loop drains, and the worker cleanly exits before posting child_started.
+ * Main then rejects startup and tears down stores while sibling workers are still loading
+ * ("Database not open" cascade).
+ *
+ * The fixture component deterministically recreates that window: in workers its load awaits
+ * a promise resolved only by an unref'd timer. Without the liveness guarantee the workers
+ * exit 0 before ready and startup aborts; with it they stay alive, the timer fires, and the
+ * instance becomes ready.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { resolve, join } from 'node:path';
+import { readFile, mkdtemp, cp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'fixtures/worker-startup-liveness');
+const WORKERS = 2;
+
+suite('worker startup liveness (pre-ready event-loop drain)', (ctx: ContextWithHarper) => {
+	let rootFixtureCopy: string;
+
+	before(async () => {
+		// Mount the fixture twice: as a regular app (app-component window) and as a root config
+		// component (root-component window, where the CI failures die). The root mount points at a
+		// throwaway copy because symlinkHarperModule writes a node_modules/harper symlink into the
+		// mounted directory, which must never land in the source tree.
+		rootFixtureCopy = await mkdtemp(join(tmpdir(), 'harper-liveness-root-'));
+		await cp(FIXTURE_PATH, rootFixtureCopy, { recursive: true });
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+			config: {
+				'threads': { count: WORKERS },
+				'liveness-root': { package: `file:${rootFixtureCopy}` },
+			},
+			env: {},
+		});
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+		if (rootFixtureCopy) await rm(rootFixtureCopy, { recursive: true, force: true });
+	});
+
+	test('workers survive a load-time await with no ref-holding completion source', async () => {
+		ok(ctx.harper.process && ctx.harper.process.exitCode === null, 'Harper process should be running');
+		const { username, password } = ctx.harper.admin;
+		const authorization = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+		const response = await fetch(`${ctx.harper.httpURL}/LivenessProbe/`, {
+			headers: { Authorization: authorization },
+		});
+		strictEqual(response.status, 200, `expected the fixture resource to serve; got ${response.status}`);
+	});
+
+	test('no worker exited before reporting ready', async () => {
+		const logDir = ctx.harper.logDir ?? join(ctx.harper.dataRootDir, 'log');
+		let contents = '';
+		try {
+			contents = await readFile(join(logDir, 'hdb.log'), 'utf8');
+		} catch {
+			// no log file means nothing was logged — acceptable
+		}
+		ok(
+			!/exited with code \d+ before reporting ready/.test(contents),
+			`a worker exited before reporting ready:\n${contents.slice(-2000)}`
+		);
+	});
+});

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -188,6 +188,15 @@ function startServers() {
 	}
 	let loaded = require('../loadRootComponents.js')
 		.loadRootComponents(true)
+		.catch((err) => {
+			// With the pre-ready ref above, a rejected load would otherwise leave this worker
+			// parked forever (and main awaiting workersReady) instead of failing startup fast.
+			// Main-as-worker (no parentPort) propagates to its caller's own exit path instead.
+			if (!parentPort) throw err;
+			console.error(`Failed to load components on worker ${threadId}`, err);
+			harperLogger.fatal('Failed to load root components during worker startup', err);
+			realExit(1);
+		})
 		.then(() => {
 			parentPort
 				?.on('message', (message) => {

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -168,6 +168,8 @@ function closeServers() {
 	return Promise.all(promises);
 }
 
+const STARTUP_READY_TIMEOUT_MS = 600_000;
+let startupDeadline;
 function startServers() {
 	// A worker that has not yet posted child_started owns no ref'd handle: addPort()
 	// (manageThreads) unrefs parentPort, component watchers are persistent:false, and the
@@ -178,6 +180,17 @@ function startServers() {
 	// handshake and aborting the whole node's startup. Hold a ref for the entire pre-ready
 	// window; the SHUTDOWN path unrefs it for graceful exit as before.
 	parentPort?.ref();
+	// The ref also means a load that HANGS (or a sync throw swallowed by the uncaughtException
+	// handler) would park this worker forever where it previously drained and failed loudly, so
+	// bound the pre-ready window. Deliberately far above restartWorkers' 60s replacement-worker
+	// backstop: timing out here aborts the whole node's startup, so a slow-but-succeeding boot
+	// must never be killed.
+	if (parentPort && !startupDeadline) {
+		startupDeadline = setTimeout(() => {
+			harperLogger.fatal(`Worker ${threadId} did not become ready within ${STARTUP_READY_TIMEOUT_MS}ms`);
+			realExit(1);
+		}, STARTUP_READY_TIMEOUT_MS);
+	}
 	const rootPath = env.get(terms.CONFIG_PARAMS.ROOTPATH);
 	if (rootPath) {
 		try {
@@ -193,8 +206,7 @@ function startServers() {
 			// parked forever (and main awaiting workersReady) instead of failing startup fast.
 			// Main-as-worker (no parentPort) propagates to its caller's own exit path instead.
 			if (!parentPort) throw err;
-			console.error(`Failed to load components on worker ${threadId}`, err);
-			harperLogger.fatal('Failed to load root components during worker startup', err);
+			harperLogger.fatal(`Failed to load root components on worker ${threadId}`, harperLogger.errorForLog(err));
 			realExit(1);
 		})
 		.then(() => {
@@ -252,6 +264,7 @@ function startServers() {
 							console.error('Error displaying start-up log', err);
 						}
 					}
+					clearTimeout(startupDeadline);
 					parentPort?.postMessage({ type: terms.ITC_EVENT_TYPES.CHILD_STARTED });
 				})
 				.catch((err) => {

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -169,6 +169,15 @@ function closeServers() {
 }
 
 function startServers() {
+	// A worker that has not yet posted child_started owns no ref'd handle: addPort()
+	// (manageThreads) unrefs parentPort, component watchers are persistent:false, and the
+	// reporting timers are unref'd. An await inside loadRootComponents whose completion
+	// arrives through a non-ref-holding source — e.g. rocksdb-js delivers cross-thread
+	// lock-release and parked-commit-retry wakes through unref'd threadsafe functions —
+	// can then drain the event loop, exiting the worker cleanly (code 0) before the ready
+	// handshake and aborting the whole node's startup. Hold a ref for the entire pre-ready
+	// window; the SHUTDOWN path unrefs it for graceful exit as before.
+	parentPort?.ref();
 	const rootPath = env.get(terms.CONFIG_PARAMS.ROOTPATH);
 	if (rootPath) {
 		try {

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -168,8 +168,6 @@ function closeServers() {
 	return Promise.all(promises);
 }
 
-const STARTUP_READY_TIMEOUT_MS = 600_000;
-let startupDeadline;
 function startServers() {
 	// A worker that has not yet posted child_started owns no ref'd handle: addPort()
 	// (manageThreads) unrefs parentPort, component watchers are persistent:false, and the
@@ -180,17 +178,6 @@ function startServers() {
 	// handshake and aborting the whole node's startup. Hold a ref for the entire pre-ready
 	// window; the SHUTDOWN path unrefs it for graceful exit as before.
 	parentPort?.ref();
-	// The ref also means a load that HANGS (or a sync throw swallowed by the uncaughtException
-	// handler) would park this worker forever where it previously drained and failed loudly, so
-	// bound the pre-ready window. Deliberately far above restartWorkers' 60s replacement-worker
-	// backstop: timing out here aborts the whole node's startup, so a slow-but-succeeding boot
-	// must never be killed.
-	if (parentPort && !startupDeadline) {
-		startupDeadline = setTimeout(() => {
-			harperLogger.fatal(`Worker ${threadId} did not become ready within ${STARTUP_READY_TIMEOUT_MS}ms`);
-			realExit(1);
-		}, STARTUP_READY_TIMEOUT_MS);
-	}
 	const rootPath = env.get(terms.CONFIG_PARAMS.ROOTPATH);
 	if (rootPath) {
 		try {
@@ -208,6 +195,7 @@ function startServers() {
 			if (!parentPort) throw err;
 			harperLogger.fatal(`Failed to load root components on worker ${threadId}`, harperLogger.errorForLog(err));
 			realExit(1);
+			return new Promise(() => {});
 		})
 		.then(() => {
 			parentPort
@@ -264,7 +252,6 @@ function startServers() {
 							console.error('Error displaying start-up log', err);
 						}
 					}
-					clearTimeout(startupDeadline);
 					parentPort?.postMessage({ type: terms.ITC_EVENT_TYPES.CHILD_STARTED });
 				})
 				.catch((err) => {

--- a/unitTests/components/symlinkHarperModuleLockWait.test.js
+++ b/unitTests/components/symlinkHarperModuleLockWait.test.js
@@ -13,7 +13,9 @@ const { Status } = require('#src/server/status/index');
 describe('componentLoader symlinkHarperModule lock wait', () => {
 	let componentDirectory;
 	let createdTimers;
+	let clearedTimers;
 	const realSetTimeout = global.setTimeout;
+	const realClearTimeout = global.clearTimeout;
 
 	before(() => {
 		componentDirectory = mkdtempSync(join(tmpdir(), 'harper-symlink-lock-wait-'));
@@ -21,6 +23,7 @@ describe('componentLoader symlinkHarperModule lock wait', () => {
 
 	beforeEach(() => {
 		createdTimers = [];
+		clearedTimers = new Set();
 		const trackingSetTimeout = (callback, ms, ...args) => {
 			const timer = realSetTimeout(callback, ms, ...args);
 			createdTimers.push({ timer, ms });
@@ -28,17 +31,23 @@ describe('componentLoader symlinkHarperModule lock wait', () => {
 		};
 		Object.assign(trackingSetTimeout, realSetTimeout); // keep setTimeout.__promisify__ etc.
 		global.setTimeout = trackingSetTimeout;
+		global.clearTimeout = (timer) => {
+			clearedTimers.add(timer);
+			return realClearTimeout(timer);
+		};
 	});
 
 	afterEach(() => {
 		global.setTimeout = realSetTimeout;
+		global.clearTimeout = realClearTimeout;
 	});
 
 	after(() => {
 		rmSync(componentDirectory, { recursive: true, force: true });
 	});
 
-	const liveRefdLockWaitTimer = () => createdTimers.some(({ timer, ms }) => ms === 10_000 && timer.hasRef());
+	const liveRefdLockWaitTimer = () =>
+		createdTimers.some(({ timer, ms }) => ms === 10_000 && timer.hasRef() && !clearedTimers.has(timer));
 
 	it('a waiter behind a held lock keeps a ref-holding timer until the unlock wake arrives', async () => {
 		const store = Status.primaryStore;

--- a/unitTests/components/symlinkHarperModuleLockWait.test.js
+++ b/unitTests/components/symlinkHarperModuleLockWait.test.js
@@ -7,11 +7,9 @@ const { join } = require('node:path');
 const { _symlinkHarperModuleForTests } = require('#src/components/componentLoader');
 const { Status } = require('#src/server/status/index');
 
-// The lock-wait branch of symlinkHarperModule must hold a ref'd timer while it waits for the
-// lock holder's unlock wake: that wake is delivered through an unref'd threadsafe function,
-// which does not keep the event loop alive, so a pre-ready worker parked here without the
-// timer has zero ref-holding handles, drains its loop, and exits cleanly with code 0 before
-// the ready handshake (harper#2312).
+// The lock-wait branch must hold a ref'd timer while parked: the unlock wake arrives via an
+// unref'd threadsafe function (see the invariant comment in threadServer.startServers,
+// harper#2312).
 describe('componentLoader symlinkHarperModule lock wait', () => {
 	let componentDirectory;
 	let createdTimers;
@@ -40,8 +38,7 @@ describe('componentLoader symlinkHarperModule lock wait', () => {
 		rmSync(componentDirectory, { recursive: true, force: true });
 	});
 
-	const liveRefdLockWaitTimer = () =>
-		createdTimers.some(({ timer, ms }) => ms === 10_000 && timer._destroyed !== true && timer.hasRef());
+	const liveRefdLockWaitTimer = () => createdTimers.some(({ timer, ms }) => ms === 10_000 && timer.hasRef());
 
 	it('a waiter behind a held lock keeps a ref-holding timer until the unlock wake arrives', async () => {
 		const store = Status.primaryStore;
@@ -53,11 +50,7 @@ describe('componentLoader symlinkHarperModule lock wait', () => {
 			});
 			await new Promise((resolve) => realSetTimeout(resolve, 50));
 			assert.strictEqual(resolved, false, 'waiter should still be pending while the lock is held');
-			assert.ok(
-				liveRefdLockWaitTimer(),
-				'waiter must hold a ref-holding timer while parked on the lock — without it a pre-ready ' +
-					'worker has no ref-holding handle and its event loop can drain (clean exit 0 before ready)'
-			);
+			assert.ok(liveRefdLockWaitTimer(), 'waiter must hold a ref-holding timer while parked on the lock');
 			store.unlock(componentDirectory);
 			await waiting;
 		} finally {

--- a/unitTests/components/symlinkHarperModuleLockWait.test.js
+++ b/unitTests/components/symlinkHarperModuleLockWait.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const assert = require('node:assert');
+const { mkdtempSync, rmSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const { _symlinkHarperModuleForTests } = require('#src/components/componentLoader');
+const { Status } = require('#src/server/status/index');
+
+// The lock-wait branch of symlinkHarperModule must hold a ref'd timer while it waits for the
+// lock holder's unlock wake: that wake is delivered through an unref'd threadsafe function,
+// which does not keep the event loop alive, so a pre-ready worker parked here without the
+// timer has zero ref-holding handles, drains its loop, and exits cleanly with code 0 before
+// the ready handshake (harper#2312).
+describe('componentLoader symlinkHarperModule lock wait', () => {
+	let componentDirectory;
+	let createdTimers;
+	const realSetTimeout = global.setTimeout;
+
+	before(() => {
+		componentDirectory = mkdtempSync(join(tmpdir(), 'harper-symlink-lock-wait-'));
+	});
+
+	beforeEach(() => {
+		createdTimers = [];
+		const trackingSetTimeout = (callback, ms, ...args) => {
+			const timer = realSetTimeout(callback, ms, ...args);
+			createdTimers.push({ timer, ms });
+			return timer;
+		};
+		Object.assign(trackingSetTimeout, realSetTimeout); // keep setTimeout.__promisify__ etc.
+		global.setTimeout = trackingSetTimeout;
+	});
+
+	afterEach(() => {
+		global.setTimeout = realSetTimeout;
+	});
+
+	after(() => {
+		rmSync(componentDirectory, { recursive: true, force: true });
+	});
+
+	const liveRefdLockWaitTimer = () =>
+		createdTimers.some(({ timer, ms }) => ms === 10_000 && timer._destroyed !== true && timer.hasRef());
+
+	it('a waiter behind a held lock keeps a ref-holding timer until the unlock wake arrives', async () => {
+		const store = Status.primaryStore;
+		assert.strictEqual(store.tryLock(componentDirectory), true, 'test could not take the lock');
+		try {
+			let resolved = false;
+			const waiting = _symlinkHarperModuleForTests(componentDirectory).then(() => {
+				resolved = true;
+			});
+			await new Promise((resolve) => realSetTimeout(resolve, 50));
+			assert.strictEqual(resolved, false, 'waiter should still be pending while the lock is held');
+			assert.ok(
+				liveRefdLockWaitTimer(),
+				'waiter must hold a ref-holding timer while parked on the lock — without it a pre-ready ' +
+					'worker has no ref-holding handle and its event loop can drain (clean exit 0 before ready)'
+			);
+			store.unlock(componentDirectory);
+			await waiting;
+		} finally {
+			// unlock is idempotent; make sure a failing assertion above cannot leak the lock
+			store.unlock(componentDirectory);
+		}
+	});
+
+	it('the winner completes without leaving a timer armed', async () => {
+		await _symlinkHarperModuleForTests(componentDirectory);
+		assert.strictEqual(
+			liveRefdLockWaitTimer(),
+			false,
+			'winner path must not leave a stale timer that could later unlock a re-acquired lock'
+		);
+	});
+});

--- a/unitTests/server/threads/threadServerStartupLiveness-fixture.js
+++ b/unitTests/server/threads/threadServerStartupLiveness-fixture.js
@@ -4,25 +4,31 @@ const assert = require('node:assert');
 const { parentPort, workerData } = require('node:worker_threads');
 
 process.env.STORAGE_PATH = workerData.storagePath;
-process.env.HDB_ROOT = workerData.storagePath;
+process.env.ROOTPATH = workerData.storagePath;
 
-const loadRootComponentsPath = require.resolve('#src/server/loadRootComponents');
+let stubRan = false;
+const loadRootComponentsPath = require.resolve('#js/server/loadRootComponents');
 require.cache[loadRootComponentsPath] = {
 	id: loadRootComponentsPath,
 	filename: loadRootComponentsPath,
 	loaded: true,
 	exports: {
 		loadRootComponents() {
-			return new Promise((resolve) => {
-				const completionTimer = setTimeout(resolve, 50);
-				completionTimer.unref();
-				assert.equal(completionTimer.hasRef(), false, 'fixture completion source must not hold the event loop');
+			stubRan = true;
+			let resolveLoading;
+			const loading = new Promise((resolve) => {
+				resolveLoading = resolve;
 			});
+			const completionTimer = setTimeout(resolveLoading, 50);
+			completionTimer.unref();
+			assert.equal(completionTimer.hasRef(), false, 'fixture completion source must not hold the event loop');
+			return loading;
 		},
 	},
 };
 
-const { startServers } = require('#src/server/threads/threadServer');
+const { startServers } = require('#js/server/threads/threadServer');
 
 parentPort.unref();
 startServers();
+assert.equal(stubRan, true, 'fixture loadRootComponents stub was not used');

--- a/unitTests/server/threads/threadServerStartupLiveness-fixture.js
+++ b/unitTests/server/threads/threadServerStartupLiveness-fixture.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const assert = require('node:assert');
+const { parentPort, workerData } = require('node:worker_threads');
+
+process.env.STORAGE_PATH = workerData.storagePath;
+process.env.HDB_ROOT = workerData.storagePath;
+
+const loadRootComponentsPath = require.resolve('#src/server/loadRootComponents');
+require.cache[loadRootComponentsPath] = {
+	id: loadRootComponentsPath,
+	filename: loadRootComponentsPath,
+	loaded: true,
+	exports: {
+		loadRootComponents() {
+			return new Promise((resolve) => {
+				const completionTimer = setTimeout(resolve, 50);
+				completionTimer.unref();
+				assert.equal(completionTimer.hasRef(), false, 'fixture completion source must not hold the event loop');
+			});
+		},
+	},
+};
+
+const { startServers } = require('#src/server/threads/threadServer');
+
+parentPort.unref();
+startServers();

--- a/unitTests/server/threads/threadServerStartupLiveness.test.js
+++ b/unitTests/server/threads/threadServerStartupLiveness.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('node:assert');
-const { mkdtempSync, rmSync } = require('node:fs');
+const { mkdtempSync, readFileSync, rmSync, writeFileSync } = require('node:fs');
 const { tmpdir } = require('node:os');
 const { join } = require('node:path');
 const { Worker } = require('node:worker_threads');
@@ -11,6 +11,12 @@ const FIXTURE = join(__dirname, 'threadServerStartupLiveness-fixture.js');
 describe('threadServer startup liveness', () => {
 	it('keeps a pre-ready worker alive while component loading has no ref-holding completion source', async () => {
 		const storagePath = mkdtempSync(join(tmpdir(), 'harper-worker-liveness-'));
+		const config = readFileSync(join(__dirname, '../../../static/defaultConfig.yaml'), 'utf8')
+			.replace(/^  file: true$/m, '  file: false')
+			.replace(/^  root: null$/m, `  root: ${JSON.stringify(storagePath)}`)
+			.replace(/^rootPath: null$/m, `rootPath: ${JSON.stringify(storagePath)}`)
+			.replace(/^  path: null$/m, `  path: ${JSON.stringify(storagePath)}`);
+		writeFileSync(join(storagePath, 'harper-config.yaml'), config);
 		let worker;
 		try {
 			worker = new Worker(FIXTURE, {

--- a/unitTests/server/threads/threadServerStartupLiveness.test.js
+++ b/unitTests/server/threads/threadServerStartupLiveness.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const assert = require('node:assert');
+const { mkdtempSync, rmSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const { Worker } = require('node:worker_threads');
+
+const FIXTURE = join(__dirname, 'threadServerStartupLiveness-fixture.js');
+
+describe('threadServer startup liveness', () => {
+	it('keeps a pre-ready worker alive while component loading has no ref-holding completion source', async () => {
+		const storagePath = mkdtempSync(join(tmpdir(), 'harper-worker-liveness-'));
+		let worker;
+		try {
+			worker = new Worker(FIXTURE, {
+				workerData: { addPorts: [], addThreadIds: [], noServerStart: true, storagePath },
+			});
+			const message = await new Promise((resolve, reject) => {
+				const timeout = setTimeout(() => finish(new Error('worker did not report ready')), 15_000);
+				const onError = (error) => finish(error);
+				const onExit = (code) => finish(new Error(`worker exited with code ${code} before reporting ready`));
+				const onMessage = (message) => {
+					if (message.type === 'child_started') finish(null, message);
+				};
+				function finish(error, message) {
+					clearTimeout(timeout);
+					worker.removeListener('error', onError);
+					worker.removeListener('exit', onExit);
+					worker.removeListener('message', onMessage);
+					if (error) reject(error);
+					else resolve(message);
+				}
+				worker.on('error', onError);
+				worker.on('exit', onExit);
+				worker.on('message', onMessage);
+			});
+			assert.equal(message.type, 'child_started');
+		} finally {
+			await worker?.terminate();
+			rmSync(storagePath, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
Fixes the recurring Linux Integration Tests failure `Worker (index N) exited with code 0 before reporting ready` from `createWorkerReadyPromise`. Refs #2312.

## Summary

A pre-ready worker can have no ref-holding handle while `loadRootComponents()` awaits a completion delivered by an unref'd source. Its event loop then drains, the worker exits cleanly with code 0, and main aborts startup.

- [`startServers()` refs `parentPort` before component loading](https://github.com/HarperFast/harper/pull/2314/changes?w=1#diff-d6ac497db42595bd89baa27ec98b82d5fd3cabd497962cc64ab475d46839be5bR180), preserving the worker until it reports `child_started`; the existing shutdown path still unrefs the port.
- [Rejected root-component loads terminate the ready chain](https://github.com/HarperFast/harper/pull/2314/changes?w=1#diff-d6ac497db42595bd89baa27ec98b82d5fd3cabd497962cc64ab475d46839be5bR191), including a never-settling fallback if the worker exit primitive is ever replaced with a returning test double.
- [`symlinkHarperModule()` gives only a contended waiter a ref'd 10-second timer](https://github.com/HarperFast/harper/pull/2314/changes?w=1#diff-cb052ff87cbadee003a6254cb87b7f05365677a40d1d112c4f62bcf033f13c98R399). This removes the winner's stale timer, which could later unlock a lock another thread owned, while preserving liveness during the native lock wake.
- The initially proposed fatal 10-minute startup deadline was removed after review. This PR intentionally does not introduce a startup availability policy or configuration surface.

## Regression coverage

- [The lock-wait unit tests track both timer creation and clearing](https://github.com/HarperFast/harper/pull/2314/changes?w=1#diff-ba451f78d579238a093c229069226de3ded62564d508e107c81f000ec1075df9R24), so the waiter assertion now fails against the original `clearTimeout(timeout)` bug and the winner assertion fails against its stale timer.
- [The standalone Worker regression executes the real `threadServer.startServers()` path](https://github.com/HarperFast/harper/pull/2314/changes?w=1#diff-44ef9ad40164679aa781a18d9f3ff972f93a153487716e01283501a13c788c8fR12) with an asserted-unref'd completion timer and hermetic temporary Harper config. Replacing the production `parentPort.ref()` with `unref()` fails with the historical `worker exited with code 0 before reporting ready` signature.
- The integration fixture mounts the liveness probe in both app-component and root-component startup windows and verifies the instance reaches ready and serves it.

## For the human reviewer

- Removing the fatal deadline means a component load that never settles can leave startup waiting indefinitely. That is the explicit owner decision for this focused liveness fix; watchdog and recovery policy belongs in a dedicated startup-coordinator change.
- A waiter that reaches the symlink-lock timeout continues with the link in its current state. The native lock API exposes no callback cancellation or safe stale-owner reclamation, so a dead holder can leave future loads paying the same timeout; changing that needs a separate lock-recovery design.
- `realExit(1)` is the existing immediate worker-failure contract. An outside reviewer proposed draining for logger flush instead, but that would materially change failure and shutdown semantics and is not included here.
- The direct `_symlinkHarperModuleForTests` export is retained to keep lock timing deterministic without adding a broader component-loading injection surface.

## Verification

- `npm run build` — passed.
- `npm run lint:required` and `npm run format:write` — passed.
- Focused unit tests — 3 passed.
- Mutation checks — removing the startup port ref fails with exit code 0 before ready; clearing the waiter timer fails the live-timer assertion.
- `npm run test:integration -- integrationTests/server/worker-startup-liveness.test.ts` — passed.
- `npm run test:unit:main` progressed normally but hung in an existing component-status suite and was interrupted; `test:unit:server` aborts because its glob directly loads `fixtures/processGroupOwnerWorker.js` with a null `parentPort`.
- Full independent review on the final behavioral head plus a focused delta review of the fixture-isolation changes; exact-head receipt at `945f40ea8`.

Complexity: 3

Refs #2312

— GPT-5 Codex

🤖 Generated with [Codex](https://openai.com/codex/)

<sub>Review-Coverage: authored=codex; ran=gemini,claude; declined=cursor-grok,cursor-composer,domain; rounds=3 @ 945f40ea8f75</sub>

<sub>Human-Review-Need: 4 @ 945f40ea8f75</sub>
