### PR TITLE
Pin the dispatched test workflows to a read-only token on v5.1

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@82c9484f6f2560be4a37032858311e429bccd56c # main 2026-07-21 (#73 severity-deflation + fail-closed calibration, #74 caller hygiene; on 9cf49d2 = #70 + #71)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@4b59dc0ddb15aff517884127b58204f79193b4f2 # main 2026-08-20 (#86 reliable review evidence, context, and run binding)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -60,7 +60,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 82c9484f6f2560be4a37032858311e429bccd56c
+      ai-review-prompts-ref: 4b59dc0ddb15aff517884127b58204f79193b4f2
       # CANARY (2026-07-11): run this repo's Claude reviews on Sonnet 5
       # while the fleet default stays claude-sonnet-4-6. Every ai-review-log
       # entry records `Model:`, so calibration can compare sonnet-5 vs

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,6 +17,11 @@ on:
           - '24'
           - '26'
 
+# Dispatched by cherry-pick-patch.yml against a branch built from PR commits, so this
+# runs PR-authored build/test scripts. The repo default is a write-scoped token.
+permissions:
+  contents: read
+
 jobs:
   generate-node-version-matrix:
     name: Generate Node Version Matrix

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,6 +17,11 @@ on:
           - '24'
           - '26'
 
+# Dispatched by cherry-pick-patch.yml against a branch built from PR commits, so this
+# runs PR-authored build/test scripts. The repo default is a write-scoped token.
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     name: Unit Test (Node.js v${{ matrix.node-version }})


### PR DESCRIPTION
`cherry-pick-patch.yml` dispatches this repo's test workflows with `workflow_dispatch --ref cherry-pick/<release>/pr-<N>` — a branch built from a release branch plus a PR's commits. Those runs therefore execute PR-authored build and test scripts inside the base repo.

`workflow_dispatch` resolves `permissions:` from the workflow file **on the dispatched ref**, so a pin added on `main` does nothing for a dispatch against this branch. `default_workflow_permissions` is `write` on this repo, which means every cherry-pick test run on this release line currently executes PR-authored scripts under a write-scoped `GITHUB_TOKEN`.

This pins `contents: read` here, where the dispatch actually resolves it.

Pre-existing exposure, not introduced by any current change — but it is being widened: HarperFast/harper#2317 moves release targeting from the opt-in `patch` label to the PR Milestone, which is set on nearly every triaged PR. That PR adds the same pin on `main`; this one covers the branch the dispatch resolves against.
## Also here: the `claude-review.yml` caller resync (CI fix)

`review / review` was failing on this PR for a reason unrelated to the `permissions:` change. `claude-code-action` exchanges an OIDC token for a Claude GitHub App token and rejects the exchange unless the entry workflow file is byte-identical to the copy on the repository's default branch — the run failed with `401 Unauthorized - Workflow validation failed` ([run 32873314624](https://github.com/HarperFast/harper/actions/runs/32873314624/job/97885353060)). This branch's caller still pinned ai-review-prompts `82c9484` (last synced 2026-07-23, d4f969e2e) while `main` moved to `4b59dc0` on 2026-08-21 (#2256), so **every** v5.1 PR has failed that check since.

The second commit copies `main`'s `claude-review.yml` verbatim — the reusable `uses:` SHA and the matching `ai-review-prompts-ref` input. `4b59dc0` is also the current head of `_claude-review.yml` on `HarperFast/ai-review-prompts` `main`, so the pin is not stale in the other direction.

## For the human reviewer

- **Why only this caller was resynced.** v5.1's other callers are also behind — `gemini-review.yml` on `9cf49d2` (2026-06-29), `claude-mention.yml` / `claude-issue-to-pr.yml` / `validate-caller-workflows.yml` on `441d2a3`–`6463b3d` — but the default-branch identity check is specific to `claude-code-action`'s own app-token exchange. `_gemini-review.yml@9cf49d2` authenticates solely through `actions/create-github-app-token` with the org app credentials and never calls `claude-code-action`, so it does not fail this way (and its check reports `skipping` on this PR regardless). A broader v5.1 caller sweep is worth doing, but it is not what unblocks this check.
- **`format-check.yml` is a wider hole than the two workflows pinned here** — no `permissions:` block, and it runs `npm install` *without* `--ignore-scripts` (`.github/workflows/format-check.yml:25`), so a dependency install script on a same-repo PR run executes under the write-scoped default token. Left out of scope here; worth its own change, or the repo-level "Workflow permissions → read-only" flip, which would cover it and every future workflow at once.
- **The pin only binds on the branch the dispatcher targets.** `cherry-pick-patch.yml:45` resolves the cherry-pick base as `vars.RELEASE_BRANCH || 'v5.0'`; this PR covers v5.1 and #2317 covers `main`. If `vars.RELEASE_BRANCH` is unset or still `v5.0`, that line needs the same block.


## Verification

Neither workflow references `secrets.` or `GITHUB_TOKEN` — confirmed by grep on this branch — so nothing in them needs write scope. `actions/upload-artifact` uses the Actions runtime token, which `permissions:` does not govern, so artifact upload is unaffected. YAML parses with the block in place.

The change is additive and scoped to a single top-level key; the existing CI on this PR exercises it.


The caller resync is verified byte-identical to `origin/main:.github/workflows/claude-review.yml`, prettier-clean, YAML-parsing, and both SHA occurrences are the same 40-char commit id that `validate-caller-workflows` requires. Whether the OIDC exchange actually succeeds can only be proven by the pushed run — this PR's own `review / review` is the test.

<sub>Review-Coverage: authored=claude; ran=gemini,cursor-grok,codex; adjudicated=domain; declined=cursor-composer; rounds=1 @ cc118172f386</sub>

<sub>Human-Review-Need: 4 (decisions: token-ceiling-per-workflow-vs-repo-default, hardening-scope-two-workflows, claude-only-caller-resync) @ cc118172f386</sub>
