### PR TITLE
Pin the dispatched test workflows to a read-only token on v5.0

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,6 +17,11 @@ on:
           - '22'
           - '24'
 
+# Dispatched by cherry-pick-patch.yml against a branch built from PR commits, so this
+# runs PR-authored build/test scripts. The repo default is a write-scoped token.
+permissions:
+  contents: read
+
 jobs:
   generate-node-version-matrix:
     name: Generate Node Version Matrix

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,6 +17,11 @@ on:
           - '22'
           - '24'
 
+# Dispatched by cherry-pick-patch.yml against a branch built from PR commits, so this
+# runs PR-authored build/test scripts. The repo default is a write-scoped token.
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     name: Unit Test (Node.js v${{ matrix.node-version }})


### PR DESCRIPTION
`cherry-pick-patch.yml` dispatches this repo's test workflows with `workflow_dispatch --ref cherry-pick/<release>/pr-<N>` — a branch built from a release branch plus a PR's commits. Those runs therefore execute PR-authored build and test scripts inside the base repo.

`workflow_dispatch` resolves `permissions:` from the workflow file **on the dispatched ref**, so a pin added on `main` does nothing for a dispatch against this branch. `default_workflow_permissions` is `write` on this repo, which means every cherry-pick test run on this release line currently executes PR-authored scripts under a write-scoped `GITHUB_TOKEN`.

This pins `contents: read` here, where the dispatch actually resolves it.

Pre-existing exposure, not introduced by any current change — but it is being widened: HarperFast/harper#2317 moves release targeting from the opt-in `patch` label to the PR Milestone, which is set on nearly every triaged PR. That PR adds the same pin on `main`; this one covers the branch the dispatch resolves against.

## Verification

Neither workflow references `secrets.` or `GITHUB_TOKEN` — confirmed by grep on this branch — so nothing in them needs write scope. `actions/upload-artifact` uses the Actions runtime token, which `permissions:` does not govern, so artifact upload is unaffected. YAML parses with the block in place.

The change is additive and scoped to a single top-level key; the existing CI on this PR exercises it.
