### PR TITLE
ci: adopt ai-review-prompts #89 — sonnet-5/xhigh/96-turn review defaults

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -22,11 +22,11 @@ concurrency:
 
 jobs:
   work:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5 # main 2026-08-25 (#89 fleet turn/effort/model defaults; #88 sibling + cannot-fail-test lenses; #85/#87 calibration)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@be549ad08aa6d34b909ea8b542a7ffebdaae1e81 # main 2026-08-25 (#90 cost gates: draft skip, mechanical-diff skip, effort-by-size, debounce; #89 defaults; #88 lenses)
     with:
       # Same SHA as the `uses:` ref above. See the comment in
       # claude-mention.yml for why the duplication is unavoidable.
-      ai-review-prompts-ref: 4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5
+      ai-review-prompts-ref: be549ad08aa6d34b909ea8b542a7ffebdaae1e81
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -22,11 +22,11 @@ concurrency:
 
 jobs:
   work:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@54d9e61c9c827d19e34229a5c460773a9fb080a0 # main 2026-07-24 (#79: deep path / :bug,:test escalation -> claude-opus-5)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@8401fe113e229d8842283c67e99457b862ab3b89 # main 2026-08-25 (#89 fleet turn/effort/model defaults: sonnet-5, xhigh, 96 turns)
     with:
       # Same SHA as the `uses:` ref above. See the comment in
       # claude-mention.yml for why the duplication is unavoidable.
-      ai-review-prompts-ref: 54d9e61c9c827d19e34229a5c460773a9fb080a0
+      ai-review-prompts-ref: 8401fe113e229d8842283c67e99457b862ab3b89
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -22,11 +22,11 @@ concurrency:
 
 jobs:
   work:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@8401fe113e229d8842283c67e99457b862ab3b89 # main 2026-08-25 (#89 fleet turn/effort/model defaults: sonnet-5, xhigh, 96 turns)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5 # main 2026-08-25 (#89 fleet turn/effort/model defaults; #88 sibling + cannot-fail-test lenses; #85/#87 calibration)
     with:
       # Same SHA as the `uses:` ref above. See the comment in
       # claude-mention.yml for why the duplication is unavoidable.
-      ai-review-prompts-ref: 8401fe113e229d8842283c67e99457b862ab3b89
+      ai-review-prompts-ref: 4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   mention:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@54d9e61c9c827d19e34229a5c460773a9fb080a0 # main 2026-07-24 (#79: deep path / :bug,:test escalation -> claude-opus-5)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@8401fe113e229d8842283c67e99457b862ab3b89 # main 2026-08-25 (#89 fleet turn/effort/model defaults: sonnet-5, xhigh, 96 turns)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (parse + auth scripts)
@@ -34,7 +34,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to
       # the CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 54d9e61c9c827d19e34229a5c460773a9fb080a0
+      ai-review-prompts-ref: 8401fe113e229d8842283c67e99457b862ab3b89
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   mention:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5 # main 2026-08-25 (#89 fleet turn/effort/model defaults; #88 sibling + cannot-fail-test lenses; #85/#87 calibration)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@be549ad08aa6d34b909ea8b542a7ffebdaae1e81 # main 2026-08-25 (#90 cost gates: draft skip, mechanical-diff skip, effort-by-size, debounce; #89 defaults; #88 lenses)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (parse + auth scripts)
@@ -34,7 +34,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to
       # the CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5
+      ai-review-prompts-ref: be549ad08aa6d34b909ea8b542a7ffebdaae1e81
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   mention:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@8401fe113e229d8842283c67e99457b862ab3b89 # main 2026-08-25 (#89 fleet turn/effort/model defaults: sonnet-5, xhigh, 96 turns)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5 # main 2026-08-25 (#89 fleet turn/effort/model defaults; #88 sibling + cannot-fail-test lenses; #85/#87 calibration)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (parse + auth scripts)
@@ -34,7 +34,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to
       # the CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 8401fe113e229d8842283c67e99457b862ab3b89
+      ai-review-prompts-ref: 4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@8401fe113e229d8842283c67e99457b862ab3b89 # main 2026-08-25 (#89 fleet turn/effort/model defaults: sonnet-5, xhigh, 96 turns)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5 # main 2026-08-25 (#89 fleet turn/effort/model defaults; #88 sibling + cannot-fail-test lenses; #85/#87 calibration)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -60,7 +60,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 8401fe113e229d8842283c67e99457b862ab3b89
+      ai-review-prompts-ref: 4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,7 +32,10 @@ jobs:
     # label. The reusable's authorize job still owns WHO is admitted.
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
-    if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
+    # `ready_for_review` is admitted when the PR still carries the
+    # opt-in label, so a draft opted in via `claude-review` resumes
+    # review when it flips ready even with CLAUDE_ALWAYS_ON unset.
+    if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'claude-review')) }}
     uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@be549ad08aa6d34b909ea8b542a7ffebdaae1e81 # main 2026-08-25 (#90 cost gates: draft skip, mechanical-diff skip, effort-by-size, debounce; #89 defaults; #88 lenses)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@4b59dc0ddb15aff517884127b58204f79193b4f2 # main 2026-08-20 (#86 reliable review evidence, context, and run binding)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@8401fe113e229d8842283c67e99457b862ab3b89 # main 2026-08-25 (#89 fleet turn/effort/model defaults: sonnet-5, xhigh, 96 turns)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -60,15 +60,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 4b59dc0ddb15aff517884127b58204f79193b4f2
-      # CANARY (2026-07-11): run this repo's Claude reviews on Sonnet 5
-      # while the fleet default stays claude-sonnet-4-6. Every ai-review-log
-      # entry records `Model:`, so calibration can compare sonnet-5 vs
-      # sonnet-4-6 verdict mix directly — watch the severity-deflation rate
-      # (Sonnet 5 follows blocker-only instructions more literally; known
-      # code-review-harness effect). Promote to the reusable's default or
-      # revert based on the next calibration cycle.
-      model: claude-sonnet-5
+      ai-review-prompts-ref: 8401fe113e229d8842283c67e99457b862ab3b89
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,7 +18,7 @@ on:
   pull_request:
     # `labeled` admits the `claude-review` label gesture for
     # bot-authored PRs (renovate, dependabot). See ai-review-prompts#38.
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5 # main 2026-08-25 (#89 fleet turn/effort/model defaults; #88 sibling + cannot-fail-test lenses; #85/#87 calibration)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@be549ad08aa6d34b909ea8b542a7ffebdaae1e81 # main 2026-08-25 (#90 cost gates: draft skip, mechanical-diff skip, effort-by-size, debounce; #89 defaults; #88 lenses)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -60,7 +60,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5
+      ai-review-prompts-ref: be549ad08aa6d34b909ea8b542a7ffebdaae1e81
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -52,7 +52,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@8401fe113e229d8842283c67e99457b862ab3b89 # main 2026-08-25 (#89 fleet turn/effort/model defaults: sonnet-5, xhigh, 96 turns)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5 # main 2026-08-25 (#89 fleet turn/effort/model defaults; #88 sibling + cannot-fail-test lenses; #85/#87 calibration)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -70,7 +70,7 @@ jobs:
       # duplication is unavoidable: reusable workflows can't introspect
       # their own ref (`github.workflow_ref` resolves to the CALLER's
       # ref in workflow_call context), and `uses: …@<ref>` is literal.
-      ai-review-prompts-ref: 8401fe113e229d8842283c67e99457b862ab3b89
+      ai-review-prompts-ref: 4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -52,7 +52,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@4b59dc0ddb15aff517884127b58204f79193b4f2 # main 2026-08-20 (#86 reliable review evidence, context, and run binding)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@8401fe113e229d8842283c67e99457b862ab3b89 # main 2026-08-25 (#89 fleet turn/effort/model defaults: sonnet-5, xhigh, 96 turns)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -70,7 +70,7 @@ jobs:
       # duplication is unavoidable: reusable workflows can't introspect
       # their own ref (`github.workflow_ref` resolves to the CALLER's
       # ref in workflow_call context), and `uses: …@<ref>` is literal.
-      ai-review-prompts-ref: 4b59dc0ddb15aff517884127b58204f79193b4f2
+      ai-review-prompts-ref: 8401fe113e229d8842283c67e99457b862ab3b89
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -51,7 +51,9 @@ jobs:
     # (CODEOWNERS trust set; the labeler, not the author, on `labeled`).
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
-    if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
+    # `ready_for_review` is admitted when the PR still carries the
+    # opt-in label — mirrors claude-review.yml.
+    if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'gemini-review')) }}
     uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@be549ad08aa6d34b909ea8b542a7ffebdaae1e81 # main 2026-08-25 (#90 cost gates: draft skip, mechanical-diff skip, effort-by-size, debounce; #89 defaults; #88 lenses)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -32,7 +32,7 @@ on:
     # `labeled` admits the `gemini-review` opt-in gesture. `vars.*`
     # can't be read in `on:` (only in a job `if:`), so the trigger
     # lists the union and the `review` job gates on GEMINI_ALWAYS_ON.
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 concurrency:
   # Different group key from claude-review so the two providers can run
@@ -52,7 +52,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5 # main 2026-08-25 (#89 fleet turn/effort/model defaults; #88 sibling + cannot-fail-test lenses; #85/#87 calibration)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@be549ad08aa6d34b909ea8b542a7ffebdaae1e81 # main 2026-08-25 (#90 cost gates: draft skip, mechanical-diff skip, effort-by-size, debounce; #89 defaults; #88 lenses)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -70,7 +70,7 @@ jobs:
       # duplication is unavoidable: reusable workflows can't introspect
       # their own ref (`github.workflow_ref` resolves to the CALLER's
       # ref in workflow_call context), and `uses: …@<ref>` is literal.
-      ai-review-prompts-ref: 4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5
+      ai-review-prompts-ref: be549ad08aa6d34b909ea8b542a7ffebdaae1e81
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -27,9 +27,9 @@ on:
 
 jobs:
   validate:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@8401fe113e229d8842283c67e99457b862ab3b89 # main 2026-08-25 (#89 fleet turn/effort/model defaults: sonnet-5, xhigh, 96 turns)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5 # main 2026-08-25 (#89 fleet turn/effort/model defaults; #88 sibling + cannot-fail-test lenses; #85/#87 calibration)
     with:
       # Same SHA as the `uses:` ref above — the reusable uses this
       # to check out the validator script at the matching version.
       # Same SHA-twice pattern as the other caller workflows.
-      ai-review-prompts-ref: 8401fe113e229d8842283c67e99457b862ab3b89
+      ai-review-prompts-ref: 4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -27,9 +27,9 @@ on:
 
 jobs:
   validate:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@4b59dc0ddb15aff517884127b58204f79193b4f2 # main 2026-08-20 (#86 reliable review evidence, context, and run binding)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@8401fe113e229d8842283c67e99457b862ab3b89 # main 2026-08-25 (#89 fleet turn/effort/model defaults: sonnet-5, xhigh, 96 turns)
     with:
       # Same SHA as the `uses:` ref above — the reusable uses this
       # to check out the validator script at the matching version.
       # Same SHA-twice pattern as the other caller workflows.
-      ai-review-prompts-ref: 4b59dc0ddb15aff517884127b58204f79193b4f2
+      ai-review-prompts-ref: 8401fe113e229d8842283c67e99457b862ab3b89

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -27,9 +27,9 @@ on:
 
 jobs:
   validate:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5 # main 2026-08-25 (#89 fleet turn/effort/model defaults; #88 sibling + cannot-fail-test lenses; #85/#87 calibration)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@be549ad08aa6d34b909ea8b542a7ffebdaae1e81 # main 2026-08-25 (#90 cost gates: draft skip, mechanical-diff skip, effort-by-size, debounce; #89 defaults; #88 lenses)
     with:
       # Same SHA as the `uses:` ref above — the reusable uses this
       # to check out the validator script at the matching version.
       # Same SHA-twice pattern as the other caller workflows.
-      ai-review-prompts-ref: 4632c5d93dae1e6548e6c30c5ced8fb2df69f4e5
+      ai-review-prompts-ref: be549ad08aa6d34b909ea8b542a7ffebdaae1e81


### PR DESCRIPTION
Bumps every ai-review-prompts pin (claude-review, gemini-review, claude-mention, claude-issue-to-pr, validate-caller-workflows) to `be549ad` — current main, which carries:

- [ai-review-prompts#90](https://github.com/HarperFast/ai-review-prompts/pull/90): **cost gates** — draft PRs skip review until flipped ready (label opts a draft in), mechanical diffs skip before the agent runs, reasoning effort scales with diff size (≤60 → high, ≤1500 → xhigh, larger → max), synchronize runs debounce 120s. Both review callers gain the `ready_for_review` trigger type.
- [#89](https://github.com/HarperFast/ai-review-prompts/pull/89): fleet defaults — claude-sonnet-5, 96-turn review budget, 30m timeouts.
- [#88](https://github.com/HarperFast/ai-review-prompts/pull/88): sibling-implementations and cannot-fail-test lenses; [#85](https://github.com/HarperFast/ai-review-prompts/pull/85)/[#87](https://github.com/HarperFast/ai-review-prompts/pull/87): calibration prompt edits.

**Expected on this PR**: the claude-review check errors with the workflow-must-match-default-branch validation — normal for workflow-editing PRs.

**Merge order**: this PR first, then #2330 and #2331 (the release-branch syncs, refreshed to matching content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S94XethbGXpAb4DRKMD4kt