### PR TITLE
Honor the documented dry_run flag in install_node_modules

### DIFF
--- a/unitTests/utility/npmUtilities.test.js
+++ b/unitTests/utility/npmUtilities.test.js
@@ -43,10 +43,10 @@ describe('install_node_modules', () => {
 		fs.rmSync(path.join(componentsRoot, 'application', 'node_modules'), { recursive: true, force: true });
 	});
 
-	// npm still reports the dependency it would add under --dry-run, so asserting on the output
+	// npm still reports the dependency it would add under --dry-run, so asserting on that output
 	// distinguishes a real dry run from npm never running at all
 	function assertDryRun(response) {
-		assert.match(String(response.application.npm_output), /add local-dependency/);
+		assert.match(JSON.stringify(response.application.npm_output), /add local-dependency/);
 		assert.equal(installedDependencyExists(), false);
 	}
 
@@ -87,5 +87,14 @@ describe('install_node_modules', () => {
 		const response = await installModules({ projects: ['application'] });
 
 		assertInstalled(response);
+	});
+
+	it('rejects a request carrying both dry_run spellings', async () => {
+		await assert.rejects(installModules({ projects: ['application'], dry_run: true, dryRun: false }));
+		assert.equal(installedDependencyExists(), false);
+	});
+
+	it('rejects a request without projects', async () => {
+		await assert.rejects(installModules({ dry_run: true }));
 	});
 });

--- a/unitTests/utility/npmUtilities.test.js
+++ b/unitTests/utility/npmUtilities.test.js
@@ -90,11 +90,14 @@ describe('install_node_modules', () => {
 	});
 
 	it('rejects a request carrying both dry_run spellings', async () => {
-		await assert.rejects(installModules({ projects: ['application'], dry_run: true, dryRun: false }));
+		await assert.rejects(installModules({ projects: ['application'], dry_run: true, dryRun: false }), {
+			statusCode: 400,
+			message: /dryRun/,
+		});
 		assert.equal(installedDependencyExists(), false);
 	});
 
 	it('rejects a request without projects', async () => {
-		await assert.rejects(installModules({ dry_run: true }));
+		await assert.rejects(installModules({ dry_run: true }), { statusCode: 400, message: /'projects'/ });
 	});
 });

--- a/unitTests/utility/npmUtilities.test.js
+++ b/unitTests/utility/npmUtilities.test.js
@@ -39,9 +39,29 @@ describe('install_node_modules', () => {
 		fs.rmSync(componentsRoot, { recursive: true, force: true });
 	});
 
+	afterEach(() => {
+		fs.rmSync(path.join(componentsRoot, 'application', 'node_modules'), { recursive: true, force: true });
+	});
+
 	it('honors the documented dry_run field', async () => {
 		await installModules({ projects: ['application'], dry_run: true });
 
 		assert.equal(fs.existsSync(path.join(componentsRoot, 'application', 'node_modules')), false);
+	});
+
+	it('honors a dry_run field that arrives as a string', async () => {
+		await installModules({ projects: ['application'], dry_run: 'true' });
+
+		assert.equal(fs.existsSync(path.join(componentsRoot, 'application', 'node_modules')), false);
+	});
+
+	it('installs when dry_run is false or omitted', async () => {
+		await installModules({ projects: ['application'], dry_run: 'false' });
+		assert.equal(fs.existsSync(path.join(componentsRoot, 'application', 'node_modules')), true);
+
+		fs.rmSync(path.join(componentsRoot, 'application', 'node_modules'), { recursive: true, force: true });
+
+		await installModules({ projects: ['application'] });
+		assert.equal(fs.existsSync(path.join(componentsRoot, 'application', 'node_modules')), true);
 	});
 });

--- a/unitTests/utility/npmUtilities.test.js
+++ b/unitTests/utility/npmUtilities.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const env = require('#src/utility/environment/environmentManager');
+const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+const { installModules } = require('#src/utility/npmUtilities');
+
+describe('install_node_modules', () => {
+	let componentsRoot;
+
+	before(() => {
+		componentsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'harper-install-modules-'));
+		env.setProperty(CONFIG_PARAMS.COMPONENTSROOT, componentsRoot);
+
+		fs.mkdirSync(path.join(componentsRoot, 'dependency'));
+		fs.writeFileSync(
+			path.join(componentsRoot, 'dependency', 'package.json'),
+			JSON.stringify({ name: 'local-dependency', version: '1.0.0' })
+		);
+		fs.mkdirSync(path.join(componentsRoot, 'application'));
+		fs.writeFileSync(
+			path.join(componentsRoot, 'application', 'package.json'),
+			JSON.stringify({
+				name: 'application',
+				version: '1.0.0',
+				dependencies: { 'local-dependency': 'file:../dependency' },
+			})
+		);
+	});
+
+	after(() => {
+		fs.rmSync(componentsRoot, { recursive: true, force: true });
+	});
+
+	it('honors the documented dry_run field', async () => {
+		await installModules({ projects: ['application'], dry_run: true });
+
+		assert.equal(fs.existsSync(path.join(componentsRoot, 'application', 'node_modules')), false);
+	});
+});

--- a/unitTests/utility/npmUtilities.test.js
+++ b/unitTests/utility/npmUtilities.test.js
@@ -43,25 +43,49 @@ describe('install_node_modules', () => {
 		fs.rmSync(path.join(componentsRoot, 'application', 'node_modules'), { recursive: true, force: true });
 	});
 
-	it('honors the documented dry_run field', async () => {
-		await installModules({ projects: ['application'], dry_run: true });
+	// npm still reports the dependency it would add under --dry-run, so asserting on the output
+	// distinguishes a real dry run from npm never running at all
+	function assertDryRun(response) {
+		assert.match(String(response.application.npm_output), /add local-dependency/);
+		assert.equal(installedDependencyExists(), false);
+	}
 
-		assert.equal(fs.existsSync(path.join(componentsRoot, 'application', 'node_modules')), false);
+	function assertInstalled(response) {
+		assert.equal(response.application.npm_output.added, 1, JSON.stringify(response.application));
+		assert.equal(installedDependencyExists(), true);
+	}
+
+	function installedDependencyExists() {
+		return fs.existsSync(path.join(componentsRoot, 'application', 'node_modules', 'local-dependency'));
+	}
+
+	it('honors the documented dry_run field', async () => {
+		const response = await installModules({ projects: ['application'], dry_run: true });
+
+		assertDryRun(response);
 	});
 
 	it('honors a dry_run field that arrives as a string', async () => {
-		await installModules({ projects: ['application'], dry_run: 'true' });
+		const response = await installModules({ projects: ['application'], dry_run: 'true' });
 
-		assert.equal(fs.existsSync(path.join(componentsRoot, 'application', 'node_modules')), false);
+		assertDryRun(response);
 	});
 
-	it('installs when dry_run is false or omitted', async () => {
-		await installModules({ projects: ['application'], dry_run: 'false' });
-		assert.equal(fs.existsSync(path.join(componentsRoot, 'application', 'node_modules')), true);
+	it('honors the undocumented camelCase dryRun spelling', async () => {
+		const response = await installModules({ projects: ['application'], dryRun: true });
 
-		fs.rmSync(path.join(componentsRoot, 'application', 'node_modules'), { recursive: true, force: true });
+		assertDryRun(response);
+	});
 
-		await installModules({ projects: ['application'] });
-		assert.equal(fs.existsSync(path.join(componentsRoot, 'application', 'node_modules')), true);
+	it('installs when dry_run is false', async () => {
+		const response = await installModules({ projects: ['application'], dry_run: 'false' });
+
+		assertInstalled(response);
+	});
+
+	it('installs when dry_run is omitted', async () => {
+		const response = await installModules({ projects: ['application'] });
+
+		assertInstalled(response);
 	});
 });

--- a/unitTests/validation/validateBySchema.test.js
+++ b/unitTests/validation/validateBySchema.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const assert = require('node:assert');
+const Joi = require('joi');
+
+const { validateBySchema, validateAndConvertBySchema } = require('#src/validation/validationWrapper');
+
+const schema = Joi.object({
+	name: Joi.string().required(),
+	enabled: Joi.boolean().default(false),
+});
+
+describe('validateBySchema', () => {
+	it('returns nothing for a valid object', () => {
+		assert.equal(validateBySchema({ name: 'a' }, schema), undefined);
+	});
+
+	it('returns an error for an invalid object', () => {
+		const error = validateBySchema({}, schema);
+
+		assert.ok(error instanceof Error);
+		assert.match(error.message, /'name'/);
+	});
+});
+
+describe('validateAndConvertBySchema', () => {
+	it('applies schema defaults and coercion to the returned value', () => {
+		const { error, value } = validateAndConvertBySchema({ name: 'a', enabled: 'true' }, schema);
+
+		assert.equal(error, undefined);
+		assert.deepEqual(value, { name: 'a', enabled: true });
+	});
+
+	it('returns an error for an invalid object', () => {
+		const { error } = validateAndConvertBySchema({ enabled: true }, schema);
+
+		assert.ok(error instanceof Error);
+		assert.match(error.message, /'name'/);
+	});
+});

--- a/unitTests/validation/validationWrapper.test.js
+++ b/unitTests/validation/validationWrapper.test.js
@@ -6,7 +6,6 @@ const sinon_chai = require('sinon-chai').default;
 const { expect } = chai;
 chai.use(sinon_chai);
 
-const Joi = require('joi');
 const rewire = require('rewire');
 let validationWrapper_rw = rewire('#src/validation/validationWrapper');
 
@@ -99,32 +98,6 @@ describe('Test validateWrapper module', () => {
 
 			expect(result).to.be.instanceof(Error);
 			expect(result.message).to.equal(test_err_msg[0]);
-		});
-	});
-
-	describe('Test validateAndConvertBySchema function', () => {
-		const schema = Joi.object({
-			name: Joi.string().required(),
-			enabled: Joi.boolean().default(false),
-		});
-
-		it('should apply schema defaults and coercion to the returned value', () => {
-			const { error, value } = validationWrapper_rw.validateAndConvertBySchema({ name: 'a', enabled: 'true' }, schema);
-
-			expect(error).to.equal(undefined);
-			expect(value).to.deep.equal({ name: 'a', enabled: true });
-		});
-
-		it('should return an error for an invalid object', () => {
-			const { error } = validationWrapper_rw.validateAndConvertBySchema({ enabled: true }, schema);
-
-			expect(error).to.be.instanceof(Error);
-			expect(error.message).to.contain("'name'");
-		});
-
-		it('should keep validateBySchema returning only the error', () => {
-			expect(validationWrapper_rw.validateBySchema({ name: 'a' }, schema)).to.equal(undefined);
-			expect(validationWrapper_rw.validateBySchema({}, schema)).to.be.instanceof(Error);
 		});
 	});
 });

--- a/unitTests/validation/validationWrapper.test.js
+++ b/unitTests/validation/validationWrapper.test.js
@@ -6,6 +6,7 @@ const sinon_chai = require('sinon-chai').default;
 const { expect } = chai;
 chai.use(sinon_chai);
 
+const Joi = require('joi');
 const rewire = require('rewire');
 let validationWrapper_rw = rewire('#src/validation/validationWrapper');
 
@@ -98,6 +99,32 @@ describe('Test validateWrapper module', () => {
 
 			expect(result).to.be.instanceof(Error);
 			expect(result.message).to.equal(test_err_msg[0]);
+		});
+	});
+
+	describe('Test validateAndConvertBySchema function', () => {
+		const schema = Joi.object({
+			name: Joi.string().required(),
+			enabled: Joi.boolean().default(false),
+		});
+
+		it('should apply schema defaults and coercion to the returned value', () => {
+			const { error, value } = validationWrapper_rw.validateAndConvertBySchema({ name: 'a', enabled: 'true' }, schema);
+
+			expect(error).to.equal(undefined);
+			expect(value).to.deep.equal({ name: 'a', enabled: true });
+		});
+
+		it('should return an error for an invalid object', () => {
+			const { error } = validationWrapper_rw.validateAndConvertBySchema({ enabled: true }, schema);
+
+			expect(error).to.be.instanceof(Error);
+			expect(error.message).to.contain("'name'");
+		});
+
+		it('should keep validateBySchema returning only the error', () => {
+			expect(validationWrapper_rw.validateBySchema({ name: 'a' }, schema)).to.equal(undefined);
+			expect(validationWrapper_rw.validateBySchema({}, schema)).to.be.instanceof(Error);
 		});
 	});
 });

--- a/utility/npmUtilities.ts
+++ b/utility/npmUtilities.ts
@@ -26,12 +26,12 @@ export async function installModules(req: any) {
 		'install_node_modules is deprecated. Dependencies are automatically installed on' +
 		' deploy, and install_node_modules can lead to inconsistent behavior';
 	harperLogger.warn(deprecationWarning, req.projects);
-	const validation = modulesValidator(req);
+	const { error: validation, value: validatedRequest } = modulesValidator(req);
 	if (validation) {
 		throw handleHDBError(validation, validation.message, HTTP_STATUS_CODES.BAD_REQUEST);
 	}
 
-	let { projects, dry_run: dryRun } = req;
+	const { projects, dry_run: dryRun } = validatedRequest;
 
 	const componentsRootDirPath = getConfigPath(CONFIG_PARAMS.COMPONENTSROOT);
 
@@ -93,7 +93,7 @@ function parseNPMStdErr(stderr: string) {
 /**
  * Validator for both installModules & auditModules
  * @param {Object} req
- * @returns {*}
+ * @returns {{ error: Error | undefined, value: any }}
  */
 function modulesValidator(req: any) {
 	const funcSchema = Joi.object({
@@ -101,5 +101,5 @@ function modulesValidator(req: any) {
 		dry_run: Joi.boolean().default(false),
 	});
 
-	return validator.validateBySchema(req, funcSchema);
+	return validator.validateAndConvertBySchema(req, funcSchema);
 }

--- a/utility/npmUtilities.ts
+++ b/utility/npmUtilities.ts
@@ -91,15 +91,15 @@ function parseNPMStdErr(stderr: string) {
 }
 
 /**
- * Validator for both installModules & auditModules
+ * Validator for installModules
  * @param {Object} req
- * @returns {{ error: Error | undefined, value: any }}
  */
 function modulesValidator(req: any) {
+	// `dryRun` was the only spelling that worked before dry_run was honored; keep it accepted
 	const funcSchema = Joi.object({
 		projects: Joi.array().min(1).items(Joi.string()).required(),
 		dry_run: Joi.boolean().default(false),
-	});
+	}).rename('dryRun', 'dry_run', { override: true, ignoreUndefined: true });
 
 	return validator.validateAndConvertBySchema(req, funcSchema);
 }

--- a/utility/npmUtilities.ts
+++ b/utility/npmUtilities.ts
@@ -31,7 +31,7 @@ export async function installModules(req: any) {
 		throw handleHDBError(validation, validation.message, HTTP_STATUS_CODES.BAD_REQUEST);
 	}
 
-	let { projects, dryRun } = req;
+	let { projects, dry_run: dryRun } = req;
 
 	const componentsRootDirPath = getConfigPath(CONFIG_PARAMS.COMPONENTSROOT);
 

--- a/utility/npmUtilities.ts
+++ b/utility/npmUtilities.ts
@@ -95,11 +95,12 @@ function parseNPMStdErr(stderr: string) {
  * @param {Object} req
  */
 function modulesValidator(req: any) {
-	// `dryRun` was the only spelling that worked before dry_run was honored; keep it accepted
+	// `dryRun` was the only spelling that worked before dry_run was honored; keep it accepted, but
+	// reject a request that carries both rather than picking a winner
 	const funcSchema = Joi.object({
 		projects: Joi.array().min(1).items(Joi.string()).required(),
 		dry_run: Joi.boolean().default(false),
-	}).rename('dryRun', 'dry_run', { override: true, ignoreUndefined: true });
+	}).rename('dryRun', 'dry_run', { ignoreUndefined: true });
 
 	return validator.validateAndConvertBySchema(req, funcSchema);
 }

--- a/validation/validationWrapper.ts
+++ b/validation/validationWrapper.ts
@@ -95,13 +95,13 @@ export function validateBySchema(object, schema) {
 }
 
 /**
- * Same validation as `validateBySchema`, but also returns Joi's converted value, so callers can use
- * the coerced types and schema defaults instead of the raw request body.
+ * Validates like `validateBySchema` and additionally hands back Joi's converted value (coerced
+ * types and schema defaults). `value` is Joi's best-effort conversion, so it is only meaningful
+ * when `error` is undefined.
  * @param {{}} object
  * @param {Joi.ObjectSchema} schema
- * @returns {{ error: Error | undefined, value: any }}
  */
-export function validateAndConvertBySchema(object, schema) {
+export function validateAndConvertBySchema(object, schema): { error: Error | undefined; value: any } {
 	const result = schema.validate(object, { allowUnknown: true, abortEarly: false, errors: { wrap: { label: "'" } } });
 
 	return { error: result.error ? new Error(result.error.message) : undefined, value: result.value };

--- a/validation/validationWrapper.ts
+++ b/validation/validationWrapper.ts
@@ -84,6 +84,8 @@ export async function validateObjectAsync(object, fileConstraints) {
 	return null;
 }
 
+const SCHEMA_VALIDATION_OPTIONS = { allowUnknown: true, abortEarly: false, errors: { wrap: { label: "'" } } };
+
 /**
  *
  * @param {{}} object
@@ -91,7 +93,10 @@ export async function validateObjectAsync(object, fileConstraints) {
  * @returns {*}
  */
 export function validateBySchema(object, schema) {
-	return validateAndConvertBySchema(object, schema).error;
+	const { error } = schema.validate(object, SCHEMA_VALIDATION_OPTIONS);
+	if (error) {
+		return new Error(error.message);
+	}
 }
 
 /**
@@ -102,7 +107,7 @@ export function validateBySchema(object, schema) {
  * @param {Joi.ObjectSchema} schema
  */
 export function validateAndConvertBySchema(object, schema): { error: Error | undefined; value: any } {
-	const result = schema.validate(object, { allowUnknown: true, abortEarly: false, errors: { wrap: { label: "'" } } });
+	const { error, value } = schema.validate(object, SCHEMA_VALIDATION_OPTIONS);
 
-	return { error: result.error ? new Error(result.error.message) : undefined, value: result.value };
+	return { error: error ? new Error(error.message) : undefined, value };
 }

--- a/validation/validationWrapper.ts
+++ b/validation/validationWrapper.ts
@@ -91,9 +91,18 @@ export async function validateObjectAsync(object, fileConstraints) {
  * @returns {*}
  */
 export function validateBySchema(object, schema) {
-	let result = schema.validate(object, { allowUnknown: true, abortEarly: false, errors: { wrap: { label: "'" } } });
+	return validateAndConvertBySchema(object, schema).error;
+}
 
-	if (result.error) {
-		return new Error(result.error.message);
-	}
+/**
+ * Same validation as `validateBySchema`, but also returns Joi's converted value, so callers can use
+ * the coerced types and schema defaults instead of the raw request body.
+ * @param {{}} object
+ * @param {Joi.ObjectSchema} schema
+ * @returns {{ error: Error | undefined, value: any }}
+ */
+export function validateAndConvertBySchema(object, schema) {
+	const result = schema.validate(object, { allowUnknown: true, abortEarly: false, errors: { wrap: { label: "'" } } });
+
+	return { error: result.error ? new Error(result.error.message) : undefined, value: result.value };
 }


### PR DESCRIPTION
`install_node_modules`'s documented `dry_run: true` did not prevent a real `npm install --force`: the operation destructured `dryRun` (camelCase) off the raw request body, so the documented snake_case field never reached the flag check. The root cause is one layer down — `validateBySchema` returns only Joi's error and throws away `result.value`, so every schema default and coercion in the codebase is discarded, `dry_run`'s `.default(false)` included.

- `validation/validationWrapper.ts` gains [`validateAndConvertBySchema`](https://github.com/HarperFast/harper/pull/2340/changes?w=1#diff-ac1fbae8880a821f81b371675c40fb2e335dbbea07e96cf75fb0e6190024fe61R103), which returns both the error and Joi's converted value. [`validateBySchema`](https://github.com/HarperFast/harper/pull/2340/changes?w=1#diff-ac1fbae8880a821f81b371675c40fb2e335dbbea07e96cf75fb0e6190024fe61R95) is unchanged in behavior and now shares the validation options constant instead of building one per call.
- `install_node_modules` [validates through the new helper](https://github.com/HarperFast/harper/pull/2340/changes?w=1#diff-aab51787131300406743175a786a0896ca9bdc7ce9b86458c3d1fdc36cf34aebR105) and [reads `dry_run` off the converted value](https://github.com/HarperFast/harper/pull/2340/changes?w=1#diff-aab51787131300406743175a786a0896ca9bdc7ce9b86458c3d1fdc36cf34aebR34), so booleans, Joi-coercible strings, and the `false` default all behave as documented.
- Because `dryRun` was the only spelling that actually worked before, [the schema renames it onto `dry_run`](https://github.com/HarperFast/harper/pull/2340/changes?w=1#diff-aab51787131300406743175a786a0896ca9bdc7ce9b86458c3d1fdc36cf34aebR103) rather than silently turning those callers' dry runs into real installs. A request carrying **both** spellings is [rejected with a 400](https://github.com/HarperFast/harper/pull/2340/changes?w=1#diff-f0ada45d0d4b92fce70a6e89934360d60e453be2bd36f99b55c6b4a478699c53R93) instead of one winning quietly.

## For the human reviewer

- **Scope of the wrapper fix.** Only `install_node_modules` was migrated to the converting helper. Two other call sites already carry comments about this same discarded conversion (`components/deploymentRecorder.ts:575`, a coerced number thrown away; `security/authn/oidc/trustPolicyOperations.ts:256`, compensating with `.strict()`). Migrating them is independent work and left out deliberately; if you'd rather do it in one sweep, say so and I'll widen it.
- **[`validateBySchema` duplicates two lines](https://github.com/HarperFast/harper/pull/2340/changes?w=1#diff-ac1fbae8880a821f81b371675c40fb2e335dbbea07e96cf75fb0e6190024fe61R95) of `validateAndConvertBySchema`** rather than delegating to it. Delegating allocates an `{ error, value }` wrapper on every operation-body validation in the codebase; two reviewers flagged that, so the error-only path validates directly.
- **Rejecting the ambiguous request** (`{ dry_run: true, dryRun: false }`) is a judgment call — the alternative is letting the documented field win silently. The rejection message is Joi's own rename-conflict wording.
- **Investing in a deprecated operation:** the code calls `install_node_modules` deprecated in its own warning. This fixes the safety flag rather than sunsetting the operation; sunsetting is a breaking API change on its own schedule.
- The unit tests spawn a real `npm install` against a temp fixture with a `file:` dependency (no registry access, ~1.5s total) rather than stubbing the spawn, so they assert what npm actually did.

## Verification

- `npm run test:unit:main` (4993 passing) and `npm run test:unit:resources` (1747 passing).
- Full integration suite run in groups: deploy+components (176), security+database (373), apiTests+server (1127, 1 pre-existing failure in `integrationTests/server/ollama-backend.test.ts` — needs a live Ollama instance), resources+mqtt (123), mcp+upgrade (61).
- Fails-on-base check: reverting only `utility/npmUtilities.ts` and `validation/validationWrapper.ts` to `origin/main` makes the two dry-run tests fail (`node_modules/local-dependency` created), and they pass with the fix.
- New unit coverage: `unitTests/utility/npmUtilities.test.js` (documented, string, and camelCase dry runs; real installs for `false` and omitted; 400s for the conflicting-spelling and missing-`projects` requests) and `unitTests/validation/validateBySchema.test.js` (defaults, coercion, error shape for both wrapper APIs).

Fixes #2332

Complexity: medium

<sub>Review-Coverage: authored=claude; ran=codex; blocked=gemini(no-output); declined=cursor-grok,cursor-composer,domain; rounds=4 @ ab6a778ca492</sub>

<sub>Human-Review-Need: 3 @ ab6a778ca492</sub>
