### PR TITLE
Prevent HTTP workers from exiting before startup completes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -284,6 +284,14 @@ A package-manager timeout must not release this lock while npm descendants are s
 
 Boot's `harper-application-lock.json` records an application configuration only after preparation fulfills. Recording at queue time would make a failed install look complete and suppress its retry on the next boot.
 
+Each non-root component also needs `node_modules/harper` (and an existing legacy `harperdb` entry)
+linked to the running package. `componentLoader.symlinkHarperModule()` validates those links before
+taking the cross-thread store lock, so normal multi-worker startup does not serialize on already-valid
+links. A repair winner revalidates under the lock and clears its timeout before releasing ownership. A
+loser retains a bounded, ref'd wait and validates the winner's result when notified, but never calls
+`unlock()` itself: a wait timeout does not transfer lock ownership, and unlocking there can release a
+different worker's critical section and leave a stale timer to unlock a later owner.
+
 ## Peer-side deploy_component payload read: retryable blob stalls and `Readable.from()` cancellation
 
 `readPayloadBlobWithRetry` (`components/deploymentRecorder.ts`) wraps the peer's read of a replicated `hdb_deployment` row's `payload_blob` so a transient 503 `BlobReadError` (`BLOB_UNAVAILABLE_STATUS`, `resources/blob.ts`) — content bytes not arriving within `blobReadTimeout`, e.g. a parked blob send on the origin — retries instead of failing the whole deploy. Two non-obvious constraints shaped the design:

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -392,7 +392,7 @@ function harperModulesAreLinked(componentDirectory: string) {
 	const harperModule = join(nodeModulesDir, 'harper');
 	try {
 		lstatSync(harperModule);
-		if (realpathSync(harperModule) !== realpathSync(PACKAGE_ROOT)) return false;
+		if (realpathSync(harperModule) !== PACKAGE_ROOT) return false;
 	} catch {
 		return false;
 	}
@@ -404,7 +404,7 @@ function harperModulesAreLinked(componentDirectory: string) {
 		return true;
 	}
 	try {
-		return realpathSync(harperdbModule) === realpathSync(PACKAGE_ROOT);
+		return realpathSync(harperdbModule) === PACKAGE_ROOT;
 	} catch {
 		return false;
 	}
@@ -418,7 +418,7 @@ function repairHarperModuleLinks(componentDirectory: string) {
 	let harperModuleLinked = false;
 	try {
 		lstatSync(harperModule);
-		harperModuleLinked = realpathSync(harperModule) === realpathSync(PACKAGE_ROOT);
+		harperModuleLinked = realpathSync(harperModule) === PACKAGE_ROOT;
 	} catch {}
 	if (!harperModuleLinked) {
 		rmSync(harperModule, { recursive: true, force: true });
@@ -431,7 +431,7 @@ function repairHarperModuleLinks(componentDirectory: string) {
 	try {
 		lstatSync(harperdbModule);
 		harperdbModulePresent = true;
-		harperdbModuleLinked = realpathSync(harperdbModule) === realpathSync(PACKAGE_ROOT);
+		harperdbModuleLinked = realpathSync(harperdbModule) === PACKAGE_ROOT;
 	} catch {}
 	if (harperdbModulePresent && !harperdbModuleLinked) {
 		rmSync(harperdbModule, { recursive: true, force: true });

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -60,6 +60,7 @@ import { ComponentPreparationLockTimeoutError } from './componentPreparationLock
 import { pathToFileURL } from 'node:url';
 
 const CF_ROUTES_DIR = getConfigPath(CONFIG_PARAMS.COMPONENTSROOT);
+const COMPONENT_SYMLINK_LOCK_TIMEOUT = 10_000;
 let loadedComponents = new Map<any, any>();
 let watchesSetup;
 let resources;
@@ -386,60 +387,94 @@ export const getComponentName = () => compName;
  * ../index.ts), so the import yields live data, not an empty separate copy. The link is verified on
  * every non-root component load and repaired if missing or pointing elsewhere.
  */
-function symlinkHarperModule(componentDirectory: string) {
+function harperModulesAreLinked(componentDirectory: string) {
+	const nodeModulesDir = join(componentDirectory, 'node_modules');
+	const harperModule = join(nodeModulesDir, 'harper');
+	try {
+		lstatSync(harperModule);
+		if (realpathSync(harperModule) !== realpathSync(PACKAGE_ROOT)) return false;
+	} catch {
+		return false;
+	}
+
+	const harperdbModule = join(nodeModulesDir, 'harperdb');
+	try {
+		lstatSync(harperdbModule);
+	} catch {
+		return true;
+	}
+	try {
+		return realpathSync(harperdbModule) === realpathSync(PACKAGE_ROOT);
+	} catch {
+		return false;
+	}
+}
+
+function repairHarperModuleLinks(componentDirectory: string) {
+	const nodeModulesDir = join(componentDirectory, 'node_modules');
+	if (!existsSync(nodeModulesDir)) mkdirSync(nodeModulesDir);
+
+	const harperModule = join(nodeModulesDir, 'harper');
+	let harperModuleLinked = false;
+	try {
+		lstatSync(harperModule);
+		harperModuleLinked = realpathSync(harperModule) === realpathSync(PACKAGE_ROOT);
+	} catch {}
+	if (!harperModuleLinked) {
+		rmSync(harperModule, { recursive: true, force: true });
+		symlinkSync(PACKAGE_ROOT, harperModule, 'dir');
+	}
+
+	const harperdbModule = join(nodeModulesDir, 'harperdb');
+	let harperdbModulePresent = false;
+	let harperdbModuleLinked = false;
+	try {
+		lstatSync(harperdbModule);
+		harperdbModulePresent = true;
+		harperdbModuleLinked = realpathSync(harperdbModule) === realpathSync(PACKAGE_ROOT);
+	} catch {}
+	if (harperdbModulePresent && !harperdbModuleLinked) {
+		rmSync(harperdbModule, { recursive: true, force: true });
+		symlinkSync(PACKAGE_ROOT, harperdbModule, 'dir');
+	}
+}
+
+export function symlinkHarperModule(
+	componentDirectory: string,
+	store = Status.primaryStore,
+	lockTimeout = COMPONENT_SYMLINK_LOCK_TIMEOUT
+) {
+	if (harperModulesAreLinked(componentDirectory)) return Promise.resolve();
+
 	return new Promise<void>((resolve, reject) => {
-		const store = Status.primaryStore;
-		// Create timeout to avoid deadlocks
 		const timeout = setTimeout(() => {
-			store.unlock(componentDirectory);
+			// A waiter never owns the lock, so timing out must not unlock another worker's
+			// critical section. The owner releases it, including when that worker closes.
 			reject(new Error('symlinking harperdb module timed out'));
-		}, 10_000);
+		}, lockTimeout);
 
 		const callback = () => {
 			clearTimeout(timeout);
-			resolve();
+			if (harperModulesAreLinked(componentDirectory)) resolve();
+			else reject(new Error('symlinking harperdb module completed without valid links'));
 		};
-		const lockAcquired = store.tryLock(componentDirectory, callback);
-
-		if (!lockAcquired) {
+		let lockAcquired;
+		try {
+			lockAcquired = store.tryLock(componentDirectory, callback);
+		} catch (error) {
 			clearTimeout(timeout);
-		} else {
+			reject(error);
+			return;
+		}
+
+		if (lockAcquired) {
 			try {
-				// validate node_modules directory exists
-				const nodeModulesDir = join(componentDirectory, 'node_modules');
-				if (!existsSync(nodeModulesDir)) {
-					// create it if not
-					mkdirSync(nodeModulesDir);
-				}
-
-				// validate harper module
-				const harperModule = join(nodeModulesDir, 'harper');
-				let harperModuleLinked = false;
-				try {
-					lstatSync(harperModule); // throws ENOENT if absent; succeeds even for dangling symlinks
-					harperModuleLinked = realpathSync(harperModule) === realpathSync(PACKAGE_ROOT);
-				} catch {}
-				if (!harperModuleLinked) {
-					rmSync(harperModule, { recursive: true, force: true });
-					symlinkSync(PACKAGE_ROOT, harperModule, 'dir');
-				}
-				// if there is a harperdb module, fix that too
-				const harperdbModule = join(nodeModulesDir, 'harperdb');
-				let harperdbModulePresent = false;
-				let harperdbModuleLinked = false;
-				try {
-					lstatSync(harperdbModule);
-					harperdbModulePresent = true;
-					harperdbModuleLinked = realpathSync(harperdbModule) === realpathSync(PACKAGE_ROOT);
-				} catch {}
-				if (harperdbModulePresent && !harperdbModuleLinked) {
-					rmSync(harperdbModule, { recursive: true, force: true });
-					symlinkSync(PACKAGE_ROOT, harperdbModule, 'dir');
-				}
-
+				repairHarperModuleLinks(componentDirectory);
 				resolve();
+			} catch (error) {
+				reject(error);
 			} finally {
-				// finally release the lock
+				clearTimeout(timeout);
 				store.unlock(componentDirectory);
 			}
 		}

--- a/integrationTests/server/fixtures/worker-startup-liveness/preload.cjs
+++ b/integrationTests/server/fixtures/worker-startup-liveness/preload.cjs
@@ -1,7 +1,10 @@
 'use strict';
 
 const Module = require('node:module');
+const { writeFileSync } = require('node:fs');
+const { join } = require('node:path');
 const { setTimeout: delay } = require('node:timers/promises');
+const { threadId } = require('node:worker_threads');
 
 // Worker execArgv loads this before threadServer. Replacing only the worker-side root loader
 // isolates the ready handshake from incidental component/storage handles; the main process still
@@ -12,6 +15,7 @@ replacement.filename = loadRootComponentsPath;
 replacement.loaded = true;
 replacement.exports = {
 	loadRootComponents() {
+		writeFileSync(join(process.env.HARPER_TEST_WORKER_STARTUP_MARKER_DIR, `worker-${threadId}`), '');
 		const startupMode = process.env.HARPER_TEST_WORKER_STARTUP_MODE;
 		return delay(100, undefined, { ref: startupMode === 'ref' }).then(() => {
 			if (startupMode === 'reject') throw new Error('deliberate worker component startup rejection');

--- a/integrationTests/server/fixtures/worker-startup-liveness/preload.cjs
+++ b/integrationTests/server/fixtures/worker-startup-liveness/preload.cjs
@@ -1,0 +1,21 @@
+'use strict';
+
+const Module = require('node:module');
+const { setTimeout: delay } = require('node:timers/promises');
+
+// Worker execArgv loads this before threadServer. Replacing only the worker-side root loader
+// isolates the ready handshake from incidental component/storage handles; the main process still
+// boots normally and creates the actual four-worker HTTP pool exercised by the test.
+const loadRootComponentsPath = require.resolve(process.env.HARPER_TEST_LOAD_ROOT_COMPONENTS_PATH);
+const replacement = new Module(loadRootComponentsPath);
+replacement.filename = loadRootComponentsPath;
+replacement.loaded = true;
+replacement.exports = {
+	loadRootComponents() {
+		const startupMode = process.env.HARPER_TEST_WORKER_STARTUP_MODE;
+		return delay(100, undefined, { ref: startupMode === 'ref' }).then(() => {
+			if (startupMode === 'reject') throw new Error('deliberate worker component startup rejection');
+		});
+	},
+};
+require.cache[loadRootComponentsPath] = replacement;

--- a/integrationTests/server/worker-startup-liveness.test.ts
+++ b/integrationTests/server/worker-startup-liveness.test.ts
@@ -1,30 +1,48 @@
+/**
+ * Run: npm run build && npm run test:integration -- "integrationTests/server/worker-startup-liveness.test.ts"
+ * The harness is pinned to this repository's dist build because the preload replaces one of its modules.
+ */
 import assert from 'node:assert';
-import { resolve } from 'node:path';
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { suite, test } from 'node:test';
 import { createHarperContext, HarperStartupError, startHarper, teardownHarper } from '@harperfast/integration-testing';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'fixtures/worker-startup-liveness');
+const REPO_ROOT = resolve(import.meta.dirname, '..', '..');
 const PRELOAD_PATH = resolve(FIXTURE_PATH, 'preload.cjs');
-const LOAD_ROOT_COMPONENTS_PATH = resolve(process.cwd(), 'dist/server/loadRootComponents.js');
+const HARPER_BIN_PATH = resolve(REPO_ROOT, 'dist/bin/harper.js');
+const LOAD_ROOT_COMPONENTS_PATH = resolve(REPO_ROOT, 'dist/server/loadRootComponents.js');
 const WORKER_COUNT = 4;
 
-function startupOptions(mode: 'ref' | 'unref' | 'reject') {
+function startupOptions(mode: 'ref' | 'unref' | 'reject', markerDirectory: string) {
 	return {
+		harperBinPath: HARPER_BIN_PATH,
 		config: {
 			threads: { count: WORKER_COUNT, preloadRequire: PRELOAD_PATH },
 			logging: { console: true, level: 'error' },
 		},
 		env: {
 			HARPER_TEST_LOAD_ROOT_COMPONENTS_PATH: LOAD_ROOT_COMPONENTS_PATH,
+			HARPER_TEST_WORKER_STARTUP_MARKER_DIR: markerDirectory,
 			HARPER_TEST_WORKER_STARTUP_MODE: mode,
 		},
 	};
 }
 
+function assertPreloadRan(markerDirectory: string, expectedCount: number | null = WORKER_COUNT) {
+	const markers = readdirSync(markerDirectory).sort();
+	if (expectedCount === null) assert(markers.length > 0, 'expected the worker preload to write a marker');
+	else
+		assert.strictEqual(markers.length, expectedCount, `expected one preload marker per worker: ${markers.join(', ')}`);
+}
+
 async function startWithMode(mode: 'ref' | 'unref') {
 	const context = createHarperContext(`worker-startup-${mode}`);
+	const markerDirectory = mkdtempSync(join(tmpdir(), `worker-startup-${mode}-`));
 	try {
-		const startedContext = await startHarper(context, startupOptions(mode));
+		const startedContext = await startHarper(context, startupOptions(mode, markerDirectory));
 		const response = await fetch(startedContext.harper.operationsAPIURL, {
 			method: 'POST',
 			headers: {
@@ -36,12 +54,20 @@ async function startWithMode(mode: 'ref' | 'unref') {
 		const body = (await response.json()) as { threads?: unknown[] };
 		assert.strictEqual(response.status, 200, JSON.stringify(body));
 		assert.strictEqual(body.threads?.length, WORKER_COUNT);
+		assertPreloadRan(markerDirectory);
 	} finally {
-		await teardownHarper(context);
+		try {
+			await teardownHarper(context);
+		} finally {
+			rmSync(markerDirectory, { recursive: true, force: true });
+		}
 	}
 }
 
-suite('HTTP worker startup liveness', { skip: process.platform === 'win32' }, () => {
+// Bun does not pass preloadRequire through worker execArgv, so it cannot install this fixture.
+const skipSuite = process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun';
+
+suite('HTTP worker startup liveness', { skip: skipSuite }, () => {
 	test('starts all workers when component initialization owns a ref handle', async () => {
 		await startWithMode('ref');
 	});
@@ -52,17 +78,28 @@ suite('HTTP worker startup liveness', { skip: process.platform === 'win32' }, ()
 
 	test('exits explicitly when worker component initialization rejects', async () => {
 		const context = createHarperContext('worker-startup-reject');
+		const markerDirectory = mkdtempSync(join(tmpdir(), 'worker-startup-reject-'));
 		let startupError;
 		try {
-			await startHarper(context, startupOptions('reject'));
+			await startHarper(context, startupOptions('reject', markerDirectory));
 		} catch (error) {
 			startupError = error;
 		} finally {
-			await teardownHarper(context);
+			try {
+				await teardownHarper(context);
+			} catch (error) {
+				rmSync(markerDirectory, { recursive: true, force: true });
+				throw error;
+			}
 		}
 
-		assert(startupError instanceof HarperStartupError, 'expected startup to fail');
-		assert.match(startupError.stderr, /Failed to load root components in worker/);
-		assert.doesNotMatch(startupError.message, /maximum startup time|produced no startup output/);
+		try {
+			assertPreloadRan(markerDirectory, null);
+			assert(startupError instanceof HarperStartupError, 'expected startup to fail');
+			assert.match(startupError.stderr, /Failed to load root components in worker/);
+			assert.doesNotMatch(startupError.message, /maximum startup time|produced no startup output/);
+		} finally {
+			rmSync(markerDirectory, { recursive: true, force: true });
+		}
 	});
 });

--- a/integrationTests/server/worker-startup-liveness.test.ts
+++ b/integrationTests/server/worker-startup-liveness.test.ts
@@ -97,7 +97,6 @@ suite('HTTP worker startup liveness', { skip: skipSuite }, () => {
 			assertPreloadRan(markerDirectory, null);
 			assert(startupError instanceof HarperStartupError, 'expected startup to fail');
 			assert.match(startupError.stderr, /Failed to load root components in worker/);
-			assert.doesNotMatch(startupError.message, /maximum startup time|produced no startup output/);
 		} finally {
 			rmSync(markerDirectory, { recursive: true, force: true });
 		}

--- a/integrationTests/server/worker-startup-liveness.test.ts
+++ b/integrationTests/server/worker-startup-liveness.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert';
+import { resolve } from 'node:path';
+import { suite, test } from 'node:test';
+import { createHarperContext, HarperStartupError, startHarper, teardownHarper } from '@harperfast/integration-testing';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'fixtures/worker-startup-liveness');
+const PRELOAD_PATH = resolve(FIXTURE_PATH, 'preload.cjs');
+const LOAD_ROOT_COMPONENTS_PATH = resolve(process.cwd(), 'dist/server/loadRootComponents.js');
+const WORKER_COUNT = 4;
+
+function startupOptions(mode: 'ref' | 'unref' | 'reject') {
+	return {
+		config: {
+			threads: { count: WORKER_COUNT, preloadRequire: PRELOAD_PATH },
+			logging: { console: true, level: 'error' },
+		},
+		env: {
+			HARPER_TEST_LOAD_ROOT_COMPONENTS_PATH: LOAD_ROOT_COMPONENTS_PATH,
+			HARPER_TEST_WORKER_STARTUP_MODE: mode,
+		},
+	};
+}
+
+async function startWithMode(mode: 'ref' | 'unref') {
+	const context = createHarperContext(`worker-startup-${mode}`);
+	try {
+		const startedContext = await startHarper(context, startupOptions(mode));
+		const response = await fetch(startedContext.harper.operationsAPIURL, {
+			method: 'POST',
+			headers: {
+				'Authorization': `Basic ${Buffer.from(`${startedContext.harper.admin.username}:${startedContext.harper.admin.password}`).toString('base64')}`,
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ operation: 'system_information', attributes: ['threads'] }),
+		});
+		const body = (await response.json()) as { threads?: unknown[] };
+		assert.strictEqual(response.status, 200, JSON.stringify(body));
+		assert.strictEqual(body.threads?.length, WORKER_COUNT);
+	} finally {
+		await teardownHarper(context);
+	}
+}
+
+suite('HTTP worker startup liveness', { skip: process.platform === 'win32' }, () => {
+	test('starts all workers when component initialization owns a ref handle', async () => {
+		await startWithMode('ref');
+	});
+
+	test('starts all workers when component initialization awaits only an unref handle', async () => {
+		await startWithMode('unref');
+	});
+
+	test('exits explicitly when worker component initialization rejects', async () => {
+		const context = createHarperContext('worker-startup-reject');
+		let startupError;
+		try {
+			await startHarper(context, startupOptions('reject'));
+		} catch (error) {
+			startupError = error;
+		} finally {
+			await teardownHarper(context);
+		}
+
+		assert(startupError instanceof HarperStartupError, 'expected startup to fail');
+		assert.match(startupError.stderr, /Failed to load root components in worker/);
+		assert.doesNotMatch(startupError.message, /maximum startup time|produced no startup output/);
+	});
+});

--- a/server/DESIGN.md
+++ b/server/DESIGN.md
@@ -91,6 +91,12 @@ and it force-terminates the remaining worker set rather than waiting for applica
 
 > Workers receive `workerData.noServerStart = true` — never start the server inside a worker.
 >
+> An HTTP worker refs its `parentPort` synchronously on entry to `threadServer.startServers()` and
+> holds that ref through root-component loading. Startup is allowed to await work whose own handles
+> are unref'd, so the parent port owns liveness until the worker posts `child_started`; a root-load
+> rejection is terminal. Shutdown still unrefs the port in `manageThreads`, including when the
+> shutdown message arrives during component loading.
+>
 > `threadServer.listenOnDomainSocket()` skips a listener only when its path exceeds the platform's
 > `sockaddr_un.sun_path` byte limit (some Node versions reject it; others silently truncate it).
 > Every actual `listen()` error rejects startup, and the temporary bind-error listener is removed

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -169,6 +169,10 @@ function closeServers() {
 }
 
 function startServers() {
+	// manageThreads unrefs this port during worker setup so idle workers can terminate. Startup may
+	// legitimately await only unref'd work (for example, a storage lock wake), so keep the worker
+	// alive until it either reports ready or receives a shutdown request.
+	parentPort?.ref();
 	const rootPath = env.get(terms.CONFIG_PARAMS.ROOTPATH);
 	if (rootPath) {
 		try {
@@ -177,51 +181,49 @@ function startServers() {
 			// ignore any errors with this; just a best effort for now
 		}
 	}
-	let loaded = require('../loadRootComponents.js')
+	const loaded = require('../loadRootComponents.js')
 		.loadRootComponents(true)
 		.then(() => {
-			parentPort
-				?.on('message', (message) => {
-					if (message.type === terms.ITC_EVENT_TYPES.SHUTDOWN) {
-						harperLogger.trace('received shutdown request', threadId);
-						// shutdown (for these threads) means stop listening for incoming requests (finish what we are working) and
-						// close connections as possible, then let the event loop complete.
-						// First, gracefully drain any in-flight work registered by components — notably a
-						// replication blob *send* streaming to a peer, which is cheaper to finish than to interrupt
-						// (interrupting leaves the peer's copy diverged until it re-requests). The drain waits only
-						// on work still making progress, bounded by an absolute deadline. When there is real work to
-						// drain we push the termination backstops out to that deadline first so the drain isn't cut
-						// short, then restore the normal short backstop once draining is done — so any later hang
-						// (closeServers / scope disposal) is still force-killed on the normal timeout, and a worker
-						// with no such work is never affected.
-						const drainDeadline = Date.now() + getShutdownDrainCeilingMs();
-						const extendedForDrain = shutdownDrainsHaveWork();
-						if (extendedForDrain) extendShutdownDeadline(drainDeadline);
-						// Wait for application scopes to finish closing before exiting — some dispose a native
-						// runtime asynchronously (e.g. @harperfast/vite's rolldown dev server), and exiting the
-						// worker while that runtime is still live crashes the process. The manageThreads backstop
-						// timers still bound this if a scope's disposal hangs.
-						runShutdownDrains(drainDeadline)
-							.then(() => {
-								if (extendedForDrain) restoreShutdownDeadline();
-							})
-							.then(() => closeServers())
-							.then(() => whenScopesClosed())
-							.then(() => {
-								realExit(0);
-							});
-						// Clean up per-thread UDS socket and metadata files
-						httpComponent.cleanupUdsFiles();
-						if (!isBun && (debugThreads || process.env.DEV_MODE)) {
-							try {
-								require('inspector').close();
-							} catch (error) {
-								harperLogger.info('Could not close debugger', error);
-							}
+			parentPort?.on('message', (message) => {
+				if (message.type === terms.ITC_EVENT_TYPES.SHUTDOWN) {
+					harperLogger.trace('received shutdown request', threadId);
+					// shutdown (for these threads) means stop listening for incoming requests (finish what we are working) and
+					// close connections as possible, then let the event loop complete.
+					// First, gracefully drain any in-flight work registered by components — notably a
+					// replication blob *send* streaming to a peer, which is cheaper to finish than to interrupt
+					// (interrupting leaves the peer's copy diverged until it re-requests). The drain waits only
+					// on work still making progress, bounded by an absolute deadline. When there is real work to
+					// drain we push the termination backstops out to that deadline first so the drain isn't cut
+					// short, then restore the normal short backstop once draining is done — so any later hang
+					// (closeServers / scope disposal) is still force-killed on the normal timeout, and a worker
+					// with no such work is never affected.
+					const drainDeadline = Date.now() + getShutdownDrainCeilingMs();
+					const extendedForDrain = shutdownDrainsHaveWork();
+					if (extendedForDrain) extendShutdownDeadline(drainDeadline);
+					// Wait for application scopes to finish closing before exiting — some dispose a native
+					// runtime asynchronously (e.g. @harperfast/vite's rolldown dev server), and exiting the
+					// worker while that runtime is still live crashes the process. The manageThreads backstop
+					// timers still bound this if a scope's disposal hangs.
+					runShutdownDrains(drainDeadline)
+						.then(() => {
+							if (extendedForDrain) restoreShutdownDeadline();
+						})
+						.then(() => closeServers())
+						.then(() => whenScopesClosed())
+						.then(() => {
+							realExit(0);
+						});
+					// Clean up per-thread UDS socket and metadata files
+					httpComponent.cleanupUdsFiles();
+					if (!isBun && (debugThreads || process.env.DEV_MODE)) {
+						try {
+							require('inspector').close();
+						} catch (error) {
+							harperLogger.info('Could not close debugger', error);
 						}
 					}
-				})
-				.ref(); // use this to keep the thread running until we are ready to shutdown and clean up handles
+				}
+			});
 			const listening = listenOnPorts();
 
 			// notify that we are now ready to start receiving requests
@@ -247,6 +249,15 @@ function startServers() {
 					realExit(1);
 				});
 		});
+	if (!isMainThread) {
+		void loaded.catch((err) => {
+			// The process-wide unhandledRejection handler intentionally keeps workers alive for
+			// background failures. Root-component loading is different: startup cannot complete.
+			console.error(`Failed to load root components in worker ${threadId}`, err);
+			harperLogger.fatal('Failed to load root components during startup', err);
+			realExit(1);
+		});
+	}
 	componentsLoadedResolve(loaded);
 	// Clean up UDS files and force-close Bun server connections on unexpected exit.
 	// Without the stop(true) call, clients holding keep-alive connections to a dead Bun

--- a/unitTests/components/symlinkHarperModule.test.js
+++ b/unitTests/components/symlinkHarperModule.test.js
@@ -100,4 +100,38 @@ describe('symlinkHarperModule', () => {
 
 		await linked;
 	});
+
+	it('rejects a lock waiter when the winning worker did not repair the links', async () => {
+		let notifyUnlocked;
+		const linked = symlinkHarperModule(
+			componentDirectory,
+			{
+				tryLock(_key, callback) {
+					notifyUnlocked = callback;
+					return false;
+				},
+				unlock() {
+					throw new Error('waiter must not unlock');
+				},
+			},
+			100
+		);
+
+		notifyUnlocked();
+
+		await assert.rejects(linked, /completed without valid links/);
+	});
+
+	it('preserves a tryLock error and clears the wait timer', async () => {
+		const lockError = new Error('lock store unavailable');
+		await assert.rejects(
+			symlinkHarperModule(componentDirectory, {
+				tryLock() {
+					throw lockError;
+				},
+				unlock() {},
+			}),
+			(error) => error === lockError
+		);
+	});
 });

--- a/unitTests/components/symlinkHarperModule.test.js
+++ b/unitTests/components/symlinkHarperModule.test.js
@@ -46,6 +46,7 @@ describe('symlinkHarperModule', () => {
 
 		await symlinkHarperModule(componentDirectory, store);
 
+		assert.strictEqual(readlinkSync(join(nodeModulesDirectory, 'harper')), PACKAGE_ROOT);
 		assert.strictEqual(readlinkSync(join(nodeModulesDirectory, 'harperdb')), PACKAGE_ROOT);
 	});
 
@@ -122,7 +123,7 @@ describe('symlinkHarperModule', () => {
 		await assert.rejects(linked, /completed without valid links/);
 	});
 
-	it('preserves a tryLock error and clears the wait timer', async () => {
+	it('preserves a tryLock error', async () => {
 		const lockError = new Error('lock store unavailable');
 		await assert.rejects(
 			symlinkHarperModule(componentDirectory, {

--- a/unitTests/components/symlinkHarperModule.test.js
+++ b/unitTests/components/symlinkHarperModule.test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const assert = require('node:assert');
+const { mkdtempSync, mkdirSync, readlinkSync, rmSync, symlinkSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const { setTimeout: delay } = require('node:timers/promises');
+const { symlinkHarperModule } = require('#src/components/componentLoader');
+const { PACKAGE_ROOT } = require('#js/utility/packageUtils');
+
+describe('symlinkHarperModule', () => {
+	let componentDirectory;
+
+	beforeEach(() => {
+		componentDirectory = mkdtempSync(join(tmpdir(), 'harper-module-link-'));
+	});
+
+	afterEach(() => {
+		rmSync(componentDirectory, { recursive: true, force: true });
+	});
+
+	it('skips the lock when the Harper module link is already valid', async () => {
+		const nodeModulesDirectory = join(componentDirectory, 'node_modules');
+		mkdirSync(nodeModulesDirectory);
+		symlinkSync(PACKAGE_ROOT, join(nodeModulesDirectory, 'harper'), 'dir');
+
+		await symlinkHarperModule(componentDirectory, {
+			tryLock() {
+				throw new Error('valid links must not take the lock');
+			},
+			unlock() {},
+		});
+	});
+
+	it('repairs a dangling legacy harperdb link instead of treating it as absent', async () => {
+		const nodeModulesDirectory = join(componentDirectory, 'node_modules');
+		mkdirSync(nodeModulesDirectory);
+		symlinkSync(PACKAGE_ROOT, join(nodeModulesDirectory, 'harper'), 'dir');
+		symlinkSync(join(componentDirectory, 'missing'), join(nodeModulesDirectory, 'harperdb'), 'dir');
+		const store = {
+			tryLock() {
+				return true;
+			},
+			unlock() {},
+		};
+
+		await symlinkHarperModule(componentDirectory, store);
+
+		assert.strictEqual(readlinkSync(join(nodeModulesDirectory, 'harperdb')), PACKAGE_ROOT);
+	});
+
+	it('does not unlock another owner when a lock wait times out', async () => {
+		let unlockCount = 0;
+		const store = {
+			tryLock() {
+				return false;
+			},
+			unlock() {
+				unlockCount++;
+			},
+		};
+
+		await assert.rejects(symlinkHarperModule(componentDirectory, store, 20), /timed out/);
+		assert.strictEqual(unlockCount, 0);
+	});
+
+	it('clears the lock winner timeout after releasing its lock', async () => {
+		let unlockCount = 0;
+		const store = {
+			tryLock() {
+				return true;
+			},
+			unlock() {
+				unlockCount++;
+			},
+		};
+
+		await symlinkHarperModule(componentDirectory, store, 20);
+		await delay(40);
+		assert.strictEqual(unlockCount, 1);
+	});
+
+	it('resolves a lock waiter only after the winning worker repaired the links', async () => {
+		let notifyUnlocked;
+		const store = {
+			tryLock(_key, callback) {
+				notifyUnlocked = callback;
+				return false;
+			},
+			unlock() {
+				throw new Error('waiter must not unlock');
+			},
+		};
+		const linked = symlinkHarperModule(componentDirectory, store, 100);
+
+		const nodeModulesDirectory = join(componentDirectory, 'node_modules');
+		mkdirSync(nodeModulesDirectory);
+		symlinkSync(PACKAGE_ROOT, join(nodeModulesDirectory, 'harper'), 'dir');
+		notifyUnlocked();
+
+		await linked;
+	});
+});


### PR DESCRIPTION
Refs #2312. [Keep HTTP workers alive for the entire startup handshake](https://github.com/HarperFast/harper/pull/2343/changes?w=1#diff-203cc9c9c5531f3f084fdd3b3f51473caef679476c20f7db9328d12ecd334269R175), make [root-component startup rejection terminal in workers](https://github.com/HarperFast/harper/pull/2343/changes?w=1#diff-203cc9c9c5531f3f084fdd3b3f51473caef679476c20f7db9328d12ecd334269R253), and avoid unnecessary cross-worker contention while validating Harper package links. Concurrent startup now survives an initialization await backed only by unref'd handles without weakening the existing pre-ready code-0 fatal path.

The independent review left three bounded limits for human attention: a waiter currently reports rather than retries if a symlink repair owner dies mid-repair; the 10-second lock timeout remains ref'd during shutdown; and lock-contract tests use an injected store rather than the native cross-thread implementation.

This is a replacement candidate for #2314. That PR identified the same liveness invariant but reports that its full-instance regression did not reproduce against unmodified sources; this draft's concurrent unref and rejection arms are mechanically red against a full rebuild of `origin/main`.

## For the human reviewer

1. **Startup liveness owner:** This refs `parentPort` at `startServers()` entry instead of depending on incidental component-loader handles or a separate startup sentinel. That makes the handshake owner responsible for liveness and preserves `manageThreads` shutdown unref behavior; rejecting this choice requires another explicit startup keepalive mechanism.
2. **Symlink coordination shape:** [Every worker validates links without locking and only contends when repair is required](https://github.com/HarperFast/harper/pull/2343/changes?w=1#diff-1e3a919bf3d6ba479113144854f95e5126e6926774ef0af6770ea9feaff170b7R447), rather than serializing every component startup or moving link preparation into the main thread. This is localized and reversible, but deliberately trades a small amount of synchronous metadata I/O for removal of the reported lock-contention window.
3. **Startup failure signaling:** A root-load rejection is logged and exits the worker with code 1 instead of adding a structured worker-to-parent failure protocol. The direct exit fits the existing supervisor policy; rejecting it means adding a moderate protocol change so the parent owns termination and diagnostics.

## Verification

- `npm run build` — passed from a clean full build, including after the final rebase.
- `npm run lint:required` — passed.
- `npx mocha unitTests/components/symlinkHarperModule.test.js` — 7 passing.
- Focused worker-startup integration suite — the [ref control and unref regression](https://github.com/HarperFast/harper/pull/2343/changes?w=1#diff-aee784333554762f95a756c7981a22ad966565b2655c35caf0196937146dd899R75) and [terminal rejection](https://github.com/HarperFast/harper/pull/2343/changes?w=1#diff-aee784333554762f95a756c7981a22ad966565b2655c35caf0196937146dd899R99) arms passed; the unref and rejection arms were also proven red against rebuilt `origin/main` production sources, with the unref arm producing `Worker (index 2) exited with code 0 before reporting ready`.
- Broader suites were exercised but retain unrelated baseline/environment failures: the resource suite reached 1,737 passing/22 pending with 10 audit/cache/transaction failures, and `test:integration:all` included blob-path striping failures. Focused touched-path coverage is green.

Complexity: complicated

— GPT-5 Codex

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)

<sub>Review-Coverage: authored=codex; ran=claude,gemini; declined=cursor-grok,cursor-composer,domain; rounds=4 @ e85f54bd4cfc</sub>

<sub>Human-Review-Need: 4 @ e85f54bd4cfc</sub>
