### PR TITLE
feat(operations): remove attributes over the operations API (`full_record`, `__unset__`)

### DIFF
--- a/dataLayer/harperBridge/ResourceBridge.ts
+++ b/dataLayer/harperBridge/ResourceBridge.ts
@@ -8,6 +8,7 @@ import {
 	VALUE_SEARCH_COMPARATORS,
 	VALUE_SEARCH_COMPARATORS_REVERSE_LOOKUP,
 	READ_AUDIT_LOG_SEARCH_TYPES_ENUM,
+	UNSET_ATTRIBUTES as OPERATIONS_UNSET_KEY,
 } from '../../utility/hdbTerms.ts';
 import * as signalling from '../../utility/signalling.ts';
 import { SchemaEventMsg } from '../../server/threads/itc.js';
@@ -276,12 +277,24 @@ export class ResourceBridge extends BridgeMethods {
 						}
 					}
 				}
+				const unset = takeUnsetAttributes(record, Table.primaryKey);
+				// `__unset__` removes named attributes while everything else still merges, which a patch
+				// cannot express — so it resolves the merge here, against the record this transaction
+				// already loaded, and writes the result as a full replace. Doing it server-side inside the
+				// write transaction is the point: a client emulating this with read-then-replace races
+				// every other writer, and `full_record` would make the caller resend attributes it never
+				// meant to touch. Under `full_record` the submitted record is already the whole intended
+				// state, so there is nothing to merge and the names are simply dropped from it.
+				const toWrite = unset.length && existingRecord && !fullRecord ? { ...existingRecord, ...record } : record;
+				for (const attribute of unset) {
+					delete toWrite[attribute];
+				}
 				await (id == undefined
-					? Table.create(record, context)
-					: existingRecord && !fullRecord
-						? Table.patch(record, context)
-						: Table.put(record, context));
-				keys.push(record[Table.primaryKey]);
+					? Table.create(toWrite, context)
+					: existingRecord && !fullRecord && !unset.length
+						? Table.patch(toWrite, context)
+						: Table.put(toWrite, context));
+				keys.push(toWrite[Table.primaryKey]);
 			}
 			return {
 				txn_time: (transaction as any).timestamp,
@@ -787,4 +800,24 @@ async function* groupRecordsInHistory(table, start?, end?, limit?) {
 		}
 	}
 	if (enqueued) yield enqueued;
+}
+
+/**
+ * Read and remove a record's `__unset__` list, returning the attribute names to drop.
+ *
+ * Removed from the record because it is a directive, not data: leaving it in place would store it as
+ * an attribute. Shape is already validated (`validation/insertValidator.ts`); the primary key is
+ * refused here instead, since only this layer knows which attribute that is. Unsetting it would
+ * otherwise be silently ignored — `Table._writeUpdate` re-asserts the primary key on a full update —
+ * and a directive that quietly does nothing is worse than one that says no.
+ */
+function takeUnsetAttributes(record: Record<string, unknown>, primaryKey: string): string[] {
+	const unset = record[OPERATIONS_UNSET_KEY];
+	if (unset === undefined) return [];
+	delete record[OPERATIONS_UNSET_KEY];
+	const names = unset as string[];
+	if (primaryKey && names.includes(primaryKey)) {
+		throw new ClientError(`'${primaryKey}' is the primary key of this table and cannot be unset`);
+	}
+	return names;
 }

--- a/dataLayer/harperBridge/ResourceBridge.ts
+++ b/dataLayer/harperBridge/ResourceBridge.ts
@@ -203,6 +203,23 @@ export class ResourceBridge extends BridgeMethods {
 		const { attributes } = insertUpdateValidate(upsertObj);
 
 		let new_attributes;
+		// `full_record: true` makes this a full replace instead of a merge: an attribute absent from
+		// the submitted record is REMOVED rather than left at its stored value. Without it, a write
+		// over an existing record lands on `Table.patch`, so there is no way to drop an attribute
+		// through the operations API — omitting it keeps the stored value and `null` stores a null
+		// (HarperFast/studio#1643).
+		//
+		// The flag is orthogonal to each operation's create rule, which is what makes one flag cover
+		// both useful shapes: `update` still requires an existing record (a missing one is skipped),
+		// while `upsert` still creates one — so `upsert` + `full_record` is exactly REST's
+		// `PUT /Table/id`, and `update` + `full_record` is that same replace, refused if the record
+		// isn't there. It has no effect on `insert`, which never writes over an existing record.
+		//
+		// Compared with the delete-then-insert this replaces, a full replace is one operation rather
+		// than two: the record is never absent between them, subscribers see a single write instead of
+		// a delete followed by an insert, and `__createdtime__` survives (`Table._writeUpdate` retains
+		// the stored created time on a full update and only stamps a new one for a new entry).
+		const fullRecord = upsertObj.full_record === true;
 		const Table = getDatabases()[upsertObj.schema][upsertObj.table];
 		const context: Context = {
 			user: upsertObj.hdb_user,
@@ -261,7 +278,7 @@ export class ResourceBridge extends BridgeMethods {
 				}
 				await (id == undefined
 					? Table.create(record, context)
-					: existingRecord
+					: existingRecord && !fullRecord
 						? Table.patch(record, context)
 						: Table.put(record, context));
 				keys.push(record[Table.primaryKey]);

--- a/dataLayer/harperBridge/bridgeUtility/insertUpdateValidate.js
+++ b/dataLayer/harperBridge/bridgeUtility/insertUpdateValidate.js
@@ -4,6 +4,7 @@ const hdbUtils = require('../../../utility/common_utils.ts');
 const log = require('../../../utility/logging/harper_logger.ts');
 const { getDatabases } = require('../../../resources/databases.ts');
 const { ClientError } = require('../../../utility/errors/hdbError.ts');
+const { UNSET_ATTRIBUTES } = require('../../../utility/hdbTerms.ts');
 
 module.exports = insertUpdateValidate;
 
@@ -73,6 +74,10 @@ function insertUpdateValidate(writeObject) {
 		dups.add(hdbUtils.autoCast(record[hash_attribute]));
 
 		for (let attr in record) {
+			// `__unset__` names attributes to remove; it is not one itself. Collecting it would make an
+			// open (non-schemaDefined) table register `__unset__` as a real attribute, since
+			// upsertRecords feeds this list straight to Table.addAttributes.
+			if (attr === UNSET_ATTRIBUTES) continue;
 			attributes[attr] = 1;
 		}
 	});

--- a/dataLayer/insert.ts
+++ b/dataLayer/insert.ts
@@ -15,6 +15,7 @@ import * as globalSchema from '../utility/globalSchema.ts';
 import log from '../utility/logging/harper_logger.ts';
 import { handleHDBError } from '../utility/errors/hdbError.ts';
 import { HTTP_STATUS_CODES } from '../utility/errors/commonErrors.ts';
+import * as terms from '../utility/hdbTerms.ts';
 
 const pGlobalSchema = util.promisify(globalSchema.getTableSchema);
 
@@ -89,6 +90,10 @@ export async function validation(writeObject: any) {
 		dups.add(hdbUtils.autoCast(record[hash_attribute]));
 
 		for (let attr in record) {
+			// Kept in step with the sync twin in harperBridge/bridgeUtility/insertUpdateValidate.js:
+			// `__unset__` names attributes to remove and is not one itself, so it must not be registered
+			// as a table attribute.
+			if (attr === terms.UNSET_ATTRIBUTES) continue;
 			attributes[attr] = 1;
 		}
 	});

--- a/integrationTests/database/full-record-write.test.ts
+++ b/integrationTests/database/full-record-write.test.ts
@@ -1,0 +1,343 @@
+/**
+ * `full_record: true` on the operations API — full replace instead of merge.
+ *
+ * Background: `update` and `upsert` both land on `Table.patch` for a record that already exists
+ * (`dataLayer/harperBridge/ResourceBridge.ts` `upsertRecords`), which merges the submitted
+ * attributes onto the stored record. An attribute the request omits keeps its stored value, and
+ * `null` stores a null — so before this flag there was no way to REMOVE an attribute through the
+ * operations API. Clients worked around it by deleting the record and inserting it again, which
+ * leaves the record absent between two writes, resets `__createdtime__`, and shows subscribers a
+ * delete followed by an insert (HarperFast/studio#1643).
+ *
+ * The flag is orthogonal to each operation's create rule, and these probes pin both halves:
+ *   update + full_record → full replace, still refuses a record that isn't there
+ *   upsert + full_record → full replace, still creates one — i.e. exactly REST `PUT /Table/id`
+ *
+ * Reproduction:
+ *   npm run test:integration -- "integrationTests/database/full-record-write.test.ts"
+ *   HARPER_STORAGE_ENGINE=lmdb npm run test:integration -- "integrationTests/database/full-record-write.test.ts"
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual, deepStrictEqual } from 'node:assert';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import request from 'supertest';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error no type declarations
+import { createApiClient } from '../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'full-record-write');
+
+const skipSuite = process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun';
+
+const ctx: ContextWithHarper = {} as any;
+
+// Password for the scoped roles the authorization probes create.
+const SCOPED_PASSWORD = 'Abc12345!';
+
+suite('full_record: full replace over the operations API', { skip: skipSuite }, () => {
+	let client: ReturnType<typeof createApiClient>;
+
+	async function ops(body: Record<string, unknown>) {
+		const r = await client.req().send(body).timeout(8_000);
+		return { status: r.status as number, body: r.body };
+	}
+
+	async function insert(table: string, records: Record<string, unknown>[]) {
+		const r = await ops({ operation: 'insert', table, records });
+		strictEqual(r.status, 200, `seed insert should 200; got ${r.status} ${JSON.stringify(r.body)}`);
+		return r;
+	}
+
+	/** The stored record, read back by id through search_by_id. */
+	async function read(table: string, id: string) {
+		const r = await ops({ operation: 'search_by_id', table, ids: [id], get_attributes: ['*'] });
+		strictEqual(r.status, 200, `search_by_id should 200; got ${r.status} ${JSON.stringify(r.body)}`);
+		return r.body?.[0];
+	}
+
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: {}, env: {} });
+		client = createApiClient(ctx.harper);
+
+		const deadline = Date.now() + 30_000;
+		while (Date.now() < deadline) {
+			try {
+				const r = await client.reqRest('/Dog/').timeout(3_000);
+				if (r.status !== 404) break;
+			} catch {
+				// not ready yet
+			}
+			await sleep(300);
+		}
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	// The defect the flag exists to fix. Without it this same request leaves `color` in place.
+	test('update + full_record removes an attribute the request omits', async () => {
+		await insert('Dog', [{ id: 'fr-1', name: 'Penny', breed: 'Mutt', color: 'black' }]);
+
+		const r = await ops({
+			operation: 'update',
+			table: 'Dog',
+			full_record: true,
+			records: [{ id: 'fr-1', name: 'Penny', breed: 'Mutt' }],
+		});
+		strictEqual(r.status, 200, `update should 200; got ${r.status} ${JSON.stringify(r.body)}`);
+
+		const stored = await read('Dog', 'fr-1');
+		ok(!('color' in stored), `color should be gone, not nulled; stored=${JSON.stringify(stored)}`);
+		strictEqual(stored.name, 'Penny');
+		strictEqual(stored.breed, 'Mutt');
+	});
+
+	// The control: the default merge must be untouched by this change. This is the v4-compatible
+	// behaviour every existing client depends on.
+	test('update without the flag still merges, keeping an omitted attribute', async () => {
+		await insert('Dog', [{ id: 'fr-2', name: 'Penny', breed: 'Mutt', color: 'black' }]);
+
+		const r = await ops({ operation: 'update', table: 'Dog', records: [{ id: 'fr-2', name: 'Pen' }] });
+		strictEqual(r.status, 200, `update should 200; got ${r.status} ${JSON.stringify(r.body)}`);
+
+		const stored = await read('Dog', 'fr-2');
+		strictEqual(stored.color, 'black', 'an omitted attribute must survive a merge');
+		strictEqual(stored.breed, 'Mutt');
+		strictEqual(stored.name, 'Pen');
+	});
+
+	// `null` is a value Harper stores. A full replace must keep it as a stored null rather than
+	// treating it as a removal — omission is the only thing that removes.
+	test('full_record keeps an explicit null as a stored null', async () => {
+		await insert('Dog', [{ id: 'fr-3', name: 'Penny', breed: 'Mutt', color: 'black' }]);
+
+		await ops({
+			operation: 'update',
+			table: 'Dog',
+			full_record: true,
+			records: [{ id: 'fr-3', name: 'Penny', breed: null }],
+		});
+
+		const stored = await read('Dog', 'fr-3');
+		ok('breed' in stored, `an explicit null must remain a stored attribute; stored=${JSON.stringify(stored)}`);
+		strictEqual(stored.breed, null);
+		ok(!('color' in stored), 'the omitted attribute is the one that goes');
+	});
+
+	// What a delete-then-insert cannot do: `Table._writeUpdate` retains the stored created time on a
+	// full update, and only stamps a fresh one for a genuinely new entry.
+	test('full_record preserves @createdTime and re-stamps @updatedTime', async () => {
+		await insert('Dog', [{ id: 'fr-4', name: 'Penny', breed: 'Mutt', color: 'black' }]);
+		const before = await read('Dog', 'fr-4');
+		ok(typeof before.createdAt === 'number', `seed should carry a createdAt; got ${JSON.stringify(before)}`);
+		await sleep(10);
+
+		await ops({
+			operation: 'update',
+			table: 'Dog',
+			full_record: true,
+			records: [{ id: 'fr-4', name: 'Penny' }],
+		});
+
+		const after = await read('Dog', 'fr-4');
+		strictEqual(after.createdAt, before.createdAt, '@createdTime must survive a full replace');
+		ok(
+			after.updatedAt > before.updatedAt,
+			`@updatedTime should advance; before=${before.updatedAt} after=${after.updatedAt}`
+		);
+	});
+
+	// The flag does not change which records an operation is willing to write: `update` still
+	// requires an existing one, so a typo'd primary key is skipped rather than silently created.
+	test('update + full_record still skips a record that does not exist', async () => {
+		const r = await ops({
+			operation: 'update',
+			table: 'Dog',
+			full_record: true,
+			records: [{ id: 'fr-absent', name: 'Nobody' }],
+		});
+		strictEqual(r.status, 200, `update should 200; got ${r.status} ${JSON.stringify(r.body)}`);
+		deepStrictEqual(r.body.skipped_hashes, ['fr-absent'], `expected a skip; got ${JSON.stringify(r.body)}`);
+
+		const stored = await read('Dog', 'fr-absent');
+		ok(stored == null, `nothing should have been created; got ${JSON.stringify(stored)}`);
+	});
+
+	// ...while `upsert` still creates one, which makes upsert + full_record the operations-API
+	// equivalent of REST PUT.
+	test('upsert + full_record creates a missing record and replaces an existing one', async () => {
+		const created = await ops({
+			operation: 'upsert',
+			table: 'Dog',
+			full_record: true,
+			records: [{ id: 'fr-5', name: 'New', color: 'brown' }],
+		});
+		strictEqual(created.status, 200, `upsert should 200; got ${created.status} ${JSON.stringify(created.body)}`);
+		strictEqual((await read('Dog', 'fr-5')).name, 'New');
+
+		await ops({
+			operation: 'upsert',
+			table: 'Dog',
+			full_record: true,
+			records: [{ id: 'fr-5', name: 'Replaced' }],
+		});
+
+		const stored = await read('Dog', 'fr-5');
+		strictEqual(stored.name, 'Replaced');
+		ok(!('color' in stored), `the replace should have dropped color; stored=${JSON.stringify(stored)}`);
+	});
+
+	// Parity: the two doors to a full replace must agree, since REST PUT is the behaviour this
+	// operation is mirroring.
+	test('upsert + full_record matches REST PUT', async () => {
+		await insert('Dog', [{ id: 'fr-rest', name: 'Penny', breed: 'Mutt', color: 'black' }]);
+		await insert('Dog', [{ id: 'fr-ops', name: 'Penny', breed: 'Mutt', color: 'black' }]);
+
+		const put = await request(client.restURL)
+			.put('/Dog/fr-rest')
+			.set(client.headers)
+			.send({ id: 'fr-rest', name: 'Penny', breed: 'Mutt' })
+			.timeout(8_000);
+		ok(put.status === 200 || put.status === 204, `REST PUT should succeed; got ${put.status}`);
+
+		await ops({
+			operation: 'upsert',
+			table: 'Dog',
+			full_record: true,
+			records: [{ id: 'fr-ops', name: 'Penny', breed: 'Mutt' }],
+		});
+
+		const viaRest = await read('Dog', 'fr-rest');
+		const viaOps = await read('Dog', 'fr-ops');
+		deepStrictEqual(
+			Object.keys(viaOps).sort(),
+			Object.keys(viaRest).sort(),
+			`the two surfaces should store the same attributes; rest=${JSON.stringify(viaRest)} ops=${JSON.stringify(viaOps)}`
+		);
+	});
+
+	// A full replace that carries the foreign key keeps the relationship resolvable throughout —
+	// the property a delete-then-insert gives up, since the record is absent between its two writes.
+	test('full_record keeps a relationship foreign key resolvable', async () => {
+		await insert('Owner', [{ id: 'own-1', name: 'Ada' }]);
+		await insert('OwnedDog', [{ id: 'od-1', name: 'Penny', ownerId: 'own-1', nickname: 'Pen' }]);
+
+		await ops({
+			operation: 'update',
+			table: 'OwnedDog',
+			full_record: true,
+			records: [{ id: 'od-1', name: 'Penny', ownerId: 'own-1' }],
+		});
+
+		const stored = await read('OwnedDog', 'od-1');
+		ok(!('nickname' in stored), `nickname should be gone; stored=${JSON.stringify(stored)}`);
+		strictEqual(stored.ownerId, 'own-1', 'the foreign key must survive the replace');
+
+		// Resolve from the far side: the to-many relationship still finds the record.
+		const owner = await request(client.restURL).get('/Owner/own-1?select(id,dogs{id})').set(client.headers);
+		strictEqual(owner.status, 200, `owner GET should 200; got ${owner.status}`);
+		const dogIds = (owner.body?.dogs ?? []).map((d: any) => d.id);
+		ok(dogIds.includes('od-1'), `the relationship should still resolve; got ${JSON.stringify(owner.body)}`);
+	});
+
+	// A full replace removes the attributes the request omits, and attribute permissions are only
+	// checked against the attributes it SUPPLIES — so an attribute-scoped role could otherwise erase
+	// an attribute it has no permission to write. Refused in `verifyPerms` rather than silently
+	// narrowed, since nothing has read the stored record at that point.
+	// The role fixtures for the authorization probes below. Created once; both tests read them.
+	async function addScopedRole(role: string, permission: Record<string, unknown>, username: string) {
+		const r = await ops({ operation: 'add_role', role, permission });
+		strictEqual(r.status, 200, `add_role should 200; got ${r.status} ${JSON.stringify(r.body)}`);
+		const u = await ops({ operation: 'add_user', role, username, password: SCOPED_PASSWORD, active: true });
+		strictEqual(u.status, 200, `add_user should 200; got ${u.status} ${JSON.stringify(u.body)}`);
+		return {
+			...client.headers,
+			Authorization: `Basic ${Buffer.from(`${username}:${SCOPED_PASSWORD}`).toString('base64')}`,
+		};
+	}
+
+	function asUser(headers: Record<string, string>, body: Record<string, unknown>) {
+		return client.reqAs(headers).send(body).timeout(8_000);
+	}
+
+	// A full replace removes the attributes the request omits, and attribute permissions are only
+	// checked against the attributes it SUPPLIES — so an attribute-scoped role could otherwise erase
+	// an attribute it has no permission to write. Refused in `verifyPerms` rather than silently
+	// narrowed, since nothing has read the stored record at that point.
+	//
+	test('a role with attribute permissions may not use full_record', async () => {
+		await insert('Dog', [{ id: 'fr-perm', name: 'Penny', breed: 'Mutt', color: 'black' }]);
+		const headers = await addScopedRole(
+			'attr_scoped',
+			{
+				data: {
+					tables: {
+						Dog: {
+							read: true,
+							insert: true,
+							update: true,
+							delete: false,
+							// Once a table carries attribute_permissions they act as a per-attribute allowlist:
+							// an attribute that isn't listed reads as absent. So list what the role may write
+							// as well as the one it may not — `color` is the denial under test, and the
+							// grants on id/name are what let the merge probe below still succeed.
+							// read/insert/update are all required per entry (ATTR_CRU_KEYS).
+							attribute_permissions: [
+								{ attribute_name: 'id', read: true, insert: true, update: true },
+								{ attribute_name: 'name', read: true, insert: true, update: true },
+								{ attribute_name: 'color', read: true, insert: true, update: false },
+							],
+						},
+					},
+				},
+			},
+			'attr_scoped_user'
+		);
+
+		const denied = await asUser(headers, {
+			operation: 'update',
+			database: 'data',
+			table: 'Dog',
+			full_record: true,
+			records: [{ id: 'fr-perm', name: 'Penny' }],
+		});
+		strictEqual(
+			denied.status,
+			403,
+			`full_record should be refused for an attribute-scoped role; got ${denied.status} ${JSON.stringify(denied.body)}`
+		);
+
+		// A refusal, not a partially-applied write.
+		strictEqual((await read('Dog', 'fr-perm')).color, 'black', 'the denied request must not have removed anything');
+
+		// The denial is scoped to the replace: the same role can still merge the attributes it owns.
+		const merged = await asUser(headers, {
+			operation: 'update',
+			database: 'data',
+			table: 'Dog',
+			records: [{ id: 'fr-perm', name: 'Pen' }],
+		});
+		strictEqual(
+			merged.status,
+			200,
+			`a plain merge should still work; got ${merged.status} ${JSON.stringify(merged.body)}`
+		);
+	});
+
+	test('a non-boolean full_record is rejected rather than coerced', async () => {
+		await insert('Dog', [{ id: 'fr-6', name: 'Penny', breed: 'Mutt', color: 'black' }]);
+
+		const r = await ops({
+			operation: 'update',
+			table: 'Dog',
+			full_record: 'false',
+			records: [{ id: 'fr-6', name: 'Penny' }],
+		});
+		ok(r.status >= 400, `a string full_record should be rejected; got ${r.status} ${JSON.stringify(r.body)}`);
+
+		const stored = await read('Dog', 'fr-6');
+		strictEqual(stored.color, 'black', 'the rejected request must not have replaced anything');
+	});
+});

--- a/integrationTests/database/full-record-write.test.ts
+++ b/integrationTests/database/full-record-write.test.ts
@@ -22,7 +22,7 @@
  *   npm run test:integration -- "integrationTests/database/full-record-write.test.ts"
  *   HARPER_STORAGE_ENGINE=lmdb npm run test:integration -- "integrationTests/database/full-record-write.test.ts"
  */
-import { suite, test, before, after } from 'node:test';
+import { suite, test, describe, before, after } from 'node:test';
 import { ok, strictEqual, deepStrictEqual } from 'node:assert';
 import { resolve } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -549,6 +549,78 @@ suite('full_record: full replace over the operations API', { skip: skipSuite }, 
 			ok(r.status >= 400, `__unset__: ${JSON.stringify(unset)} should be refused; got ${r.status}`);
 		}
 		strictEqual((await read('Dog', 'us-8')).color, 'black', 'no rejected request may have written');
+	});
+
+	// The attribute-permission denials above are scoped to the operations the directives actually
+	// change. `verifyPerms` runs for every operation, and both keys pass validation on requests where
+	// they mean nothing — so an unscoped check denies a client that simply sets them on every call.
+	describe('the directives do not deny operations they have no effect on', () => {
+		let headers: Record<string, string>;
+
+		before(async () => {
+			headers = await addScopedRole(
+				'attr_scoped_inert',
+				{
+					data: {
+						tables: {
+							Dog: {
+								read: true,
+								insert: true,
+								update: true,
+								delete: false,
+								attribute_permissions: [
+									{ attribute_name: 'id', read: true, insert: true, update: true },
+									{ attribute_name: 'name', read: true, insert: true, update: true },
+									// Neither writable nor removable by this role — the trigger for both denials.
+									{ attribute_name: 'color', read: true, insert: false, update: false },
+								],
+							},
+						},
+					},
+				},
+				'attr_scoped_inert_user'
+			);
+		});
+
+		// `full_record` is inert on `insert` (there is never an existing record to replace), and the
+		// shared insert/update/upsert validator accepts the key, so an insert carrying it must not 403.
+		test('full_record does not deny an insert', async () => {
+			const r = await asUser(headers, {
+				operation: 'insert',
+				database: 'data',
+				table: 'Dog',
+				full_record: true,
+				records: [{ id: 'inert-1', name: 'Penny' }],
+			});
+			strictEqual(r.status, 200, `insert should not be denied; got ${r.status} ${JSON.stringify(r.body)}`);
+			strictEqual((await read('Dog', 'inert-1')).name, 'Penny');
+		});
+
+		// Unknown keys pass validation everywhere, so a stray flag on a read must not deny it either.
+		test('a stray full_record does not deny a search', async () => {
+			const r = await asUser(headers, {
+				operation: 'search_by_id',
+				database: 'data',
+				table: 'Dog',
+				ids: ['inert-1'],
+				get_attributes: ['id', 'name'],
+				full_record: true,
+			});
+			strictEqual(r.status, 200, `search should not be denied; got ${r.status} ${JSON.stringify(r.body)}`);
+		});
+
+		// Same shape for `__unset__`: it removes nothing on an insert, so its names must not be
+		// demanded as attributes the insert is writing.
+		test('__unset__ does not deny an insert naming an attribute the role cannot write', async () => {
+			const r = await asUser(headers, {
+				operation: 'insert',
+				database: 'data',
+				table: 'Dog',
+				records: [{ id: 'inert-2', name: 'Penny', __unset__: ['color'] }],
+			});
+			strictEqual(r.status, 200, `insert should not be denied; got ${r.status} ${JSON.stringify(r.body)}`);
+			strictEqual((await read('Dog', 'inert-2')).name, 'Penny');
+		});
 	});
 
 	test('a non-boolean full_record is rejected rather than coerced', async () => {

--- a/integrationTests/database/full-record-write.test.ts
+++ b/integrationTests/database/full-record-write.test.ts
@@ -1,5 +1,6 @@
 /**
- * `full_record: true` on the operations API — full replace instead of merge.
+ * Removing an attribute over the operations API: `full_record: true` (full replace) and
+ * `__unset__: ["attr"]` (merge, minus named attributes).
  *
  * Background: `update` and `upsert` both land on `Table.patch` for a record that already exists
  * (`dataLayer/harperBridge/ResourceBridge.ts` `upsertRecords`), which merges the submitted
@@ -12,6 +13,10 @@
  * The flag is orthogonal to each operation's create rule, and these probes pin both halves:
  *   update + full_record → full replace, still refuses a record that isn't there
  *   upsert + full_record → full replace, still creates one — i.e. exactly REST `PUT /Table/id`
+ *
+ * `__unset__` is the narrower tool: it keeps merge semantics for everything the request does send,
+ * so the caller doesn't have to resend (and therefore risk clobbering) attributes it never meant to
+ * touch, and the removals are visible to the attribute-permission check by name.
  *
  * Reproduction:
  *   npm run test:integration -- "integrationTests/database/full-record-write.test.ts"
@@ -324,6 +329,226 @@ suite('full_record: full replace over the operations API', { skip: skipSuite }, 
 			200,
 			`a plain merge should still work; got ${merged.status} ${JSON.stringify(merged.body)}`
 		);
+	});
+
+	// `__unset__`: remove named attributes, merge everything else. The distinguishing property vs
+	// full_record is that unsent attributes are KEPT, so a caller can drop one field without having
+	// to resend (and risk clobbering) the rest of the record.
+	test('__unset__ removes the named attributes and merges the rest', async () => {
+		await insert('Dog', [{ id: 'us-1', name: 'Penny', breed: 'Mutt', color: 'black' }]);
+
+		const r = await ops({
+			operation: 'update',
+			table: 'Dog',
+			records: [{ id: 'us-1', name: 'Pen', __unset__: ['color'] }],
+		});
+		strictEqual(r.status, 200, `update should 200; got ${r.status} ${JSON.stringify(r.body)}`);
+
+		const stored = await read('Dog', 'us-1');
+		ok(!('color' in stored), `color should be gone; stored=${JSON.stringify(stored)}`);
+		strictEqual(stored.name, 'Pen', 'a supplied attribute is still written');
+		strictEqual(stored.breed, 'Mutt', 'an attribute the request never mentioned must survive');
+		ok(!('__unset__' in stored), 'the directive itself must never be stored');
+	});
+
+	test('__unset__ removes several attributes at once', async () => {
+		await insert('Dog', [{ id: 'us-2', name: 'Penny', breed: 'Mutt', color: 'black' }]);
+
+		await ops({
+			operation: 'update',
+			table: 'Dog',
+			records: [{ id: 'us-2', __unset__: ['color', 'breed'] }],
+		});
+
+		const stored = await read('Dog', 'us-2');
+		ok(!('color' in stored) && !('breed' in stored), `both should be gone; stored=${JSON.stringify(stored)}`);
+		strictEqual(stored.name, 'Penny');
+	});
+
+	// The directive is not data. `upsertRecords` collects the submitted keys and feeds any it doesn't
+	// recognise to `Table.addAttributes` — but only when `!Table.schemaDefined`, so this needs a table
+	// created WITHOUT a declared schema. The fixture's graphql tables are schema-defined and never
+	// reach that branch, which is exactly why this probe creates its own open table: against a
+	// schema-defined table the assertion passes whether or not the key is excluded.
+	test('__unset__ does not become an attribute of an open table', async () => {
+		const created = await ops({ operation: 'create_table', database: 'data', table: 'OpenDog', primary_key: 'id' });
+		strictEqual(created.status, 200, `create_table should 200; got ${created.status} ${JSON.stringify(created.body)}`);
+		await insert('OpenDog', [{ id: 'us-3', name: 'Penny', color: 'black' }]);
+
+		const r = await ops({ operation: 'update', table: 'OpenDog', records: [{ id: 'us-3', __unset__: ['color'] }] });
+		strictEqual(r.status, 200, `update should 200; got ${r.status} ${JSON.stringify(r.body)}`);
+
+		const described = await ops({ operation: 'describe_table', database: 'data', table: 'OpenDog' });
+		strictEqual(described.status, 200, `describe_table should 200; got ${described.status}`);
+		const names = (described.body?.attributes ?? []).map((a: any) => a.attribute);
+		ok(!names.includes('__unset__'), `__unset__ must not be an attribute; got ${JSON.stringify(names)}`);
+
+		// ...and the removal still worked. Read with SQL rather than the `read()` helper: on a legacy
+		// open table the operations-API attribute projection reports every REGISTERED attribute, filling
+		// in `null` for one the record doesn't have (see the next test), so it cannot tell a removed
+		// attribute from a present-and-null one. `SELECT *` reflects the stored record.
+		const rows = await ops({ operation: 'sql', sql: `SELECT * FROM data.OpenDog WHERE id = 'us-3'` });
+		strictEqual(rows.status, 200, `sql should 200; got ${rows.status} ${JSON.stringify(rows.body)}`);
+		const stored = rows.body?.[0];
+		ok(!('color' in stored), `color should be gone; stored=${JSON.stringify(stored)}`);
+		strictEqual(stored.name, 'Penny');
+	});
+
+	// Not a property of this feature, but the reason the probe above can't use the usual read, and
+	// worth pinning because it makes a successful removal LOOK like a failed one: on a legacy open
+	// table the operations-API attribute projection is driven by the table's registered attributes, so
+	// an attribute the record simply does not have comes back as `null`. A record that never had the
+	// attribute reads identically to one it was removed from. Schema-defined tables omit it properly.
+	// Consequence for clients: after removing an attribute from an open table, a `get_attributes` read
+	// still shows the key with a null value even though nothing is stored.
+	test('an absent attribute reads back as null on an open table (read-path projection)', async () => {
+		await ops({ operation: 'create_table', database: 'data', table: 'OpenNull', primary_key: 'id' });
+		// Registers `color` as a table attribute...
+		await insert('OpenNull', [{ id: 'had-color', name: 'A', color: 'black' }]);
+		// ...which this record never sets.
+		await insert('OpenNull', [{ id: 'never-had', name: 'B' }]);
+
+		const projected = await read('OpenNull', 'never-had');
+		ok('color' in projected, `expected the projection to include color; got ${JSON.stringify(projected)}`);
+		strictEqual(projected.color, null, 'an attribute the record never had projects as null');
+
+		const rows = await ops({ operation: 'sql', sql: `SELECT * FROM data.OpenNull WHERE id = 'never-had'` });
+		const row = rows.body?.[0];
+		ok(row, `sql should have returned the row; got ${JSON.stringify(rows.body)}`);
+		ok(!('color' in row), `nothing is stored for it; got ${JSON.stringify(row)}`);
+	});
+
+	test('__unset__ preserves @createdTime, like any other merge', async () => {
+		await insert('Dog', [{ id: 'us-4', name: 'Penny', color: 'black' }]);
+		const before = await read('Dog', 'us-4');
+		await sleep(10);
+
+		await ops({ operation: 'update', table: 'Dog', records: [{ id: 'us-4', __unset__: ['color'] }] });
+
+		const after = await read('Dog', 'us-4');
+		strictEqual(after.createdAt, before.createdAt, '@createdTime must survive');
+		ok(after.updatedAt > before.updatedAt, `@updatedTime should advance; ${before.updatedAt} -> ${after.updatedAt}`);
+	});
+
+	// Relationship attributes are resolved at read time from a stored foreign key. Resolving the
+	// merge server-side reads the stored record back, so this pins that a relationship table survives
+	// the round trip — a read that materialised a relationship property would fail the write, since
+	// Harper rejects any record that assigns one.
+	test('__unset__ works on a table with relationships, and keeps the foreign key', async () => {
+		await insert('Owner', [{ id: 'us-own', name: 'Ada' }]);
+		await insert('OwnedDog', [{ id: 'us-od', name: 'Penny', ownerId: 'us-own', nickname: 'Pen' }]);
+
+		const r = await ops({
+			operation: 'update',
+			table: 'OwnedDog',
+			records: [{ id: 'us-od', __unset__: ['nickname'] }],
+		});
+		strictEqual(r.status, 200, `update should 200; got ${r.status} ${JSON.stringify(r.body)}`);
+
+		const stored = await read('OwnedDog', 'us-od');
+		ok(!('nickname' in stored), `nickname should be gone; stored=${JSON.stringify(stored)}`);
+		strictEqual(stored.ownerId, 'us-own', 'the foreign key must survive');
+
+		const owner = await request(client.restURL).get('/Owner/us-own?select(id,dogs{id})').set(client.headers);
+		strictEqual(owner.status, 200, `owner GET should 200; got ${owner.status}`);
+		const dogIds = (owner.body?.dogs ?? []).map((d: any) => d.id);
+		ok(dogIds.includes('us-od'), `the relationship should still resolve; got ${JSON.stringify(owner.body)}`);
+	});
+
+	test('__unset__ of an attribute the record does not have is a no-op', async () => {
+		await insert('Dog', [{ id: 'us-5', name: 'Penny' }]);
+
+		const r = await ops({
+			operation: 'update',
+			table: 'Dog',
+			records: [{ id: 'us-5', __unset__: ['nonexistent'] }],
+		});
+		strictEqual(r.status, 200, `update should 200; got ${r.status} ${JSON.stringify(r.body)}`);
+		strictEqual((await read('Dog', 'us-5')).name, 'Penny');
+	});
+
+	// A removal is a write to that attribute, so it needs the same `update` permission writing it
+	// would — otherwise `__unset__` would be a way around attribute permissions, which is exactly
+	// what the blanket `full_record` denial exists to prevent. Here the removals are named, so the
+	// check can be precise instead: the role may unset what it can write, and nothing else.
+	test('__unset__ is checked against attribute update permission', async () => {
+		await insert('Dog', [{ id: 'us-perm', name: 'Penny', breed: 'Mutt', color: 'black' }]);
+		const headers = await addScopedRole(
+			'unset_scoped',
+			{
+				data: {
+					tables: {
+						Dog: {
+							read: true,
+							insert: true,
+							update: true,
+							delete: false,
+							attribute_permissions: [
+								{ attribute_name: 'id', read: true, insert: true, update: true },
+								{ attribute_name: 'breed', read: true, insert: true, update: true },
+								{ attribute_name: 'color', read: true, insert: true, update: false },
+							],
+						},
+					},
+				},
+			},
+			'unset_scoped_user'
+		);
+
+		const denied = await asUser(headers, {
+			operation: 'update',
+			database: 'data',
+			table: 'Dog',
+			records: [{ id: 'us-perm', __unset__: ['color'] }],
+		});
+		strictEqual(
+			denied.status,
+			403,
+			`unsetting an attribute the role can't update must be refused; got ${denied.status} ${JSON.stringify(denied.body)}`
+		);
+		strictEqual((await read('Dog', 'us-perm')).color, 'black', 'the denied request must not have removed anything');
+
+		const allowed = await asUser(headers, {
+			operation: 'update',
+			database: 'data',
+			table: 'Dog',
+			records: [{ id: 'us-perm', __unset__: ['breed'] }],
+		});
+		strictEqual(
+			allowed.status,
+			200,
+			`unsetting an attribute the role CAN update must work; got ${allowed.status} ${JSON.stringify(allowed.body)}`
+		);
+		ok(!('breed' in (await read('Dog', 'us-perm'))), 'breed should be gone');
+	});
+
+	test('__unset__ refuses the primary key rather than silently ignoring it', async () => {
+		await insert('Dog', [{ id: 'us-6', name: 'Penny' }]);
+
+		const r = await ops({ operation: 'update', table: 'Dog', records: [{ id: 'us-6', __unset__: ['id'] }] });
+		ok(r.status >= 400, `unsetting the primary key should be refused; got ${r.status} ${JSON.stringify(r.body)}`);
+		strictEqual((await read('Dog', 'us-6')).name, 'Penny', 'nothing should have changed');
+	});
+
+	test('__unset__ refuses a system timestamp', async () => {
+		await insert('Dog', [{ id: 'us-7', name: 'Penny' }]);
+
+		const r = await ops({
+			operation: 'update',
+			table: 'Dog',
+			records: [{ id: 'us-7', __unset__: ['__createdtime__'] }],
+		});
+		ok(r.status >= 400, `unsetting a system timestamp should be refused; got ${r.status} ${JSON.stringify(r.body)}`);
+	});
+
+	test('a malformed __unset__ is rejected', async () => {
+		await insert('Dog', [{ id: 'us-8', name: 'Penny', color: 'black' }]);
+
+		for (const unset of ['color', { color: 1 }, [''], [42]]) {
+			const r = await ops({ operation: 'update', table: 'Dog', records: [{ id: 'us-8', __unset__: unset }] });
+			ok(r.status >= 400, `__unset__: ${JSON.stringify(unset)} should be refused; got ${r.status}`);
+		}
+		strictEqual((await read('Dog', 'us-8')).color, 'black', 'no rejected request may have written');
 	});
 
 	test('a non-boolean full_record is rejected rather than coerced', async () => {

--- a/integrationTests/database/full-record-write/config.yaml
+++ b/integrationTests/database/full-record-write/config.yaml
@@ -1,0 +1,3 @@
+graphqlSchema:
+  files: '*.graphql'
+rest: true

--- a/integrationTests/database/full-record-write/schema.graphql
+++ b/integrationTests/database/full-record-write/schema.graphql
@@ -1,0 +1,32 @@
+# `full_record: true` on the operations API — full replace instead of merge.
+#
+# Open (non-@sealed) tables, because the behaviour under test is about attributes coming and
+# going: a sealed table would reject an attribute the schema doesn't declare, which is a
+# different failure from the one these probes look for.
+
+# Timestamps declared so a probe can assert __createdtime__ survives a full replace (a
+# delete-then-insert cannot preserve it, which is the point of exposing this).
+type Dog @table @export {
+	id: ID @primaryKey
+	name: String
+	breed: String
+	color: String
+	createdAt: Float @createdTime
+	updatedAt: Float @updatedTime
+}
+
+# Relationship pair: a full replace must keep a foreign key resolvable, where a
+# delete-then-insert leaves the record absent between the two writes.
+type Owner @table @export {
+	id: ID @primaryKey
+	name: String
+	dogs: [OwnedDog] @relationship(to: "ownerId")
+}
+
+type OwnedDog @table @export {
+	id: ID @primaryKey
+	name: String
+	ownerId: ID @indexed
+	nickname: String
+	owner: Owner @relationship(from: "ownerId")
+}

--- a/utility/errors/commonErrors.ts
+++ b/utility/errors/commonErrors.ts
@@ -132,6 +132,8 @@ const OPERATION_AUTH_ERROR_MSGS = {
 	OP_IS_SU_ONLY: (op) => `Operation '${op}' is restricted to 'super_user' roles`,
 	OP_NOT_FOUND: (op) => `Operation '${op}' not found`,
 	OP_NOT_IN_OPERATIONS: (op) => `Operation '${op}' is not permitted for this role's operations configuration`,
+	FULL_RECORD_WITH_ATTRIBUTE_PERMS: (schema, table) =>
+		`'full_record' is not permitted for a role with attribute permissions on '${schema}.${table}', because a full replace removes the attributes the request omits and those removals cannot be checked against attribute permissions. Write the record without 'full_record' to merge, or use a REST PUT, which restores attributes the role may not update.`,
 	OPERATIONS_MUST_BE_ARRAY: "Permission 'operations' must be an array of operation names or group names",
 	INVALID_OPERATIONS_OP: (op) =>
 		`Invalid operations value '${op}'. Must be a valid operation name or group (e.g. 'read_only').`,

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -879,6 +879,14 @@ export const TIME_STAMP_NAMES_ENUM = {
 export const TIME_STAMP_NAMES = [CREATED_TIME, UPDATED_TIME] as const;
 
 /**
+ * Reserved record key naming attributes to REMOVE, for `update`/`upsert`: `__unset__: ["age"]`.
+ * A write is otherwise a merge, so an attribute can only be dropped by replacing the whole record
+ * (`full_record`); this removes named attributes while still merging everything else.
+ * Reserved like the timestamp keys above — it is never stored, and never becomes a table attribute.
+ */
+export const UNSET_ATTRIBUTES = '__unset__';
+
+/**
  * This value is used to help evaluate whether or not a permissions translation error is related to old permissions values or if it could be another code-related bug/error.
  */
 export const PERMS_UPDATE_RELEASE_TIMESTAMP = 1598486400000;

--- a/utility/operation_authorization.ts
+++ b/utility/operation_authorization.ts
@@ -841,7 +841,16 @@ export function verifyPerms(requestJson: any, operation: any, options?: { apiOpe
 	// runs before any record is read. So refuse the combination outright rather than authorize a
 	// write whose removals nobody checked. Roles that scope no attribute are unaffected, which is
 	// every role that hasn't deliberately been given `attribute_permissions` on this table.
-	if (attrPermissions.size > 0 && requestJson.full_record === true) {
+	// Scoped to the two operations the flag actually changes. `verifyPerms` runs for EVERY operation
+	// and `full_record` is an accepted key on the shared insert/update/upsert validator (and unknown
+	// keys pass validation everywhere), so an unscoped test denies an `insert`, a `search_by_*`, or
+	// anything else whose body merely carries the flag — plausible for a client that sets it on every
+	// write. Those operations never reach `Table.patch`, so there is nothing for the check to protect.
+	if (
+		attrPermissions.size > 0 &&
+		requestJson.full_record === true &&
+		(op === write.update.name || op === write.upsert.name)
+	) {
 		return permsResponse.handleUnauthorizedItem(
 			HDB_ERROR_MSGS.FULL_RECORD_WITH_ATTRIBUTE_PERMS(operationSchema, table)
 		);
@@ -1094,9 +1103,16 @@ function getRecordAttributes(json) {
 					// instead of the key itself, so removing one is checked against the same `update`
 					// permission that writing it would be. Without this the removals are invisible to
 					// checkAttributePerms, which only ever sees the attributes a request supplies.
+					//
+					// Only for the operations it does something on. `upsertRecords` strips the directive
+					// for every write, so on an `insert` — which never writes over an existing record —
+					// it removes nothing, and contributing its names would demand `insert` permission on
+					// attributes the request is not touching.
 					if (key === terms.UNSET_ATTRIBUTES) {
 						const unset = record[key];
-						if (Array.isArray(unset)) {
+						const removes =
+							json.operation === terms.OPERATIONS_ENUM.UPDATE || json.operation === terms.OPERATIONS_ENUM.UPSERT;
+						if (removes && Array.isArray(unset)) {
 							for (const name of unset) {
 								affectedAttributes.add(name);
 							}

--- a/utility/operation_authorization.ts
+++ b/utility/operation_authorization.ts
@@ -1090,6 +1090,19 @@ function getRecordAttributes(json) {
 			for (const record of json.records) {
 				let keys = Object.keys(record);
 				for (const key of keys) {
+					// `__unset__` is a directive, not an attribute: contribute the attributes it REMOVES
+					// instead of the key itself, so removing one is checked against the same `update`
+					// permission that writing it would be. Without this the removals are invisible to
+					// checkAttributePerms, which only ever sees the attributes a request supplies.
+					if (key === terms.UNSET_ATTRIBUTES) {
+						const unset = record[key];
+						if (Array.isArray(unset)) {
+							for (const name of unset) {
+								affectedAttributes.add(name);
+							}
+						}
+						continue;
+					}
 					affectedAttributes.add(key);
 				}
 			}

--- a/utility/operation_authorization.ts
+++ b/utility/operation_authorization.ts
@@ -833,6 +833,19 @@ export function verifyPerms(requestJson: any, operation: any, options?: { apiOpe
 
 	const recordAttrs = getRecordAttributes(requestJson);
 	const attrPermissions = getAttributePermissions(requestJson.hdb_user?.role?.permission, operationSchema, table);
+	// `full_record: true` makes a write a full replace, which REMOVES every attribute the request
+	// omits. `checkAttributePerms` below only sees the attributes the request SUPPLIES, so it cannot
+	// police that: an attribute-scoped role could erase an attribute it has no `update` permission
+	// for simply by leaving it out. REST's `PUT` closes the same gap in `Table.allowUpdate`, by
+	// restoring those attributes from the stored record — which needs the stored record, and this
+	// runs before any record is read. So refuse the combination outright rather than authorize a
+	// write whose removals nobody checked. Roles that scope no attribute are unaffected, which is
+	// every role that hasn't deliberately been given `attribute_permissions` on this table.
+	if (attrPermissions.size > 0 && requestJson.full_record === true) {
+		return permsResponse.handleUnauthorizedItem(
+			HDB_ERROR_MSGS.FULL_RECORD_WITH_ATTRIBUTE_PERMS(operationSchema, table)
+		);
+	}
 	checkAttributePerms(recordAttrs, attrPermissions, op, table, operationSchema, permsResponse, action);
 
 	//This result value will be null if no perms issues were found in checkAttributePerms

--- a/validation/insertValidator.ts
+++ b/validation/insertValidator.ts
@@ -33,6 +33,16 @@ const insertSchema = Joi.object({
 	schema: hdbDatabase,
 	table: hdbTable,
 	records: Joi.array().items(Joi.object().custom(customRecordsVal)).required(),
+	// Full replace rather than merge, for `update`/`upsert` (see ResourceBridge.upsertRecords).
+	//
+	// Declared even though `validateBySchema` allows unknown keys, and `.strict()` on this one key
+	// (not the whole object, which would tighten the long-standing contract of the others) so it has
+	// to be an actual boolean. Joi coerces by default and `validateBySchema` discards the converted
+	// value, so without this a string `"false"` would validate and then reach the bridge still a
+	// string — and a request that never asked for a replace decides the question by truthiness.
+	// Rejecting is the safe direction: silently ignoring `"true"` would be just as wrong in reverse.
+	// Same rationale as `analyticsValidator`'s `.strict()`.
+	full_record: Joi.boolean().strict(),
 });
 
 export default function (insertObject: any) {

--- a/validation/insertValidator.ts
+++ b/validation/insertValidator.ts
@@ -1,5 +1,6 @@
 import { hdbTable, hdbDatabase } from './common_validators.ts';
 import * as validator from './validationWrapper.ts';
+import { TIME_STAMP_NAMES, UNSET_ATTRIBUTES } from '../utility/hdbTerms.ts';
 import Joi from 'joi';
 const INVALID_ATTRIBUTE_NAMES = {
 	undefined: 'undefined',
@@ -25,8 +26,45 @@ const customRecordsVal = (value, helpers) => {
 		return helpers.message(errorMsg);
 	}
 
+	const unsetError = unsetAttributesError(value[UNSET_ATTRIBUTES]);
+	if (unsetError) {
+		return helpers.message(unsetError);
+	}
+
 	return value;
 };
+
+/**
+ * `__unset__` names the attributes a write should remove (see `ResourceBridge.upsertRecords`). It is
+ * a reserved record key rather than a stored attribute, so it is validated here per record instead
+ * of by the operation schema below.
+ *
+ * An array of names, not a map with ignored values: the value would carry no meaning, and a shape
+ * that accepts anything invites callers to read significance into it.
+ */
+function unsetAttributesError(unset: unknown): string | undefined {
+	if (unset === undefined) {
+		return undefined;
+	}
+	if (!Array.isArray(unset)) {
+		return `'${UNSET_ATTRIBUTES}' must be an array of attribute names`;
+	}
+	for (const name of unset) {
+		if (typeof name !== 'string' || name.length === 0) {
+			return `'${UNSET_ATTRIBUTES}' must contain only non-empty attribute names`;
+		}
+		// The server owns these; `checkAttributePerms` already refuses to let a role write them, and
+		// a full-record write retains __createdtime__ rather than dropping it, so removing them here
+		// would be the one way to lose them.
+		if ((TIME_STAMP_NAMES as readonly string[]).includes(name)) {
+			return `'${name}' is maintained by Harper and cannot be unset`;
+		}
+		if (name === UNSET_ATTRIBUTES) {
+			return `'${UNSET_ATTRIBUTES}' is not an attribute and cannot be unset`;
+		}
+	}
+	return undefined;
+}
 
 const insertSchema = Joi.object({
 	database: hdbDatabase,


### PR DESCRIPTION
## What

Adds `full_record: true` to `update` and `upsert`, selecting a **full replace** instead of the
default merge.

```json
{ "operation": "update", "database": "dev", "table": "dog", "full_record": true,
  "records": [{ "id": 1, "dog_name": "Penny" }] }
```

The stored record becomes exactly that — any attribute not in the payload is removed.

## Why

There is currently no way to remove an attribute from a record through the operations API.
`update` and `upsert` both land on `Table.patch` for a record that already exists
(`ResourceBridge.upsertRecords`), which merges: an omitted attribute keeps its stored value, and
`null` stores a null. A full replace exists only over REST (`PUT /Table/id` → `resource.put`),
which a client speaking the operations API can't reach — and can't reach at all through a proxied
operations endpoint.

Reported downstream as HarperFast/studio#1643, where Studio's row editor silently dropped a
property deletion. The workaround available to clients today is to `delete` the record and
`insert` it again, which:

- leaves the record **absent between two writes** — concurrent reads, relationship resolutions
  from the far side, and replicas all observe the gap;
- **resets `__createdtime__`** (a real `put` retains it — `Table._writeUpdate` keeps the stored
  created time on a full update and only stamps a new one for a new entry);
- shows subscribers a **delete followed by an insert** instead of one write.

A single full-replace write has none of those properties.

## Design

The flag is **orthogonal to each operation's create rule**, so one flag covers both useful shapes
without a new verb:

| request | behaviour |
| --- | --- |
| `update` | merge, requires an existing record (unchanged) |
| `upsert` | merge, creates a missing record (unchanged) |
| `update` + `full_record` | full replace, still skips a record that isn't there |
| `upsert` + `full_record` | full replace, still creates one — i.e. exactly REST `PUT /Table/id` |

No effect on `insert`, which never writes over an existing record.

**The merge default is deliberately untouched.** `5da23c3ef` originally used `Table.put` and
hand-copied missing properties from the existing record to emulate a merge; `5bd363946`
("Update/upsert records should use patch") replaced that with a real `Table.patch`, and
`b302a16e7` added the `put` fallback for a missing record. So merge semantics is load-bearing v4
compatibility, and changing `upsert` in place would be breaking. Hence a flag rather than new
semantics — even though the newer resource/type layer already reads `upsert` as PUT
(`defineTable.ts`: `UPSERT (PUT): full replace`, and `defineResource.ts` treats `upsert` and
`patch` as distinct projections).

### Two details worth a look

**`.strict()` on the validator key, not the whole object.** `validateBySchema` passes unknown keys
through and discards Joi's converted value, so without `.strict()` a string `"false"` would
validate and then reach the bridge *still a string* — letting truthiness decide a destructive
question. Strict on the one key rejects it instead; making the whole object strict would tighten
the long-standing contract of `database`/`schema`/`table`/`records`. Same rationale as
`analyticsValidator`'s `.strict()`.

**A role with `attribute_permissions` on the table is refused.** Attribute permissions are checked
against the attributes a request *supplies* (`checkAttributePerms`), which is sufficient for a
merge but not for a replace, where an omitted attribute is *removed* — so an attribute-scoped role
could otherwise erase an attribute it has no `update` permission for simply by leaving it out.
REST closes the same gap in `Table.allowUpdate` ("if this is a full put operation that removes
missing properties, we don't want to remove properties that the user doesn't have permission to
remove") by restoring those attributes from the stored record, which needs the stored record;
authorization runs before anything is read, so it denies rather than silently narrowing the write.
Roles that scope no attribute — every role without deliberate `attribute_permissions` on the table
— are unaffected. Happy to swap this for a restore-based approach if you'd rather it mirror REST.

## `__unset__` — removing an attribute without resending the record

`full_record` can drop an attribute, but only by replacing the whole record, so a caller who wants
to remove one field has to resend every other field — and anything it fails to resend is dropped
too. `__unset__` is the narrower tool:

```json
{ "operation": "update", "database": "dev", "table": "dog",
  "records": [{ "id": 1, "__unset__": ["age"] }] }
```

`age` is removed; every attribute the request didn't mention keeps its value. An array of names
rather than a map with ignored values — the values would carry no meaning, and a shape that accepts
anything invites callers to read significance into it.

Resolved server-side in `upsertRecords`, against the record the write transaction has already
loaded, and written as a full replace. Doing it here rather than in the client is the point: the
merge and the write are one transaction, where a client emulating it with read-then-replace races
every other writer.

Reserved like `__createdtime__`/`__updatedtime__` (`terms.UNSET_ATTRIBUTES`) and never stored. Both
copies of the attribute-collection loop skip it — `insertUpdateValidate.js` and its documented async
twin in `insert.ts` — because `upsertRecords` feeds that list to `Table.addAttributes`, so on an
open (non-`schemaDefined`) table an unrecognised `__unset__` would be registered as a real table
attribute. Refused: the primary key (in the bridge, the only layer that knows which attribute that
is — `_writeUpdate` re-asserts it on a full update, so unsetting it would otherwise be silently
ignored), the system timestamps, and any malformed value.

**Attribute permissions are checked precisely here**, which is the part worth reviewing:
`getRecordAttributes` contributes the names `__unset__` *removes* instead of the key itself, so
removing an attribute needs the same `update` permission that writing it would. A role may unset
what it can write and nothing else. That's strictly better than the blanket `full_record` denial
above, because the removals are named — if you'd prefer, `full_record` could later be narrowed the
same way by resolving its removals against the stored record.

### One behaviour found while testing, pinned rather than changed

On a legacy **open** (non-`schemaDefined`) table, the operations-API attribute projection reports
every *registered* attribute, filling in `null` for one the record doesn't have. So after removing
an attribute from an open table, a `get_attributes` read still shows `key: null` — identically to a
record that never had it. `SELECT *` reflects the stored record and omits it.

It's a read-path artifact, not storage: verified by inserting a record that never had the attribute
and getting the same `null`. It applies equally to `full_record`, and it predates both. Called out
because it makes a successful removal look like a failed one, which is exactly the symptom
studio#1643 was originally reported as — a client removing attributes from open tables needs to know
the read lies. There's a test pinning it so it can't drift silently.

## Testing

`integrationTests/database/full-record-write.test.ts` — 21 probes, all passing on rocksdb.

For `full_record`:

- the removal itself, and the merge default still merging (the control)
- an explicit `null` staying a stored null (omission is the only thing that removes)
- `__createdtime__` surviving and `__updatedtime__` re-stamping
- both create rules (`update` skips a missing record, `upsert` creates one)
- parity with REST `PUT` — same stored attribute set through both doors
- a relationship foreign key still resolving from the far side after a replace
- the attribute-permission denial, and that the same role can still merge
- a non-boolean `full_record` rejected rather than coerced

For `__unset__`: the removal with everything else merged, several at once, `__createdtime__`
preserved, a relationship table surviving the server-side merge with its foreign key intact, an
unset of an attribute the record doesn't have being a no-op, the attribute-permission check
(denied for an attribute the role can't update, allowed for one it can), the primary-key and
system-timestamp refusals, malformed values rejected, `__unset__` not becoming an attribute of an
open table, and the open-table read-path projection above.

```
npm run test:integration -- "integrationTests/database/full-record-write.test.ts"
ℹ tests 21   ℹ pass 21   ℹ fail 0
```

Every guard was mutation-checked — reverting it has to turn a test red. Making the bridge ignore
`full_record` fails 5; dropping the server-side merge fails 4; not expanding `__unset__` for the
permission check fails 1; letting `__unset__` register as an attribute fails 1. That last one is
why the open-table probe creates its own table: the first version asserted against a
schema-defined table and passed with the guard removed, i.e. it tested nothing.

Also ran, green, for regressions around authorization and write semantics:
`integrationTests/security/{user-role-management,sql-unqualified-table-authz,query-row-allowread-checkpermission}`
and `integrationTests/database/{auto-fields,bulk-conditional-mutation,patch-disjoint-field-merge}`
— 59 tests, re-run after `__unset__` landed.

**Not covered / not done:**

- **Replication is untested here.** A `full_record` write replicates as a `put`, the same as REST
  `PUT` already does, but I have not proven it — no multi-node probe in this suite.
- **LMDB run not done** (`HARPER_STORAGE_ENGINE=lmdb`). The suite is written to run under it.
- **Unit suites not run** — a local Harper instance held the RocksDB lock and stopping it wasn't
  mine to do. Nothing in this change has unit coverage; it's all integration.
- **Docs not written.** `reference/operations-api/operations.md` in the documentation repo needs
  both `full_record` and `__unset__` on the `update` and `upsert` entries, plus a note about the
  open-table read projection. Happy to open that PR once the shape here is agreed.
- **`__unset__` on `insert`** is accepted and ignored (there is no existing record to remove from).
  Rejecting it instead would be easy if you'd rather it be an error.
- No cross-model review pass yet.

Draft until the naming (`full_record`, `__unset__`) and the two attribute-permission decisions get
a maintainer opinion — all public API surface, all cheap to change now and awkward later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
