### PR TITLE
ci: keep ineligible runs out of the review concurrency group

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,10 +21,12 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 concurrency:
+  # NOTE: this predicate and the review job's `if:` must stay textually
+  # in sync — GitHub Actions YAML has no anchors to share them.
   # Ineligible events (per the review job's opt-in gate) get a unique
   # run_id group so they can never cancel an in-flight eligible review —
   # workflow-level cancel-in-progress fires before job `if:` is evaluated.
-  group: claude-review-${{ github.event.pull_request.number }}-${{ (vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'claude-review'))) && 'eligible' || github.run_id }}
+  group: claude-review-${{ github.event.pull_request.number }}-${{ ((github.event.action == 'labeled' && github.event.label.name == 'claude-review') || (github.event.action != 'labeled' && vars.CLAUDE_ALWAYS_ON == 'true') || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'claude-review'))) && 'eligible' || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -38,7 +40,7 @@ jobs:
     # `ready_for_review` is admitted when the PR still carries the
     # opt-in label, so a draft opted in via `claude-review` resumes
     # review when it flips ready even with CLAUDE_ALWAYS_ON unset.
-    if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'claude-review')) }}
+    if: ${{ (github.event.action == 'labeled' && github.event.label.name == 'claude-review') || (github.event.action != 'labeled' && vars.CLAUDE_ALWAYS_ON == 'true') || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'claude-review')) }}
     uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@be549ad08aa6d34b909ea8b542a7ffebdaae1e81 # main 2026-08-25 (#90 cost gates: draft skip, mechanical-diff skip, effort-by-size, debounce; #89 defaults; #88 lenses)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,7 +21,10 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
+  # Ineligible events (per the review job's opt-in gate) get a unique
+  # run_id group so they can never cancel an in-flight eligible review —
+  # workflow-level cancel-in-progress fires before job `if:` is evaluated.
+  group: claude-review-${{ github.event.pull_request.number }}-${{ (vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'claude-review'))) && 'eligible' || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -39,7 +39,8 @@ concurrency:
   # in parallel on the same PR. cancel-in-progress is per-group, so a
   # synchronize push cancels the in-flight Gemini run without touching
   # the Claude run (and vice versa).
-  group: gemini-review-${{ github.event.pull_request.number }}
+  # Ineligible events get a unique run_id group — see claude-review.yml.
+  group: gemini-review-${{ github.event.pull_request.number }}-${{ (vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'gemini-review'))) && 'eligible' || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -39,8 +39,10 @@ concurrency:
   # in parallel on the same PR. cancel-in-progress is per-group, so a
   # synchronize push cancels the in-flight Gemini run without touching
   # the Claude run (and vice versa).
+  # NOTE: this predicate and the review job's `if:` must stay textually
+  # in sync — GitHub Actions YAML has no anchors to share them.
   # Ineligible events get a unique run_id group — see claude-review.yml.
-  group: gemini-review-${{ github.event.pull_request.number }}-${{ (vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'gemini-review'))) && 'eligible' || github.run_id }}
+  group: gemini-review-${{ github.event.pull_request.number }}-${{ ((github.event.action == 'labeled' && github.event.label.name == 'gemini-review') || (github.event.action != 'labeled' && vars.GEMINI_ALWAYS_ON == 'true') || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'gemini-review'))) && 'eligible' || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -54,7 +56,7 @@ jobs:
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     # `ready_for_review` is admitted when the PR still carries the
     # opt-in label — mirrors claude-review.yml.
-    if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'gemini-review')) }}
+    if: ${{ (github.event.action == 'labeled' && github.event.label.name == 'gemini-review') || (github.event.action != 'labeled' && vars.GEMINI_ALWAYS_ON == 'true') || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'gemini-review')) }}
     uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@be549ad08aa6d34b909ea8b542a7ffebdaae1e81 # main 2026-08-25 (#90 cost gates: draft skip, mechanical-diff skip, effort-by-size, debounce; #89 defaults; #88 lenses)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below


### PR DESCRIPTION
## What this changes, concretely

Both review callers use a shared concurrency group per PR with `cancel-in-progress: true`, so a newer run can cancel an in-flight review. GitHub evaluates that cancellation **when the new run is queued — before any job `if:` runs**. That means an event that was never going to produce a review could still kill one in progress:

- opt-in mode: any push, or flipping ready without the opt-in label, cancelled a running label-triggered review; the replacement run then skipped, so the requested review silently never completed;
- both modes: applying an **unrelated** label (e.g. `bug`) mid-review did the same — the replacement died at the reusable's exact-label authorize gate.

## The fix

The concurrency group key now ends in `eligible` only for events that would actually produce a review; every other event gets a unique `github.run_id` suffix, i.e. its own group, so it can never cancel anything. "Would produce a review" means, per caller:

- the provider's **own** opt-in label was just applied (`labeled` + `label.name == 'claude-review'` / `'gemini-review'`), or
- any non-label event while `*_ALWAYS_ON` is on, or
- a draft flipped ready while it carries the opt-in label.

The review job's `if:` uses the identical predicate (kept textually in sync — Actions YAML has no anchors), so eligible runs both start the review and may supersede an in-flight one, and ineligible runs do neither.

Findings by @kriszyp and the Codex pass on the pin-bump series (harper-pro#766, #2330/#2331); the unrelated-label variant predated this series in always-on mode and is closed by the same change. Full event matrix in the fa04115 commit message.

**Merge order**: this before #2330/#2331 — the sync PRs carry this fix and must stay byte-identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S94XethbGXpAb4DRKMD4kt
