### PR TITLE
Close a streamed HTTP response on Bun when the client asked for it (fixes hung iterable REST responses)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -887,6 +887,29 @@ extensionModule.handleApplication` gate (`components/componentLoader.ts`) means 
 Corollary: with `threads: 0` the ops API shares the worker where `handleApplication` _did_ run,
 so ops responses **will** carry the headers there (benign).
 
+## Under Bun, the main HTTP port is served by `node:http`, not `Bun.serve`
+
+Worth knowing before debugging anything Bun-specific on the HTTP path: `getBunHTTPServer()` builds
+the `Bun.serve()` fetch config, but `onWebSocket()` calls `getHTTPServer()` unconditionally — it has
+a uWS branch and no Bun branch, because Bun native WebSockets are unimplemented (nothing ever sets
+`config.websocket`, so WS relies on the Node `ws` server attached to an `http.Server`). MQTT's
+`handleApplication` registers WS on the default port before REST's `httpServer()` call for that same
+port, so `httpServers[port]` is already a Node server by then and `getBunHTTPServer` early-returns
+without registering a serve config. The port is bound by `registerServer()`'s Node server via
+`listenOnPortsBun`'s trailing "non-HTTP servers" loop, and the fetch handler is never invoked for it
+(only the exclusive operations port reaches `Bun.serve`). Consequence: on Bun the `Request`/`Response`
+fetch path is dead code for the main port, and its divergences show up as `node:http`-emulation
+divergences instead.
+
+One such divergence, `#2210`: Bun's `node:http` never derives keep-alive from the request. For a
+`Connection: close` request `shouldKeepAlive` stays `true`, and neither a `Connection: close` response
+header nor `response.socket.end()` closes the connection — a **stream-ended** response (an async
+source ended through `pipeline()`; a direct `response.end()` is fine) delivers its full body and
+terminal chunk, then hangs the client until its own timeout. `pipeBodyToResponse()` therefore ends
+`request.socket` itself when the client asked to close (`endConnectionIfClientRequestedClose`,
+`isBun`-gated, HTTP/1 only, clean path only — the error path already closes because `pipeline()`
+destroys the response). Ending the _request's_ socket is the only remedy that works on Bun.
+
 ## The published shrinkwrap governs registry installs but not tarball installs (`build-tools/`)
 
 npm decides whether to honor a dependency's bundled `npm-shrinkwrap.json` from the `_hasShrinkwrap`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -918,10 +918,11 @@ Node does and what Bun then handles correctly.
 
 `pipeBodyToResponse()` therefore ends `request.socket` itself for those shapes
 (`endConnectionIfClientExpectsClose`, `isBun`-gated, HTTP/1 only, clean path only — the error path
-already closes because `pipeline()` destroys the response). Ending the _request's_ socket is the only
-remedy that works on Bun: a `Connection: close` response header, `response.socket.end()` and
-`response.destroy()` were all measured as no-ops there. `socket.end()` is graceful, so it does not
-truncate — 8 MB over plain TCP and 6 MB over TLS to a deliberately slow reader each arrive whole. The
+already closes because `pipeline()` destroys the response with the stream error). Ending the
+_request's_ socket is the only remedy that works after a clean stream end on Bun: a `Connection:
+close` response header, `response.socket.end()` and `response.destroy()` were all measured as no-ops
+there. `socket.end()` is graceful, so it does not truncate — 8 MB over plain TCP and 6 MB over TLS to
+a deliberately slow reader each arrive whole. The
 `Content-Length` check reads `response.hasHeader()`, which Bun populates from the `writeHead(status,
 headers)` fast path this file uses (Node does not, but the branch is Bun-only). A
 keep-alive arm pins the other direction (such a client keeps its connection and reuses it); the two

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -905,10 +905,28 @@ One such divergence, `#2210`: Bun's `node:http` never derives keep-alive from th
 `Connection: close` request `shouldKeepAlive` stays `true`, and neither a `Connection: close` response
 header nor `response.socket.end()` closes the connection — a **stream-ended** response (an async
 source ended through `pipeline()`; a direct `response.end()` is fine) delivers its full body and
-terminal chunk, then hangs the client until its own timeout. `pipeBodyToResponse()` therefore ends
-`request.socket` itself when the client asked to close (`endConnectionIfClientRequestedClose`,
-`isBun`-gated, HTTP/1 only, clean path only — the error path already closes because `pipeline()`
-destroys the response). Ending the _request's_ socket is the only remedy that works on Bun.
+terminal chunk, then holds the connection until Bun's own idle timeout — a chunked-aware client
+completes the message and can walk away, but the un-honored close still violates RFC 9112 §9.6 and
+strands the socket; a raw client waiting on the FIN (and the HTTP/1.0 case below, which has no
+terminal chunk to stop at) hangs outright. An HTTP/1.0 client hangs the same way
+without asking to close at all, since 1.0 persistence needs both an explicit `keep-alive` and a length
+to read to — so a 1.0 response that got no `Content-Length` is close-delimited, the same line Node
+draws (Node closes it at ~7ms; Bun never does). An explicit `close` token wins over `keep-alive` on
+both versions. A 1.0 `keep-alive` request whose response _did_ get a
+`Content-Length` (`body.size` on a blob, `server/http.ts:698-709`) is left open, which is again what
+Node does and what Bun then handles correctly.
+
+`pipeBodyToResponse()` therefore ends `request.socket` itself for those shapes
+(`endConnectionIfClientExpectsClose`, `isBun`-gated, HTTP/1 only, clean path only — the error path
+already closes because `pipeline()` destroys the response). Ending the _request's_ socket is the only
+remedy that works on Bun: a `Connection: close` response header, `response.socket.end()` and
+`response.destroy()` were all measured as no-ops there. `socket.end()` is graceful, so it does not
+truncate — 8 MB over plain TCP and 6 MB over TLS to a deliberately slow reader each arrive whole. The
+`Content-Length` check reads `response.hasHeader()`, which Bun populates from the `writeHead(status,
+headers)` fast path this file uses (Node does not, but the branch is Bun-only). A
+keep-alive arm pins the other direction (such a client keeps its connection and reuses it); the two
+HTTP/1.0 arms are Node/Bun-only, because uWS does not route an HTTP/1.0 request to the resource at
+all.
 
 ## The published shrinkwrap governs registry installs but not tarball installs (`build-tools/`)
 

--- a/integrationTests/server/stream-error-contract.test.ts
+++ b/integrationTests/server/stream-error-contract.test.ts
@@ -120,7 +120,7 @@ function rawCapture(
 	authHeader: string,
 	surface: string,
 	throwPoint: string,
-	opts: { timeoutMs?: number } = {}
+	opts: { timeoutMs?: number; http10?: boolean; connection?: string } = {}
 ): Promise<RawCapture> {
 	const timeoutMs = opts.timeoutMs ?? 15_000;
 	const url = new URL(restBase);
@@ -135,12 +135,13 @@ function rawCapture(
 		let settled = false;
 
 		const socket = net.createConnection({ host, port }, () => {
+			const connection = opts.connection ?? (opts.http10 ? undefined : 'close');
 			const req =
-				`GET ${path} HTTP/1.1\r\n` +
+				`GET ${path} HTTP/${opts.http10 ? '1.0' : '1.1'}\r\n` +
 				`Host: ${host}:${port}\r\n` +
 				`Accept: ${acceptHeader}\r\n` +
 				`Authorization: ${authHeader}\r\n` +
-				`Connection: close\r\n` +
+				(connection ? `Connection: ${connection}\r\n` : '') +
 				`\r\n`;
 			socket.write(req);
 		});
@@ -207,6 +208,50 @@ function assertServerTerminated(cap: RawCapture) {
 		cap.socketEvents.some((e) => e.startsWith('close(')),
 		`${cap.caseName}: connection never closed (events: ${cap.socketEvents.join(', ')})`
 	);
+}
+
+function captureKeepAliveReuse(
+	restBase: string,
+	path: string,
+	acceptHeader: string,
+	authHeader: string,
+	timeoutMs = 10_000
+): Promise<{ responses: number; serverClosedEarly: boolean }> {
+	const url = new URL(restBase);
+	const host = url.hostname;
+	const port = Number.parseInt(url.port, 10) || (url.protocol === 'https:' ? 443 : 80);
+	const request =
+		`GET ${path} HTTP/1.1\r\n` +
+		`Host: ${host}:${port}\r\n` +
+		`Accept: ${acceptHeader}\r\n` +
+		`Authorization: ${authHeader}\r\n` +
+		`Connection: keep-alive\r\n` +
+		`\r\n`;
+
+	return new Promise((resolvePromise) => {
+		let raw = '';
+		let sentSecond = false;
+		let settled = false;
+		const socket = net.createConnection({ host, port }, () => socket.write(request));
+		const finish = (serverClosedEarly: boolean) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			socket.destroy();
+			resolvePromise({ responses: raw.split('HTTP/1.1 200').length - 1, serverClosedEarly });
+		};
+		const timer = setTimeout(() => finish(false), timeoutMs);
+		socket.on('data', (d: Buffer) => {
+			raw += d.toString('latin1');
+			const completeResponses = raw.split('0\r\n\r\n').length - 1;
+			if (!sentSecond && completeResponses >= 1) {
+				sentSecond = true;
+				socket.write(request);
+			} else if (sentSecond && completeResponses >= 2) finish(false);
+		});
+		socket.on('end', () => finish(!settled));
+		socket.on('error', () => finish(false));
+	});
 }
 
 async function getProbeJson(restBase: string, authHeaders: Record<string, string>): Promise<any> {
@@ -368,6 +413,32 @@ suite(
 			);
 			captures.push(cap);
 			assertCleanCompletion(cap);
+		});
+
+		// A 1.0 response with no Content-Length is close-delimited whatever the client asked for
+		for (const connection of [undefined, 'keep-alive']) {
+			test(
+				`control: IterHealth iterable-rest over HTTP/1.0${connection ? ` (Connection: ${connection})` : ''} clean completion`,
+				{ timeout: 20_000, skip: VARIANT === 'uws' ? 'uWS does not serve HTTP/1.0 requests' : false },
+				async () => {
+					const cap = await captureWithLifecycle('iterHealth', () =>
+						rawCapture(restBase, '/IterHealth/', 'application/json', authHeader, 'iterable-rest', 'control-http10', {
+							http10: true,
+							connection,
+						})
+					);
+					captures.push(cap);
+					strictEqual(cap.status, 200, `expected 200, got ${cap.status}`);
+					deepStrictEqual(decodedRecords(cap), [{ n: 0 }, { n: 1 }, { n: 2 }]);
+					assertServerTerminated(cap);
+				}
+			);
+		}
+
+		test('control: a keep-alive client is left connected and reuses the socket', { timeout: 20_000 }, async () => {
+			const reuse = await captureKeepAliveReuse(restBase, '/IterHealth/', 'application/json', authHeader);
+			strictEqual(reuse.serverClosedEarly, false, 'server closed a keep-alive connection after a streamed response');
+			strictEqual(reuse.responses, 2, 'a keep-alive client must get both responses on one connection');
 		});
 
 		// ── Pre-first-yield throw: the core question ──────────────────────────────────────────────

--- a/integrationTests/server/stream-error-contract.test.ts
+++ b/integrationTests/server/stream-error-contract.test.ts
@@ -23,6 +23,7 @@
  * Reproduction:
  *   Node: npm run test:integration -- "integrationTests/server/stream-error-contract.test.ts"
  *   uWS:  HARPER_UWS_HTTP=1 npm run test:integration -- "integrationTests/server/stream-error-contract.test.ts"
+ *   Bun:  HARPER_RUNTIME=bun npm run test:integration -- "integrationTests/server/stream-error-contract.test.ts"
  *
  * Each run prints a per-case capture table to stdout.
  */
@@ -39,10 +40,6 @@ import { createApiClient } from '../apiTests/utils/client.mjs';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'stream-error-contract');
 const skipSuite = process.platform === 'win32';
-const skipBunIterableRest =
-	process.env.HARPER_RUNTIME === 'bun'
-		? '#2210: Bun leaves finite iterable REST connections open after Connection: close'
-		: false;
 const VARIANT = process.env.HARPER_UWS_HTTP === '1' ? 'uws' : 'node';
 
 type Client = ReturnType<typeof createApiClient>;
@@ -365,17 +362,13 @@ suite(
 			assertCleanCompletion(cap);
 		});
 
-		test(
-			'control: IterHealth iterable-rest (default json) clean completion',
-			{ timeout: 20_000, skip: skipBunIterableRest },
-			async () => {
-				const cap = await captureWithLifecycle('iterHealth', () =>
-					rawCapture(restBase, '/IterHealth/', 'application/json', authHeader, 'iterable-rest', 'control')
-				);
-				captures.push(cap);
-				assertCleanCompletion(cap);
-			}
-		);
+		test('control: IterHealth iterable-rest (default json) clean completion', { timeout: 20_000 }, async () => {
+			const cap = await captureWithLifecycle('iterHealth', () =>
+				rawCapture(restBase, '/IterHealth/', 'application/json', authHeader, 'iterable-rest', 'control')
+			);
+			captures.push(cap);
+			assertCleanCompletion(cap);
+		});
 
 		// ── Pre-first-yield throw: the core question ──────────────────────────────────────────────
 
@@ -437,20 +430,16 @@ suite(
 			assertMidStreamTermination(cap);
 		});
 
-		test(
-			'iterable-rest: mid-stream throw (2 of 5) -- raw byte capture',
-			{ timeout: 20_000, skip: skipBunIterableRest },
-			async () => {
-				const cap = await captureWithLifecycle('iterMidStream', () =>
-					rawCapture(restBase, '/IterMidStream/', 'application/json', authHeader, 'iterable-rest', 'mid-stream')
-				);
-				captures.push(cap);
-				console.log(
-					`[QA-890][iterable-rest/mid] status=${cap.status} totalBytes=${cap.totalBytes} decodedBody=${cap.decodedBody}`
-				);
-				assertMidStreamTermination(cap);
-			}
-		);
+		test('iterable-rest: mid-stream throw (2 of 5) -- raw byte capture', { timeout: 20_000 }, async () => {
+			const cap = await captureWithLifecycle('iterMidStream', () =>
+				rawCapture(restBase, '/IterMidStream/', 'application/json', authHeader, 'iterable-rest', 'mid-stream')
+			);
+			captures.push(cap);
+			console.log(
+				`[QA-890][iterable-rest/mid] status=${cap.status} totalBytes=${cap.totalBytes} decodedBody=${cap.decodedBody}`
+			);
+			assertMidStreamTermination(cap);
+		});
 
 		test('Z: liveness canary -- worker survived every throw shape above', { timeout: 30_000 }, async () => {
 			const health = await rawCapture(restBase, '/SseHealth/', 'text/event-stream', authHeader, 'sse', 'canary');

--- a/server/http.ts
+++ b/server/http.ts
@@ -543,32 +543,45 @@ export function pipeBodyToResponse(
 		} else {
 			recordAction(performance.now() - endTime, 'transfer', handlerPath, method);
 			recordAction(bytesSent, 'bytes-sent', handlerPath, method);
-			endConnectionIfClientRequestedClose(nodeResponse);
+			endConnectionIfClientExpectsClose(nodeResponse);
 		}
 	});
 }
 
 /**
- * Close the connection of a client that sent `Connection: close`, once a streamed response has
- * flushed. Bun's node:http never derives keep-alive from the request — `shouldKeepAlive` stays true
- * for a `Connection: close` request, and neither a `Connection: close` response header nor
- * `response.socket.end()` closes the connection — so a stream-ended response delivers its full body
- * and terminal chunk and then leaves the client hanging until its own timeout (#2210). Ending the
- * request's socket is the one thing that works on both runtimes; it flushes what's queued before the
- * FIN, unlike a destroy. Node closes such a connection itself, so this only ever fires under Bun.
- * The error path needs nothing: pipeline() destroys the response, which closes the connection on
- * both runtimes.
+ * Bun's node:http never derives keep-alive from the request, so a stream-ended response delivers its
+ * full body and then leaves the client attached until its own timeout (#2210). Ending the *request's*
+ * socket is the only remedy that works there, and it is graceful, so nothing is truncated (measured
+ * on plain TCP and TLS). DESIGN.md carries the measurements and the alternatives that don't work.
  */
-function endConnectionIfClientRequestedClose(nodeResponse: any) {
+function endConnectionIfClientExpectsClose(nodeResponse: any) {
 	if (!isBun) return;
 	const nodeRequest = nodeResponse.req;
-	// HTTP/2 multiplexes streams over one connection, so there is no per-request socket to end
 	if (nodeRequest?.httpVersionMajor !== 1) return;
+	const socket = nodeRequest.socket;
+	// a peer that RSTs right after the terminal chunk can leave this callback holding a destroyed
+	// socket; end()ing it would throw from inside stream internals, i.e. an uncaughtException
+	if (!socket || socket.destroyed) return;
 	const connection = nodeRequest.headers?.connection;
-	if (!connection) return;
-	for (const token of connection.split(',')) {
-		if (token.trim().toLowerCase() === 'close') return nodeRequest.socket?.end();
+	const tokens = typeof connection === 'string' ? connection.split(',') : [];
+	if (hasConnectionToken(tokens, 'close')) {
+		socket.end();
+		return;
 	}
+	// HTTP/1.0 persistence needs an explicit keep-alive AND a length to read to, so a 1.0 response
+	// that got no Content-Length is delimited by the close — the same line Node draws
+	if (
+		nodeRequest.httpVersionMinor === 0 &&
+		!(hasConnectionToken(tokens, 'keep-alive') && nodeResponse.hasHeader?.('content-length'))
+	)
+		socket.end();
+}
+
+function hasConnectionToken(tokens: string[], wanted: string) {
+	for (const token of tokens) {
+		if (token.trim().toLowerCase() === wanted) return true;
+	}
+	return false;
 }
 
 function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {

--- a/server/http.ts
+++ b/server/http.ts
@@ -543,8 +543,32 @@ export function pipeBodyToResponse(
 		} else {
 			recordAction(performance.now() - endTime, 'transfer', handlerPath, method);
 			recordAction(bytesSent, 'bytes-sent', handlerPath, method);
+			endConnectionIfClientRequestedClose(nodeResponse);
 		}
 	});
+}
+
+/**
+ * Close the connection of a client that sent `Connection: close`, once a streamed response has
+ * flushed. Bun's node:http never derives keep-alive from the request — `shouldKeepAlive` stays true
+ * for a `Connection: close` request, and neither a `Connection: close` response header nor
+ * `response.socket.end()` closes the connection — so a stream-ended response delivers its full body
+ * and terminal chunk and then leaves the client hanging until its own timeout (#2210). Ending the
+ * request's socket is the one thing that works on both runtimes; it flushes what's queued before the
+ * FIN, unlike a destroy. Node closes such a connection itself, so this only ever fires under Bun.
+ * The error path needs nothing: pipeline() destroys the response, which closes the connection on
+ * both runtimes.
+ */
+function endConnectionIfClientRequestedClose(nodeResponse: any) {
+	if (!isBun) return;
+	const nodeRequest = nodeResponse.req;
+	// HTTP/2 multiplexes streams over one connection, so there is no per-request socket to end
+	if (nodeRequest?.httpVersionMajor !== 1) return;
+	const connection = nodeRequest.headers?.connection;
+	if (!connection) return;
+	for (const token of connection.split(',')) {
+		if (token.trim().toLowerCase() === 'close') return nodeRequest.socket?.end();
+	}
 }
 
 function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {


### PR DESCRIPTION
Under Bun, a streamed HTTP response delivered its full body and then never closed the connection, so a client that asked for a close was left attached until its own timeout — a finite iterable REST response was the shape #2210 reported, and the two integration arms #2070 had to gate are un-gated again by this fix.

Bun's `node:http` never derives keep-alive from the request: `shouldKeepAlive` stays `true` for a `Connection: close` request, and neither a `Connection: close` response header, `response.socket.end()`, nor `response.destroy()` closes the connection — all three measured as no-ops. Ending the *request's* socket is the one remedy that works, so `pipeBodyToResponse()` now does that [after a clean stream finish](https://github.com/HarperFast/harper/pull/2351/changes?w=1#diff-df0a865ce41dd6dd95036d1be97cc57d8f0a22d83eec5619914f0b34274b09c3R546) for [the shapes that are close-delimited](https://github.com/HarperFast/harper/pull/2351/changes?w=1#diff-df0a865ce41dd6dd95036d1be97cc57d8f0a22d83eec5619914f0b34274b09c3R567): an explicit `Connection: close` on either HTTP version, and [HTTP/1.0 without both an explicit `keep-alive` and a `Content-Length`](https://github.com/HarperFast/harper/pull/2351/changes?w=1#diff-df0a865ce41dd6dd95036d1be97cc57d8f0a22d83eec5619914f0b34274b09c3R574). That is the same line Node draws. It is `isBun`-gated, HTTP/1-only, and clean-path-only — `pipeline()` already destroys the response on error, which closes the connection on both runtimes.

Worth recording for whoever debugs Bun next, and now in `DESIGN.md`: this is a `node:http`-emulation defect rather than a `Bun.serve` one because **the main HTTP port on Bun is served by `node:http`, not `Bun.serve`**. `onWebSocket()` calls `getHTTPServer()` unconditionally ([the DESIGN.md note recording this](https://github.com/HarperFast/harper/pull/2351/changes?w=1#diff-3dc5dd454e080eb849ee5efaf79df2585fbe0a06804d69249b4c81da05a63875R890)) (it has a uWS branch and no Bun branch, since Bun native WebSockets are unimplemented), and MQTT registers WS on the default port before REST's `httpServer()` call, so `httpServers[port]` is already a Node server by the time `getBunHTTPServer` runs and it returns without registering a serve config. Only the exclusive operations port reaches `Bun.serve`. That is a separate, larger issue, not this PR.

Fixes #2210. Resolves the decision in #2349 — it is the product bug it appeared to be, so the suite is un-gated rather than kept skipped.

## For the human reviewer

1. **Carry the workaround in Harper, or file it upstream and stay gated?** Chosen: fix it here, because the Bun shard is otherwise red and #2210 blocks it. The cost is a Bun-gated branch with no expiry marker — nothing will prompt us to delete it when Bun fixes its emulation. If you want an upstream issue filed and referenced from the code, say so and I'll open one.
2. **HTTP/1.0 parity with Node, or just always close on 1.0 under Bun?** Chosen: parity — close-delimit 1.0 unless the client sent `keep-alive` *and* the response got a `Content-Length`. That exemption is the one path with no test arm (the fixture has no sized streamed body; a blob GET is the real-world shape). It is measured, not assumed: [the `hasHeader('content-length')` check](https://github.com/HarperFast/harper/pull/2351/changes?w=1#diff-df0a865ce41dd6dd95036d1be97cc57d8f0a22d83eec5619914f0b34274b09c3R575) returns `true` under Bun after the `writeHead(status, headers)` fast path this file uses, and both runtimes then serve two responses on one 1.0 keep-alive socket. "Always close on 1.0" is a one-line simplification that costs a keep-alive optimization almost no modern client asks for — a reasonable call to make differently.
3. **Reaching through the response to `request.socket`.** A response-piping helper now ends the connection, which is a layering choice other paths could copy. It rests on the measurement that the response-layer alternatives are no-ops under Bun, and [a destroyed-socket guard](https://github.com/HarperFast/harper/pull/2351/changes?w=1#diff-df0a865ce41dd6dd95036d1be97cc57d8f0a22d83eec5619914f0b34274b09c3R564) keeps a peer RST from turning the pipeline callback into an uncaughtException; those are local runs on Bun 1.3.14, recorded in `DESIGN.md`.
4. **Clean streamed path only.** Non-streamed Bun responses were measured separately and do close correctly on `response.end()` (with and without a final chunk), so the call site is deliberately narrow rather than "everywhere a Bun HTTP/1 response completes".

## Verification

Route: existing integration spec, un-gated and extended — `integrationTests/server/stream-error-contract.test.ts`, which drives a raw `net.Socket` so the close mechanism is visible on the wire.

- Fails on base, with `origin/main` sources and a forced rebuild: the two Bun arms time out at 15s each (`control: IterHealth iterable-rest` and `iterable-rest: mid-stream throw`). With the fix they complete in ~11ms and ~6ms.
- Both new HTTP/1.0 arms are load-bearing: deleting only the `httpVersionMinor` branch makes both hang for 15s under Bun while the other 10 arms pass.
- [The new keep-alive arm](https://github.com/HarperFast/harper/pull/2351/changes?w=1#diff-d05fa0134bb2f721a182f5f40352622ac331a55586325b6b770cf4f6378fefb4R438) is load-bearing in the other direction: making the HTTP/1.1 path close unconditionally fails only that arm.
- Full spec after the rebase: Bun 13/13, Node 13/13, uWS 11/11 + 2 skips (the HTTP/1.0 arms — uWS never routes an HTTP/1.0 request to the resource).
- A 45-test Bun slice of the HTTP-response-path suites (SSE event data, cache headers, security headers, caching, operations server) passes.
- Two reviewed risks measured and not reproduced: `socket.end()` truncates nothing (8 MB over plain TCP and 6 MB over TLS to a deliberately slow reader each arrive whole, terminal chunk included), and the `hasHeader` check is not inert under Bun.

Not covered: HTTP/2 (excluded by the guard — no per-request socket), and the HTTP/1.0 keep-alive-with-`Content-Length` exemption (judgment call 2 above).

Complexity: medium

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=2 @ 58380fcb3aea</sub>

<sub>Human-Review-Need: 3 @ 58380fcb3aea</sub>
