### PR TITLE
ci: ready_for_review runs review but never cancels

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,12 +21,15 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 concurrency:
-  # NOTE: this predicate and the review job's `if:` must stay textually
-  # in sync — GitHub Actions YAML has no anchors to share them.
+  # NOTE: this predicate is deliberately NARROWER than the review job's
+  # `if:` — the cancelling set must be a subset of the running set.
+  # ready_for_review runs review (job gate) but never cancel: their
+  # authorization is author-based, so on a bot-authored PR they could
+  # kill a labeler-authorized run and then be rejected themselves.
   # Ineligible events (per the review job's opt-in gate) get a unique
   # run_id group so they can never cancel an in-flight eligible review —
   # workflow-level cancel-in-progress fires before job `if:` is evaluated.
-  group: claude-review-${{ github.event.pull_request.number }}-${{ ((github.event.action == 'labeled' && github.event.label.name == 'claude-review') || (github.event.action != 'labeled' && vars.CLAUDE_ALWAYS_ON == 'true') || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'claude-review'))) && 'eligible' || github.run_id }}
+  group: claude-review-${{ github.event.pull_request.number }}-${{ ((github.event.action == 'labeled' && github.event.label.name == 'claude-review') || (github.event.action != 'labeled' && vars.CLAUDE_ALWAYS_ON == 'true')) && 'eligible' || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -39,10 +39,13 @@ concurrency:
   # in parallel on the same PR. cancel-in-progress is per-group, so a
   # synchronize push cancels the in-flight Gemini run without touching
   # the Claude run (and vice versa).
-  # NOTE: this predicate and the review job's `if:` must stay textually
-  # in sync — GitHub Actions YAML has no anchors to share them.
+  # NOTE: this predicate is deliberately NARROWER than the review job's
+  # `if:` — the cancelling set must be a subset of the running set.
+  # ready_for_review runs review (job gate) but never cancel: their
+  # authorization is author-based, so on a bot-authored PR they could
+  # kill a labeler-authorized run and then be rejected themselves.
   # Ineligible events get a unique run_id group — see claude-review.yml.
-  group: gemini-review-${{ github.event.pull_request.number }}-${{ ((github.event.action == 'labeled' && github.event.label.name == 'gemini-review') || (github.event.action != 'labeled' && vars.GEMINI_ALWAYS_ON == 'true') || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'gemini-review'))) && 'eligible' || github.run_id }}
+  group: gemini-review-${{ github.event.pull_request.number }}-${{ ((github.event.action == 'labeled' && github.event.label.name == 'gemini-review') || (github.event.action != 'labeled' && vars.GEMINI_ALWAYS_ON == 'true')) && 'eligible' || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Follow-up to #2348, from @kriszyp's finding on harper-pro#767: the label-opted `ready_for_review` event shared the `eligible` concurrency group, so on a **bot-authored** PR it could cancel the trusted labeler's in-flight review and then be rejected by author-based authorization (non-labeled events authorize against the PR author, not the labeler) — leaving no completed review.

Fix: the **cancelling set** (concurrency predicate) excludes `ready_for_review`; the **running set** (job gate) keeps it. Trusted-author ready-flips still get their review — they just can't kill anyone else's. The two predicates now deliberately diverge, with the comment explaining why (cancelling ⊆ running). Revisit if the reusable gains persisted-label authorization.

**Merge order**: before #2330/#2331 (they carry this fix and must stay byte-identical to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S94XethbGXpAb4DRKMD4kt