### PR TITLE
Continuously enforce RocksDB audit log retention

### DIFF
--- a/dataLayer/harperBridge/ResourceBridge.ts
+++ b/dataLayer/harperBridge/ResourceBridge.ts
@@ -514,7 +514,7 @@ export class ResourceBridge extends BridgeMethods {
 			if (tables) {
 				for (const table of Object.values(tables)) {
 					if (table.primaryStore instanceof RocksDatabase) {
-						const deleted = table.primaryStore.purgeLogs({ before, includeEntryCounts: true });
+						const deleted = table.auditStore.purgeLogs({ before, includeEntryCounts: true });
 						totalResults.log_files_deleted += deleted.length;
 						totalResults.entries_deleted += deleted.reduce((acc, file) => acc + file.entries, 0);
 						break;

--- a/integrationTests/database/audit-retention-lmdb.test.ts
+++ b/integrationTests/database/audit-retention-lmdb.test.ts
@@ -8,16 +8,15 @@
  * and its concurrency seam, never the automatic retention driver.
  *
  * Why this matters (source read at Harper `b8c843a24`, re-verified rather than assumed):
- *   - `resources/auditStore.ts:224-226` — `scheduleAuditCleanup()` runs once at store-open, on
- *     the last worker only, for BOTH engines.
- *   - `resources/auditStore.ts:174-222` — the LMDB branch arms a `setTimeout`, walks
+ *   - `resources/auditStore.ts` — `scheduleAuditCleanup()` starts at store-open on the last
+ *     worker for both engines.
+ *   - The LMDB branch arms a `setTimeout`, walks
  *     `auditStore.getRange({start: 1, end: <cutoff>})` deleting aged entries, and re-schedules
- *     ITSELF from its own `finally` (line 216), backing off when idle. That self-re-arm is the
+ *     itself from `finally`, backing off when idle. That self-re-arm is the
  *     whole mechanism under test: if it ever stops re-arming, audit entries grow without bound
  *     and the only recovery is an explicit operator prune.
- *   - `resources/auditStore.ts:164-172` — the RocksDB branch calls `purgeLogs()` once and
- *     returns with no re-arm (F-218). That asymmetry is deliberately NOT asserted here; this
- *     file pins only the behavior that is correct today, so it stays green.
+ *   - The RocksDB branch has separate passive-rearm coverage in `audit-retention-rocks.test.ts`;
+ *     this file pins LMDB's per-entry cleanup behavior.
  *   - `resources/databases.ts:862` — `HARPER_STORAGE_ENGINE` wins over config, which is how the
  *     LMDB arm is selected (same mechanism as `eviction-secondary-index.test.ts`).
  *

--- a/integrationTests/database/audit-retention-lmdb/resources.js
+++ b/integrationTests/database/audit-retention-lmdb/resources.js
@@ -31,3 +31,15 @@ export class StorageEngineInfo extends Resource {
 		};
 	}
 }
+
+export class TransactionLogStats extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		const rootStore = tables['Ledger']?.primaryStore?.rootStore;
+		if (!rootStore?.auditStore?.log) throw new Error('RocksDB transaction log is not available');
+		if (typeof rootStore.auditStore.log.getStats !== 'function') {
+			throw new Error('RocksDB transaction-log statistics are not available');
+		}
+		return rootStore.auditStore.log.getStats();
+	}
+}

--- a/integrationTests/database/audit-retention-rocks.test.ts
+++ b/integrationTests/database/audit-retention-rocks.test.ts
@@ -1,0 +1,99 @@
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+	setupHarperWithFixture,
+	teardownHarper,
+	sendOperation,
+	type ContextWithHarper,
+} from '@harperfast/integration-testing';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'audit-retention-lmdb');
+const skipSuite = process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun';
+
+function authHeader(ctx: ContextWithHarper): string {
+	const { username, password } = ctx.harper.admin;
+	return 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
+}
+
+async function getStats(ctx: ContextWithHarper): Promise<any> {
+	const response = await fetch(`${ctx.harper.httpURL}/TransactionLogStats/`, {
+		headers: { Authorization: authHeader(ctx) },
+	});
+	ok(response.ok, `TransactionLogStats failed with ${response.status}`);
+	return response.json();
+}
+
+async function waitForStats(ctx: ContextWithHarper): Promise<void> {
+	const deadline = Date.now() + 60_000;
+	while (Date.now() < deadline) {
+		try {
+			if (await getStats(ctx)) return;
+		} catch {}
+		await sleep(250);
+	}
+	throw new Error('TransactionLogStats did not become ready');
+}
+
+async function waitForPurgeRun(ctx: ContextWithHarper, previousRuns: number): Promise<number> {
+	const deadline = Date.now() + 15_000;
+	while (Date.now() < deadline) {
+		try {
+			const runs = (await getStats(ctx))?.totals?.purgeRuns;
+			if (typeof runs === 'number' && runs > previousRuns) return runs;
+		} catch {}
+		await sleep(250);
+	}
+	throw new Error(`RocksDB transaction-log cleanup did not advance past purgeRuns=${previousRuns}`);
+}
+
+suite(
+	'RocksDB audit retention self-rearms without storage pressure (#2140)',
+	{ skip: skipSuite },
+	(ctx: ContextWithHarper) => {
+		before(async () => {
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+				config: {
+					threads: { count: 1 },
+					logging: { auditLog: true, auditRetention: 2 },
+				},
+				env: {
+					HARPER_STORAGE_ENGINE: 'rocksdb',
+					STORAGE_RECLAMATION_THRESHOLD: 0,
+				},
+			});
+			await waitForStats(ctx);
+		});
+
+		after(async () => {
+			await teardownHarper(ctx);
+		});
+
+		test('runs more than one passive purge pass', { timeout: 40_000 }, async () => {
+			const engineResponse = await fetch(`${ctx.harper.httpURL}/StorageEngineInfo/`, {
+				headers: { Authorization: authHeader(ctx) },
+			});
+			const engine = await engineResponse.json();
+			strictEqual(engine.engineGuess, 'rocksdb');
+
+			await sendOperation(ctx.harper, {
+				operation: 'insert',
+				schema: 'data',
+				table: 'Ledger',
+				records: [{ id: 'first-pass', seq: 1, payload: 'first-pass' }],
+			});
+			const initialRuns = (await getStats(ctx))?.totals?.purgeRuns ?? 0;
+			const firstRun = await waitForPurgeRun(ctx, initialRuns);
+
+			await sendOperation(ctx.harper, {
+				operation: 'insert',
+				schema: 'data',
+				table: 'Ledger',
+				records: [{ id: 'second-pass', seq: 2, payload: 'second-pass' }],
+			});
+			const secondRun = await waitForPurgeRun(ctx, firstRun);
+			ok(secondRun > firstRun, `expected a re-armed purge pass after ${firstRun}, got ${secondRun}`);
+		});
+	}
+);

--- a/integrationTests/database/blob-delete-reclaim-audit-expiry.test.ts
+++ b/integrationTests/database/blob-delete-reclaim-audit-expiry.test.ts
@@ -3,7 +3,7 @@
  * audit-log expiry when using RocksDB audit store").
  *
  * #708's claim: `scheduleAuditCleanup()` (resources/auditStore.ts) branches on the audit
- * store type; for RocksDB it calls `rootStore.purgeLogs()` and returns WITHOUT ever calling
+ * store type; for RocksDB it calls `rootStore.purgeLogs()` WITHOUT ever calling
  * `removeAuditEntry()` — the function that invokes the blob-file delete callbacks — so blob
  * files supposedly accumulate forever once a blob-bearing record is deleted.
  *

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -23,6 +23,11 @@ type TransactionLogIterator = Iterator<TransactionEntry | number> & {
 	removeLog(logName: string);
 };
 
+type NotifyingArrayBuffer = ArrayBuffer & {
+	notify(): boolean;
+	cancel(): void;
+};
+
 // Logs (once per log) when a corrupt frame ends a query iterator early; see
 // endIteratorOnCorruptFrame in replayLogsGuards.ts for why this is end-of-log, not a crash.
 function warnCorruptFrame(logName: string) {
@@ -42,6 +47,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 	logByName: Map<string, TransactionLog> = new Map();
 	updates = 0; // the number of updates to the list of logs that have occurred
 	rootStore: RocksDatabase;
+	purgeNotification?: NotifyingArrayBuffer;
 	reusableIterable = true; // flag indicating that iterable can be reused to resume iterating through audit log
 	// Highest structureVersion appended to each per-node TransactionLog, tracked per tableId. Drives the
 	// per-log HAS_STRUCTURE_UPDATE flag in put(). Keyed by (log, tableId): a per-node log interleaves entries
@@ -54,6 +60,13 @@ export class RocksTransactionLogStore extends EventEmitter {
 		super();
 		this.log = rootDatabase.useLog('local');
 		this.rootStore = rootDatabase;
+		try {
+			this.purgeNotification = rootDatabase.getUserSharedBuffer('audit-log-purged', new ArrayBuffer(1), {
+				callback: () => this.invalidateLogBuffers(),
+			}) as NotifyingArrayBuffer;
+		} catch (error) {
+			harperLogger.warn('Failed to register transaction-log purge notifications', error);
+		}
 	}
 
 	/**
@@ -245,6 +258,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 				}
 				if (!log) {
 					log = this.rootStore.useLog(options.log);
+					this.addLogToMaps(log.name, log);
 				}
 			}
 			const queryIterator = endIteratorOnCorruptFrame(log.query(options), warnCorruptFrame(log.name));
@@ -462,6 +476,46 @@ export class RocksTransactionLogStore extends EventEmitter {
 			logs,
 			totalSize,
 		};
+	}
+
+	invalidateLogBuffers() {
+		try {
+			const logs = new Set<TransactionLog | undefined>([
+				this.log,
+				...this.logByName.values(),
+				...(this.nodeLogs ?? []),
+			]);
+			for (const log of logs) {
+				if (!log) continue;
+				log._logBuffers?.clear();
+				(log as any)._currentLogBuffer = undefined;
+			}
+		} catch (error) {
+			harperLogger.warn('Failed to invalidate transaction-log buffers after purge', error);
+		}
+	}
+
+	purgeLogs(options?: any): any[] {
+		const purged = this.rootStore.purgeLogs(options);
+		if (purged.length > 0) {
+			this.invalidateLogBuffers();
+			try {
+				// Every worker has its own TransactionLog objects, so notify all workers to drop stale mmaps.
+				// Iterators already in progress retain their own buffer references and can finish safely.
+				this.purgeNotification?.notify();
+			} catch (error) {
+				harperLogger.warn('Failed to invalidate transaction-log buffers after purge', error);
+			}
+		}
+		return purged;
+	}
+
+	stopPurgeNotifications() {
+		try {
+			this.purgeNotification?.cancel();
+		} catch (error) {
+			harperLogger.warn('Failed to cancel transaction-log purge notifications', error);
+		}
 	}
 
 	getUserSharedBuffer(key: string | symbol, defaultBuffer: ArrayBuffer, options?: { callback?: () => void }) {

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -117,7 +117,9 @@ const warnedBodylessMints = new Set<string>();
 const warnedBodylessTables = new Set<number>();
 const FLOAT_TARGET = new Float64Array(1);
 const FLOAT_BUFFER = new Uint8Array(FLOAT_TARGET.buffer);
-let DEFAULT_AUDIT_CLEANUP_DELAY = 10000; // default delay of 10 seconds
+// Also the RocksDB cadence floor: file eligibility changes only on rotation/flush, so RocksDB must
+// not inherit LMDB's millisecond-scale productive-pass retries.
+let DEFAULT_AUDIT_CLEANUP_DELAY = 10000;
 let timestampErrored = false;
 export function openAuditStore(rootStore) {
 	let auditStore;
@@ -146,6 +148,7 @@ export function openAuditStore(rootStore) {
 	rootStore.auditStore = auditStore;
 	auditStore.rootStore = rootStore;
 	auditStore.tableStores = [];
+	const isRocksTransactionLogStore = auditStore instanceof RocksTransactionLogStore;
 	const deleteCallbacks = [];
 	auditStore.addDeleteRemovalCallback = function (tableId, table, callback) {
 		deleteCallbacks[tableId] = callback;
@@ -164,6 +167,7 @@ export function openAuditStore(rootStore) {
 	let lastCleanupResolution: Promise<void>;
 	let cleanupPriority = 0;
 	let auditCleanupDelay = DEFAULT_AUDIT_CLEANUP_DELAY;
+	let cleanupStopped = false;
 	onStorageReclamation(rootStore.path, (priority) => {
 		cleanupPriority = priority; // update the priority
 		if (priority) {
@@ -181,13 +185,7 @@ export function openAuditStore(rootStore) {
 	 */
 	function scheduleAuditCleanup(newCleanupDelay?: number): Promise<void> {
 		// Skip audit cleanup/purge in read-only mode
-		if (isReadOnlyMode()) return Promise.resolve();
-		if (auditStore instanceof RocksTransactionLogStore) {
-			auditStore.rootStore.purgeLogs({
-				before: Date.now() - auditRetention / (1 + cleanupPriority * cleanupPriority),
-			});
-			return Promise.resolve();
-		}
+		if (cleanupStopped || isReadOnlyMode()) return Promise.resolve();
 
 		if (newCleanupDelay) auditCleanupDelay = newCleanupDelay;
 		// the pass we are about to cancel has not started, so its callers are handed over to this one
@@ -196,6 +194,7 @@ export function openAuditStore(rootStore) {
 		const resolution = new Promise<void>((resolve) => {
 			pendingCleanupResolve = resolve;
 			pendingCleanup = setTimeout(async () => {
+				pendingCleanup = null;
 				pendingCleanupResolve = null; // started, so a later schedule can no longer cancel this pass
 				// claim the serialization slot before yielding: assigning it after the await lets every
 				// pass released by the same resolution run concurrently over the same range
@@ -203,7 +202,7 @@ export function openAuditStore(rootStore) {
 				lastCleanupResolution = resolution;
 				await previousCleanup;
 				// query for audit entries that are old
-				if (auditStore.rootStore.status === 'closed' || auditStore.rootStore.status === 'closing') {
+				if (cleanupStopped || auditStore.rootStore.status === 'closed' || auditStore.rootStore.status === 'closing') {
 					// nothing to clean up and nothing to reschedule, but leaving `resolution` pending would
 					// wedge the loop permanently: it is now the resolution every later pass awaits
 					resolve();
@@ -212,24 +211,30 @@ export function openAuditStore(rootStore) {
 				let deleted = 0;
 				let lastKey: any;
 				try {
-					for (const auditRecord of auditStore.getRange({
-						start: 1, // must not be zero or it will be interpreted as null and overlap with symbols in search
-						snapshot: false,
-						end: Date.now() - auditRetention / (1 + cleanupPriority * cleanupPriority), // remove up until the audit retention time, reducing audit retention time if cleanup is higher priority
-					})) {
-						try {
-							// awaited so a rejection (not just a synchronous throw) is caught here instead of
-							// escaping as an unhandled rejection once a later iteration's promise replaces this one
-							await removeAuditEntry(auditStore, auditRecord);
-						} catch (error) {
-							harperLogger.warn('Error removing audit entry', error);
-						}
-						lastKey = auditRecord.key;
-						await new Promise(setImmediate);
-						if (++deleted >= MAX_DELETES_PER_CLEANUP) {
-							// limit the amount we cleanup per event turn so we don't use too much memory/CPU
-							auditCleanupDelay = 10; // and keep trying very soon
-							break;
+					if (isRocksTransactionLogStore) {
+						auditStore.purgeLogs({
+							before: Date.now() - auditRetention / (1 + cleanupPriority * cleanupPriority),
+						});
+					} else {
+						for (const auditRecord of auditStore.getRange({
+							start: 1, // must not be zero or it will be interpreted as null and overlap with symbols in search
+							snapshot: false,
+							end: Date.now() - auditRetention / (1 + cleanupPriority * cleanupPriority), // remove up until the audit retention time, reducing audit retention time if cleanup is higher priority
+						})) {
+							try {
+								// awaited so a rejection (not just a synchronous throw) is caught here instead of
+								// escaping as an unhandled rejection once a later iteration's promise replaces this one
+								await removeAuditEntry(auditStore, auditRecord);
+							} catch (error) {
+								harperLogger.warn('Error removing audit entry', error);
+							}
+							lastKey = auditRecord.key;
+							await new Promise(setImmediate);
+							if (++deleted >= MAX_DELETES_PER_CLEANUP) {
+								// limit the amount we cleanup per event turn so we don't use too much memory/CPU
+								auditCleanupDelay = 10; // and keep trying very soon
+								break;
+							}
 						}
 					}
 				} catch (error) {
@@ -243,7 +248,12 @@ export function openAuditStore(rootStore) {
 					// serialization barrier every later pass awaits, and never settling it wedges the
 					// cleanup loop for the life of the store.
 					resolve();
-					if (deleted === 0) {
+					if (isRocksTransactionLogStore) {
+						auditCleanupDelay = Math.max(
+							DEFAULT_AUDIT_CLEANUP_DELAY,
+							Math.min(auditRetention / (1 + cleanupPriority * cleanupPriority) / 10, MAX_CLEANUP_DELAY)
+						);
+					} else if (deleted === 0) {
 						// if we didn't delete anything, we can increase the delay (double until we get to one tenth of
 						// the retention time). Plain arithmetic, not `<<`/`>>`: those coerce to int32, so a
 						// sub-millisecond retention collapsed the delay to 0 permanently (0 << 1 is 0), and a
@@ -255,7 +265,13 @@ export function openAuditStore(rootStore) {
 						// and do updates faster
 						if (auditCleanupDelay > 100) auditCleanupDelay = auditCleanupDelay / 2;
 					}
-					scheduleAuditCleanup();
+					if (
+						!cleanupStopped &&
+						(!isRocksTransactionLogStore || getWorkerIndex() === getWorkerCount() - 1) &&
+						(!isRocksTransactionLogStore || !pendingCleanupResolve)
+					) {
+						scheduleAuditCleanup();
+					}
 				}
 				// we can run this pretty frequently since there is very little overhead to these queries
 			}, auditCleanupDelay).unref();
@@ -264,6 +280,14 @@ export function openAuditStore(rootStore) {
 		return resolution;
 	}
 	auditStore.scheduleAuditCleanup = scheduleAuditCleanup;
+	auditStore.stopAuditCleanup = function () {
+		cleanupStopped = true;
+		clearTimeout(pendingCleanup);
+		pendingCleanup = null;
+		pendingCleanupResolve?.();
+		pendingCleanupResolve = null;
+		auditStore.stopPurgeNotifications?.();
+	};
 	if (getWorkerIndex() === getWorkerCount() - 1) {
 		scheduleAuditCleanup();
 	}
@@ -330,7 +354,10 @@ export function setAuditRetention(retentionTime, defaultDelay = DEFAULT_AUDIT_CL
 export function purgeAgedLogs(rootStore: RocksDatabase): string[] {
 	// Mirror the read-only guard in scheduleAuditCleanup: never delete log files in read-only mode.
 	if (isReadOnlyMode()) return [];
-	return rootStore.purgeLogs({ before: Date.now() - auditRetention });
+	const auditStore = (rootStore as any).auditStore;
+	return auditStore instanceof RocksTransactionLogStore
+		? auditStore.purgeLogs({ before: Date.now() - auditRetention })
+		: rootStore.purgeLogs({ before: Date.now() - auditRetention });
 }
 
 const HAS_RECORD = 16;

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1177,6 +1177,7 @@ export function openBranchDatabase(path: string, databaseName: string, storeName
  */
 function closeBranchHandles(path: string, rootStore?: RootDatabaseKind, openedStores: any[] = []): void {
 	const reclamationPaths = new Set<string>([path]);
+	(rootStore as any)?.auditStore?.stopAuditCleanup?.();
 	const closeStore = (store: any, description: string) => {
 		if (store?.path) reclamationPaths.add(store.path);
 		try {
@@ -1460,6 +1461,7 @@ export async function dropDatabase(databaseName) {
 		databaseEventsEmitter.emit('dropDatabase', databaseName);
 
 		if (rootStore) {
+			rootStore.auditStore?.stopAuditCleanup?.();
 			if (rootStore.status === 'open') {
 				if (rootStore instanceof RocksDatabase) {
 					rootStore.close();
@@ -1474,6 +1476,7 @@ export async function dropDatabase(databaseName) {
 			// a tableless database resolves its root store here rather than in the loop above, so take
 			// the drop lock now (still before any destructive step)
 			if (rootStore instanceof RocksDatabase) lockDatabaseForDrop(rootStore.path, databaseName, restoreLocks);
+			rootStore.auditStore?.stopAuditCleanup?.();
 			if (rootStore instanceof RocksDatabase) {
 				rootStore.close();
 				rootStore.destroy();
@@ -1522,6 +1525,7 @@ export function closeDatabase(databaseName: string): boolean {
 	const definedRoot = (definedDatabases?.get(databaseName) as any)?.rootStore;
 	if (definedRoot) rootStores.add(definedRoot);
 	for (const rootStore of rootStores) {
+		rootStore.auditStore?.stopAuditCleanup?.();
 		closeStore(rootStore.dbisDb, 'attributes store');
 		closeStore(rootStore, 'root store');
 		lmdbDatabaseEnvs.delete(rootStore.path);

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -1,19 +1,28 @@
 const assert = require('assert');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
-const {
-	setAuditRetention,
-	readAuditEntry,
-	createAuditEntry,
-	transactionKeyEncoder,
-	removeAuditEntry,
-} = require('#src/resources/auditStore');
+const auditStoreModule = require('#src/resources/auditStore');
+const { setAuditRetention, readAuditEntry, createAuditEntry, transactionKeyEncoder, removeAuditEntry } =
+	auditStoreModule;
 const { RocksTransactionLogStore } = require('#src/resources/RocksTransactionLogStore');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { setTimeout: delay } = require('node:timers/promises');
 const { waitFor } = require('../waitFor');
 const harperLogger = require('#src/utility/logging/harper_logger');
 require('#src/server/serverHelpers/serverUtilities');
+
+function withUserSharedBuffer(fakeRoot) {
+	fakeRoot.getUserSharedBuffer = (_key, buffer, options = {}) => {
+		buffer.notify = () => {
+			options.callback?.();
+			return true;
+		};
+		buffer.cancel = () => {};
+		return buffer;
+	};
+	return fakeRoot;
+}
+
 describe('Audit log', () => {
 	let AuditedTable;
 	let events = [];
@@ -41,7 +50,86 @@ describe('Audit log', () => {
 		};
 	});
 	afterEach(function () {
-		setAuditRetention(60000);
+		setAuditRetention(60000, 10000);
+	});
+	it('re-arms RocksDB transaction-log cleanup without storage pressure', async function () {
+		if (!(AuditedTable.auditStore instanceof RocksTransactionLogStore)) return this.skip();
+		this.timeout(5_000);
+		const auditStore = AuditedTable.auditStore;
+		const rootStore = auditStore.rootStore;
+		const originalPurgeLogs = rootStore.purgeLogs;
+		const originalLogBuffers = auditStore.log._logBuffers;
+		const originalCurrentLogBuffer = auditStore.log._currentLogBuffer;
+		const originalRetention = auditStoreModule.auditRetention;
+		const purgeCalls = [];
+		rootStore.purgeLogs = (options) => {
+			purgeCalls.push(options);
+			return purgeCalls.length === 1 ? ['purged.txnlog'] : [];
+		};
+		try {
+			auditStore.log.query({ start: 0 }).next();
+			assert.ok(auditStore.log._logBuffers instanceof Map, 'rocksdb-js should expose its mmap cache');
+			const retainedBuffer = {};
+			auditStore.log._logBuffers = new Map([[1, new WeakRef(retainedBuffer)]]);
+			auditStore.log._currentLogBuffer = retainedBuffer;
+			setAuditRetention(100, 25);
+			const before = Date.now();
+			await auditStore.scheduleAuditCleanup(1);
+			const after = Date.now();
+			assert.equal(purgeCalls.length, 1, 'the requested cleanup pass should purge once');
+			assert.ok(
+				purgeCalls[0].before >= before - 100 && purgeCalls[0].before <= after - 100,
+				'the purge should honor the configured retention cutoff'
+			);
+			await waitFor(() => auditStore.log._logBuffers.size === 0 && auditStore.log._currentLogBuffer === undefined, {
+				timeout: 2_000,
+				message: 'purged mmap buffers should be invalidated',
+			});
+			await waitFor(() => purgeCalls.length >= 2, {
+				timeout: 2_000,
+				message: 'RocksDB cleanup did not re-arm after the requested pass',
+			});
+		} finally {
+			rootStore.purgeLogs = originalPurgeLogs;
+			auditStore.log._logBuffers = originalLogBuffers;
+			auditStore.log._currentLogBuffer = originalCurrentLogBuffer;
+			setAuditRetention(originalRetention, 10000);
+			auditStore.scheduleAuditCleanup(60_000);
+		}
+	});
+	it('broadcasts purge cache invalidation to every transaction-log store', () => {
+		const callbacks = new Set();
+		function createRoot(log) {
+			return {
+				useLog: () => log,
+				on: () => null,
+				listLogs: () => ['local'],
+				purgeLogs: () => ['purged.txnlog'],
+				getUserSharedBuffer(_key, buffer, options) {
+					callbacks.add(options.callback);
+					buffer.notify = () => {
+						for (const callback of callbacks) callback();
+						return true;
+					};
+					buffer.cancel = () => callbacks.delete(options.callback);
+					return buffer;
+				},
+			};
+		}
+		const firstLog = { name: 'local', query: () => null, addEntry: () => null, on: () => null };
+		const secondLog = { name: 'local', query: () => null, addEntry: () => null, on: () => null };
+		const firstStore = new RocksTransactionLogStore(createRoot(firstLog));
+		const secondStore = new RocksTransactionLogStore(createRoot(secondLog));
+		const retainedBuffer = {};
+		secondLog._logBuffers = new Map([[1, new WeakRef(retainedBuffer)]]);
+		secondLog._currentLogBuffer = retainedBuffer;
+
+		firstStore.purgeLogs({ before: Date.now() });
+
+		assert.equal(secondLog._logBuffers.size, 0, 'another worker should clear its mmap cache');
+		assert.equal(secondLog._currentLogBuffer, undefined, 'another worker should clear its current mmap buffer');
+		firstStore.stopPurgeNotifications();
+		secondStore.stopPurgeNotifications();
 	});
 	it('check log after writes and prune', async () => {
 		events = [];
@@ -99,7 +187,7 @@ describe('Audit log', () => {
 			'two-changed',
 			"id 2's final delivered event should be its latest put"
 		);
-		if (AuditedTable.auditStore.reusableIterable) return; // rocksdb doesn't have any audit log cleanup from JS
+		if (AuditedTable.auditStore.reusableIterable) return; // RocksDB purges whole files; the per-entry assertions below are LMDB-only
 		setAuditRetention(0.001, 1);
 		// scheduleAuditCleanup() resolves once the pass serving the call has committed its deletions.
 		// This first one races the put below, so it may or may not see record 3's audit entry.
@@ -998,11 +1086,11 @@ describe('Audit log', () => {
 				addEntry: () => null,
 				on: () => null,
 			};
-			const fakeRoot = {
+			const fakeRoot = withUserSharedBuffer({
 				useLog: () => fakeLog,
 				on: () => null,
 				listLogs: () => [],
-			};
+			});
 			const store = new RocksTransactionLogStore(fakeRoot);
 
 			// Bypass loadLogs(): inject a one-element nodeLogs whose query() yields a
@@ -1052,7 +1140,7 @@ describe('Audit log', () => {
 		// that crashed the worker on every commit after a SIGKILL-induced torn write.
 		it('terminates the failing log iterator instead of propagating a corrupt-entry throw out of the aggregate', () => {
 			const fakeLog = { query: () => null, addEntry: () => null, on: () => null };
-			const fakeRoot = { useLog: () => fakeLog, on: () => null, listLogs: () => [] };
+			const fakeRoot = withUserSharedBuffer({ useLog: () => fakeLog, on: () => null, listLogs: () => [] });
 			const store = new RocksTransactionLogStore(fakeRoot);
 
 			// First log: yields one good entry, then throws (mirrors a torn entry past
@@ -1137,7 +1225,7 @@ describe('Audit log', () => {
 
 	it('addLogToMaps assigns nodeId 0 to the local log and populates nodeLogs[0]', () => {
 		const fakeLog = { query: () => null, addEntry: () => null, on: () => null };
-		const fakeRoot = { useLog: () => fakeLog, on: () => null, listLogs: () => [] };
+		const fakeRoot = withUserSharedBuffer({ useLog: () => fakeLog, on: () => null, listLogs: () => [] });
 		const store = new RocksTransactionLogStore(fakeRoot);
 		store.nodeLogs = [];
 		const nodeId = store.addLogToMaps('local', fakeLog);

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -5,8 +5,12 @@ const auditStoreModule = require('#src/resources/auditStore');
 const { setAuditRetention, readAuditEntry, createAuditEntry, transactionKeyEncoder, removeAuditEntry } =
 	auditStoreModule;
 const { RocksTransactionLogStore } = require('#src/resources/RocksTransactionLogStore');
+const { RocksDatabase } = require('@harperfast/rocksdb-js');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { setTimeout: delay } = require('node:timers/promises');
+const { mkdtempSync, readdirSync, rmSync, utimesSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { basename, join } = require('node:path');
 const { waitFor } = require('../waitFor');
 const harperLogger = require('#src/utility/logging/harper_logger');
 require('#src/server/serverHelpers/serverUtilities');
@@ -130,6 +134,94 @@ describe('Audit log', () => {
 		assert.equal(secondLog._currentLogBuffer, undefined, 'another worker should clear its current mmap buffer');
 		firstStore.stopPurgeNotifications();
 		secondStore.stopPurgeNotifications();
+	});
+	it('keeps mapped bytes readable but silently skips unread purged sequences on POSIX', async function () {
+		// Windows cannot unlink a live mapping; POSIX keeps the mapped sequence readable after unlink.
+		if (process.platform === 'win32') return this.skip();
+		const databasePath = mkdtempSync(join(tmpdir(), 'harper-audit-purge-iterator-'));
+		let database;
+		let auditStore;
+		try {
+			database = RocksDatabase.open(databasePath, {
+				transactionLogMaxSize: 256,
+				transactionLogMaxAgeThreshold: 0,
+			});
+			auditStore = new RocksTransactionLogStore(database);
+			const entryPayload = 'x'.repeat(120);
+			const oldEntryCount = 11;
+			for (let index = 0; index < oldEntryCount; index++) {
+				const value = `${index}:${entryPayload}`;
+				await database.transaction(async (transaction) => {
+					await transaction.put(`key-${index}`, value);
+					transaction.useLog('local').addEntry(Buffer.from(value));
+				});
+			}
+			await database.flush();
+			const oldFiles = readdirSync(auditStore.log.path)
+				.filter((file) => file.endsWith('.txnlog'))
+				.sort((left, right) => Number.parseInt(left) - Number.parseInt(right));
+			assert.deepStrictEqual(
+				oldFiles,
+				Array.from({ length: oldEntryCount }, (_, index) => `${index + 1}.txnlog`),
+				'each old entry must occupy its own rotated sequence'
+			);
+			const retainedValue = `${oldEntryCount}:${entryPayload}`;
+			await database.transaction(async (transaction) => {
+				await transaction.put(`key-${oldEntryCount}`, retainedValue);
+				transaction.useLog('local').addEntry(Buffer.from(retainedValue));
+			});
+			await database.flush();
+			assert.equal(
+				auditStore.log.getStats().fileCount,
+				oldEntryCount + 1,
+				'the retained entry must rotate into a newer sequence'
+			);
+			for (const file of oldFiles) {
+				utimesSync(join(auditStore.log.path, file), new Date(0), new Date(0));
+			}
+			const logStats = auditStore.log.getStats();
+			assert.equal(logStats.replayGapBytes, 0, 'every old sequence must be flushed before purge');
+			assert.equal(logStats.purge.retainedUnflushedFiles, 0, 'no old sequence may be protected by an unflushed write');
+			const purgeBefore = Date.now() - 1_000;
+
+			const iterator = auditStore.log.query({ start: 0 });
+			const first = iterator.next();
+			assert.equal(first.done, false, 'the lagging iterator must map the oldest sequence before purge');
+			const mappedEntry = first.value.data;
+
+			const purged = auditStore.purgeLogs({ before: purgeBefore, includeEntryCounts: true });
+			assert.deepStrictEqual(
+				purged.map(({ path }) => basename(path)).sort((left, right) => Number.parseInt(left) - Number.parseInt(right)),
+				oldFiles,
+				'all old sequences, including unread sequence 2, must be purged'
+			);
+			assert.equal(
+				purged.reduce((entries, file) => entries + file.entries, 0),
+				oldEntryCount,
+				'the purge must remove every old entry'
+			);
+			assert.equal(auditStore.log._logBuffers.size, 0, 'purge must invalidate the real transaction-log mmap cache');
+			assert.equal(mappedEntry.toString(), `0:${entryPayload}`, 'the already-mapped sequence remains readable');
+			assert.deepStrictEqual(
+				iterator.next(),
+				{ value: undefined, done: true },
+				'the lagging iterator silently ends when the next sequence has been purged'
+			);
+
+			const freshEntries = Array.from(auditStore.log.query({ start: 0 }), ({ data }) => data.toString());
+			assert.deepStrictEqual(
+				freshEntries,
+				[retainedValue],
+				'a fresh iterator must prove the retained entry still exists after the lagging iterator ended'
+			);
+		} finally {
+			auditStore?.stopPurgeNotifications();
+			try {
+				database?.close();
+			} finally {
+				rmSync(databasePath, { recursive: true, force: true });
+			}
+		}
 	});
 	it('check log after writes and prune', async () => {
 		events = [];

--- a/unitTests/resources/transactionLogStructureUpdate.test.js
+++ b/unitTests/resources/transactionLogStructureUpdate.test.js
@@ -17,7 +17,17 @@ function makeLog() {
 // nodeLogs is indexed by nodeId; logById() reads it directly, so we can drive put() against
 // distinct per-node logs without a real RocksDB.
 function makeStore(logs) {
-	const store = new RocksTransactionLogStore({ useLog: () => makeLog() });
+	const store = new RocksTransactionLogStore({
+		useLog: () => makeLog(),
+		getUserSharedBuffer(_key, buffer, options) {
+			buffer.notify = () => {
+				options.callback();
+				return true;
+			};
+			buffer.cancel = () => {};
+			return buffer;
+		},
+	});
 	store.nodeLogs = logs;
 	return store;
 }


### PR DESCRIPTION
Fixes #2140 by [continuously re-arming RocksDB audit-retention cleanup](https://github.com/HarperFast/harper/pull/2356/changes?w=1#diff-db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356baR214), [routing purges through local and sibling-worker cache invalidation](https://github.com/HarperFast/harper/pull/2356/changes?w=1#diff-56c43863dc5f281e19328e36b0082523391cfb5373c0bd88a8d3d94bfa1ab46cR498), and [stopping cleanup when a database closes](https://github.com/HarperFast/harper/pull/2356/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1180).

This is ready for review with a known reliability gap that requires an explicit decision before merge: a live reusable replication or subscription iterator may be permanently retired if retention purges a sequence it has not reached. Continuous cleanup makes that pre-existing edge substantially more likely, and the intended lagging-consumer recovery contract needs an explicit decision before merge. The Windows mapping/deletion order and process-wide completion semantics also need focused review.

## For the human reviewer

1. Decide whether mmap coherence belongs in Harper through the current rocksdb-js private cache fields, or in a public engine-owned purge/invalidation API. This has cross-platform implications, including whether Windows can delete mapped files before invalidation runs.
2. Decide the lagging-consumer policy: block retention for active iterators, or terminate lagging consumers with an explicit checkpoint/full-copy recovery signal. A real POSIX RocksDB characterization now confirms that the mapped sequence remains readable after unlink, but the lagging iterator silently ends when it advances to an unread purged sequence; a fresh iterator can still read the retained newer entry.
3. Confirm the passive purge cadence of `max(10 seconds, retention / 10)` versus tying cleanup to transaction-log rotation or flush events.
4. Define whether purge completion means local file deletion or process-wide cache visibility. The current sibling-worker notification is asynchronous.
5. Confirm cleanup lifecycle ownership: explicit calls from each database close/drop path versus audit/root-store close owning teardown.
6. Confirm whether the POSIX iterator characterization plus the [two native `purgeRuns` increments](https://github.com/HarperFast/harper/pull/2356/changes?w=1#diff-15a71cb8fd6cbba0c23096e17c53bce57fb884df40ef082c2f46d4d4a7bcb921R73) are sufficient regression evidence, or whether the integration test should also rotate aged files and prove deletion plus multi-worker read visibility.

## Verification

- `npm exec mocha -- unitTests/resources/auditLog.test.js --grep "silently skips unread purged sequences"` — passed in 10/10 repeated runs.
- `npm exec mocha -- unitTests/resources/auditLog.test.js` — 29 passing, 6 pending.
- `npx prettier --check unitTests/resources/auditLog.test.js`, file-scoped oxlint, and `git diff --check` — passed.
- `npm run build` — passed.
- `npm run lint:required` — passed.
- `npx mocha unitTests/resources/auditLog.test.js unitTests/resources/auditPurge.test.js unitTests/resources/transactionLogStructureUpdate.test.js` — 35 passing, 6 pending.
- `npm run test:integration -- --isolation=none "integrationTests/database/audit-retention-rocks.test.ts"` — 1 passing in about 25 seconds.
- `npm run test:unit:main` — the local run was terminated after entering a non-terminating TLS retry loop against deleted test certificates; no assertion failure was reported before termination. CI is authoritative for the full gate.
- `git diff --check` — passed.
- No user-facing documentation or dependency changes.

Complexity: complicated

<sub>Review-Coverage: authored=codex; ran=cursor-grok; adjudicated=domain; blocked=claude(not-installed),gemini(exit-1); declined=cursor-composer; rounds=7 @ 91629e174b4d</sub>

<sub>Human-Review-Need: 4 (decisions: invalidation-owner, cleanup-cadence, shutdown-contract) @ 91629e174b4d</sub>
