### PR TITLE
ci: exclude ready_for_review from the always-on cancelling arm

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,7 +29,7 @@ concurrency:
   # Ineligible events (per the review job's opt-in gate) get a unique
   # run_id group so they can never cancel an in-flight eligible review —
   # workflow-level cancel-in-progress fires before job `if:` is evaluated.
-  group: claude-review-${{ github.event.pull_request.number }}-${{ ((github.event.action == 'labeled' && github.event.label.name == 'claude-review') || (github.event.action != 'labeled' && vars.CLAUDE_ALWAYS_ON == 'true')) && 'eligible' || github.run_id }}
+  group: claude-review-${{ github.event.pull_request.number }}-${{ ((github.event.action == 'labeled' && github.event.label.name == 'claude-review') || (github.event.action != 'labeled' && github.event.action != 'ready_for_review' && vars.CLAUDE_ALWAYS_ON == 'true')) && 'eligible' || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -45,7 +45,7 @@ concurrency:
   # authorization is author-based, so on a bot-authored PR they could
   # kill a labeler-authorized run and then be rejected themselves.
   # Ineligible events get a unique run_id group — see claude-review.yml.
-  group: gemini-review-${{ github.event.pull_request.number }}-${{ ((github.event.action == 'labeled' && github.event.label.name == 'gemini-review') || (github.event.action != 'labeled' && vars.GEMINI_ALWAYS_ON == 'true')) && 'eligible' || github.run_id }}
+  group: gemini-review-${{ github.event.pull_request.number }}-${{ ((github.event.action == 'labeled' && github.event.label.name == 'gemini-review') || (github.event.action != 'labeled' && github.event.action != 'ready_for_review' && vars.GEMINI_ALWAYS_ON == 'true')) && 'eligible' || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Corrective follow-up to #2353, from the Codex pass: `ready_for_review` is a non-labeled event, so the `ALWAYS_ON` arm of the concurrency predicate still placed it in the shared cancelling group in always-on mode — a label-opted bot PR's ready-flip could cancel the labeler's in-flight review and then fail author-based authorization. The cancelling set now excludes `ready_for_review` in **both** modes; the job gates are unchanged (ready-flips run review, in their own `run_id` group, so they run but never cancel).

Propagation: #2354 (v5.1) carries this; a v5.2 sync PR follows this merge; harper-pro #766/#767/#768 updated. An event-matrix regression check (ready_for_review + ALWAYS_ON ⇒ runs-but-does-not-cancel) lands in ai-review-prompts alongside the examples.

**Merge order**: this, then #2354 and the v5.2 sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S94XethbGXpAb4DRKMD4kt