### PR TITLE
ci: harden the Windows unit-test gate's glob, summary check, and timeout guard

### DIFF
--- a/unitTests/buildTools/windowsGate.test.mjs
+++ b/unitTests/buildTools/windowsGate.test.mjs
@@ -1,8 +1,8 @@
-// Covers unitTests/windowsGateChecks.mjs, the two calculations that decide whether the
-// Windows gate calls a group green. Both have a failure mode that reports a *pass*: a
-// summary check loose enough to accept a line a test printed itself, and a timeout the
-// runtime clamps to 1ms so every group is SIGKILLed before it runs anything. Each case
-// below fails against the version of that calculation this suite replaced.
+// Covers unitTests/windowsGateChecks.mjs. Each case below fails against the calculation it
+// replaced: the summary regex was unanchored and first-match, so a "N passing" line a test
+// printed itself made a group that never reported an epilogue green; and the timeout
+// override was unguarded, so an empty, unparseable, negative or sub-millisecond value
+// became setTimeout's 1ms clamp and SIGKILLed every group at spawn.
 import assert from 'node:assert';
 import { parsePassing, resolveTimeout } from '../windowsGateChecks.mjs';
 

--- a/unitTests/buildTools/windowsGate.test.mjs
+++ b/unitTests/buildTools/windowsGate.test.mjs
@@ -1,8 +1,8 @@
-// Covers unitTests/windowsGateChecks.mjs. Each case below fails against the calculation it
-// replaced: the summary regex was unanchored and first-match, so a "N passing" line a test
-// printed itself made a group that never reported an epilogue green; and the timeout
-// override was unguarded, so an empty, unparseable, negative or sub-millisecond value
-// became setTimeout's 1ms clamp and SIGKILLed every group at spawn.
+// Covers unitTests/windowsGateChecks.mjs. Most of these cases fail against the calculations
+// they replaced: the summary regex was unanchored and first-match, so a "N passing" line a
+// test printed itself made a group that never reported an epilogue green; and the timeout
+// override was unguarded, so an empty, unparseable, negative or sub-millisecond value became
+// setTimeout's 1ms clamp and SIGKILLed every group at spawn.
 import assert from 'node:assert';
 import { parsePassing, resolveTimeout } from '../windowsGateChecks.mjs';
 

--- a/unitTests/buildTools/windowsGate.test.mjs
+++ b/unitTests/buildTools/windowsGate.test.mjs
@@ -1,0 +1,63 @@
+// Covers unitTests/windowsGateChecks.mjs, the two calculations that decide whether the
+// Windows gate calls a group green. Both have a failure mode that reports a *pass*: a
+// summary check loose enough to accept a line a test printed itself, and a timeout the
+// runtime clamps to 1ms so every group is SIGKILLed before it runs anything. Each case
+// below fails against the version of that calculation this suite replaced.
+import assert from 'node:assert';
+import { parsePassing, resolveTimeout } from '../windowsGateChecks.mjs';
+
+const DEFAULT_MS = 600_000;
+const MAX_MS = 2_147_483_647;
+
+describe('Windows gate summary parsing', function () {
+	it('reads the count off a dot-reporter epilogue', function () {
+		assert.strictEqual(parsePassing('..........\n\n  13 passing (2s)\n'), '13');
+	});
+
+	it('takes the epilogue, not an earlier line a test printed itself', function () {
+		const output = '  0 passing is what a broken run reports\n..\n\n  13 passing (2s)\n';
+		assert.strictEqual(parsePassing(output), '13');
+	});
+
+	it('rejects a summary-shaped fragment mid-line', function () {
+		assert.strictEqual(parsePassing('checked that 7 passing rows survived the restart\n'), undefined);
+	});
+
+	it('rejects a coloured epilogue, which is why the gate runs mocha with --no-color', function () {
+		assert.strictEqual(parsePassing('\u001b[92m \u001b[0m\u001b[32m 13 passing\u001b[0m (2s)\n'), undefined);
+	});
+
+	it('reports no summary for a group that died before printing one', function () {
+		assert.strictEqual(parsePassing(''), undefined);
+		assert.strictEqual(parsePassing('..........\nSegmentation fault\n'), undefined);
+	});
+});
+
+describe('Windows gate timeout resolution', function () {
+	const cases = [
+		[undefined, DEFAULT_MS, 'unset'],
+		['', DEFAULT_MS, 'empty'],
+		['abc', DEFAULT_MS, 'unparseable'],
+		['-5', DEFAULT_MS, 'negative'],
+		['0', DEFAULT_MS, 'zero'],
+		['0.5', DEFAULT_MS, 'sub-millisecond'],
+		['0.9999', DEFAULT_MS, 'just under a millisecond'],
+		['9999999999', MAX_MS, 'past the 32-bit ceiling'],
+		['Infinity', MAX_MS, 'infinite'],
+		['5000', 5000, 'a plain override'],
+		['5000.7', 5000, 'a fractional override'],
+	];
+
+	for (const [envValue, expected, description] of cases) {
+		it(`resolves ${description} (${JSON.stringify(envValue)}) to ${expected}ms`, function () {
+			assert.strictEqual(resolveTimeout(envValue), expected);
+		});
+	}
+
+	it('never yields a value setTimeout would clamp to 1ms', function () {
+		for (const [envValue] of cases) {
+			const ms = resolveTimeout(envValue);
+			assert.ok(Number.isInteger(ms) && ms >= 1 && ms <= MAX_MS, `${JSON.stringify(envValue)} resolved to ${ms}`);
+		}
+	});
+});

--- a/unitTests/windowsGate.mjs
+++ b/unitTests/windowsGate.mjs
@@ -106,14 +106,17 @@ const EXCLUDED = [
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const MOCHA = join(repoRoot, 'node_modules', 'mocha', 'bin', 'mocha.js');
-const SUMMARY = /\b(\d+) passing\b/;
+// Line-anchored and last-match: mocha's epilogue is the final such line, so a test that logs
+// one of its own cannot stand in for it on a group that terminated before printing one.
+const SUMMARY = /^\s*(\d+) passing\b/gm;
 const GROUP_TIMEOUT_MS = Number(process.env.HARPER_WINDOWS_GATE_GROUP_TIMEOUT_MS ?? 600_000);
 
 // No --config: mocha discovers .mocharc.json itself, so the gate inherits the same
 // root config (and unitTests/mocha.init.js) as every other unit-test run.
 function runGroup(pattern) {
 	return new Promise((settle) => {
-		const args = [MOCHA, '--reporter', 'dot', pattern];
+		// --no-color: SUMMARY anchors on the line start, which an ANSI-prefixed epilogue defeats.
+		const args = [MOCHA, '--reporter', 'dot', '--no-color', pattern];
 		for (const excluded of EXCLUDED) args.push('--exclude', excluded);
 
 		const startedAt = Date.now();
@@ -140,7 +143,7 @@ function runGroup(pattern) {
 			// here on would interleave through later groups and through the summary table.
 			child.stdout?.destroy();
 			child.stderr?.destroy();
-			const passing = SUMMARY.exec(output)?.[1];
+			const passing = [...output.matchAll(SUMMARY)].at(-1)?.[1];
 			if (!reason) {
 				if (timedOut) reason = `timed out after ${GROUP_TIMEOUT_MS}ms`;
 				else if (passing === undefined) reason = `exited ${code} without reporting a summary`;

--- a/unitTests/windowsGate.mjs
+++ b/unitTests/windowsGate.mjs
@@ -38,6 +38,7 @@
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
+import { parsePassing, resolveTimeout } from './windowsGateChecks.mjs';
 
 // Same filename shape `test:unit:main` collects (package.json), so a `.test.mjs` suite under
 // one of these directories is not silently skipped.
@@ -105,13 +106,7 @@ const EXCLUDED = [
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const MOCHA = join(repoRoot, 'node_modules', 'mocha', 'bin', 'mocha.js');
-// Anchored and last-match, so a test logging its own "N passing" line cannot stand in for
-// the epilogue on a group that terminated before printing one.
-const SUMMARY = /^\s*(\d+) passing\b/gm;
-// setTimeout clamps anything outside 1..2^31-1 to 1ms, so an unguarded override that is empty,
-// unparseable, negative, sub-millisecond, or huge would SIGKILL every group at spawn.
-const overrideTimeoutMs = Number(process.env.HARPER_WINDOWS_GATE_GROUP_TIMEOUT_MS);
-const GROUP_TIMEOUT_MS = overrideTimeoutMs >= 1 ? Math.min(Math.trunc(overrideTimeoutMs), 2_147_483_647) : 600_000;
+const GROUP_TIMEOUT_MS = resolveTimeout(process.env.HARPER_WINDOWS_GATE_GROUP_TIMEOUT_MS);
 
 // No --config: mocha discovers .mocharc.json itself, so the gate inherits the same
 // root config (and unitTests/mocha.init.js) as every other unit-test run.
@@ -145,7 +140,7 @@ function runGroup(pattern) {
 			// here on would interleave through later groups and through the summary table.
 			child.stdout?.destroy();
 			child.stderr?.destroy();
-			const passing = [...output.matchAll(SUMMARY)].at(-1)?.[1];
+			const passing = parsePassing(output);
 			if (!reason) {
 				if (timedOut) reason = `timed out after ${GROUP_TIMEOUT_MS}ms`;
 				else if (passing === undefined) reason = `exited ${code} without reporting a summary`;

--- a/unitTests/windowsGate.mjs
+++ b/unitTests/windowsGate.mjs
@@ -39,9 +39,8 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 
-// One mocha process per entry. Whole directories, so new suites are picked up, and the same
-// filename shape `test:unit:main` collects, so a `.test.mjs` suite cannot run on Ubuntu while
-// this gate reports its group green having never opened the file.
+// Same filename shape `test:unit:main` collects (package.json), so a `.test.mjs` suite under
+// one of these directories is not silently skipped.
 const GROUPS = [
 	'unitTests/agent/**/*test.*js',
 	'unitTests/buildTools/**/*test.*js',
@@ -106,19 +105,20 @@ const EXCLUDED = [
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const MOCHA = join(repoRoot, 'node_modules', 'mocha', 'bin', 'mocha.js');
-// Line-anchored and last-match: mocha's epilogue is the final such line, so a test that logs
-// one of its own cannot stand in for it on a group that terminated before printing one.
+// Anchored and last-match, so a test logging its own "N passing" line cannot stand in for
+// the epilogue on a group that terminated before printing one.
 const SUMMARY = /^\s*(\d+) passing\b/gm;
-// setTimeout holds its delay in a 32-bit int and clamps anything outside 1..2^31-1 to 1ms, so
-// an override that is empty, unparseable, negative, or huge would SIGKILL every group at spawn.
+// setTimeout clamps anything outside 1..2^31-1 to 1ms, so an unguarded override that is empty,
+// unparseable, negative, sub-millisecond, or huge would SIGKILL every group at spawn.
 const overrideTimeoutMs = Number(process.env.HARPER_WINDOWS_GATE_GROUP_TIMEOUT_MS);
-const GROUP_TIMEOUT_MS = overrideTimeoutMs > 0 ? Math.min(overrideTimeoutMs, 2_147_483_647) : 600_000;
+const GROUP_TIMEOUT_MS =
+	overrideTimeoutMs >= 1 ? Math.min(Math.trunc(overrideTimeoutMs), 2_147_483_647) : 600_000;
 
 // No --config: mocha discovers .mocharc.json itself, so the gate inherits the same
 // root config (and unitTests/mocha.init.js) as every other unit-test run.
 function runGroup(pattern) {
 	return new Promise((settle) => {
-		// --no-color: SUMMARY anchors on the line start, which an ANSI-prefixed epilogue defeats.
+		// --no-color: an ANSI-prefixed epilogue would defeat SUMMARY's line anchor.
 		const args = [MOCHA, '--reporter', 'dot', '--no-color', pattern];
 		for (const excluded of EXCLUDED) args.push('--exclude', excluded);
 

--- a/unitTests/windowsGate.mjs
+++ b/unitTests/windowsGate.mjs
@@ -39,16 +39,18 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 
-/** One mocha process per entry. Whole directories, so new suites are picked up. */
+// One mocha process per entry. Whole directories, so new suites are picked up, and the same
+// filename shape `test:unit:main` collects, so a `.test.mjs` suite cannot run on Ubuntu while
+// this gate reports its group green having never opened the file.
 const GROUPS = [
-	'unitTests/agent/**/*.test.js',
-	'unitTests/buildTools/**/*.test.js',
-	'unitTests/components/**/*.test.js',
-	'unitTests/config/**/*.test.js',
-	'unitTests/server/**/*.test.js',
-	'unitTests/sqlEngine/**/*.test.js',
-	'unitTests/utility/**/*.test.js',
-	'unitTests/validation/**/*.test.js',
+	'unitTests/agent/**/*test.*js',
+	'unitTests/buildTools/**/*test.*js',
+	'unitTests/components/**/*test.*js',
+	'unitTests/config/**/*test.*js',
+	'unitTests/server/**/*test.*js',
+	'unitTests/sqlEngine/**/*test.*js',
+	'unitTests/utility/**/*test.*js',
+	'unitTests/validation/**/*test.*js',
 	// Individually verified files from directories not yet covered wholesale.
 	'unitTests/resources/blob.test.js',
 ];

--- a/unitTests/windowsGate.mjs
+++ b/unitTests/windowsGate.mjs
@@ -109,7 +109,10 @@ const MOCHA = join(repoRoot, 'node_modules', 'mocha', 'bin', 'mocha.js');
 // Line-anchored and last-match: mocha's epilogue is the final such line, so a test that logs
 // one of its own cannot stand in for it on a group that terminated before printing one.
 const SUMMARY = /^\s*(\d+) passing\b/gm;
-const GROUP_TIMEOUT_MS = Number(process.env.HARPER_WINDOWS_GATE_GROUP_TIMEOUT_MS ?? 600_000);
+// setTimeout holds its delay in a 32-bit int and clamps anything outside 1..2^31-1 to 1ms, so
+// an override that is empty, unparseable, negative, or huge would SIGKILL every group at spawn.
+const overrideTimeoutMs = Number(process.env.HARPER_WINDOWS_GATE_GROUP_TIMEOUT_MS);
+const GROUP_TIMEOUT_MS = overrideTimeoutMs > 0 ? Math.min(overrideTimeoutMs, 2_147_483_647) : 600_000;
 
 // No --config: mocha discovers .mocharc.json itself, so the gate inherits the same
 // root config (and unitTests/mocha.init.js) as every other unit-test run.

--- a/unitTests/windowsGate.mjs
+++ b/unitTests/windowsGate.mjs
@@ -112,7 +112,7 @@ const GROUP_TIMEOUT_MS = resolveTimeout(process.env.HARPER_WINDOWS_GATE_GROUP_TI
 // root config (and unitTests/mocha.init.js) as every other unit-test run.
 function runGroup(pattern) {
 	return new Promise((settle) => {
-		// --no-color: an ANSI-prefixed epilogue would defeat SUMMARY's line anchor.
+		// --no-color: an ANSI-prefixed epilogue would defeat parsePassing()'s line anchor.
 		const args = [MOCHA, '--reporter', 'dot', '--no-color', pattern];
 		for (const excluded of EXCLUDED) args.push('--exclude', excluded);
 

--- a/unitTests/windowsGate.mjs
+++ b/unitTests/windowsGate.mjs
@@ -111,8 +111,7 @@ const SUMMARY = /^\s*(\d+) passing\b/gm;
 // setTimeout clamps anything outside 1..2^31-1 to 1ms, so an unguarded override that is empty,
 // unparseable, negative, sub-millisecond, or huge would SIGKILL every group at spawn.
 const overrideTimeoutMs = Number(process.env.HARPER_WINDOWS_GATE_GROUP_TIMEOUT_MS);
-const GROUP_TIMEOUT_MS =
-	overrideTimeoutMs >= 1 ? Math.min(Math.trunc(overrideTimeoutMs), 2_147_483_647) : 600_000;
+const GROUP_TIMEOUT_MS = overrideTimeoutMs >= 1 ? Math.min(Math.trunc(overrideTimeoutMs), 2_147_483_647) : 600_000;
 
 // No --config: mocha discovers .mocharc.json itself, so the gate inherits the same
 // root config (and unitTests/mocha.init.js) as every other unit-test run.

--- a/unitTests/windowsGateChecks.mjs
+++ b/unitTests/windowsGateChecks.mjs
@@ -1,8 +1,8 @@
 // Split out of unitTests/windowsGate.mjs, which runs the gate on import and so cannot be
 // loaded by a test.
 
-// Anchored and last-match, so a line a test printed itself cannot stand in for the epilogue
-// of a group that terminated before printing one. The anchor holds only against uncoloured
+// Anchored and last-match, so an inline mention of "N passing" does not count and a real
+// epilogue always wins over an earlier line. The anchor holds only against uncoloured
 // output, which is why the gate runs mocha with --no-color.
 const SUMMARY = /^\s*(\d+) passing\b/gm;
 

--- a/unitTests/windowsGateChecks.mjs
+++ b/unitTests/windowsGateChecks.mjs
@@ -1,13 +1,9 @@
-/*
- * The two pure decisions the Windows gate makes about a finished group, kept out of
- * unitTests/windowsGate.mjs because that file runs the whole gate on import and so cannot
- * be loaded by a test. Both encode a failure mode that reads as a green gate, which is why
- * they are worth locking: see unitTests/buildTools/windowsGate.test.mjs.
- */
+// Split out of unitTests/windowsGate.mjs, which runs the gate on import and so cannot be
+// loaded by a test.
 
-// Anchored and last-match, so a test logging its own "N passing" line cannot stand in for
-// the epilogue on a group that terminated before printing one. The anchor only holds
-// against uncoloured output, which is why the gate runs mocha with --no-color.
+// Anchored and last-match, so a line a test printed itself cannot stand in for the epilogue
+// of a group that terminated before printing one. The anchor holds only against uncoloured
+// output, which is why the gate runs mocha with --no-color.
 const SUMMARY = /^\s*(\d+) passing\b/gm;
 
 const DEFAULT_GROUP_TIMEOUT_MS = 600_000;
@@ -15,12 +11,10 @@ const DEFAULT_GROUP_TIMEOUT_MS = 600_000;
 // unparseable, negative, sub-millisecond, or huge would SIGKILL every group at spawn.
 const MAX_TIMEOUT_MS = 2_147_483_647;
 
-/** The last line-anchored mocha epilogue count in `output`, or undefined if it printed none. */
 export function parsePassing(output) {
 	return [...output.matchAll(SUMMARY)].at(-1)?.[1];
 }
 
-/** A raw HARPER_WINDOWS_GATE_GROUP_TIMEOUT_MS value as an integer setTimeout will not clamp. */
 export function resolveTimeout(envValue) {
 	const overrideMs = Number(envValue);
 	return overrideMs >= 1 ? Math.min(Math.trunc(overrideMs), MAX_TIMEOUT_MS) : DEFAULT_GROUP_TIMEOUT_MS;

--- a/unitTests/windowsGateChecks.mjs
+++ b/unitTests/windowsGateChecks.mjs
@@ -1,0 +1,27 @@
+/*
+ * The two pure decisions the Windows gate makes about a finished group, kept out of
+ * unitTests/windowsGate.mjs because that file runs the whole gate on import and so cannot
+ * be loaded by a test. Both encode a failure mode that reads as a green gate, which is why
+ * they are worth locking: see unitTests/buildTools/windowsGate.test.mjs.
+ */
+
+// Anchored and last-match, so a test logging its own "N passing" line cannot stand in for
+// the epilogue on a group that terminated before printing one. The anchor only holds
+// against uncoloured output, which is why the gate runs mocha with --no-color.
+const SUMMARY = /^\s*(\d+) passing\b/gm;
+
+const DEFAULT_GROUP_TIMEOUT_MS = 600_000;
+// setTimeout clamps anything outside 1..2^31-1 to 1ms, so an unguarded override that is empty,
+// unparseable, negative, sub-millisecond, or huge would SIGKILL every group at spawn.
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
+/** The last line-anchored mocha epilogue count in `output`, or undefined if it printed none. */
+export function parsePassing(output) {
+	return [...output.matchAll(SUMMARY)].at(-1)?.[1];
+}
+
+/** A raw HARPER_WINDOWS_GATE_GROUP_TIMEOUT_MS value as an integer setTimeout will not clamp. */
+export function resolveTimeout(envValue) {
+	const overrideMs = Number(envValue);
+	return overrideMs >= 1 ? Math.min(Math.trunc(overrideMs), MAX_TIMEOUT_MS) : DEFAULT_GROUP_TIMEOUT_MS;
+}


### PR DESCRIPTION
## Why this changed shape

This PR originally added Windows unit-level CI coverage from scratch (`unit-test-windows` job + `unitTests/windowsGate.mjs`) across 9 commits. While it sat unreviewed, [#2367](https://github.com/HarperFast/harper/pull/2367) — an independently-evolved sibling with the same starting commit — merged to `main` and shipped that same feature: the `unit-test-windows` job, `windowsGate.mjs`, and the fixture-based approach that makes `harper_logger`/`logRotator`/`globalIsolation`/`terminalShutdown` not need an installed Harper (now an explicit `AGENTS.md` invariant: "No ambient Harper install").

Rebasing onto `main` therefore isn't a textual conflict, it's two implementations of the same script. This PR is now just the residual: **3 fixes this branch had that #2367's independent implementation doesn't**, re-applied on top of `main`'s merged version, plus regression coverage for the two of them that are calculations. Everything else from the original stack — the `Setup Harper` CI step, `resolveHarperConfig`, the orphaned-descendant/`exitCode` handling — is dropped, either superseded by #2367's fixture approach or independently reinvented there.

## What's in this diff

The three fixes, on top of `main`'s merged gate:

- [`GROUPS`](https://github.com/HarperFast/harper/pull/2361/changes?w=1#diff-fc246680a36d8be12666c7cbd9aa797681fe0925748e86ced7b9d304d1734fa8R45) globs `**/*test.*js` — the same shape `test:unit:main` collects (`package.json:72`) — not `**/*.test.js`, so a `.test.mjs` suite under a covered directory can't run on Ubuntu while this gate reports its group green having never opened the file.
- [The summary regex](https://github.com/HarperFast/harper/pull/2361/changes?w=1#diff-0ba32aec377e957127ac9ac517bd4518359a15b1dbf1bf7638562d040b366b7fR7) is line-anchored and takes the **last** match instead of `main`'s unanchored first match, and mocha runs [`--no-color`](https://github.com/HarperFast/harper/pull/2361/changes?w=1#diff-fc246680a36d8be12666c7cbd9aa797681fe0925748e86ced7b9d304d1734fa8R116) so an ANSI-prefixed epilogue can't defeat the anchor. Unanchored/first-match, any log line containing `"N passing"` satisfies the check.
- [The group-timeout override](https://github.com/HarperFast/harper/pull/2361/changes?w=1#diff-0ba32aec377e957127ac9ac517bd4518359a15b1dbf1bf7638562d040b366b7fR18) is guarded and capped at 2^31-1 — `main`'s `Number(env ?? 600_000)` still lets an empty, unparseable, negative, sub-millisecond, or oversized override reach `setTimeout`'s 1ms clamp, SIGKILLing every group before it runs a test.

The last two are now covered, per review feedback. Both are pure calculations, but they lived inside a script that runs the whole gate on import, so a test could not load them; they moved to [`unitTests/windowsGateChecks.mjs`](https://github.com/HarperFast/harper/pull/2361/changes?w=1#diff-0ba32aec377e957127ac9ac517bd4518359a15b1dbf1bf7638562d040b366b7fR14) as `parsePassing()` / `resolveTimeout()`, which the gate calls at [`runGroup`'s settle](https://github.com/HarperFast/harper/pull/2361/changes?w=1#diff-fc246680a36d8be12666c7cbd9aa797681fe0925748e86ced7b9d304d1734fa8R143) and at [module load](https://github.com/HarperFast/harper/pull/2361/changes?w=1#diff-fc246680a36d8be12666c7cbd9aa797681fe0925748e86ced7b9d304d1734fa8R109). [`unitTests/buildTools/windowsGate.test.mjs`](https://github.com/HarperFast/harper/pull/2361/changes?w=1#diff-402a12fee2a2c6daaa648a80e27c67b55ac6dffcbd11c5109257c6e76a26f283R12) runs the old-failing matrix — 13 of its 17 cases fail against the calculations they replaced. It is deliberately a `.test.mjs` file under a `GROUPS` directory, so the first fix above is what makes the Windows gate execute it at all.

`main`'s gate already has the spawn `'error'` listener, the orphaned-descendant grace settle, and `process.exitCode` (not `exit()`) — those 3 items from the original stack are already covered independently and don't need re-applying.

## For the human reviewer

**Planning-review framing verdict did not clear.** Adding this coverage was reviewed in planning mode and came back `better-alternative-exists`: pure-helper tests stay green if `runGroup()` later stops calling the helpers correctly, so the reviewer wanted `runGroup()` parameterized with fake-mocha fixtures covering argv, the output sink, the summary/exit-reason ladder, and timeout wiring end to end. That was escalated rather than decided here, and the call was to keep this PR scoped to the two helpers the review thread actually asked for; the end-to-end gate harness is separate work if that broader invariant is wanted. The helpers' call sites were instead verified by hand — see Verification.

Two items from earlier pre-push rounds, still open and deliberately not fixed here:

- **`unitTests/build-tools/` (hyphenated) is invisible to this gate.** `GROUPS` lists `unitTests/buildTools/` (camelCase) — pre-existing, from `main`'s implementation, untouched by this PR — but two `.test.mjs` suites (`checkShrinkwrapPins.test.mjs`, `pruneShrinkwrapDev.test.mjs`) live in the hyphenated directory. They run on Ubuntu via `package.json:72` and this gate never opens that directory, so a Windows regression in shrinkwrap-pin enforcement would ship with `unit-test-windows` green. They look platform-independent, but "looks fine on Windows" is exactly what the original `Setup Harper` gap looked like too — I don't have Windows access from this checkout to verify before widening `GROUPS`.
- **The anchored/last-match summary check narrows epilogue-spoofing, it doesn't close it.** A group that prints a line-anchored `N passing` and then exits 0 without ever printing a real epilogue is still recorded `ok` — the third test case in the new suite pins what is and isn't rejected. `unitTests/mocha.init.js`'s exit-code guard closes the common case (run started, never finished); the residual needs exiting 0 before the root `beforeAll`, with a summary-shaped line already in the buffer. Strictly better than pre-change, not airtight — the underlying design parses mocha's human-facing output as an oracle rather than a machine-readable artifact (`--reporter json`), which is `main`'s design choice, not this PR's.

The final review round also asked to delete the test file's header comment as narration. Kept: it records which failure mode each block of cases exists to lock, which the test names alone don't say.

## Verification

- `npm run test:unit:main` (canonical unit gate): 5174 passing, 195 pending, 2 failing — `tokenAuthentication.test.js` and `configValidator.test.js`, both of which fail identically when run alone without any file from this PR loaded (the configValidator one is this worktree's 183-byte path exceeding the 107-byte UDS limit).
- `npx mocha "unitTests/buildTools/**/*test.*js"`: 30 passing (13 pre-existing + 17 new).
- **Fails-on-base:** the new suite run against `main`'s `SUMMARY.exec(output)?.[1]` and `Number(env ?? 600_000)` gives 13 failing / 4 passing, so both regressions are actually locked rather than merely covered.
- **Helper call sites, end to end:** ran the real gate over the `unitTests/buildTools` group — clean run reports `ok 30 passing`; `HARPER_WINDOWS_GATE_GROUP_TIMEOUT_MS=0.5` still runs to completion (no 1ms collapse); `=1` reports `FAIL … timed out after 1ms`, so the override is honored rather than ignored.
- `npm run build` is clean, as are `npm run format:write` and `npm run lint:required`.
- Independent pre-push review: 3 further rounds on this change (delta each; the third confirmed both corrections landed). Gemini's leg could not run — local auth — so codex is the only outside lens on these commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus)

<sub>Review-Coverage: authored=claude; ran=codex; blocked=gemini(auth); declined=cursor-grok,cursor-composer,domain; rounds=13 @ 2963c0103339</sub>

<sub>Human-Review-Need: 3 @ 2963c0103339</sub>
