### PR TITLE
Schedule the self-hosted bench nightlies to finish before working hours

### DIFF
--- a/.github/workflows/large-deploy-test.yml
+++ b/.github/workflows/large-deploy-test.yml
@@ -13,7 +13,7 @@ name: Large Deploy Payload Test (self-hosted)
 
 on:
   schedule:
-    - cron: '20 9 * * 1' # weekly, Monday — last harper-bench slot, after the nightly sequence
+    - cron: '20 9 * * 1' # weekly, Monday; :20 avoids GitHub's scheduler backlog, slot order in the harper-pro runner README
   workflow_dispatch:
     inputs:
       size-mb:

--- a/.github/workflows/large-deploy-test.yml
+++ b/.github/workflows/large-deploy-test.yml
@@ -13,7 +13,7 @@ name: Large Deploy Payload Test (self-hosted)
 
 on:
   schedule:
-    - cron: '30 9 * * 1' # weekly, Monday — offset from the nightly perf/ycsb jobs
+    - cron: '20 9 * * 1' # 03:20 MDT Monday, after the nightly harper-bench chain
   workflow_dispatch:
     inputs:
       size-mb:

--- a/.github/workflows/large-deploy-test.yml
+++ b/.github/workflows/large-deploy-test.yml
@@ -13,7 +13,7 @@ name: Large Deploy Payload Test (self-hosted)
 
 on:
   schedule:
-    - cron: '20 9 * * 1' # 03:20 MDT Monday, after the nightly harper-bench chain
+    - cron: '20 9 * * 1' # weekly, Monday — last harper-bench slot, after the nightly sequence
   workflow_dispatch:
     inputs:
       size-mb:

--- a/.github/workflows/perf-benchmarks-nightly.yml
+++ b/.github/workflows/perf-benchmarks-nightly.yml
@@ -26,7 +26,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '20 8 * * *' # 02:20 MDT, last in the serialized harper-bench chain
+    - cron: '20 8 * * *' # third harper-bench slot (sequence map: harper-pro benchmarks/ycsb/runner/README.md)
   workflow_dispatch:
     inputs:
       scale:

--- a/.github/workflows/perf-benchmarks-nightly.yml
+++ b/.github/workflows/perf-benchmarks-nightly.yml
@@ -26,7 +26,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '20 8 * * *' # third harper-bench slot (sequence map: harper-pro benchmarks/ycsb/runner/README.md)
+    - cron: '20 8 * * *' # :20 avoids GitHub's scheduler backlog; slot order in harper-pro benchmarks/ycsb/runner/README.md
   workflow_dispatch:
     inputs:
       scale:

--- a/.github/workflows/perf-benchmarks-nightly.yml
+++ b/.github/workflows/perf-benchmarks-nightly.yml
@@ -26,7 +26,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '0 11 * * *' # nightly, offset from ycsb-nightly (07:00) and the cluster job
+    - cron: '20 8 * * *' # 02:20 MDT, last in the serialized harper-bench chain
   workflow_dispatch:
     inputs:
       scale:


### PR DESCRIPTION
`perf-benchmarks-nightly` ran 05:05–05:44 local time every night — inside the working day, on a machine that is also somebody's desktop. It [moves from 11:00 to 08:20 UTC](https://github.com/HarperFast/harper/pull/2362/changes?w=1#diff-ab84fc98172d9eef24407baca634c6fe129753a47784a804156e5e332a616469R29), and the weekly [`large-deploy-test` from 09:30 to 09:20 UTC Monday](https://github.com/HarperFast/harper/pull/2362/changes?w=1#diff-cf4fb1e35936179a964f585ee9fa99a9300360370e307d24a9e57f94e3728626R16), so both land in the same early-morning window as the harper-pro nightlies.

Every `harper-bench` job serializes on one machine: the JIT supervisor drains one queued job at a time across `harper` and `harper-pro`, so these two and harper-pro's two form a single sequence whose slots have to be chosen together. This PR takes the last two — `stress-large-data` at 06:20 and `ycsb-cluster-nightly` at 07:20 UTC in the companion PR, then `perf-benchmarks-nightly` at 08:20 and `large-deploy-test` at Monday 09:20 UTC here. Companion PR: HarperFast/harper-pro#774.

An hour per slot is ample. Measured wall time over the last 20 scheduled runs is 36–39 minutes for `perf-benchmarks-nightly` — one job, including `npm install` with native builds and all three benchmarks — and 2–4 minutes for `large-deploy-test`.

Both crons also move off the top of the hour, where GitHub delays scheduled workflows most. The sequence itself is documented in [the companion PR](https://github.com/HarperFast/harper-pro/pull/774), in the harper-pro runner README that already owns the cross-repo serialization story; the comments here point at it rather than restating it, and deliberately do not assert an order the mechanism cannot guarantee — `harper-bench-exclusive` is repo-scoped, so it does not serialize across the two repos.

## For the human reviewer

1. **Monday's gap is sized for the measured case, not the timeout case.** `perf-benchmarks-nightly` normally finishes around 09:00 UTC, so [`large-deploy-test` fires into a free host at 09:20](https://github.com/HarperFast/harper/pull/2362/changes?w=1#diff-cf4fb1e35936179a964f585ee9fa99a9300360370e307d24a9e57f94e3728626R16) and is done by ~09:24. But perf's cap is 120 minutes: a hang night ends at 10:20, large-deploy then starts late and its own 60-minute cap can hold the host to 11:20 UTC — 05:20 local, inside the window this PR exists to clear. The review proposed moving Monday to 10:20 UTC to sit clear of a worst-case perf run. I did not, because it makes every *normal* Monday an hour later for protection only on a hang night, and the real fix is a tighter perf timeout rather than a wider gap. Rule against me if you would rather the Monday slot be hang-proof than early — it is a one-line cron edit either way.

2. **Ordering is by wall-clock spacing, not a declared dependency**, and the same judgment call is in the companion PR — see its first entry. Worth ruling on once, for both.

3. **Cron comments carry no local times.** An earlier draft annotated them `02:20 MDT` / `03:20 MDT Monday`; both are wrong from November through March, and "last in the serialized chain" was wrong on Mondays, when `large-deploy-test` follows an hour later. They now name the slot and point at the sequence map. Flagging the convention rather than the fix: if you want local times in scheduler comments, they need to name both offsets or the whole thing needs a host-local timer.

## Verification

Not observable end-to-end: a cron change has no runtime behavior to exercise, and the real proof is the next few nights' run timestamps.

Executed instead:

- Cron syntax parses to the intended values — `yq -r '.on.schedule[].cron'` returns `20 8 * * *` and `20 9 * * 1`.
- `npx prettier --check` clean on both files.
- Schedule arithmetic against **measured** durations from the Actions API (last 20 scheduled runs, successful only, per-job `completed_at - started_at`): `perf-benchmarks-nightly` 36–39 min, `large-deploy-test` 2–4 min. Two review rounds instead inferred 60–90 minutes for perf from benchmark script config (`ttl-churn`'s self-documented 30+ min, `indexed-write` at 1M × 3 variants) and were wrong; run history is the authority. Confirmed the scheduled runs are at full nightly scale rather than something cheaper: `github.event.inputs.scale` is null on a `schedule` event, so `SCALE` falls back to `nightly`.
- Confirmed no other `harper-bench` workflow exists in this repo, so the new 08:20 UTC slot adds no fresh contention — every other scheduled workflow here is GitHub-hosted, including `npm-package-app-e2e` three minutes earlier at 08:17 UTC.
- Both workflows remain `schedule` + `workflow_dispatch` only; no `pull_request` trigger was added, so untrusted PR code still cannot reach the self-hosted host.

Complexity: easy

<sub>Review-Coverage: authored=claude; ran=gemini,codex; declined=cursor-grok,cursor-composer,domain; rounds=3 @ 326804134efa</sub>

<sub>Human-Review-Need: 3 @ 326804134efa</sub>
