### PR TITLE
Count a worker as replaced when its replacement is serving, not when it exits

### DIFF
--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -721,8 +721,7 @@ async function restartWorkers(
 					// a worker that exited on its own mid-restart is spliced out of `workers` and
 					// auto-restarted onto the new code (see the exit handler above); it is not still on
 					// the previous code even though this loop never got to it.
-					.filter((other) => (!name || other.name === name) && !other.wasShutdown && workers.includes(other))
-					.length;
+					.filter((other) => (!name || other.name === name) && !other.wasShutdown && workers.includes(other)).length;
 				harperLogger.error(
 					`${replacementsFailedToStart} replacement worker thread(s) did not start; stopping this restart with ${untouched} worker(s) still on the previous code`
 				);

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -698,16 +698,14 @@ async function restartWorkers(
 					resolve();
 				});
 			});
-			// A worker counts as replaced once its replacement is accepting connections, not merely once it
-			// has exited. Where the replacement cannot be pre-started it boots only after the old worker is
-			// gone, so throttling on the exit alone let the loop take the whole pool down while the first
-			// replacements were still booting.
-			// This promise is held unawaited between throttle points, so it must not be able to reject.
+			// A worker counts as replaced only once its replacement is accepting connections, not merely
+			// once it has exited. This promise is held unawaited between throttle points, so it must not
+			// be able to reject.
 			const replaced = (replacementStarting ? Promise.all([whenDone, replacementStarting]) : whenDone)
 				.catch((error) => harperLogger.warn('Error waiting for a worker to be replaced', error))
 				.then(() => {
-					const index = waitingToFinish.indexOf(replaced);
-					if (index > -1) waitingToFinish.splice(index, 1);
+					const at = waitingToFinish.indexOf(replaced);
+					if (at > -1) waitingToFinish.splice(at, 1);
 				});
 			waitingToFinish.push(replaced);
 			if (waitingToFinish.length >= maxWorkersDown) {
@@ -720,7 +718,11 @@ async function restartWorkers(
 			if (replacementsFailedToStart >= maxWorkersDown) {
 				const untouched = restarting
 					.slice(index + 1)
-					.filter((other) => (!name || other.name === name) && !other.wasShutdown).length;
+					// a worker that exited on its own mid-restart is spliced out of `workers` and
+					// auto-restarted onto the new code (see the exit handler above); it is not still on
+					// the previous code even though this loop never got to it.
+					.filter((other) => (!name || other.name === name) && !other.wasShutdown && workers.includes(other))
+					.length;
 				harperLogger.error(
 					`${replacementsFailedToStart} replacement worker thread(s) did not start; stopping this restart with ${untouched} worker(s) still on the previous code`
 				);

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -652,7 +652,6 @@ async function restartWorkers(
 				replacementsStarting.push(replacementStarting);
 			}
 
-
 			let whenDone = new Promise((resolve) => {
 				// in case the exit inside the thread doesn't timeout, force it from the outside
 				const armTerminate = (delay) =>

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -529,7 +529,7 @@ async function restartWorkers(
 			maxWorkersDown = maxWorkersDown * workers.length;
 		}
 		// make a copy of the workers before iterating them, as the workers array mutates a lot during this
-		let waitingToFinish = []; // promises for workers we have shut down and are waiting to exit
+		let waitingToFinish = []; // promises for workers we are replacing, spliced as each is replaced
 		// Every replacement that was started without being awaited first, so this function can still
 		// resolve only once each one is accepting connections.
 		let replacementsStarting = [];
@@ -539,6 +539,7 @@ async function restartWorkers(
 		// costs capacity until startWorker's auto-restart brings a fresh one up.
 		let workersKeptOnOldCode = 0;
 		let replacementsNotStarted = 0;
+		let replacementsFailedToStart = 0;
 		// We can only start the replacement *before* the old worker releases its port when the OS lets
 		// both listen on the same port at once (SO_REUSEPORT). Without that — Windows (no SO_REUSEPORT),
 		// macOS (unreliable SO_REUSEPORT, so workers bind exclusively), and Bun — the replacement can't
@@ -550,7 +551,9 @@ async function restartWorkers(
 		// thread keeps serving the HTTP ports throughout. This ordering is also what lets
 		// listenOnPorts() treat a dedicated listener's EADDRINUSE as an external conflict.
 		const canPreStartReplacement = process.platform !== 'win32' && process.platform !== 'darwin' && !isBun;
-		for (let worker of workers.slice(0)) {
+		const restarting = workers.slice(0);
+		for (let index = 0; index < restarting.length; index++) {
+			const worker = restarting[index];
 			// Terminal shutdown: stop replacing workers mid-loop — the guard for every replacement start below.
 			if (processShuttingDown && startReplacementThreads) break;
 			if ((name && worker.name !== name) || worker.wasShutdown) continue; // filter by type, if specified
@@ -639,13 +642,16 @@ async function restartWorkers(
 			// Overlapping types we couldn't pre-start (Windows/Bun): start the replacement now that the old
 			// worker is releasing its port. server.close() stops accepting immediately, so the port frees up
 			// well before the replacement finishes booting and binds.
-			if (overlapping && startReplacementThreads && !canPreStartReplacement && !processShuttingDown)
-				replacementsStarting.push(
-					whenWorkerStarted(worker.startCopy()).then((started) => {
-						onProgress?.();
-						return started;
-					})
-				);
+			let replacementStarting;
+			if (overlapping && startReplacementThreads && !canPreStartReplacement && !processShuttingDown) {
+				replacementStarting = whenWorkerStarted(worker.startCopy()).then((started) => {
+					if (!started) replacementsFailedToStart++;
+					onProgress?.();
+					return started;
+				});
+				replacementsStarting.push(replacementStarting);
+			}
+
 
 			let whenDone = new Promise((resolve) => {
 				// in case the exit inside the thread doesn't timeout, force it from the outside
@@ -688,17 +694,39 @@ async function restartWorkers(
 					clearTimeout(timeout);
 					onProgress?.();
 					worker.extendTerminateDeadline = undefined;
-					const index = waitingToFinish.indexOf(whenDone);
-					if (index > -1) waitingToFinish.splice(index, 1);
 					// non-overlapping types have no advance replacement, so start it once the old one is gone
 					if (!overlapping && startReplacementThreads && !processShuttingDown) worker.startCopy();
 					resolve();
 				});
 			});
-			waitingToFinish.push(whenDone);
+			// A worker counts as replaced once its replacement is accepting connections, not merely once it
+			// has exited. Where the replacement cannot be pre-started it boots only after the old worker is
+			// gone, so throttling on the exit alone let the loop take the whole pool down while the first
+			// replacements were still booting.
+			// This promise is held unawaited between throttle points, so it must not be able to reject.
+			const replaced = (replacementStarting ? Promise.all([whenDone, replacementStarting]) : whenDone)
+				.catch((error) => harperLogger.warn('Error waiting for a worker to be replaced', error))
+				.then(() => {
+					const index = waitingToFinish.indexOf(replaced);
+					if (index > -1) waitingToFinish.splice(index, 1);
+				});
+			waitingToFinish.push(replaced);
 			if (waitingToFinish.length >= maxWorkersDown) {
-				// throttle how many workers are draining/down at once to limit load
+				// throttle how many workers are down at once to limit load
 				await Promise.race(waitingToFinish);
+			}
+			// Readiness throttling bounds how many workers are down at once, but not how many *fail*: with
+			// replacements that never come up, walking the rest of the pool would leave nothing serving.
+			// The workers not yet touched are still running the old code, which beats none running at all.
+			if (replacementsFailedToStart >= maxWorkersDown) {
+				const untouched = restarting
+					.slice(index + 1)
+					.filter((other) => (!name || other.name === name) && !other.wasShutdown).length;
+				harperLogger.error(
+					`${replacementsFailedToStart} replacement worker thread(s) did not start; stopping this restart with ${untouched} worker(s) still on the previous code`
+				);
+				workersKeptOnOldCode += untouched;
+				break;
 			}
 		}
 		await Promise.all(waitingToFinish);


### PR DESCRIPTION
Split out of [#2341](https://github.com/HarperFast/harper/pull/2341) at Kris's request. #2341 has since merged (squashed, as c4dd96237) and this branch is now rebased directly onto `main`; it builds on that PR's `whenWorkerStarted` helper, which is why this diff is the restart-pacing change alone.

`restartWorkers()` advanced its `maxWorkersDown` throttle when a worker *exited*. On the platforms that cannot pre-start a replacement into the predecessor's listening port — Windows, macOS, Bun — the replacement only starts once that worker is gone, and old workers exit in milliseconds while a replacement takes seconds to boot, so the loop could walk the whole pool down before any replacement was serving. A worker now [counts as replaced only once its replacement reports `CHILD_STARTED`](https://github.com/HarperFast/harper/pull/2363/changes?w=1#diff-02c28577c2ca63129ed10809ce3db1469c70bef080e04fd273f8cbd510b6521bR704), which is what the throttle was there to bound; and if replacements keep failing to start, the restart stops rather than continuing to take down workers that are still serving. On SO_REUSEPORT platforms the replacement is already awaited before its predecessor is shut down, so nothing changes there.

## For the human reviewer

1. **The effect is structural; I could not measure it.** Two probes on macOS came back flat: fresh MQTT-over-WebSocket connections across a `restart_service http` were refused on 2.5% of attempts with this change and 2.6% without (690/695 attempts, 8 threads), and `get_status`'s per-worker roster never dipped below 8 on either build. The first is explained by a dedicated worker-owned listener having a *single* owner worker — the client-visible gap is that owner's replacement time, which no throttle shrinks; the second by the roster counting registered workers rather than ready ones. So the review's original "total downtime during a deploy" framing is overstated for macOS. What the change buys is a bound on how many worker threads are simultaneously not-yet-serving, which matters most for load on Windows/Bun, where CI's shards are the only signal I have.
2. **It changes restart pacing on three platforms.** A restart there now advances at replacement-boot speed rather than predecessor-exit speed: slower in wall-clock terms, never below the intended capacity. That is also the ordering the harper#1813 EADDRINUSE hazard lives in — a drain delaying the predecessor's port release while the replacement tries to bind. This change makes the loop *wait* on that replacement rather than move past it, which is the safer side of the hazard, but it deserves a second opinion from whoever knows that failure best.
3. **The bail-out is a policy call.** Readiness throttling bounds how many workers are down at once but not how many *fail*: with replacements that never come up, walking the rest of the pool leaves nothing serving. So the restart now [stops once the number of replacements that never started reaches `maxWorkersDown`](https://github.com/HarperFast/harper/pull/2363/changes?w=1#diff-02c28577c2ca63129ed10809ce3db1469c70bef080e04fd273f8cbd510b6521bR718), logs it, and reports the untouched workers as left on the previous code (`workersKeptOnOldCode`, which #2341 already surfaces in the log). The alternative is to keep rolling and end with an empty pool. Failed slots do free their throttle entry as they settle, so up to `maxWorkersDown` workers can be unavailable before the stop trips — that is the bound the parameter already promises, not a new one.
4. **Not fixed, disclosed.** `CHILD_STARTED` can still certify a worker whose *dedicated* listener failed to bind (harper#1813) — readiness is "the worker reported started", not "every listener is bound". And this is a no-op for job workers: they are the `!overlapping` path, their replacement is still started without being awaited, and they serve no connections. The gemini leg read that path as Windows/Bun and concluded "total downtime"; the platform axis is `canPreStartReplacement`, not `overlapping`, so that conclusion does not hold.
5. **No test.** Neither observable I tried distinguishes the two builds, so a regression test would assert something I cannot demonstrate. Pinning it needs a per-worker readiness probe that does not exist yet.
6. **Rebase note.** #2341 merging while this branch still carried its unsquashed history meant a literal per-commit `git rebase origin/main` reconflicted on content main already had (verbatim, in every file but this one). Resolved by squashing this branch's unique commits into one tree state and rebasing that single commit onto `main` — one 3-way merge instead of 24, verified by diffing the result against `main` (clean everywhere but `manageThreads.js`) and reading through the two real conflicts to confirm the branch's version was a strict superset of what `main` already had. The rebase's own pre-push review caught a real bug in the process: the abort accounting's `untouched` count (point 3 above) didn't exclude a worker that exited on its own mid-restart — it's spliced out of `workers` and auto-restarted onto the *new* code by the ordinary exit handler, but was still being counted as "left on old code". Fixed at [`manageThreads.js:724`](https://github.com/HarperFast/harper/pull/2363/changes?w=1#diff-02c28577c2ca63129ed10809ce3db1469c70bef080e04fd273f8cbd510b6521bR724).

## Verification

`npm run build` and `npm run lint:required` clean. `integrationTests/{deploy,mqtt}` 80 passed / 0 failed / 1 skipped and the `deploy-restart-topic-availability` suite 4/4 on macOS, which is a non-pre-start platform, so every restart in those suites exercises this path.

Re-verified after the rebase, on Linux: `npm run build` clean; `unitTests/components/{awaitRestart,requestRestart}.test.js` and `unitTests/server/threads/*.test.js` (58 passing); `integrationTests/mqtt/deploy-restart-topic-availability.test.ts` (4/4) and `integrationTests/components/acl-connect.test.ts` (13/13). Linux pre-starts replacements (`canPreStartReplacement`), so these don't exercise the readiness-throttle path either — see point 5 above, unchanged by the rebase.

**Pre-existing macOS breakage found while verifying, not caused by this PR:** `integrationTests/components/shutdown-drain-e2e.test.ts` fails 2/2 on a clean `main` checkout with a fresh build, with the EADDRINUSE-during-drain signature that file's own comment documents for Bun (`Failed to bind TLS listener for component 'mqtt' … address already in use`, 4 occurrences). It is skipped only under Bun, and CI runs Linux and Windows, so macOS red goes unseen. Worth its own issue — say the word and I'll file it.

Complexity: medium

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=3 @ cb6c70d9efe8</sub>

<sub>Human-Review-Need: 3 @ cb6c70d9efe8</sub>
