### PR TITLE
Stop a deleted watched path from raising an uncaught EPERM (Windows)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1245,7 +1245,7 @@ is stat polling with no fs-event handle and is outside this invariant.
 Five of those six sites arm the watch through `guardedWatch()` (`utility/watcherFallback.ts`) rather
 than calling `chokidar.watch`/`fs.watch` directly — it installs a process-level guard for a second,
 unrelated failure (a watched path deleted out from under a non-persistent chokidar watcher raises an
-unhandled `EPERM`/`ENOENT`; see that file's header comment) but does no canonicalization of its own.
+unhandled async `EPERM`; see that file's header comment) but does no canonicalization of its own.
 Every caller still resolves its own path first and passes the resolved path in, exactly as when they
 called `chokidar.watch` directly, so the invariant holds through the wrapper. `utility/watcherFallback.ts`
 itself is the one file that touches `chokidar` without canonicalizing — the watch-sites source scan

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1242,6 +1242,17 @@ New watch sites must go through it. As of this writing the sites are `components
 `server/threads/manageThreads.js`, and `resources/blob.ts`. `fs.watchFile` (`utility/logging/readLog.ts`)
 is stat polling with no fs-event handle and is outside this invariant.
 
+Five of those six sites arm the watch through `guardedWatch()` (`utility/watcherFallback.ts`) rather
+than calling `chokidar.watch`/`fs.watch` directly — it installs a process-level guard for a second,
+unrelated failure (a watched path deleted out from under a non-persistent chokidar watcher raises an
+unhandled `EPERM`/`ENOENT`; see that file's header comment) but does no canonicalization of its own.
+Every caller still resolves its own path first and passes the resolved path in, exactly as when they
+called `chokidar.watch` directly, so the invariant holds through the wrapper. `utility/watcherFallback.ts`
+itself is the one file that touches `chokidar` without canonicalizing — the watch-sites source scan
+(`unitTests/utility/watchPath.test.js`) lists it as a native watch site (it does arm one) but exempts
+it from the per-file canonicalization check, since canonicalizing is its callers' job, not its own —
+the same relationship raw `chokidar.watch` has to the other five sites.
+
 Two consequences worth knowing before adding a caller. `EntryHandler` is the one place where the
 canonical path is load-bearing past the `fs.watch` call: chokidar's `ignored` predicate receives
 absolute paths built from `cwd`, so its bases must be derived from the same spelling, while event

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -4,7 +4,7 @@ import { createHash } from 'node:crypto';
 import type { Stats } from 'node:fs';
 import { EventEmitter } from 'node:events';
 import { Component, FileAndURLPathConfig } from './Component.ts';
-import chokidar, { FSWatcher, FSWatcherEventMap } from 'chokidar';
+import { FSWatcher, FSWatcherEventMap } from 'chokidar';
 import { isAbsolute, join } from 'node:path';
 import { readFile } from 'node:fs/promises';
 import { FilesOption } from './deriveGlobOptions.ts';
@@ -12,6 +12,8 @@ import { deriveURLPath } from './deriveURLPath.ts';
 import { isMatch } from 'micromatch';
 import {
 	DIRECTORY_POLLING_FALLBACK_OPTIONS,
+	claimLostNativeWatchError,
+	guardedWatch,
 	isWatcherExhaustionError,
 	warnWatcherFallback,
 } from '../utility/watcherFallback.ts';
@@ -392,6 +394,11 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	}
 
 	#handleWatcherError(error: unknown): void {
+		// A lost native watch handle (the watched tree was deleted or replaced) is
+		// benign and not actionable by a consumer. chokidar's non-persistent branch
+		// never routes it here today — installLostNativeWatchGuard() catches it at
+		// the process instead — but the polling branch and a fixed chokidar would.
+		if (claimLostNativeWatchError(error)) return;
 		if (isWatcherExhaustionError(error)) {
 			// Swallow every exhaustion error — chokidar can emit several before the
 			// failed native watcher closes, and we don't want a flurry of ENOSPC to
@@ -555,40 +562,39 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		}
 
 		this.#openCount++;
-		const watcher = (this.#watcher = chokidar
-			.watch(watchPattern, {
-				cwd: watchDirectory,
-				persistent: false,
-				followSymlinks: false,
-				...(this.#usingPolling ? DIRECTORY_POLLING_FALLBACK_OPTIONS : {}),
-				ignored: (path) => {
-					const normalizedPath = path.replace(/\\/g, '/');
+		const watcher = (this.#watcher = guardedWatch(watchPattern, {
+			cwd: watchDirectory,
+			persistent: false,
+			followSymlinks: false,
+			...(this.#usingPolling ? DIRECTORY_POLLING_FALLBACK_OPTIONS : {}),
+			ignored: (path) => {
+				const normalizedPath = path.replace(/\\/g, '/');
 
-					// Determine the path relative to the component directory. Leading '/' is preserved
-					// (or empty when the path *is* the component directory) so the regex anchors below
-					// can use `(?:^|/)` to match the first segment without false positives on names
-					// that merely contain the same substring (e.g. `mynode_modules`, `notgit`).
-					const relativePath = normalizedPath.startsWith(normalizedDirectory)
-						? normalizedPath.slice(normalizedDirectory.length)
-						: normalizedPath;
+				// Determine the path relative to the component directory. Leading '/' is preserved
+				// (or empty when the path *is* the component directory) so the regex anchors below
+				// can use `(?:^|/)` to match the first segment without false positives on names
+				// that merely contain the same substring (e.g. `mynode_modules`, `notgit`).
+				const relativePath = normalizedPath.startsWith(normalizedDirectory)
+					? normalizedPath.slice(normalizedDirectory.length)
+					: normalizedPath;
 
-					// Skip node_modules at any depth. This allows plugins loaded from node_modules
-					// to still watch their own component files while ignoring their dependencies.
-					if (/(?:^|\/)node_modules(?:\/|$)/.test(relativePath)) return true;
+				// Skip node_modules at any depth. This allows plugins loaded from node_modules
+				// to still watch their own component files while ignoring their dependencies.
+				if (/(?:^|\/)node_modules(?:\/|$)/.test(relativePath)) return true;
 
-					// Skip transient package manager and VCS artifacts. Without these, an in-place
-					// `npm install` during a component deploy writes log files and atomic-rename
-					// temp directories that fire change events and drive an auto-reload restart
-					// storm — see harper#488.
-					if (/(?:^|\/)\.git(?:\/|$)/.test(relativePath)) return true;
-					if (/(?:^|\/)\.tmp-/.test(relativePath)) return true;
-					if (/(?:^|\/)(?:npm-debug|yarn-error|yarn-debug|pnpm-debug)\.log(?:\/|$)/.test(relativePath)) return true;
+				// Skip transient package manager and VCS artifacts. Without these, an in-place
+				// `npm install` during a component deploy writes log files and atomic-rename
+				// temp directories that fire change events and drive an auto-reload restart
+				// storm — see harper#488.
+				if (/(?:^|\/)\.git(?:\/|$)/.test(relativePath)) return true;
+				if (/(?:^|\/)\.tmp-/.test(relativePath)) return true;
+				if (/(?:^|\/)(?:npm-debug|yarn-error|yarn-debug|pnpm-debug)\.log(?:\/|$)/.test(relativePath)) return true;
 
-					return (
-						normalizedPath !== normalizedDirectory && normalizedBases.every((base) => !normalizedPath.startsWith(base))
-					);
-				},
-			})
+				return (
+					normalizedPath !== normalizedDirectory && normalizedBases.every((base) => !normalizedPath.startsWith(base))
+				);
+			},
+		})
 			.on('all', (...args) => this.#handleAll(generation, ...args))
 			.on('error', (error) => {
 				if (generation === this.#watchGeneration) this.#handleWatcherError(error);

--- a/components/OptionsWatcher.ts
+++ b/components/OptionsWatcher.ts
@@ -2,7 +2,7 @@ import { type Logger } from '../utility/logging/logger.ts';
 import { loggerWithTag } from '../utility/logging/harper_logger.ts';
 import { EventEmitter, once } from 'events';
 import yaml from 'yaml';
-import chokidar, { type FSWatcher } from 'chokidar';
+import { type FSWatcher } from 'chokidar';
 import { readFile } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import { isDeepStrictEqual } from 'util';
@@ -11,6 +11,8 @@ import { cloneDeep } from 'lodash';
 import {
 	POLLING_FALLBACK_OPTIONS,
 	PartialReadRetry,
+	claimLostNativeWatchError,
+	guardedWatch,
 	isPartialReadError,
 	isWatcherExhaustionError,
 	warnWatcherFallback,
@@ -126,11 +128,10 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 
 	#openWatcher() {
 		this.#openCount++;
-		this.#watcher = chokidar
-			.watch(this.#watchPath, {
-				persistent: false,
-				...(this.#usingPolling ? POLLING_FALLBACK_OPTIONS : {}),
-			})
+		this.#watcher = guardedWatch(this.#watchPath, {
+			persistent: false,
+			...(this.#usingPolling ? POLLING_FALLBACK_OPTIONS : {}),
+		})
 			.on('add', this.#handleChange.bind(this))
 			.on('change', this.#handleChange.bind(this))
 			.on('error', this.#handleError.bind(this))
@@ -256,6 +257,9 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 	}
 
 	#handleError(error: unknown) {
+		// See EntryHandler.#handleWatcherError: a lost native watch handle is benign
+		// and must not be surfaced to consumers as a config-watch failure.
+		if (claimLostNativeWatchError(error)) return;
 		if (isWatcherExhaustionError(error)) {
 			// Swallow every exhaustion error — chokidar can emit several before the
 			// failed native watcher closes, and we don't want a flurry of ENOSPC to

--- a/config/RootConfigWatcher.ts
+++ b/config/RootConfigWatcher.ts
@@ -1,4 +1,4 @@
-import chokidar, { FSWatcher } from 'chokidar';
+import { FSWatcher } from 'chokidar';
 import { readFileSync } from 'node:fs';
 import { getConfigFilePath } from './configUtils.ts';
 import { EventEmitter, once } from 'node:events';
@@ -6,6 +6,8 @@ import { parse } from 'yaml';
 import {
 	POLLING_FALLBACK_OPTIONS,
 	PartialReadRetry,
+	claimLostNativeWatchError,
+	guardedWatch,
 	isPartialReadError,
 	isWatcherExhaustionError,
 	warnWatcherFallback,
@@ -38,11 +40,10 @@ export class RootConfigWatcher extends EventEmitter {
 
 	#openWatcher() {
 		this.#openCount++;
-		this.#watcher = chokidar
-			.watch(this.#watchPath, {
-				persistent: false,
-				...(this.#usingPolling ? POLLING_FALLBACK_OPTIONS : {}),
-			})
+		this.#watcher = guardedWatch(this.#watchPath, {
+			persistent: false,
+			...(this.#usingPolling ? POLLING_FALLBACK_OPTIONS : {}),
+		})
 			.on('add', this.handleChange.bind(this))
 			.on('change', this.handleChange.bind(this))
 			.on('error', this.handleError.bind(this));
@@ -66,6 +67,9 @@ export class RootConfigWatcher extends EventEmitter {
 	}
 
 	handleError(error: unknown) {
+		// See EntryHandler.#handleWatcherError: a lost native watch handle is benign
+		// and must not be surfaced to consumers as a config-watch failure.
+		if (claimLostNativeWatchError(error)) return;
 		if (isWatcherExhaustionError(error)) {
 			// Swallow every exhaustion error — chokidar can emit several before the
 			// failed native watcher closes, and we don't want a flurry of ENOSPC to

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -1,7 +1,6 @@
 'use strict';
 
 import * as path from 'path';
-import { watch } from 'chokidar';
 import * as fs from 'fs-extra';
 import * as forge from 'node-forge';
 import * as net from 'net';
@@ -33,7 +32,13 @@ export const getPrivateKeys = () => privateKeys;
 import { readFileSync, statSync } from 'node:fs';
 import { getTicketKeys, onMessageFromWorkers } from '../server/threads/manageThreads.js';
 import { isMainThread } from 'worker_threads';
-import { POLLING_FALLBACK_OPTIONS, isWatcherExhaustionError, warnWatcherFallback } from '../utility/watcherFallback.ts';
+import {
+	POLLING_FALLBACK_OPTIONS,
+	claimLostNativeWatchError,
+	guardedWatch,
+	isWatcherExhaustionError,
+	warnWatcherFallback,
+} from '../utility/watcherFallback.ts';
 import { resolveWatchTarget } from '../utility/watchPath.ts';
 import { TLSSocket } from 'node:tls';
 
@@ -361,7 +366,7 @@ function loadAndWatch(path, loadCert, type) {
 	let usingPolling = watchTarget.mustPoll;
 	let liveWatcher;
 	const openWatcher = () => {
-		const opened = (liveWatcher = watch(watchTarget.path, {
+		const opened = (liveWatcher = guardedWatch(watchTarget.path, {
 			persistent: false,
 			...(usingPolling ? POLLING_FALLBACK_OPTIONS : {}),
 		}));
@@ -371,6 +376,7 @@ function loadAndWatch(path, loadCert, type) {
 			.on('change', () => loadFile(path))
 			// chokidar emits 'error' unguarded for anything but ENOENT/ENOTDIR.
 			.on('error', (error) => {
+				if (claimLostNativeWatchError(error)) return;
 				if (isWatcherExhaustionError(error)) {
 					if (usingPolling || liveWatcher !== opened) return;
 					warnWatcherFallback(path);

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -26,6 +26,8 @@ const { getConfigPath } = require('../../config/configUtils.ts');
 const { resolveWatchTarget } = require('../../utility/watchPath.ts');
 const {
 	DIRECTORY_POLLING_FALLBACK_OPTIONS,
+	claimLostNativeWatchError,
+	guardedWatch,
 	isWatcherExhaustionError,
 	warnWatcherFallback,
 } = require('../../utility/watcherFallback.ts');
@@ -49,7 +51,6 @@ function getRequireModules() {
 		);
 	return requireModules;
 }
-const chokidar = require('chokidar');
 const isBun = typeof globalThis.Bun !== 'undefined';
 const MB = 1024 * 1024;
 const workers = []; // these are our child workers that we are managing
@@ -1506,7 +1507,7 @@ if (isMainThread) {
 		let usingPolling = watchTarget.mustPoll;
 		let liveWatcher;
 		const openWatcher = () => {
-			const opened = (liveWatcher = chokidar.watch(watchTarget.path, {
+			const opened = (liveWatcher = guardedWatch(watchTarget.path, {
 				persistent: false,
 				...(usingPolling ? DIRECTORY_POLLING_FALLBACK_OPTIONS : {}),
 				ignored: (path) => {
@@ -1517,6 +1518,7 @@ if (isMainThread) {
 				// This runs on the thread that owns every worker, and chokidar emits 'error' unguarded for
 				// anything but ENOENT/ENOTDIR.
 				.on('error', (error) => {
+					if (claimLostNativeWatchError(error)) return;
 					if (isWatcherExhaustionError(error)) {
 						if (usingPolling || liveWatcher !== opened) return;
 						warnWatcherFallback(dir);

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -18,6 +18,9 @@ let sweptSocketsDirectory = false;
 if (isMainThread) {
 	process.on('uncaughtException', (error) => {
 		// TODO: Maybe we should try to log the first of each type of error
+		// Same `isHandled` contract as threadServer.js: an error another handler has already
+		// classified (a lost native file watch, for instance) must not be logged again here.
+		if ((error as any).isHandled) return;
 		if ((error as any).code === 'ECONNRESET') return; // that's what network connections do
 		if ((error as any).code === 'EIO') {
 			// that means the terminal is closed

--- a/unitTests/security/keys.test.js
+++ b/unitTests/security/keys.test.js
@@ -1077,7 +1077,7 @@ describe('Test keys module', () => {
 		const watchPollers = keys.__get__('certificateWatchPollers');
 		const localSandbox = sinon.createSandbox();
 		const chokidar = require('chokidar');
-		const realChokidarWatch = chokidar.watch;
+		const realChokidarWatch = chokidar.default.watch;
 		let watchPath;
 
 		// Never open a real watcher here: these tests exercise only the poll/reopen paths, and real
@@ -1094,13 +1094,13 @@ describe('Test keys module', () => {
 		};
 
 		beforeEach(() => {
-			chokidar.watch = () => fakeWatcher();
+			chokidar.default.watch = () => fakeWatcher();
 			watchPath = path.join(test_dir, `watch-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.pem`);
 			fs.writeFileSync(watchPath, 'PEM-V1');
 		});
 
 		afterEach(() => {
-			chokidar.watch = realChokidarWatch;
+			chokidar.default.watch = realChokidarWatch;
 			localSandbox.restore();
 			// warnWatcherFallback's first-fallback gate is process-global; leaving it set would make a
 			// later suite's warning assertion silently observe nothing.
@@ -1134,7 +1134,7 @@ describe('Test keys module', () => {
 			// chokidar v4 defaults alwaysStat:false, so the 'change' handler is called with undefined
 			// stats; loadFile must stat the file itself rather than throw and silently skip the reload.
 			let changeHandler;
-			chokidar.watch = () =>
+			chokidar.default.watch = () =>
 				fakeWatcher((event, handler) => {
 					if (event === 'change') changeHandler = handler;
 				});
@@ -1159,7 +1159,7 @@ describe('Test keys module', () => {
 			const openedOptions = [];
 			const errorHandlers = [];
 			const exhausted = () => Object.assign(new Error('inotify watch limit reached'), { code: 'ENOSPC' });
-			chokidar.watch = (_watchedPath, options) => {
+			chokidar.default.watch = (_watchedPath, options) => {
 				openedOptions.push(options);
 				return fakeWatcher((event, handler) => {
 					if (event === 'error') errorHandlers.push(handler);
@@ -1189,7 +1189,7 @@ describe('Test keys module', () => {
 			// of reopening on polling.
 			const openedOptions = [];
 			const errorHandlers = [];
-			chokidar.watch = (_watchedPath, options) => {
+			chokidar.default.watch = (_watchedPath, options) => {
 				openedOptions.push(options);
 				const watcher = {
 					on: (event, handler) => {

--- a/unitTests/server/threads/watchDirFallback.test.js
+++ b/unitTests/server/threads/watchDirFallback.test.js
@@ -7,10 +7,10 @@ const { watchDir } = require('#src/server/threads/manageThreads');
 const { _resetForTests: resetWatcherFallbackWarning } = require('#src/utility/watcherFallback');
 
 describe('watchDir watcher fallback', () => {
-	const realWatch = chokidar.watch;
+	const realWatch = chokidar.default.watch;
 
 	afterEach(() => {
-		chokidar.watch = realWatch;
+		chokidar.default.watch = realWatch;
 		// warnWatcherFallback's first-fallback gate is process-global; leaving it set would make a
 		// later suite's warning assertion silently observe nothing.
 		resetWatcherFallbackWarning();
@@ -23,7 +23,7 @@ describe('watchDir watcher fallback', () => {
 	const stubChokidar = (close) => {
 		const openedOptions = [];
 		const errorHandlers = [];
-		chokidar.watch = (_watchedPath, options) => {
+		chokidar.default.watch = (_watchedPath, options) => {
 			openedOptions.push(options);
 			const watcher = {
 				on: (event, handler) => {

--- a/unitTests/utility/fixtures/lostWatchHarness.cjs
+++ b/unitTests/utility/fixtures/lostWatchHarness.cjs
@@ -9,9 +9,35 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { guardedWatch, _lostNativeWatchCountForTests } = require('#src/utility/watcherFallback');
+const {
+	claimLostNativeWatchError,
+	guardedWatch,
+	_lostNativeWatchCountForTests,
+} = require('#src/utility/watcherFallback');
 
 const mode = process.argv[2];
+
+if (mode === 'warn-threshold') {
+	// No watcher needed: claim a run of synthetic lost-watch errors and let the caller count the
+	// warnings that reach the log. Warn is the default level, so this is the visible cadence.
+	for (let i = 0; i < 12; i++) {
+		claimLostNativeWatchError(
+			Object.assign(new Error('EPERM: watch'), { code: 'EPERM', syscall: 'watch', filename: null })
+		);
+	}
+	process.stdout.write(`claimed=${_lostNativeWatchCountForTests()}\n`);
+	process.exit(0);
+}
+
+if (mode === 'prepend-ordering') {
+	// Stands in for the handlers in server/threads/threadServer.js and socketRouter.ts, which are
+	// registered at module load — before any watcher exists. They skip errors already marked
+	// handled, which only works if the guard's listener runs ahead of them.
+	process.on('uncaughtException', (error) => {
+		process.stdout.write(`thread-handler saw isHandled=${error.isHandled}\n`);
+		process.exit(0);
+	});
+}
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'harper-lost-watch-'));
 const watched = path.join(root, 'component');
@@ -24,6 +50,15 @@ fs.writeFileSync(path.join(watched, 'resources', 'index.js'), '// fixture\n');
 const watcher = guardedWatch('.', { cwd: watched, persistent: false, followSymlinks: false });
 
 watcher.on('ready', () => {
+	if (mode === 'prepend-ordering') {
+		fs.rmSync(watched, { recursive: true, force: true });
+		setTimeout(() => {
+			process.stdout.write('thread-handler never ran\n');
+			process.exit(3);
+		}, 1500);
+		return;
+	}
+
 	if (mode === 'sync-watch-failure') {
 		// A synchronous fs.watch() throw shares the guard's syscall ('watch') but carries a `path`,
 		// which is what keeps an ordinary "watching a path that isn't there" misconfiguration fatal

--- a/unitTests/utility/fixtures/lostWatchHarness.cjs
+++ b/unitTests/utility/fixtures/lostWatchHarness.cjs
@@ -76,14 +76,34 @@ watcher.on('ready', () => {
 	}
 
 	if (mode === 'frozen-claim') {
-		// A lost-watch-shaped error the guard cannot mark handled: `isHandled` is unassignable on a
-		// frozen object, so classifying it throws. That throw happens inside the guard's
-		// 'uncaughtException' listener, which runs first, so an unprotected guard would replace this
-		// error's report with a TypeError and exit 7 instead of leaving it fatal on its own terms.
+		// A lost-watch-shaped error the guard cannot mark handled, because `isHandled` is
+		// unassignable on a frozen object. Marking is bookkeeping, so the claim still stands and the
+		// process lives; an unprotected guard would instead throw from inside its own
+		// 'uncaughtException' listener, replacing the report with a TypeError and exiting 7.
 		setTimeout(() => {
 			throw Object.freeze(
 				Object.assign(new Error('frozen lost watch'), { code: 'EPERM', syscall: 'watch', filename: null })
 			);
+		}, 10);
+		setTimeout(() => {
+			process.stdout.write(`survived lostWatchCount=${_lostNativeWatchCountForTests()}\n`);
+			process.exit(0);
+		}, 200);
+		return;
+	}
+
+	if (mode === 'unclassifiable-throw') {
+		// Classification is the one step left that can throw: reading the shape runs this getter.
+		// An error the guard cannot classify is not its to claim, so it has to stay fatal rather
+		// than take the process down with a TypeError from inside the guard's own listener.
+		setTimeout(() => {
+			throw {
+				syscall: 'watch',
+				code: 'EPERM',
+				get path() {
+					throw new Error('probe getter');
+				},
+			};
 		}, 10);
 		return;
 	}

--- a/unitTests/utility/fixtures/lostWatchHarness.cjs
+++ b/unitTests/utility/fixtures/lostWatchHarness.cjs
@@ -1,0 +1,43 @@
+'use strict';
+
+// Child-process harness for the lost-native-watch guard. It deliberately does NOT
+// register an 'uncaughtException' listener of its own: the whole point is that the
+// guard installed by guardedWatch() is the only thing standing between a deleted
+// watched path and a dead process, and a listener here would mask that.
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { guardedWatch, _lostNativeWatchCountForTests } = require('#src/utility/watcherFallback');
+
+const mode = process.argv[2];
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'harper-lost-watch-'));
+const watched = path.join(root, 'component');
+fs.mkdirSync(path.join(watched, 'resources'), { recursive: true });
+fs.writeFileSync(path.join(watched, 'config.yaml'), 'name: fixture\n');
+fs.writeFileSync(path.join(watched, 'resources', 'index.js'), '// fixture\n');
+
+// Matches EntryHandler's shape: a relative base resolved against `cwd`, which is
+// what a component watcher actually opens.
+const watcher = guardedWatch('.', { cwd: watched, persistent: false, followSymlinks: false });
+
+watcher.on('ready', () => {
+	if (mode === 'unrelated-throw') {
+		// The guard is installed now. An unrelated uncaught exception must still be
+		// fatal — a guard that swallows everything turns crashes into silent hangs.
+		setTimeout(() => {
+			throw new Error('unrelated harness failure');
+		}, 10);
+		return;
+	}
+
+	// The delete is what raises `EPERM: operation not permitted, watch` on Windows,
+	// asynchronously, on a native watcher chokidar never attached a listener to.
+	fs.rmSync(watched, { recursive: true, force: true });
+	setTimeout(() => {
+		process.stdout.write(`survived lostWatchCount=${_lostNativeWatchCountForTests()}\n`);
+		process.exit(0);
+	}, 1500);
+});

--- a/unitTests/utility/fixtures/lostWatchHarness.cjs
+++ b/unitTests/utility/fixtures/lostWatchHarness.cjs
@@ -24,6 +24,16 @@ fs.writeFileSync(path.join(watched, 'resources', 'index.js'), '// fixture\n');
 const watcher = guardedWatch('.', { cwd: watched, persistent: false, followSymlinks: false });
 
 watcher.on('ready', () => {
+	if (mode === 'sync-watch-failure') {
+		// A synchronous fs.watch() throw shares the guard's syscall ('watch') but carries a `path`,
+		// which is what keeps an ordinary "watching a path that isn't there" misconfiguration fatal
+		// instead of being mistaken for a benign lost watch and swallowed.
+		setTimeout(() => {
+			fs.watch(path.join(root, 'no-such-directory'), { persistent: false }, () => {});
+		}, 10);
+		return;
+	}
+
 	if (mode === 'unrelated-throw') {
 		// The guard is installed now. An unrelated uncaught exception must still be
 		// fatal — a guard that swallows everything turns crashes into silent hangs.

--- a/unitTests/utility/fixtures/lostWatchHarness.cjs
+++ b/unitTests/utility/fixtures/lostWatchHarness.cjs
@@ -17,6 +17,21 @@ const {
 
 const mode = process.argv[2];
 
+// How long to wait for an asynchronous watch failure. On Windows it is the error itself we are
+// waiting for, and delivery competes with everything else on a loaded CI runner; elsewhere nothing
+// will ever arrive and this is only a settle period, so it stays short. Cases that can observe the
+// error poll for it and exit early, so the deadline is a ceiling, not a sleep.
+const DELIVERY_DEADLINE_MS = process.platform === 'win32' ? 5000 : 1500;
+
+function waitForDelivery(isDelivered, onDeadline) {
+	const deadline = Date.now() + DELIVERY_DEADLINE_MS;
+	const poll = setInterval(() => {
+		if (!isDelivered() && Date.now() < deadline) return;
+		clearInterval(poll);
+		onDeadline();
+	}, 50);
+}
+
 if (mode === 'warn-threshold') {
 	// No watcher needed: claim a run of synthetic lost-watch errors and let the caller count the
 	// warnings that reach the log. Warn is the default level, so this is the visible cadence.
@@ -52,10 +67,24 @@ const watcher = guardedWatch('.', { cwd: watched, persistent: false, followSymli
 watcher.on('ready', () => {
 	if (mode === 'prepend-ordering') {
 		fs.rmSync(watched, { recursive: true, force: true });
+		// The handler above exits as soon as it runs, so reaching this is the failure.
 		setTimeout(() => {
 			process.stdout.write('thread-handler never ran\n');
 			process.exit(3);
-		}, 1500);
+		}, DELIVERY_DEADLINE_MS);
+		return;
+	}
+
+	if (mode === 'frozen-claim') {
+		// A lost-watch-shaped error the guard cannot mark handled: `isHandled` is unassignable on a
+		// frozen object, so classifying it throws. That throw happens inside the guard's
+		// 'uncaughtException' listener, which runs first, so an unprotected guard would replace this
+		// error's report with a TypeError and exit 7 instead of leaving it fatal on its own terms.
+		setTimeout(() => {
+			throw Object.freeze(
+				Object.assign(new Error('frozen lost watch'), { code: 'EPERM', syscall: 'watch', filename: null })
+			);
+		}, 10);
 		return;
 	}
 
@@ -81,8 +110,11 @@ watcher.on('ready', () => {
 	// The delete is what raises `EPERM: operation not permitted, watch` on Windows,
 	// asynchronously, on a native watcher chokidar never attached a listener to.
 	fs.rmSync(watched, { recursive: true, force: true });
-	setTimeout(() => {
-		process.stdout.write(`survived lostWatchCount=${_lostNativeWatchCountForTests()}\n`);
-		process.exit(0);
-	}, 1500);
+	waitForDelivery(
+		() => _lostNativeWatchCountForTests() > 0,
+		() => {
+			process.stdout.write(`survived lostWatchCount=${_lostNativeWatchCountForTests()}\n`);
+			process.exit(0);
+		}
+	);
 });

--- a/unitTests/utility/fixtures/lostWatchHarness.cjs
+++ b/unitTests/utility/fixtures/lostWatchHarness.cjs
@@ -17,10 +17,9 @@ const {
 
 const mode = process.argv[2];
 
-// How long to wait for an asynchronous watch failure. On Windows it is the error itself we are
-// waiting for, and delivery competes with everything else on a loaded CI runner; elsewhere nothing
-// will ever arrive and this is only a settle period, so it stays short. Cases that can observe the
-// error poll for it and exit early, so the deadline is a ceiling, not a sleep.
+// A ceiling, not a sleep: observers poll and exit early. Windows is where the error actually
+// arrives, and delivery competes with everything else on a loaded runner; elsewhere nothing ever
+// arrives and this is only a settle period.
 const DELIVERY_DEADLINE_MS = process.platform === 'win32' ? 5000 : 1500;
 
 function waitForDelivery(isDelivered, onDeadline) {
@@ -76,10 +75,9 @@ watcher.on('ready', () => {
 	}
 
 	if (mode === 'frozen-claim') {
-		// A lost-watch-shaped error the guard cannot mark handled, because `isHandled` is
-		// unassignable on a frozen object. Marking is bookkeeping, so the claim still stands and the
-		// process lives; an unprotected guard would instead throw from inside its own
-		// 'uncaughtException' listener, replacing the report with a TypeError and exiting 7.
+		// `isHandled` is unassignable on a frozen error, and marking is only bookkeeping, so the claim
+		// stands and the process lives. An unprotected guard would throw from inside its own
+		// 'uncaughtException' listener instead, replacing the report with a TypeError and exiting 7.
 		setTimeout(() => {
 			throw Object.freeze(
 				Object.assign(new Error('frozen lost watch'), { code: 'EPERM', syscall: 'watch', filename: null })
@@ -93,9 +91,8 @@ watcher.on('ready', () => {
 	}
 
 	if (mode === 'unclassifiable-throw') {
-		// Classification is the one step left that can throw: reading the shape runs this getter.
-		// An error the guard cannot classify is not its to claim, so it has to stay fatal rather
-		// than take the process down with a TypeError from inside the guard's own listener.
+		// Reading the shape runs this getter, which is the one step left that can throw. An error the
+		// guard cannot classify is not its to claim and has to stay fatal on its own terms.
 		setTimeout(() => {
 			throw {
 				syscall: 'watch',

--- a/unitTests/utility/watchPath.test.js
+++ b/unitTests/utility/watchPath.test.js
@@ -155,7 +155,15 @@ describe('watchPath', () => {
 			'resources/blob.ts',
 			'security/keys.ts',
 			'server/threads/manageThreads.js',
+			'utility/watcherFallback.ts',
 		];
+
+		// Sites whose own file canonicalization call is exempt: `guardedWatch` in
+		// utility/watcherFallback.ts is the shared primitive underneath every
+		// `guardedWatch(...)` call site below, taking an already-resolved path from
+		// its caller rather than resolving one of its own — the same relationship
+		// raw `chokidar.watch` has to the other listed sites.
+		const CANONICALIZES_VIA_CALLER = new Set(['utility/watcherFallback.ts']);
 
 		// `watch`, not `watchFile`: the latter is stat polling with no fs-event handle, so it is outside
 		// the invariant (`utility/logging/readLog.ts`). `node:fs/promises` counts — its async iterator
@@ -168,6 +176,7 @@ describe('watchPath', () => {
 			new RegExp(`\\{[^}]*\\bwatch\\b[^}]*\\}\\s*=\\s*require\\(\\s*['"]${FS_MODULE}['"]\\s*\\)`),
 			new RegExp(`require\\(\\s*['"]${FS_MODULE}['"]\\s*\\)\\s*\\.watch\\s*\\(`),
 			/\bfs(?:Promises|p)?\.watch\s*\(/,
+			/\bguardedWatch\s*\(/,
 		];
 
 		const repoRoot = join(__dirname, '..', '..');
@@ -212,9 +221,12 @@ describe('watchPath', () => {
 		});
 
 		// File-level: catches a site that never canonicalizes, not a second raw watch beside a
-		// canonicalized one.
+		// canonicalized one. A CANONICALIZES_VIA_CALLER site is skipped here: its own callers are
+		// each listed in NATIVE_WATCH_SITES too (none of them exempted), so this same loop already
+		// requires every one of them to canonicalize before calling it.
 		it('all route their path through the canonicalization helper', () => {
 			for (const site of NATIVE_WATCH_SITES) {
+				if (CANONICALIZES_VIA_CALLER.has(site)) continue;
 				const source = readFileSync(join(repoRoot, site), 'utf8');
 				assert.ok(
 					/\bresolveWatchTarget\b|\bcanonicalizeWatchPath\b/.test(source),

--- a/unitTests/utility/watcherFallback.test.js
+++ b/unitTests/utility/watcherFallback.test.js
@@ -1,10 +1,14 @@
 const {
+	claimLostNativeWatchError,
+	isLostNativeWatchError,
 	isWatcherExhaustionError,
 	POLLING_FALLBACK_OPTIONS,
 	warnWatcherFallback,
 	_resetForTests,
 } = require('#src/utility/watcherFallback');
 const assert = require('node:assert');
+const { spawn } = require('node:child_process');
+const { once } = require('node:events');
 
 describe('watcherFallback', () => {
 	describe('isWatcherExhaustionError', () => {
@@ -55,6 +59,102 @@ describe('watcherFallback', () => {
 		it('does not throw on repeated invocation', () => {
 			assert.doesNotThrow(() => warnWatcherFallback('/some/path'));
 			assert.doesNotThrow(() => warnWatcherFallback('/some/other/path'));
+		});
+	});
+
+	describe('isLostNativeWatchError', () => {
+		const watchError = (code) => Object.assign(new Error(`${code}: watch`), { code, syscall: 'watch', errno: -4048 });
+
+		it('identifies the Windows EPERM raised when a watched path is deleted', () => {
+			assert.equal(isLostNativeWatchError(watchError('EPERM')), true);
+		});
+
+		it('identifies an ENOENT watch failure', () => {
+			assert.equal(isLostNativeWatchError(watchError('ENOENT')), true);
+		});
+
+		// The guard swallows whatever this claims, process-wide, so the two neighbouring
+		// error shapes it must never claim are worth pinning: an EPERM from a config
+		// rename is a real failure the caller has to see, and exhaustion belongs to the
+		// polling-fallback route above, not here.
+		it('rejects an EPERM from a syscall other than watch', () => {
+			assert.equal(
+				isLostNativeWatchError(Object.assign(new Error('EPERM: rename'), { code: 'EPERM', syscall: 'rename' })),
+				false
+			);
+		});
+
+		it('rejects watcher exhaustion errors', () => {
+			assert.equal(isLostNativeWatchError(watchError('ENOSPC')), false);
+			assert.equal(isLostNativeWatchError(watchError('EMFILE')), false);
+		});
+
+		it('rejects an EPERM with no syscall', () => {
+			assert.equal(isLostNativeWatchError(Object.assign(new Error('boom'), { code: 'EPERM' })), false);
+		});
+
+		it('rejects non-error values', () => {
+			assert.equal(isLostNativeWatchError(null), false);
+			assert.equal(isLostNativeWatchError(undefined), false);
+			assert.equal(isLostNativeWatchError('EPERM'), false);
+		});
+	});
+
+	describe('claimLostNativeWatchError', () => {
+		afterEach(() => {
+			_resetForTests();
+		});
+
+		it('claims a lost watch and marks it handled so the thread-level handler stays quiet', () => {
+			const error = Object.assign(new Error('EPERM: watch'), { code: 'EPERM', syscall: 'watch' });
+			assert.equal(claimLostNativeWatchError(error), true);
+			assert.equal(error.isHandled, true);
+		});
+
+		it('leaves an unrelated error alone', () => {
+			const error = Object.assign(new Error('boom'), { code: 'EACCES' });
+			assert.equal(claimLostNativeWatchError(error), false);
+			assert.equal(error.isHandled, undefined);
+		});
+	});
+
+	// chokidar never attaches an 'error' listener to the underlying Node
+	// FSWatcher when `persistent: false` (which every Harper watcher uses), so an async
+	// watch failure is an uncaughtException rather than something the watcher can route.
+	// These run in a child process because the harness must be the only thing standing
+	// between the error and process death — mocha's own uncaughtException listener would
+	// otherwise absorb it and the test would pass regardless.
+	describe('lost native watch guard', () => {
+		const runHarness = async (mode) => {
+			const harness = spawn(process.execPath, [require.resolve('./fixtures/lostWatchHarness.cjs'), mode], {
+				stdio: ['ignore', 'pipe', 'pipe'],
+			});
+			let stdout = '';
+			let stderr = '';
+			harness.stdout.on('data', (chunk) => (stdout += chunk));
+			harness.stderr.on('data', (chunk) => (stderr += chunk));
+			const [code] = await once(harness, 'close');
+			return { code, stdout, stderr };
+		};
+
+		it('survives deletion of a watched directory', async function () {
+			this.timeout(30000);
+			const { code, stdout, stderr } = await runHarness('delete-watched-dir');
+			assert.equal(code, 0, `harness exited ${code}: ${stderr}`);
+			assert.match(stdout, /survived lostWatchCount=(\d+)/);
+			if (process.platform === 'win32') {
+				// Only Windows actually raises the error; elsewhere this case is a smoke
+				// test that the guard doesn't disturb ordinary watching.
+				const claimed = Number(stdout.match(/lostWatchCount=(\d+)/)[1]);
+				assert.ok(claimed > 0, 'expected the guard to have claimed at least one lost watch on Windows');
+			}
+		});
+
+		it('leaves an unrelated uncaught exception fatal', async function () {
+			this.timeout(30000);
+			const { code, stderr } = await runHarness('unrelated-throw');
+			assert.equal(code, 1);
+			assert.match(stderr, /unrelated harness failure/);
 		});
 	});
 });

--- a/unitTests/utility/watcherFallback.test.js
+++ b/unitTests/utility/watcherFallback.test.js
@@ -178,8 +178,8 @@ describe('watcherFallback', () => {
 		// uncaughtException listener regardless, so ordering is the whole mechanism.
 		it('runs ahead of a thread-level handler registered before the first watcher', async function () {
 			this.timeout(30000);
-			const { code, stdout, stderr } = await runHarness('prepend-ordering');
 			if (process.platform !== 'win32') return this.skip(); // only Windows raises the error
+			const { code, stdout, stderr } = await runHarness('prepend-ordering');
 			assert.equal(code, 0, `harness exited ${code}: ${stderr}`);
 			assert.match(stdout, /thread-handler saw isHandled=true/);
 		});
@@ -202,6 +202,19 @@ describe('watcherFallback', () => {
 			const { code, stderr } = await runHarness('sync-watch-failure');
 			assert.equal(code, 1);
 			assert.match(stderr, /ENOENT/);
+		});
+
+		// The guard runs before every other uncaughtException listener, so a throw out of its own
+		// classification would cost the process both the original error's report (exit 7, with the
+		// guard's TypeError in its place) and the thread-level handlers' turn. A frozen error of
+		// exactly the claimed shape is the reachable version of that: reading it succeeds, marking
+		// it handled does not.
+		it('stays out of the way when it cannot mark an error handled', async function () {
+			this.timeout(30000);
+			const { code, stderr } = await runHarness('frozen-claim');
+			assert.equal(code, 1, `expected the original error to stay fatal, got exit ${code}: ${stderr}`);
+			assert.match(stderr, /frozen lost watch/);
+			assert.doesNotMatch(stderr, /not extensible/);
 		});
 	});
 });

--- a/unitTests/utility/watcherFallback.test.js
+++ b/unitTests/utility/watcherFallback.test.js
@@ -63,14 +63,30 @@ describe('watcherFallback', () => {
 	});
 
 	describe('isLostNativeWatchError', () => {
-		const watchError = (code) => Object.assign(new Error(`${code}: watch`), { code, syscall: 'watch', errno: -4048 });
+		// The async shape Node delivers to the watch handle's 'error' event: no `path`, and a
+		// `filename` that is null.
+		const watchError = (code) =>
+			Object.assign(new Error(`${code}: watch`), { code, syscall: 'watch', errno: -4048, filename: null });
 
 		it('identifies the Windows EPERM raised when a watched path is deleted', () => {
 			assert.equal(isLostNativeWatchError(watchError('EPERM')), true);
 		});
 
-		it('identifies an ENOENT watch failure', () => {
-			assert.equal(isLostNativeWatchError(watchError('ENOENT')), true);
+		// Whatever this claims is swallowed process-wide, so the shapes it must NOT claim matter
+		// as much as the one it must. A synchronous fs.watch() throw carries a `path`; an async
+		// ENOENT from a watch handle has never been observed, while a synchronous one is the
+		// ordinary "watch a path that isn't there" misconfiguration and has to stay fatal.
+		it('rejects a synchronous fs.watch throw, which carries a path', () => {
+			assert.equal(
+				isLostNativeWatchError(
+					Object.assign(new Error('EPERM: watch'), { code: 'EPERM', syscall: 'watch', path: '/some/dir' })
+				),
+				false
+			);
+		});
+
+		it('rejects an ENOENT watch failure', () => {
+			assert.equal(isLostNativeWatchError(watchError('ENOENT')), false);
 		});
 
 		// The guard swallows whatever this claims, process-wide, so the two neighbouring
@@ -155,6 +171,16 @@ describe('watcherFallback', () => {
 			const { code, stderr } = await runHarness('unrelated-throw');
 			assert.equal(code, 1);
 			assert.match(stderr, /unrelated harness failure/);
+		});
+
+		// The guard sees every uncaught exception in the process, so the bound that keeps it from
+		// masking real failures is the error shape. A misconfigured raw fs.watch() shares its
+		// syscall and would be swallowed if the shape check were any looser.
+		it('leaves a synchronous fs.watch failure on a missing path fatal', async function () {
+			this.timeout(30000);
+			const { code, stderr } = await runHarness('sync-watch-failure');
+			assert.equal(code, 1);
+			assert.match(stderr, /ENOENT/);
 		});
 	});
 });

--- a/unitTests/utility/watcherFallback.test.js
+++ b/unitTests/utility/watcherFallback.test.js
@@ -173,6 +173,27 @@ describe('watcherFallback', () => {
 			assert.match(stderr, /unrelated harness failure/);
 		});
 
+		// The `isHandled` marker only suppresses the thread-level handlers if the guard's listener
+		// runs before theirs — which is why it is prepended, not appended. Node calls every
+		// uncaughtException listener regardless, so ordering is the whole mechanism.
+		it('runs ahead of a thread-level handler registered before the first watcher', async function () {
+			this.timeout(30000);
+			const { code, stdout, stderr } = await runHarness('prepend-ordering');
+			if (process.platform !== 'win32') return this.skip(); // only Windows raises the error
+			assert.equal(code, 0, `harness exited ${code}: ${stderr}`);
+			assert.match(stdout, /thread-handler saw isHandled=true/);
+		});
+
+		it('warns on the first occurrence and at each tenfold increase', async function () {
+			this.timeout(30000);
+			const { code, stdout, stderr } = await runHarness('warn-threshold');
+			assert.equal(code, 0, `harness exited ${code}: ${stderr}`);
+			assert.match(stdout, /claimed=12/);
+			// 12 claims => warnings at occurrence 1 and 10, and no others.
+			const warnings = `${stdout}${stderr}`.match(/failed asynchronously/g) ?? [];
+			assert.equal(warnings.length, 2, `expected 2 warnings across 12 claims, got ${warnings.length}`);
+		});
+
 		// The guard sees every uncaught exception in the process, so the bound that keeps it from
 		// masking real failures is the error shape. A misconfigured raw fs.watch() shares its
 		// syscall and would be swallowed if the shape check were any looser.

--- a/unitTests/utility/watcherFallback.test.js
+++ b/unitTests/utility/watcherFallback.test.js
@@ -132,6 +132,15 @@ describe('watcherFallback', () => {
 			assert.equal(claimLostNativeWatchError(error), false);
 			assert.equal(error.isHandled, undefined);
 		});
+
+		// The watcher 'error' routes in EntryHandler, OptionsWatcher, RootConfigWatcher, keys.ts and
+		// manageThreads.js call this directly, outside the process guard's own try/catch, so marking
+		// an error it cannot mark has to be survivable here rather than only there.
+		it('claims an error it cannot mark handled instead of throwing', () => {
+			const error = Object.freeze(Object.assign(new Error('EPERM: watch'), { code: 'EPERM', syscall: 'watch' }));
+			assert.equal(claimLostNativeWatchError(error), true);
+			assert.equal(error.isHandled, undefined);
+		});
 	});
 
 	// chokidar never attaches an 'error' listener to the underlying Node
@@ -204,17 +213,25 @@ describe('watcherFallback', () => {
 			assert.match(stderr, /ENOENT/);
 		});
 
-		// The guard runs before every other uncaughtException listener, so a throw out of its own
-		// classification would cost the process both the original error's report (exit 7, with the
-		// guard's TypeError in its place) and the thread-level handlers' turn. A frozen error of
-		// exactly the claimed shape is the reachable version of that: reading it succeeds, marking
-		// it handled does not.
-		it('stays out of the way when it cannot mark an error handled', async function () {
+		// The guard runs before every other uncaughtException listener, so a throw out of the guard
+		// itself costs the process both the original error's report (exit 7, with the guard's own
+		// TypeError in its place) and the thread-level handlers' turn. These two pin the boundary
+		// either side of the classification: bookkeeping that fails must not un-claim a benign
+		// error, and a shape the guard cannot read is not its error to claim.
+		it('still claims a lost watch it cannot mark handled', async function () {
 			this.timeout(30000);
-			const { code, stderr } = await runHarness('frozen-claim');
-			assert.equal(code, 1, `expected the original error to stay fatal, got exit ${code}: ${stderr}`);
-			assert.match(stderr, /frozen lost watch/);
+			const { code, stdout, stderr } = await runHarness('frozen-claim');
+			assert.equal(code, 0, `harness exited ${code}: ${stderr}`);
+			assert.match(stdout, /survived lostWatchCount=1/);
 			assert.doesNotMatch(stderr, /not extensible/);
+		});
+
+		it('leaves an error it cannot classify fatal', async function () {
+			this.timeout(30000);
+			const { code, stderr } = await runHarness('unclassifiable-throw');
+			assert.equal(code, 1, `expected the original throw to stay fatal, got exit ${code}: ${stderr}`);
+			assert.match(stderr, /EPERM/);
+			assert.doesNotMatch(stderr, /probe getter/); // the guard's own throw, had it not caught
 		});
 	});
 });

--- a/unitTests/utility/watcherFallback.test.js
+++ b/unitTests/utility/watcherFallback.test.js
@@ -133,9 +133,7 @@ describe('watcherFallback', () => {
 			assert.equal(error.isHandled, undefined);
 		});
 
-		// The watcher 'error' routes in EntryHandler, OptionsWatcher, RootConfigWatcher, keys.ts and
-		// manageThreads.js call this directly, outside the process guard's own try/catch, so marking
-		// an error it cannot mark has to be survivable here rather than only there.
+		// The five watcher 'error' routes call this directly, outside the process guard's try/catch.
 		it('claims an error it cannot mark handled instead of throwing', () => {
 			const error = Object.freeze(Object.assign(new Error('EPERM: watch'), { code: 'EPERM', syscall: 'watch' }));
 			assert.equal(claimLostNativeWatchError(error), true);
@@ -213,11 +211,9 @@ describe('watcherFallback', () => {
 			assert.match(stderr, /ENOENT/);
 		});
 
-		// The guard runs before every other uncaughtException listener, so a throw out of the guard
-		// itself costs the process both the original error's report (exit 7, with the guard's own
-		// TypeError in its place) and the thread-level handlers' turn. These two pin the boundary
-		// either side of the classification: bookkeeping that fails must not un-claim a benign
-		// error, and a shape the guard cannot read is not its error to claim.
+		// The two sides of the boundary: bookkeeping that fails must not un-claim a benign error, and
+		// a shape the guard cannot read is not its error to claim. A throw out of the guard itself
+		// would cost the process the original report (exit 7) and the thread-level handlers' turn.
 		it('still claims a lost watch it cannot mark handled', async function () {
 			this.timeout(30000);
 			const { code, stdout, stderr } = await runHarness('frozen-claim');

--- a/utility/watcherFallback.ts
+++ b/utility/watcherFallback.ts
@@ -191,7 +191,18 @@ export function claimLostNativeWatchError(error: unknown): boolean {
 let lostNativeWatchGuardInstalled = false;
 
 function handleUncaughtException(error: unknown): void {
-	if (claimLostNativeWatchError(error)) return;
+	let claimed = false;
+	try {
+		claimed = claimLostNativeWatchError(error);
+	} catch {
+		// Classifying must never be the thing that kills the process. A throw from inside an
+		// 'uncaughtException' listener replaces Node's report with this one and exits 7, and this
+		// listener runs first, so it would also cost the thread-level handlers their turn. A frozen
+		// error (`isHandled` unassignable) or a throwing property getter lands here; "not ours" is
+		// the safe reading, leaving the original exception fatal exactly as it would have been.
+		claimed = false;
+	}
+	if (claimed) return;
 	// Not ours. Node suppresses its default fatal handling as soon as *any*
 	// 'uncaughtException' listener exists, so if this guard is the only listener
 	// its mere presence would turn unrelated crashes into silent hangs. Step out

--- a/utility/watcherFallback.ts
+++ b/utility/watcherFallback.ts
@@ -5,7 +5,7 @@
 // events. Polling-based watching doesn't consume inotify handles or per-watcher
 // file descriptors, so we fall back to it once and warn — see harper#488.
 
-import chokidar, { type ChokidarOptions, type FSWatcher } from 'chokidar';
+import { watch as chokidarWatch, type ChokidarOptions, type FSWatcher } from 'chokidar';
 import { loggerWithTag } from './logging/harper_logger.ts';
 
 // One-time process-wide warning so a thundering herd of failing watchers doesn't
@@ -75,6 +75,10 @@ export function _resetForTests(): void {
 	exhaustionWarned = false;
 	lostNativeWatchCount = 0;
 	lostNativeWatchWarnThreshold = 1;
+	// Also drop the process listener, so a case that installed the guard can't leave one
+	// attached to the test runner's process for every case that follows.
+	process.removeListener('uncaughtException', handleUncaughtException);
+	lostNativeWatchGuardInstalled = false;
 }
 
 // ---------------------------------------------------------------------------
@@ -154,9 +158,13 @@ let lostNativeWatchWarnThreshold = 1;
  */
 export function claimLostNativeWatchError(error: unknown): boolean {
 	if (!isLostNativeWatchError(error)) return false;
-	// server/threads/threadServer.js skips errors already marked handled, so the
-	// benign case doesn't also get logged there as a worker-level uncaughtException.
-	(error as { isHandled?: boolean }).isHandled = true;
+	const claimed = error as { isHandled?: boolean };
+	// Already claimed. Counting the same instance twice would inflate the tally and trip the
+	// decade warning early, so report it as claimed and stop.
+	if (claimed.isHandled) return true;
+	// server/threads/threadServer.js and server/threads/socketRouter.ts skip errors already
+	// marked handled, so the benign case doesn't also get logged there as an uncaughtException.
+	claimed.isHandled = true;
 	lostNativeWatchCount++;
 	fallbackLogger.trace?.(`Lost native file watch handle (occurrence ${lostNativeWatchCount}):`, error);
 	// Never go fully silent. Node gives this error no path, so it cannot be attributed to the
@@ -190,6 +198,10 @@ function handleUncaughtException(error: unknown): void {
 	// of the way and let the exception be fatal exactly as it would have been.
 	if (process.listenerCount('uncaughtException') > 1) return;
 	process.removeListener('uncaughtException', handleUncaughtException);
+	// Stepping aside is meant to be terminal, but say so in the state rather than assuming it:
+	// clearing the flag means a process that somehow survives re-arms on its next guardedWatch()
+	// instead of running unguarded for the rest of its life.
+	lostNativeWatchGuardInstalled = false;
 	// Re-raising on the next tick (rather than throwing from inside the handler)
 	// keeps Node's normal report and exit code 1; a throw from within the handler
 	// exits 7 instead.
@@ -219,7 +231,7 @@ export function installLostNativeWatchGuard(): void {
  */
 export function guardedWatch(paths: string | string[], options?: ChokidarOptions): FSWatcher {
 	installLostNativeWatchGuard();
-	return chokidar.watch(paths, options);
+	return chokidarWatch(paths, options);
 }
 
 // Test-only: number of lost native watch errors claimed so far.

--- a/utility/watcherFallback.ts
+++ b/utility/watcherFallback.ts
@@ -162,28 +162,37 @@ export function claimLostNativeWatchError(error: unknown): boolean {
 	// Already claimed. Counting the same instance twice would inflate the tally and trip the
 	// decade warning early, so report it as claimed and stop.
 	if (claimed.isHandled) return true;
-	// server/threads/threadServer.js and server/threads/socketRouter.ts skip errors already
-	// marked handled, so the benign case doesn't also get logged there as an uncaughtException.
-	claimed.isHandled = true;
 	lostNativeWatchCount++;
-	fallbackLogger.trace?.(`Lost native file watch handle (occurrence ${lostNativeWatchCount}):`, error);
-	// Never go fully silent. Node gives this error no path, so it cannot be attributed to the
-	// watcher that raised it — ours or a dependency's — and a subsystem that has quietly stopped
-	// being watched is exactly what an operator needs to see. The default log level is `warn`, so
-	// trace alone would make every occurrence after the first invisible. Warn on the first and
-	// then at each decade, which keeps a delete storm (one error per directory in a removed tree)
-	// bounded without ever suppressing the signal outright.
-	if (lostNativeWatchCount >= lostNativeWatchWarnThreshold) {
-		lostNativeWatchWarnThreshold *= 10;
-		fallbackLogger.warn?.(
-			`A native file watch handle failed asynchronously (EPERM, syscall=watch) and was suppressed to ` +
-				`keep the thread alive; occurrence ${lostNativeWatchCount}. Node reports no path for this error, ` +
-				`so it cannot be attributed to a specific watcher — whatever was watching that path has stopped ` +
-				`reporting changes until it is re-established. On Windows this is usually a watched directory ` +
-				`being deleted or replaced (a component redeploy, a package install, a test teardown). If file ` +
-				`changes stop being picked up somewhere, this is why. Subsequent occurrences log at trace, with ` +
-				`a warning at each tenfold increase.`
-		);
+	// The claim is the classification above; everything from here is bookkeeping, and bookkeeping
+	// must not throw. This runs from a watcher's own 'error' route as well as from the process
+	// guard, so a frozen error (`isHandled` unassignable) or a logger that throws would otherwise
+	// turn a failure we just decided was benign into a fatal one.
+	try {
+		fallbackLogger.trace?.(`Lost native file watch handle (occurrence ${lostNativeWatchCount}):`, error);
+		// Never go fully silent. Node gives this error no path, so it cannot be attributed to the
+		// watcher that raised it — ours or a dependency's — and a subsystem that has quietly stopped
+		// being watched is exactly what an operator needs to see. The default log level is `warn`, so
+		// trace alone would make every occurrence after the first invisible. Warn on the first and
+		// then at each decade, which keeps a delete storm (one error per directory in a removed tree)
+		// bounded without ever suppressing the signal outright.
+		if (lostNativeWatchCount >= lostNativeWatchWarnThreshold) {
+			lostNativeWatchWarnThreshold *= 10;
+			fallbackLogger.warn?.(
+				`A native file watch handle failed asynchronously (EPERM, syscall=watch) and was suppressed to ` +
+					`keep the thread alive; occurrence ${lostNativeWatchCount}. Node reports no path for this error, ` +
+					`so it cannot be attributed to a specific watcher — whatever was watching that path has stopped ` +
+					`reporting changes until it is re-established. On Windows this is usually a watched directory ` +
+					`being deleted or replaced (a component redeploy, a package install, a test teardown). If file ` +
+					`changes stop being picked up somewhere, this is why. Subsequent occurrences log at trace, with ` +
+					`a warning at each tenfold increase.`
+			);
+		}
+		// Last, because it is the only step whose failure costs nothing that has not already
+		// happened: server/threads/threadServer.js and server/threads/socketRouter.ts skip errors
+		// already marked handled, so this only keeps the benign case from being logged twice.
+		claimed.isHandled = true;
+	} catch {
+		// Marked or not, logged or not, the error stays claimed.
 	}
 	return true;
 }
@@ -195,11 +204,11 @@ function handleUncaughtException(error: unknown): void {
 	try {
 		claimed = claimLostNativeWatchError(error);
 	} catch {
-		// Classifying must never be the thing that kills the process. A throw from inside an
-		// 'uncaughtException' listener replaces Node's report with this one and exits 7, and this
-		// listener runs first, so it would also cost the thread-level handlers their turn. A frozen
-		// error (`isHandled` unassignable) or a throwing property getter lands here; "not ours" is
-		// the safe reading, leaving the original exception fatal exactly as it would have been.
+		// Only classification can still throw here (a property getter that does), and it must not
+		// be what kills the process: a throw from inside an 'uncaughtException' listener replaces
+		// Node's report with this one and exits 7, and this listener runs first, so it would also
+		// cost the thread-level handlers their turn. An error we could not classify is not ours,
+		// and stays fatal exactly as it would have been unguarded.
 		claimed = false;
 	}
 	if (claimed) return;

--- a/utility/watcherFallback.ts
+++ b/utility/watcherFallback.ts
@@ -74,6 +74,7 @@ export function warnWatcherFallback(watchedPath: string): void {
 export function _resetForTests(): void {
 	exhaustionWarned = false;
 	lostNativeWatchCount = 0;
+	lostNativeWatchWarnThreshold = 1;
 }
 
 // ---------------------------------------------------------------------------
@@ -109,34 +110,41 @@ export function _resetForTests(): void {
 // error shape and leaves every other uncaught exception exactly as Node would
 // have handled it.
 
-// Watch failures that mean "this native watch handle is gone". The watched path
-// has been deleted or replaced; there is nothing to recover and nothing the
-// operator can do, so the error is benign. Kept deliberately narrow — anything
-// matched here is swallowed process-wide.
-const LOST_NATIVE_WATCH_CODES = new Set(['EPERM', 'ENOENT']);
-
 /**
  * Returns `true` for the asynchronous "the watched path went away" error raised
- * by Node's `fs.FSWatcher`. On Windows this is
- * `EPERM: operation not permitted, watch` (errno -4048) and it fires whenever a
- * watched directory is removed or swapped out — a component redeploy, a test
- * fixture teardown, an `npm install` that replaces a tree.
+ * by Node's `fs.FSWatcher`: `EPERM: operation not permitted, watch` (errno
+ * -4048), which fires on Windows whenever a watched directory is removed or
+ * swapped out — a component redeploy, a test fixture teardown, an `npm install`
+ * that replaces a tree.
  *
  * Deliberately distinct from {@link isWatcherExhaustionError}: exhaustion means
  * the host ran out of watch capacity and polling is a useful degradation; a lost
  * native watch means the thing being watched no longer exists, and polling would
  * only burn CPU on a path that isn't there.
+ *
+ * The three conditions are all load-bearing, because whatever this claims is
+ * swallowed process-wide:
+ *
+ *   - `syscall === 'watch'` is only ever set by fs watch handles.
+ *   - `EPERM` only. An async `ENOENT` from a watch handle has never been
+ *     observed, whereas a *synchronous* one is the ordinary "watch a path that
+ *     isn't there" misconfiguration, which must stay fatal.
+ *   - no `path`. This is what separates the async failure from a synchronous
+ *     `fs.watch()` throw: Node populates `path` on the thrown error but leaves
+ *     it absent on the one delivered to the handle's 'error' event (which
+ *     carries `filename: null` and nothing else locating it). Without this a
+ *     raw `fs.watch(missingPath)` escaping into an uncaughtException would be
+ *     mistaken for a benign lost watch and silently swallowed.
  */
 export function isLostNativeWatchError(error: unknown): boolean {
 	if (typeof error !== 'object' || error === null) return false;
-	const { code, syscall } = error as { code?: unknown; syscall?: unknown };
-	// `syscall === 'watch'` is only ever set by fs watch handles, so the pair is
-	// specific enough to claim without also inspecting the stack (whose frame
-	// text is a Node internal we don't want to depend on).
-	return syscall === 'watch' && typeof code === 'string' && LOST_NATIVE_WATCH_CODES.has(code);
+	const { code, syscall, path } = error as { code?: unknown; syscall?: unknown; path?: unknown };
+	return syscall === 'watch' && code === 'EPERM' && path == null;
 }
 
 let lostNativeWatchCount = 0;
+// Warn on occurrence 1, then 10, 100, … — see claimLostNativeWatchError().
+let lostNativeWatchWarnThreshold = 1;
 
 /**
  * If `error` is a lost native watch error, mark it handled, log it, and report
@@ -150,15 +158,24 @@ export function claimLostNativeWatchError(error: unknown): boolean {
 	// benign case doesn't also get logged there as a worker-level uncaughtException.
 	(error as { isHandled?: boolean }).isHandled = true;
 	lostNativeWatchCount++;
-	if (lostNativeWatchCount === 1) {
+	fallbackLogger.trace?.(`Lost native file watch handle (occurrence ${lostNativeWatchCount}):`, error);
+	// Never go fully silent. Node gives this error no path, so it cannot be attributed to the
+	// watcher that raised it — ours or a dependency's — and a subsystem that has quietly stopped
+	// being watched is exactly what an operator needs to see. The default log level is `warn`, so
+	// trace alone would make every occurrence after the first invisible. Warn on the first and
+	// then at each decade, which keeps a delete storm (one error per directory in a removed tree)
+	// bounded without ever suppressing the signal outright.
+	if (lostNativeWatchCount >= lostNativeWatchWarnThreshold) {
+		lostNativeWatchWarnThreshold *= 10;
 		fallbackLogger.warn?.(
-			`A file watch handle was lost because the watched path was deleted or replaced ` +
-				`(${(error as { code?: string }).code}, syscall=watch). This is expected on Windows during ` +
-				`component redeploys and is not actionable; the watcher for that path stops reporting changes ` +
-				`and is re-established the next time the path is watched. Further occurrences log at trace.`
+			`A native file watch handle failed asynchronously (EPERM, syscall=watch) and was suppressed to ` +
+				`keep the thread alive; occurrence ${lostNativeWatchCount}. Node reports no path for this error, ` +
+				`so it cannot be attributed to a specific watcher — whatever was watching that path has stopped ` +
+				`reporting changes until it is re-established. On Windows this is usually a watched directory ` +
+				`being deleted or replaced (a component redeploy, a package install, a test teardown). If file ` +
+				`changes stop being picked up somewhere, this is why. Subsequent occurrences log at trace, with ` +
+				`a warning at each tenfold increase.`
 		);
-	} else {
-		fallbackLogger.trace?.(`Lost file watch handle (occurrence ${lostNativeWatchCount}):`, error);
 	}
 	return true;
 }

--- a/utility/watcherFallback.ts
+++ b/utility/watcherFallback.ts
@@ -85,60 +85,34 @@ export function _resetForTests(): void {
 // Lost native watch (predominantly Windows)
 // ---------------------------------------------------------------------------
 //
-// Every Harper watcher runs chokidar with `persistent: false` so a watcher never
-// holds the event loop open. That option takes chokidar down a code path that
-// never attaches an 'error' listener to the underlying Node `fs.FSWatcher`
-// (chokidar `handler.js`, `setFsWatchListener`):
-//
-//     if (!options.persistent) {
-//         watcher = createFsWatchInstance(path, options, listener, errHandler, rawEmitter);
-//         if (!watcher) return;
-//         return watcher.close.bind(watcher);   // <-- no watcher.on('error', ...)
-//     }
-//
-// `errHandler` is only consulted for a *synchronous* throw out of `fs.watch()`
-// (which is how ENOSPC/EMFILE reach `isWatcherExhaustionError` above). An
-// *asynchronous* watch failure — on Windows, deleting or replacing the watched
-// directory — is delivered by `node:internal/fs/watchers` as
-// `this.emit('error', err)` on an emitter with no listener, so Node turns it
-// into an uncaughtException. The error never reaches chokidar's wrapper, so
-// attaching `.on('error')` to the chokidar `FSWatcher` we hold does not help.
-//
-// chokidar's `persistent: true` branch does attach a listener and swallows this
-// exact error (its node#4337 workaround), which is why only Harper's watchers
-// see it. The upstream fix is one line — `watcher.on('error', errHandler)` in
-// the non-persistent branch — and is still missing as of chokidar 5.0.0.
-//
-// Until then `installLostNativeWatchGuard()` supplies the missing listener at
-// the only place the error is observable: the process. It claims *only* this
-// error shape and leaves every other uncaught exception exactly as Node would
-// have handled it.
+// Every Harper watcher runs `persistent: false`, which is the one chokidar
+// branch that never attaches an 'error' listener to the underlying Node
+// `fs.FSWatcher` (chokidar `handler.js`, `setFsWatchListener`; still so at
+// 5.0.0). Its `errHandler` covers only a synchronous throw out of `fs.watch()`
+// — the ENOSPC/EMFILE route above. An asynchronous failure is emitted on a
+// handle with no listener, so Node makes it an uncaughtException without it
+// ever reaching chokidar; `.on('error')` on the wrapper we hold cannot see it.
+// The process is therefore the only place it is observable, which is what
+// `installLostNativeWatchGuard()` uses.
 
 /**
  * Returns `true` for the asynchronous "the watched path went away" error raised
- * by Node's `fs.FSWatcher`: `EPERM: operation not permitted, watch` (errno
- * -4048), which fires on Windows whenever a watched directory is removed or
- * swapped out — a component redeploy, a test fixture teardown, an `npm install`
- * that replaces a tree.
+ * by Node's `fs.FSWatcher` — on Windows, `EPERM: operation not permitted, watch`
+ * (errno -4048) when a watched directory is removed or swapped out. Unlike
+ * {@link isWatcherExhaustionError} there is nothing to degrade to: polling a
+ * path that no longer exists only burns CPU.
  *
- * Deliberately distinct from {@link isWatcherExhaustionError}: exhaustion means
- * the host ran out of watch capacity and polling is a useful degradation; a lost
- * native watch means the thing being watched no longer exists, and polling would
- * only burn CPU on a path that isn't there.
- *
- * The three conditions are all load-bearing, because whatever this claims is
+ * All three conditions are load-bearing, because whatever this claims is
  * swallowed process-wide:
  *
  *   - `syscall === 'watch'` is only ever set by fs watch handles.
  *   - `EPERM` only. An async `ENOENT` from a watch handle has never been
  *     observed, whereas a *synchronous* one is the ordinary "watch a path that
  *     isn't there" misconfiguration, which must stay fatal.
- *   - no `path`. This is what separates the async failure from a synchronous
- *     `fs.watch()` throw: Node populates `path` on the thrown error but leaves
- *     it absent on the one delivered to the handle's 'error' event (which
- *     carries `filename: null` and nothing else locating it). Without this a
- *     raw `fs.watch(missingPath)` escaping into an uncaughtException would be
- *     mistaken for a benign lost watch and silently swallowed.
+ *   - no `path`. Node populates `path` on the error it throws out of
+ *     `fs.watch()` and leaves it absent on the one it delivers to the handle,
+ *     so without this a raw `fs.watch(missingPath)` reaching the guard would be
+ *     mistaken for a benign lost watch and swallowed.
  */
 export function isLostNativeWatchError(error: unknown): boolean {
 	if (typeof error !== 'object' || error === null) return false;
@@ -147,7 +121,6 @@ export function isLostNativeWatchError(error: unknown): boolean {
 }
 
 let lostNativeWatchCount = 0;
-// Warn on occurrence 1, then 10, 100, … — see claimLostNativeWatchError().
 let lostNativeWatchWarnThreshold = 1;
 
 /**
@@ -159,22 +132,17 @@ let lostNativeWatchWarnThreshold = 1;
 export function claimLostNativeWatchError(error: unknown): boolean {
 	if (!isLostNativeWatchError(error)) return false;
 	const claimed = error as { isHandled?: boolean };
-	// Already claimed. Counting the same instance twice would inflate the tally and trip the
-	// decade warning early, so report it as claimed and stop.
+	// Counting one instance twice would trip the warn threshold early.
 	if (claimed.isHandled) return true;
 	lostNativeWatchCount++;
-	// The claim is the classification above; everything from here is bookkeeping, and bookkeeping
-	// must not throw. This runs from a watcher's own 'error' route as well as from the process
-	// guard, so a frozen error (`isHandled` unassignable) or a logger that throws would otherwise
-	// turn a failure we just decided was benign into a fatal one.
+	// The claim is the classification above; the bookkeeping that follows must not be able to
+	// undo it. A frozen error (`isHandled` unassignable) or a throwing logger would otherwise
+	// make a failure just classified as benign fatal — here, or in a caller's 'error' route.
 	try {
 		fallbackLogger.trace?.(`Lost native file watch handle (occurrence ${lostNativeWatchCount}):`, error);
-		// Never go fully silent. Node gives this error no path, so it cannot be attributed to the
-		// watcher that raised it — ours or a dependency's — and a subsystem that has quietly stopped
-		// being watched is exactly what an operator needs to see. The default log level is `warn`, so
-		// trace alone would make every occurrence after the first invisible. Warn on the first and
-		// then at each decade, which keeps a delete storm (one error per directory in a removed tree)
-		// bounded without ever suppressing the signal outright.
+		// A subsystem that has silently stopped being watched is what an operator needs to see, and
+		// the default level is `warn`, so trace alone would hide every occurrence after the first.
+		// Warning at each decade keeps a delete storm bounded without ever going fully silent.
 		if (lostNativeWatchCount >= lostNativeWatchWarnThreshold) {
 			lostNativeWatchWarnThreshold *= 10;
 			fallbackLogger.warn?.(
@@ -187,9 +155,8 @@ export function claimLostNativeWatchError(error: unknown): boolean {
 					`a warning at each tenfold increase.`
 			);
 		}
-		// Last, because it is the only step whose failure costs nothing that has not already
-		// happened: server/threads/threadServer.js and server/threads/socketRouter.ts skip errors
-		// already marked handled, so this only keeps the benign case from being logged twice.
+		// Last: threadServer.js and socketRouter.ts skip errors already marked handled, so failing
+		// to mark one costs only a duplicate log line.
 		claimed.isHandled = true;
 	} catch {
 		// Marked or not, logged or not, the error stays claimed.
@@ -204,27 +171,20 @@ function handleUncaughtException(error: unknown): void {
 	try {
 		claimed = claimLostNativeWatchError(error);
 	} catch {
-		// Only classification can still throw here (a property getter that does), and it must not
-		// be what kills the process: a throw from inside an 'uncaughtException' listener replaces
-		// Node's report with this one and exits 7, and this listener runs first, so it would also
-		// cost the thread-level handlers their turn. An error we could not classify is not ours,
-		// and stays fatal exactly as it would have been unguarded.
+		// Classification is all that can still throw (a property getter that does), and a throw
+		// from inside an 'uncaughtException' listener would replace Node's report with it and
+		// exit 7. An error that cannot be classified is not ours to claim.
 		claimed = false;
 	}
 	if (claimed) return;
-	// Not ours. Node suppresses its default fatal handling as soon as *any*
-	// 'uncaughtException' listener exists, so if this guard is the only listener
-	// its mere presence would turn unrelated crashes into silent hangs. Step out
-	// of the way and let the exception be fatal exactly as it would have been.
+	// Node suppresses its default fatal handling as soon as *any* 'uncaughtException' listener
+	// exists, so being the only listener would turn unrelated crashes into silent hangs.
 	if (process.listenerCount('uncaughtException') > 1) return;
 	process.removeListener('uncaughtException', handleUncaughtException);
-	// Stepping aside is meant to be terminal, but say so in the state rather than assuming it:
-	// clearing the flag means a process that somehow survives re-arms on its next guardedWatch()
-	// instead of running unguarded for the rest of its life.
+	// A process that somehow survives re-arms on its next guardedWatch() rather than running
+	// unguarded thereafter.
 	lostNativeWatchGuardInstalled = false;
-	// Re-raising on the next tick (rather than throwing from inside the handler)
-	// keeps Node's normal report and exit code 1; a throw from within the handler
-	// exits 7 instead.
+	// nextTick, not a throw from inside the handler: that keeps Node's report and exit code 1.
 	process.nextTick(() => {
 		throw error;
 	});

--- a/utility/watcherFallback.ts
+++ b/utility/watcherFallback.ts
@@ -5,7 +5,7 @@
 // events. Polling-based watching doesn't consume inotify handles or per-watcher
 // file descriptors, so we fall back to it once and warn — see harper#488.
 
-import { watch as chokidarWatch, type ChokidarOptions, type FSWatcher } from 'chokidar';
+import chokidar, { type ChokidarOptions, type FSWatcher } from 'chokidar';
 import { loggerWithTag } from './logging/harper_logger.ts';
 
 // One-time process-wide warning so a thundering herd of failing watchers doesn't
@@ -231,7 +231,10 @@ export function installLostNativeWatchGuard(): void {
  */
 export function guardedWatch(paths: string | string[], options?: ChokidarOptions): FSWatcher {
 	installLostNativeWatchGuard();
-	return chokidarWatch(paths, options);
+	// Deliberately a property access on the default export rather than a named `watch` import:
+	// unitTests/server/threads/watchDirFallback.test.js drives the reopen-on-exhaustion chain by
+	// swapping `chokidar.default.watch`, and a named import binds past that seam.
+	return chokidar.watch(paths, options);
 }
 
 // Test-only: number of lost native watch errors claimed so far.

--- a/utility/watcherFallback.ts
+++ b/utility/watcherFallback.ts
@@ -5,6 +5,7 @@
 // events. Polling-based watching doesn't consume inotify handles or per-watcher
 // file descriptors, so we fall back to it once and warn — see harper#488.
 
+import chokidar, { type ChokidarOptions, type FSWatcher } from 'chokidar';
 import { loggerWithTag } from './logging/harper_logger.ts';
 
 // One-time process-wide warning so a thundering herd of failing watchers doesn't
@@ -72,6 +73,141 @@ export function warnWatcherFallback(watchedPath: string): void {
 // Test-only hook to reset the one-time warning gate between cases.
 export function _resetForTests(): void {
 	exhaustionWarned = false;
+	lostNativeWatchCount = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Lost native watch (predominantly Windows)
+// ---------------------------------------------------------------------------
+//
+// Every Harper watcher runs chokidar with `persistent: false` so a watcher never
+// holds the event loop open. That option takes chokidar down a code path that
+// never attaches an 'error' listener to the underlying Node `fs.FSWatcher`
+// (chokidar `handler.js`, `setFsWatchListener`):
+//
+//     if (!options.persistent) {
+//         watcher = createFsWatchInstance(path, options, listener, errHandler, rawEmitter);
+//         if (!watcher) return;
+//         return watcher.close.bind(watcher);   // <-- no watcher.on('error', ...)
+//     }
+//
+// `errHandler` is only consulted for a *synchronous* throw out of `fs.watch()`
+// (which is how ENOSPC/EMFILE reach `isWatcherExhaustionError` above). An
+// *asynchronous* watch failure — on Windows, deleting or replacing the watched
+// directory — is delivered by `node:internal/fs/watchers` as
+// `this.emit('error', err)` on an emitter with no listener, so Node turns it
+// into an uncaughtException. The error never reaches chokidar's wrapper, so
+// attaching `.on('error')` to the chokidar `FSWatcher` we hold does not help.
+//
+// chokidar's `persistent: true` branch does attach a listener and swallows this
+// exact error (its node#4337 workaround), which is why only Harper's watchers
+// see it. The upstream fix is one line — `watcher.on('error', errHandler)` in
+// the non-persistent branch — and is still missing as of chokidar 5.0.0.
+//
+// Until then `installLostNativeWatchGuard()` supplies the missing listener at
+// the only place the error is observable: the process. It claims *only* this
+// error shape and leaves every other uncaught exception exactly as Node would
+// have handled it.
+
+// Watch failures that mean "this native watch handle is gone". The watched path
+// has been deleted or replaced; there is nothing to recover and nothing the
+// operator can do, so the error is benign. Kept deliberately narrow — anything
+// matched here is swallowed process-wide.
+const LOST_NATIVE_WATCH_CODES = new Set(['EPERM', 'ENOENT']);
+
+/**
+ * Returns `true` for the asynchronous "the watched path went away" error raised
+ * by Node's `fs.FSWatcher`. On Windows this is
+ * `EPERM: operation not permitted, watch` (errno -4048) and it fires whenever a
+ * watched directory is removed or swapped out — a component redeploy, a test
+ * fixture teardown, an `npm install` that replaces a tree.
+ *
+ * Deliberately distinct from {@link isWatcherExhaustionError}: exhaustion means
+ * the host ran out of watch capacity and polling is a useful degradation; a lost
+ * native watch means the thing being watched no longer exists, and polling would
+ * only burn CPU on a path that isn't there.
+ */
+export function isLostNativeWatchError(error: unknown): boolean {
+	if (typeof error !== 'object' || error === null) return false;
+	const { code, syscall } = error as { code?: unknown; syscall?: unknown };
+	// `syscall === 'watch'` is only ever set by fs watch handles, so the pair is
+	// specific enough to claim without also inspecting the stack (whose frame
+	// text is a Node internal we don't want to depend on).
+	return syscall === 'watch' && typeof code === 'string' && LOST_NATIVE_WATCH_CODES.has(code);
+}
+
+let lostNativeWatchCount = 0;
+
+/**
+ * If `error` is a lost native watch error, mark it handled, log it, and report
+ * that it has been claimed. Exported so the per-watcher error routes can give it
+ * the same benign treatment on the day chokidar does deliver it to the wrapper
+ * (its polling and `persistent: true` branches already would).
+ */
+export function claimLostNativeWatchError(error: unknown): boolean {
+	if (!isLostNativeWatchError(error)) return false;
+	// server/threads/threadServer.js skips errors already marked handled, so the
+	// benign case doesn't also get logged there as a worker-level uncaughtException.
+	(error as { isHandled?: boolean }).isHandled = true;
+	lostNativeWatchCount++;
+	if (lostNativeWatchCount === 1) {
+		fallbackLogger.warn?.(
+			`A file watch handle was lost because the watched path was deleted or replaced ` +
+				`(${(error as { code?: string }).code}, syscall=watch). This is expected on Windows during ` +
+				`component redeploys and is not actionable; the watcher for that path stops reporting changes ` +
+				`and is re-established the next time the path is watched. Further occurrences log at trace.`
+		);
+	} else {
+		fallbackLogger.trace?.(`Lost file watch handle (occurrence ${lostNativeWatchCount}):`, error);
+	}
+	return true;
+}
+
+let lostNativeWatchGuardInstalled = false;
+
+function handleUncaughtException(error: unknown): void {
+	if (claimLostNativeWatchError(error)) return;
+	// Not ours. Node suppresses its default fatal handling as soon as *any*
+	// 'uncaughtException' listener exists, so if this guard is the only listener
+	// its mere presence would turn unrelated crashes into silent hangs. Step out
+	// of the way and let the exception be fatal exactly as it would have been.
+	if (process.listenerCount('uncaughtException') > 1) return;
+	process.removeListener('uncaughtException', handleUncaughtException);
+	// Re-raising on the next tick (rather than throwing from inside the handler)
+	// keeps Node's normal report and exit code 1; a throw from within the handler
+	// exits 7 instead.
+	process.nextTick(() => {
+		throw error;
+	});
+}
+
+/**
+ * Idempotently install the process-level listener that supplies the 'error'
+ * handler chokidar omits for non-persistent watchers. Called by
+ * {@link guardedWatch} so no watcher call site can forget it.
+ */
+export function installLostNativeWatchGuard(): void {
+	if (lostNativeWatchGuardInstalled) return;
+	lostNativeWatchGuardInstalled = true;
+	// prepend, not append: threadServer.js already has an 'uncaughtException'
+	// listener, and the `isHandled` mark above only suppresses its log line if
+	// this guard runs first.
+	process.prependListener('uncaughtException', handleUncaughtException);
+}
+
+/**
+ * `chokidar.watch()` with the lost-native-watch guard installed. Every Harper
+ * chokidar watcher must go through this — a raw `chokidar.watch(..., { persistent: false })`
+ * can take down the thread the first time its path is deleted.
+ */
+export function guardedWatch(paths: string | string[], options?: ChokidarOptions): FSWatcher {
+	installLostNativeWatchGuard();
+	return chokidar.watch(paths, options);
+}
+
+// Test-only: number of lost native watch errors claimed so far.
+export function _lostNativeWatchCountForTests(): number {
+	return lostNativeWatchCount;
 }
 
 /**


### PR DESCRIPTION
## The bug

Windows-only. Deleting or replacing a watched path raises an uncaught `EPERM: operation not permitted, watch` (errno -4048, `syscall: 'watch'`) from `node:internal/fs/watchers`. Distinct from the 8.3 short-path abort (#2309) and the config-write EPERM rename (#2339), both of which have since landed and are in this branch's base.

Every Harper chokidar watcher runs with `persistent: false` so it never holds the event loop open. That option takes chokidar down the one branch of `setFsWatchListener` that never attaches an `'error'` listener to the underlying Node `fs.FSWatcher`:

```js
if (!options.persistent) {
    watcher = createFsWatchInstance(path, options, listener, errHandler, rawEmitter);
    if (!watcher) return;
    return watcher.close.bind(watcher);      // <-- no watcher.on('error', ...)
}
```

`errHandler` there is only consulted for a *synchronous* throw out of `fs.watch()` — which is how ENOSPC/EMFILE already reach the polling fallback added in #488. An *asynchronous* watch failure is delivered as `emit('error', err)` on an emitter with no listener, so Node turns it into an uncaughtException. It never reaches chokidar's wrapper, so `.on('error')` on the `FSWatcher` we hold cannot see it. chokidar's `persistent: true` branch *does* attach a listener and swallows this exact error (its node#4337 workaround), which is why only our watchers hit it.

Live in CI: `Integration Tests 4/6 (Windows, Node.js v24)` on main logs repeated `uncaughtException Error: EPERM: operation not permitted, watch` during `Redeploy runtime-equivalence proof`, which deletes and replaces component directories.

## Why not the obvious fixes

- **Upgrade chokidar** — 5.0.0 has the identical bug. Verified by running the repro against a 5.0.0 install: same uncaught EPERM, exit 9; the same script with `persistent: true` prints `SURVIVED`. No upstream issue covers it (#1380 is a different EPERM: `syscall: 'rename'` from the caller's own `renameSync`). The upstream fix is one line, `watcher.on('error', errHandler)` in the non-persistent branch.
- **Patch chokidar locally** — no `postinstall` exists today, and patch-package patches would not apply for anyone installing `harper` from npm, so production Windows users would still crash.
- **Wrap `fs.watch`** — appears to work (chokidar's ESM facade for `node:fs` is snapshotted lazily at first ESM import, so a CJS-first patch does reach it), but *any* earlier `import … from 'node:fs'` in the graph silently defeats it and we have dozens. Verified both the working and the defeated ordering.
- **`persistent: true`** — deliberately not touched; the option exists so watchers don't hold the event loop open, and chokidar exposes no way to unref the handle.
- **Route it to a specific watcher** — impossible. The error carries `filename: null` and no `path`, so it cannot be attributed to the watcher that died.

## The fix

[`guardedWatch()`](https://github.com/HarperFast/harper/pull/2364/changes?w=1#diff-1809f175e220dbae7624752ecb2b6485fd364d5ee612aa6865352a3b03be8d50R217) in `utility/watcherFallback.ts`: `chokidar.watch()` plus an idempotent, [**prepended**](https://github.com/HarperFast/harper/pull/2364/changes?w=1#diff-1809f175e220dbae7624752ecb2b6485fd364d5ee612aa6865352a3b03be8d50R204) process-level listener that supplies the missing handler at the only place the error is observable. All five chokidar call sites route through it — `EntryHandler`, `OptionsWatcher`, `RootConfigWatcher`, `security/keys.ts`, `manageThreads.js` — so no call site can forget.

[Three conditions](https://github.com/HarperFast/harper/pull/2364/changes?w=1#diff-1809f175e220dbae7624752ecb2b6485fd364d5ee612aa6865352a3b03be8d50R120) bound what it claims, and all are load-bearing, because whatever it claims is swallowed process-wide:

- `syscall === 'watch'` — only ever set by fs watch handles.
- `code === 'EPERM'` only. Not ENOENT: an async ENOENT from a watch handle has never been observed, whereas a *synchronous* one is the ordinary "watch a path that isn't there" misconfiguration.
- **no `path`.** This separates the async failure from a synchronous `fs.watch()` throw — Node populates `path` on the thrown error but leaves it absent on the one delivered to the handle's `'error'` event. Without it, a raw `fs.watch(missingPath)` escaping into an uncaughtException would be mistaken for a benign lost watch and silently swallowed.

It also **does not become a blanket crash suppressor**: for anything it does not claim, if the guard is the only `uncaughtException` listener it [removes itself](https://github.com/HarperFast/harper/pull/2364/changes?w=1#diff-1809f175e220dbae7624752ecb2b6485fd364d5ee612aa6865352a3b03be8d50R182), clears its installed flag, and re-raises on `nextTick`, preserving Node's report and exit code 1 (a plain rethrow from inside the handler gives exit 7).

**The claim is the classification; the bookkeeping is best-effort.** Counting, logging and the `isHandled` mark all run [inside a `try`](https://github.com/HarperFast/harper/pull/2364/changes?w=1#diff-1809f175e220dbae7624752ecb2b6485fd364d5ee612aa6865352a3b03be8d50R141), in that order, and cannot un-claim an error the shape check already accepted — the same function is called directly by the five watchers' own `'error'` routes, outside the guard. A frozen error or a logger that threw would otherwise turn a failure just classified as benign into a fatal one, and this listener runs first, so its throw would take Node's report (exit 7) and the thread-level handlers' turn with it. Only classification can still throw, and an error whose shape cannot even be read is not the guard's to claim: it stays fatal.

Claimed errors are marked `isHandled`, so `threadServer.js` stops logging them as worker-level uncaughtExceptions. [`socketRouter.ts` was missing that same check](https://github.com/HarperFast/harper/pull/2364/changes?w=1#diff-545704b0f9ebb0c229b5f127dc8c710d5061aedb1e01e00514a96385babb1196R23) — added, matching the contract threadServer already documents. **Prepending is the mechanism**: Node calls every listener regardless of order, so the mark only suppresses those handlers if the guard runs first.

Logging never goes fully silent. The default level is `warn`, so a warn on the first occurrence and trace thereafter would hide every subsequent one. It warns on the first and at each tenfold increase, traces every one. The message states only what is known — that the failure cannot be attributed to a specific watcher — and names the Windows deleted-directory case as the usual, not certain, cause.

[DESIGN.md's watch-site section](https://github.com/HarperFast/harper/pull/2364/changes?w=1#diff-3dc5dd454e080eb849ee5efaf79df2585fbe0a06804d69249b4c81da05a63875R1248) records the wrapper's relationship to the canonicalization invariant: `guardedWatch` arms the watch but resolves no path of its own, so every caller still canonicalizes before calling it.

**No polling fallback for this case, deliberately.** Polling a path that no longer exists just burns CPU. The recovery case that would have justified it does not need it: an atomic rename-replace of a watched config file does *not* kill the watcher (`add`, `change`, then a live `change` on a subsequent in-place write). The trigger is specifically removal of the watched *directory*, where the component is being torn down and the watcher recreated anyway.

## For the human reviewer

The pre-push rounds ran without the domain adjudicator (auto policy pruned it on a low-risk delta), so this is the ledger written from the standing findings rather than a generated one.

1. **The recovery contract — swallow and warn, with no re-arm.** Every review round raises this as its one open major: a claimed error means that watcher is gone, and nothing re-arms it or falls back to polling, so a long-lived config or component watcher whose directory was replaced stays silent until something re-establishes it. The alternative — re-arm the affected watcher — is not implementable at this layer: Node gives this error no `path` and `filename: null`, so it cannot be attributed to a watcher, and the trigger is the watched *directory* being removed, where polling would burn CPU on a path that no longer exists. What makes it liveable is that the case where it would matter (an atomic rename-replace of a watched file) does not kill the watcher at all, and the warn line names the symptom. A "no" here means per-call-site re-arming — each site already owns a reopen chain for exhaustion, so it is a contained follow-up, not a redesign of this PR.
2. **Where the guard's boundary sits.** Classification decides; the mark and the log lines are bookkeeping that cannot un-claim the error. The alternative is fail-closed: treat any failure — a frozen error, a logger that throws — as "not ours" and let it stay fatal. Chosen against, because the shape check is the decision and losing a log line does not make the failure less benign, and because the five watchers' `'error'` routes call the same function with no guard around them. Cost of a "no": a frozen lost-watch-shaped error takes the thread down. One commit either way.
3. **`socketRouter.ts` reads `isHandled` off a possibly-primitive error.** Two lenses flag it each round. Left as a plain property read to match the pre-existing `.code` read on the next line: `throw null` crashed that handler before this PR too, so `?.` on one line moves the crash rather than removing it. Making that handler null-safe is a separate change with its own semantics to decide.
4. **The `chokidar.default.watch` test seam.** One lens calls this a blocker every round, arguing the CJS mock cannot intercept `guardedWatch`. It demonstrably does: adopting the suggested named `watch` import made both `watchDirFallback` cases see zero watcher opens, which is why 7a8acb2b8 reverted it, and the suites pass as they stand. Ruling on it here would stop it being re-litigated per round.
5. **Comment density.** Trimmed in the last commit against the house default; what remains is the chokidar mechanism, the three load-bearing conditions, and the two ordering constraints. Lenses still call some of it narration — say the word and it comes down further.

## Verification (Windows 11, Node v24.14.0, chokidar 4.0.3)

Every shape Harper actually watches crashed before and survives after:

| shape | before | after |
|---|---|---|
| `watch('.', {cwd, persistent:false, followSymlinks:false, ignored})` — EntryHandler | uncaught EPERM | survives |
| `watch(file, {persistent:false})` — OptionsWatcher / RootConfigWatcher / keys.ts | uncaught EPERM | survives |
| `watch(dir, {persistent:false, ignored})` — manageThreads | uncaught EPERM | survives |

## Tests

[`unitTests/utility/watcherFallback.test.js`](https://github.com/HarperFast/harper/pull/2364/changes?w=1#diff-751a02d56cb63107abebcb38ffe727ef8e4312d97b5a4971ed1c37c0945d0148R137) — 23 passing, 1 pending. Predicate cases pin the shapes it must *not* claim: a synchronous throw (carries `path`), `ENOENT`, `EPERM` with `syscall: 'rename'`, and the exhaustion codes that belong to the polling route. A unit case covers the watchers' direct `'error'` route: an error the claim cannot mark is claimed anyway rather than thrown back at the caller.

Seven child-process cases via `fixtures/lostWatchHarness.cjs`. Child process is required: mocha's own `uncaughtException` listener would absorb the crash and the test would pass either way.

- a deleted watched directory does not kill the process
- an unrelated uncaught exception is still fatal (exit 1, original message)
- a synchronous `fs.watch` failure on a missing path is still fatal
- a threadServer-style listener registered *before* the first watcher observes `isHandled=true` — appending would leave it false, so this is what pins the ordering (win32 only; it is the one pending case elsewhere)
- twelve claims produce exactly two warnings, at occurrences 1 and 10
- [a frozen lost-watch error is still claimed and counted](https://github.com/HarperFast/harper/pull/2364/changes?w=1#diff-751a02d56cb63107abebcb38ffe727ef8e4312d97b5a4971ed1c37c0945d0148R217) — the process lives, where an unprotected guard would exit 7 with its own `TypeError`
- [an error the guard cannot classify stays fatal](https://github.com/HarperFast/harper/pull/2364/changes?w=1#diff-751a02d56cb63107abebcb38ffe727ef8e4312d97b5a4971ed1c37c0945d0148R225) — a throwing `path` getter, re-raised as itself rather than replaced by the guard's throw

The delete case asserts survival on every platform and `lostWatchCount > 0` on win32, so it still runs as a smoke test on the ubuntu-only unit-test CI; the two cases above raise their own errors and so assert real behavior on every platform. The harness's fixed 1.5s waits are now a 5s ceiling on win32 with early exit once delivery is observed, rather than a sleep that could race a loaded runner.

Linux (Node v26.2.0), this branch: `watcherFallback` + `watchPath` + `watchDirFallback` + `security/keys` — 100 passing, 1 pending, 0 failing. The Windows table above was measured at the first commit; the three commits since change only the guard's exception path and its tests, and touch no watch-arming behavior.

## Cross-model review

Reviewed by Codex (with repository read access) and Gemini. Codex found no blocker or significant issue and verified each claim against the code. Acted on, in the commits after the first:

- the claimed set was too wide — ENOENT dropped, absence of `path` required
- repeat occurrences were invisible at the default log level
- the guard's installed flag was not cleared when it steps aside, so a process that somehow survived would have run unguarded thereafter
- `_resetForTests` left a process listener attached to the test runner
- `claimLostNativeWatchError` could count one error instance twice
- prepend ordering and the warn cadence had no test coverage

Rejected with evidence: that `require('../../utility/watcherFallback.ts')` throws `MODULE_NOT_FOUND` (that file already has eight such requires and the build rewrites them to `.js`), and that restricting the exemption to registered guarded roots would work (not implementable — the error carries no path).

One reviewer suggestion was adopted and then reverted: switching to a named `watch` import binds past the seam `unitTests/server/threads/watchDirFallback.test.js` uses to stub `chokidar.default.watch`. The property access is load-bearing and now says so.

Four further delta rounds (codex graded + Gemini) covered the commits since. Fixed in response:

- the guard could throw from inside its own `uncaughtException` listener while classifying or marking an error — exit 7 with a `TypeError` in place of the real report, and the thread-level handlers never reached
- with the mark and the log inside one boundary, a logger that threw after the mark landed would have left the error unclaimed here but skipped as handled everywhere else, so nothing would have reported it
- the same hazard reached the watchers' direct `'error'` routes, which call the claim outside the guard
- `DESIGN.md` still described the guard as covering `EPERM`/`ENOENT` after ENOENT was dropped from the claimed set
- comment volume against the house default

What each round left open is in **For the human reviewer** above.

## Not in scope

- `EntryHandler` emits Windows backslash-separated entry paths — the first of the two pre-existing `EntryHandler.test.js` failures. Filed separately; the second is a cascade of the first, since the aborted test never reaches its `close()` before the fixture directory is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=7 @ edbacf047b0a</sub>

<sub>Human-Review-Need: 4 @ edbacf047b0a</sub>
