### PR TITLE
Stop harper_logger.test.js from silently taking its mocha process down, and pin both logging suites config

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -73,3 +73,49 @@ jobs:
 
       - name: Run tests
         run: npm run test:unit:all
+
+  # Windows had no unit-level coverage at all before this job: every job above pins
+  # ubuntu-latest, and integration-tests.yml was the only workflow touching Windows.
+  # Platform-gated code and the tests written to prove it therefore never executed.
+  #
+  # It runs a scoped slice of the unit tree rather than the whole thing — a set of
+  # suites still fail on Windows for environmental or test-design reasons that
+  # reproduce on `main`, so gating on everything would land red and stay red.
+  #
+  # This is the same `npm run test:unit:windows` a developer runs locally, so a failure
+  # here is reproducible without pushing. The scope, the exclusions (each with the
+  # reason it is there) and the reason the run is split into one mocha process per
+  # directory all live in unitTests/windowsGate.mjs — read its header before changing
+  # what this job covers.
+  #
+  # Make this `unit-test-windows` job a REQUIRED status check on `main`. It fires on
+  # every PR with no `paths:` filter, so it is satisfiable.
+  unit-test-windows:
+    name: Unit Test (Windows, Node.js v24)
+    runs-on: windows-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Build
+        run: npm run build
+        continue-on-error: true # we currently have type errors so just ignore that
+
+      # Bounded below the job so a hung group fails the step rather than cancelling
+      # the job, which keeps the gate's own group table in the log. The gate caps each
+      # group at 10 minutes on its own, so this bounds a pathological run, not a
+      # healthy one — a cold Windows runner does the whole gate in well under it.
+      - name: Run unit tests
+        timeout-minutes: 30
+        run: npm run test:unit:windows

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,11 @@ npm run test:unit:components       # Component/plugin system tests
 npm run test:unit:security         # Security tests
 npm run test:unit:apitests         # API tests (stops running server first)
 npm run test:unit:lmdb             # LMDB storage engine tests
+npm run test:unit:windows          # The Windows CI gate — a scoped slice, see below
 npm run test:integration           # Full integration test suite
 ```
+
+**Windows:** `test:unit:windows` is what the `unit-test-windows` CI job runs, and it covers only the part of the unit tree verified green on Windows. If you touch platform-specific code, run it — the Ubuntu jobs will not catch a Windows-only break. `unitTests/windowsGate.mjs` holds the scope and the list of suites still excluded, each with the reason; shrinking that list is welcome work. Note that mocha handed the whole scoped set in one process on Windows exits 0 part-way through without printing an epilogue, so the gate runs one process per directory and fails any group that reports no summary — do not collapse it back into a single `mocha` call.
 
 Run a single test file directly:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ npx mocha unitTests/resources/mytest.js
 
 TypeScript is stripped at runtime via `--conditions=typestrip` (Node.js native type stripping) — no compilation required for development. Use `npm run test:unit:typestrip` to run tests with this mode.
 
+**No ambient Harper install:** a unit test must not depend on one. The Ubuntu `unit-test` job runs `harper install` before its suites; the Windows gate does not, and neither does a clean checkout — so a test that reads whatever config the machine happens to have is green on Ubuntu and red on Windows. Three suites hit exactly this: `harper_logger`/`logRotator` (no config means `logging.file` is off, and `createLogger({ path })` silently writes nothing), `globalIsolation` (`applications.allowedSpawnCommands` is empty, so `spawn('npm')` is rejected as a disallowed command), and `terminalShutdown` (`restartWorkers()` loads the root components, and `loadCertificates()` reads the config _file_, so it rejects with ENOENT). Pin what the suite needs — `unitTests/logConfigFixture.js`, `env.setProperty()`, or a `ROOTPATH` pointed at a config the test writes — instead of reading it off the machine.
+
 **Test timing:** prefer condition-waits over fixed `delay(N)` sleeps. `await delay(N); assert(sideEffectHappened)` races against loaded runners and is the root cause of a class of flakiness (#1138). Use the shared `waitFor(condition, timeout?, interval?)` helper in `unitTests/waitFor.js` to poll until the actual condition holds. Reserve fixed sleeps for genuinely modeling elapsed time (TTL/expiry windows) or asserting a non-event (that something has _not_ happened yet).
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ npm run test:unit:windows          # The Windows CI gate — a scoped slice, see
 npm run test:integration           # Full integration test suite
 ```
 
-**Windows:** `test:unit:windows` is what the `unit-test-windows` CI job runs, and it covers only the part of the unit tree verified green on Windows. If you touch platform-specific code, run it — the Ubuntu jobs will not catch a Windows-only break. `unitTests/windowsGate.mjs` holds the scope and the list of suites still excluded, each with the reason; shrinking that list is welcome work. Note that mocha handed the whole scoped set in one process on Windows exits 0 part-way through without printing an epilogue, so the gate runs one process per directory and fails any group that reports no summary — do not collapse it back into a single `mocha` call.
+**Windows:** `test:unit:windows` is what the `unit-test-windows` CI job runs, and it covers only the part of the unit tree verified green on Windows. If you touch platform-specific code, run it — the Ubuntu jobs will not catch a Windows-only break. `unitTests/windowsGate.mjs` holds the scope and the list of suites still excluded, each with the reason; shrinking that list is welcome work. The gate runs one mocha process per directory and fails any group that exits without printing a summary line — keep both. A mocha run can stop advancing with nothing failed (`timeout: 0` in `.mocharc.json` means no test ever times out), in which case the event loop drains and the process exits 0 having printed no epilogue; that reads as a pass to every runner. `unitTests/mocha.init.js` fails such a run from the inside, and the gate's summary check backstops a process that never gets that far.
 
 Run a single test file directly:
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
 		"test:unit:utility": "mocha \"unitTests/utility/**/*.js\" --exclude \"unitTests/utility/logging/**/*\"",
 		"test:unit:server": "mocha \"unitTests/server/**/*.js\"",
 		"test:unit:config": "mocha \"unitTests/config/**/*.js\"",
+		"test:unit:windows": "node unitTests/windowsGate.mjs",
 		"test:unit:typestrip": "env NODE_OPTIONS=\"--conditions=typestrip\" npm run test:unit",
 		"test:unit:typestrip:all": "npm run test:unit:typestrip unitTests"
 	},

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -1084,10 +1084,9 @@ function acquirePidFileLock(
 
 function createSpawn(spawnFunction: (...args: any) => child_process.ChildProcess, alwaysAllow?: boolean) {
 	return function (command: string, args?: any, options?: any, callback?: (...args: any[]) => void) {
-		// Read per call, not snapshotted at module load: componentLoader imports this module, so it
-		// can load before the config is resolved, and a snapshot taken then would pin an empty
-		// allowlist (and an undefined base path) for the life of the process. Anything but a
-		// configured list still denies.
+		// componentLoader imports this module, so it can load before the config is resolved; a value
+		// captured out here would pin an empty allowlist, and an undefined base path, for the life of
+		// the process. Anything but a configured list denies.
 		if (!alwaysAllow) {
 			const allowedCommands = env.get(CONFIG_PARAMS.APPLICATIONS_ALLOWEDSPAWNCOMMANDS);
 			if (!Array.isArray(allowedCommands) || !allowedCommands.includes(command.split(' ')[0])) {

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -928,7 +928,6 @@ const ALLOWED_NODE_BUILTIN_MODULES = env.get(CONFIG_PARAMS.APPLICATIONS_ALLOWEDB
 				return true;
 			},
 		};
-const ALLOWED_COMMANDS = new Set(env.get(CONFIG_PARAMS.APPLICATIONS_ALLOWEDSPAWNCOMMANDS) ?? []);
 const child_processConstrained: any = {
 	exec: createSpawn(child_process.exec),
 	execFile: createSpawn(child_process.execFile),
@@ -1084,10 +1083,15 @@ function acquirePidFileLock(
 }
 
 function createSpawn(spawnFunction: (...args: any) => child_process.ChildProcess, alwaysAllow?: boolean) {
-	const basePath = env.getHdbBasePath();
 	return function (command: string, args?: any, options?: any, callback?: (...args: any[]) => void) {
-		if (!ALLOWED_COMMANDS.has(command.split(' ')[0]) && !alwaysAllow) {
-			throw new Error(`Command ${command} is not allowed`);
+		// Resolved per call, not once at module load: componentLoader imports this module, so it can
+		// be loaded before the config is resolved, and a snapshot taken then pins an empty allowlist
+		// (and an undefined base path) for the life of the process. Absent config still denies.
+		if (!alwaysAllow) {
+			const allowedCommands = new Set<string>(env.get(CONFIG_PARAMS.APPLICATIONS_ALLOWEDSPAWNCOMMANDS) ?? []);
+			if (!allowedCommands.has(command.split(' ')[0])) {
+				throw new Error(`Command ${command} is not allowed`);
+			}
 		}
 		const processName = options?.name;
 		if (!processName)
@@ -1097,7 +1101,7 @@ function createSpawn(spawnFunction: (...args: any) => child_process.ChildProcess
 		const requestedVersion = options?.version;
 
 		// Ensure PID directory exists
-		const pidDir = join(basePath, 'pids');
+		const pidDir = join(env.getHdbBasePath(), 'pids');
 		mkdirSync(pidDir, { recursive: true });
 
 		const pidFilePath = join(pidDir, `${processName}.pid`);

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -1084,12 +1084,13 @@ function acquirePidFileLock(
 
 function createSpawn(spawnFunction: (...args: any) => child_process.ChildProcess, alwaysAllow?: boolean) {
 	return function (command: string, args?: any, options?: any, callback?: (...args: any[]) => void) {
-		// Resolved per call, not once at module load: componentLoader imports this module, so it can
-		// be loaded before the config is resolved, and a snapshot taken then pins an empty allowlist
-		// (and an undefined base path) for the life of the process. Absent config still denies.
+		// Read per call, not snapshotted at module load: componentLoader imports this module, so it
+		// can load before the config is resolved, and a snapshot taken then would pin an empty
+		// allowlist (and an undefined base path) for the life of the process. Anything but a
+		// configured list still denies.
 		if (!alwaysAllow) {
-			const allowedCommands = new Set<string>(env.get(CONFIG_PARAMS.APPLICATIONS_ALLOWEDSPAWNCOMMANDS) ?? []);
-			if (!allowedCommands.has(command.split(' ')[0])) {
+			const allowedCommands = env.get(CONFIG_PARAMS.APPLICATIONS_ALLOWEDSPAWNCOMMANDS);
+			if (!Array.isArray(allowedCommands) || !allowedCommands.includes(command.split(' ')[0])) {
 				throw new Error(`Command ${command} is not allowed`);
 			}
 		}

--- a/unitTests/components/globalIsolation.test.js
+++ b/unitTests/components/globalIsolation.test.js
@@ -7,10 +7,9 @@ const env = require('#src/utility/environment/environmentManager');
 const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
 const { ApplicationScope } = require('#src/components/ApplicationScope');
 
-// The value static/defaultConfig.yaml ships, which `harper install` writes into the config file.
-// A machine with no Harper install has no config at all, so without this the allowlist is empty
-// and `spawn('npm')` is rejected as a disallowed command before it can be rejected for having no
-// process name — which is the restriction the spawn test is about.
+// What static/defaultConfig.yaml ships. A machine with no Harper install has no config at all, so
+// without this the allowlist is empty and `spawn('npm')` is rejected as a disallowed command before
+// it can be rejected for having no process name — the restriction the spawn test is about.
 const DEFAULT_ALLOWED_SPAWN_COMMANDS = ['npm', 'node'];
 
 describe('Global Variable Isolation in testJSWithDeps', function () {

--- a/unitTests/components/globalIsolation.test.js
+++ b/unitTests/components/globalIsolation.test.js
@@ -4,11 +4,28 @@ const { loadComponent, loadedPaths } = require('#src/components/componentLoader'
 const { PACKAGE_ROOT } = require('#src/utility/packageUtils');
 const fs = require('node:fs');
 const env = require('#src/utility/environment/environmentManager');
+const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
 const { ApplicationScope } = require('#src/components/ApplicationScope');
+
+// The value static/defaultConfig.yaml ships, which `harper install` writes into the config file.
+// A machine with no Harper install has no config at all, so without this the allowlist is empty
+// and `spawn('npm')` is rejected as a disallowed command before it can be rejected for having no
+// process name — which is the restriction the spawn test is about.
+const DEFAULT_ALLOWED_SPAWN_COMMANDS = ['npm', 'node'];
 
 describe('Global Variable Isolation in testJSWithDeps', function () {
 	let mockResources;
 	let pidsDir;
+	let configuredSpawnCommands;
+
+	before(function () {
+		configuredSpawnCommands = env.get(CONFIG_PARAMS.APPLICATIONS_ALLOWEDSPAWNCOMMANDS);
+		env.setProperty(CONFIG_PARAMS.APPLICATIONS_ALLOWEDSPAWNCOMMANDS, DEFAULT_ALLOWED_SPAWN_COMMANDS);
+	});
+
+	after(function () {
+		env.setProperty(CONFIG_PARAMS.APPLICATIONS_ALLOWEDSPAWNCOMMANDS, configuredSpawnCommands);
+	});
 
 	beforeEach(function () {
 		// Create mock resources

--- a/unitTests/logConfigFixture.js
+++ b/unitTests/logConfigFixture.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+ * Pins the logger's config for a test file that asserts on what lands in a log FILE.
+ *
+ * harper_logger resolves its config once, at module load, from the machine it is running on:
+ * getPropsFilePath() -> ~/.harperdb/hdb_boot_properties.file -> settings_path -> the config's
+ * `logging` section. The module-level `log_to_file` that comes out of that gates every file write
+ * in createLogger() — with no boot properties present, initLogSettings() takes its ENOENT path,
+ * `log_to_file` is false, and `createLogger({ path })` silently writes nothing to that path.
+ *
+ * So these suites passed on a developer machine with Harper installed and failed on a clean one
+ * (a CI runner, a fresh checkout) with ENOENT on the log they just wrote. initLogSettings()
+ * tolerates a missing boot properties file when ROOTPATH names a directory holding a config, so
+ * point it at one this fixture writes and force a re-init. Now the config under test is the one
+ * in the fixture rather than whatever the machine happens to have.
+ */
+
+const fs = require('fs-extra');
+const os = require('os');
+const path = require('path');
+const hdbTerms = require('#src/utility/hdbTerms');
+const harperLoggerModule = require('#src/utility/logging/harper_logger');
+
+/**
+ * @param level the logging.level to pin
+ * @param logRoot absolute directory for the MAIN log. Defaults to a throwaway temp dir, and that
+ *   is normally what you want: point it at a directory the test itself writes into and the test's
+ *   own logger collides with the main one, because getFileLogger() keys its file loggers by path.
+ * @returns a restore function; call it from `after`
+ */
+function pinLogConfig({ level = 'trace', stdStreams = false, logRoot } = {}) {
+	const rootPath = fs.mkdtempSync(path.join(os.tmpdir(), 'harper-log-fixture-'));
+	if (!logRoot) logRoot = path.join(rootPath, 'log');
+	fs.mkdirpSync(logRoot);
+	fs.writeFileSync(
+		path.join(rootPath, hdbTerms.HARPER_CONFIG_FILE),
+		[
+			`rootPath: ${JSON.stringify(rootPath)}`,
+			'logging:',
+			'  file: true',
+			`  stdStreams: ${stdStreams}`,
+			`  level: ${level}`,
+			`  root: ${JSON.stringify(logRoot)}`,
+			'',
+		].join('\n')
+	);
+
+	const originalRootPath = process.env.ROOTPATH;
+	// initLogSettings() ends in stdioLogging(), which replaces the real process.stdout/stderr
+	// .write and adds an 'error' listener to both. Put them back on restore.
+	const originalStdio = [process.stdout, process.stderr].map((stream) => ({
+		stream,
+		write: stream.write,
+		handler: stream.harperStdioErrorHandler,
+	}));
+
+	process.env.ROOTPATH = rootPath;
+	harperLoggerModule.initLogSettings(true);
+	refreshExternalLogger();
+
+	return function restoreLogConfig() {
+		if (originalRootPath === undefined) delete process.env.ROOTPATH;
+		else process.env.ROOTPATH = originalRootPath;
+		harperLoggerModule.initLogSettings(true);
+		// Not the object that was there before: that one belonged to the mainLogger this re-init
+		// just replaced. Pointing at the live logger is the invariant that matters.
+		refreshExternalLogger();
+		for (const { stream, write, handler } of originalStdio) {
+			stream.write = write;
+			if (stream.harperStdioErrorHandler) {
+				stream.removeListener('error', stream.harperStdioErrorHandler);
+				delete stream.harperStdioErrorHandler;
+			}
+			if (handler) {
+				stream.harperStdioErrorHandler = handler;
+				stream.on('error', handler);
+			}
+		}
+		fs.removeSync(rootPath);
+	};
+}
+
+/**
+ * harper_logger ends with `module.exports = { ... externalLogger: exports.externalLogger ... }`, a
+ * one-time snapshot taken just after the module-load initLogSettings() call. A re-init reassigns
+ * the module's own externalLogger but cannot reach that snapshot, so `require(...).externalLogger`
+ * would keep pointing at a logger belonging to the previous mainLogger — writing nowhere the
+ * caller can see. Re-point it. (The double export layering is the underlying wart; this keeps the
+ * fixture from silently changing what the global logger means.)
+ */
+function refreshExternalLogger() {
+	harperLoggerModule.externalLogger = harperLoggerModule.forComponent('external');
+}
+
+module.exports = { pinLogConfig };

--- a/unitTests/logConfigFixture.js
+++ b/unitTests/logConfigFixture.js
@@ -17,8 +17,8 @@
  */
 
 const fs = require('fs-extra');
-const os = require('os');
-const path = require('path');
+const os = require('node:os');
+const path = require('node:path');
 const hdbTerms = require('#src/utility/hdbTerms');
 const harperLoggerModule = require('#src/utility/logging/harper_logger');
 

--- a/unitTests/logConfigFixture.js
+++ b/unitTests/logConfigFixture.js
@@ -77,7 +77,12 @@ function pinLogConfig({ level = 'trace', stdStreams = false, logRoot } = {}) {
 				stream.on('error', handler);
 			}
 		}
-		fs.removeSync(rootPath);
+		// requireUncached() leaves rewired module instances holding their own fd on this tree, closed
+		// only by their own 10s CLOSE_LOG_FD_TIMEOUT, and Windows refuses to remove a tree while a
+		// handle is open under it. Throwing here would fail the `after` hook of a suite that passed.
+		try {
+			fs.removeSync(rootPath);
+		} catch {}
 	};
 }
 

--- a/unitTests/mocha.init.js
+++ b/unitTests/mocha.init.js
@@ -22,6 +22,40 @@ const terms = require('#src/utility/hdbTerms');
 
 const isApiTestRun = process.argv.some((arg) => typeof arg === 'string' && arg.includes('apiTests'));
 
+/**
+ * Fail a mocha run that dies mid-flight instead of letting it look like a pass.
+ *
+ * A run can stop advancing without anything failing: a reporter write that throws inside the
+ * runner's callback chain, or a hook that never calls back. `timeout: 0` in .mocharc.json means
+ * no test ever times out, so nothing marks the stalled test failed — the event loop simply drains
+ * and the process exits 0 having printed no epilogue and no failure. Every runner reads that as
+ * success. harper_logger.test.js did exactly this to any `dot`/`tap` run before it was fixed.
+ *
+ * Root hooks bracket the run, so "started but never finished" is the signal. Report it on fd 2
+ * with writeSync, since an unwritable stdout is one of the ways to get here.
+ */
+let runStarted = false;
+let runFinished = false;
+
+module.exports.mochaHooks = {
+	beforeAll() {
+		runStarted = true;
+	},
+	afterAll() {
+		runFinished = true;
+	},
+};
+
+process.on('exit', (code) => {
+	if (!runStarted || runFinished || code !== 0) return;
+	fs.writeSync(
+		2,
+		'\n*** mocha exited 0 without finishing its run: no epilogue was printed and no test failed. ***\n' +
+			'*** The run stalled or was aborted part-way through; treat this as a failure, not a pass. ***\n'
+	);
+	process.exitCode = 1;
+});
+
 if (!isApiTestRun) {
 	const UNIT_TEST_DIR = __dirname;
 	const ENV_DIR_NAME = 'envDir';

--- a/unitTests/server/threads/fixtures/terminalShutdownHarness.cjs
+++ b/unitTests/server/threads/fixtures/terminalShutdownHarness.cjs
@@ -1,11 +1,40 @@
 'use strict';
 
+const { mkdtempSync, rmSync, writeFileSync, writeSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
 const { once } = require('node:events');
 const { waitFor } = require('../../../waitFor.js');
+const { HARPER_CONFIG_FILE } = require('#src/utility/hdbTerms');
 process.env.HARPER_SAFE_MODE = 'true';
+
+// The restart modes below call restartWorkers(), which loads the root components, which reads the
+// config FILE (loadCertificates -> getConfigFromFile) rather than the in-memory config
+// initTestEnvironment() sets up. On a machine with no Harper installed there is no such file and
+// that call rejects with ENOENT, so write one and point ROOTPATH at it — the same lever
+// `harper --ROOTPATH` uses to run without boot properties.
+const rootPath = mkdtempSync(join(tmpdir(), 'harper-terminal-shutdown-'));
+writeFileSync(join(rootPath, HARPER_CONFIG_FILE), `rootPath: ${JSON.stringify(rootPath)}\n`);
+process.env.ROOTPATH = rootPath;
+process.on('exit', () => rmSync(rootPath, { force: true, recursive: true }));
+
 require('#src/utility/environment/environmentManager').initTestEnvironment();
 const manageThreads = require('#js/server/threads/manageThreads');
 const { beginProcessShutdown, restartWorkers, shutdownWorkersNow, startWorker, workers } = manageThreads;
+
+// Bounds a hang rather than asserting how fast a restart is: these waits run in a freshly spawned
+// process on a CI runner that may be doing anything else at the time.
+const WAIT_TIMEOUT_MS = 20_000;
+
+/**
+ * The restart modes race a wait against a restartWorkers() call they do not await until afterwards.
+ * A rejection from it would otherwise sit unhandled while the wait spins to its deadline and then
+ * reports the condition it was watching — "replacement worker was not created" instead of the
+ * ENOENT that actually stopped the restart.
+ */
+function rejectionOf(promise) {
+	return new Promise((resolve, reject) => promise.catch(reject));
+}
 
 async function terminalShutdown() {
 	let starts = 0;
@@ -17,7 +46,10 @@ async function terminalShutdown() {
 	});
 	await once(worker, 'message');
 	const restart = restartWorkers('http');
-	await waitFor(() => workers.length === 2, { timeout: 5000, message: 'replacement worker was not created' });
+	await Promise.race([
+		rejectionOf(restart),
+		waitFor(() => workers.length === 2, { timeout: WAIT_TIMEOUT_MS, message: 'replacement worker was not created' }),
+	]);
 	await shutdownWorkersNow();
 	await restart;
 
@@ -50,7 +82,10 @@ async function unexpectedExit() {
 	await once(worker, 'message');
 	beginProcessShutdown();
 	worker.postMessage('exit');
-	await waitFor(() => workers.length === 0, { timeout: 5000, message: 'unexpected worker exit did not settle' });
+	await waitFor(() => workers.length === 0, {
+		timeout: WAIT_TIMEOUT_MS,
+		message: 'unexpected worker exit did not settle',
+	});
 	process.stdout.write(`${JSON.stringify({ starts, workersAfterExit: workers.length })}\n`);
 }
 
@@ -64,7 +99,10 @@ async function nonOverlappingRestart() {
 	});
 	await once(worker, 'message');
 	const restart = restartWorkers('non-overlapping-test');
-	await waitFor(() => worker.wasShutdown, { timeout: 5000, message: 'worker restart did not begin' });
+	await Promise.race([
+		rejectionOf(restart),
+		waitFor(() => worker.wasShutdown, { timeout: WAIT_TIMEOUT_MS, message: 'worker restart did not begin' }),
+	]);
 	await shutdownWorkersNow();
 	await restart;
 	process.stdout.write(`${JSON.stringify({ starts, workersAfterShutdown: workers.length })}\n`);
@@ -126,6 +164,10 @@ const modes = {
 };
 const run = modes[mode] ?? terminalShutdown;
 run().catch((error) => {
-	console.error(error);
-	process.exitCode = 1;
+	// Exit rather than setting process.exitCode: whatever the mode was doing left a worker running,
+	// which holds the event loop open forever, so the harness never exits and its caller reports a
+	// mocha timeout with none of this in it. Report on stdout, which the caller captures and puts in
+	// the assertion message, and writeSync because process.exit() drops a queued write to a pipe.
+	writeSync(1, `${error?.stack ?? error}\n`);
+	process.exit(1);
 });

--- a/unitTests/server/threads/fixtures/terminalShutdownHarness.cjs
+++ b/unitTests/server/threads/fixtures/terminalShutdownHarness.cjs
@@ -8,11 +8,10 @@ const { waitFor } = require('../../../waitFor.js');
 const { HARPER_CONFIG_FILE } = require('#src/utility/hdbTerms');
 process.env.HARPER_SAFE_MODE = 'true';
 
-// The restart modes below call restartWorkers(), which loads the root components, which reads the
-// config FILE (loadCertificates -> getConfigFromFile) rather than the in-memory config
-// initTestEnvironment() sets up. On a machine with no Harper installed there is no such file and
-// that call rejects with ENOENT, so write one and point ROOTPATH at it — the same lever
-// `harper --ROOTPATH` uses to run without boot properties.
+// restartWorkers() loads the root components, and loadCertificates() reads the config FILE rather
+// than the in-memory config initTestEnvironment() sets up — with no Harper installed there is none
+// and the restart rejects with ENOENT. ROOTPATH is the lever `harper --ROOTPATH` uses to run
+// without boot properties.
 const rootPath = mkdtempSync(join(tmpdir(), 'harper-terminal-shutdown-'));
 writeFileSync(join(rootPath, HARPER_CONFIG_FILE), `rootPath: ${JSON.stringify(rootPath)}\n`);
 process.env.ROOTPATH = rootPath;
@@ -164,10 +163,10 @@ const modes = {
 };
 const run = modes[mode] ?? terminalShutdown;
 run().catch((error) => {
-	// Exit rather than setting process.exitCode: whatever the mode was doing left a worker running,
-	// which holds the event loop open forever, so the harness never exits and its caller reports a
-	// mocha timeout with none of this in it. Report on stdout, which the caller captures and puts in
-	// the assertion message, and writeSync because process.exit() drops a queued write to a pipe.
+	// Exit rather than set process.exitCode: a worker the failed mode left running holds the event
+	// loop open forever, and the caller then reports a mocha timeout carrying none of this. stdout
+	// because the caller captures it into the assertion message; writeSync because process.exit()
+	// drops a queued write to a pipe.
 	writeSync(1, `${error?.stack ?? error}\n`);
 	process.exit(1);
 });

--- a/unitTests/server/threads/fixtures/terminalShutdownHarness.cjs
+++ b/unitTests/server/threads/fixtures/terminalShutdownHarness.cjs
@@ -15,7 +15,14 @@ process.env.HARPER_SAFE_MODE = 'true';
 const rootPath = mkdtempSync(join(tmpdir(), 'harper-terminal-shutdown-'));
 writeFileSync(join(rootPath, HARPER_CONFIG_FILE), `rootPath: ${JSON.stringify(rootPath)}\n`);
 process.env.ROOTPATH = rootPath;
-process.on('exit', () => rmSync(rootPath, { force: true, recursive: true }));
+process.on('exit', () => {
+	// Throwing here would exit the harness non-zero with an irrelevant stack, and the caller reads
+	// any non-zero exit as the mode failing. Windows refuses to remove a tree while anything still
+	// holds a handle under it, and the logger closes its fd on a timer.
+	try {
+		rmSync(rootPath, { force: true, recursive: true });
+	} catch {}
+});
 
 require('#src/utility/environment/environmentManager').initTestEnvironment();
 const manageThreads = require('#js/server/threads/manageThreads');

--- a/unitTests/server/threads/fixtures/terminalShutdownHarness.cjs
+++ b/unitTests/server/threads/fixtures/terminalShutdownHarness.cjs
@@ -163,8 +163,8 @@ const modes = {
 };
 const run = modes[mode] ?? terminalShutdown;
 run().catch((error) => {
-	// Exit rather than set process.exitCode: a worker the failed mode left running holds the event
-	// loop open forever, and the caller then reports a mocha timeout carrying none of this. stdout
+	// A worker the failed mode left running holds the event loop open forever, so an exit code
+	// alone never applies and the caller reports a mocha timeout carrying none of this. stdout
 	// because the caller captures it into the assertion message; writeSync because process.exit()
 	// drops a queued write to a pipe.
 	writeSync(1, `${error?.stack ?? error}\n`);

--- a/unitTests/server/threads/terminalShutdown.test.js
+++ b/unitTests/server/threads/terminalShutdown.test.js
@@ -4,6 +4,10 @@ const assert = require('node:assert');
 const { spawn } = require('node:child_process');
 const { once } = require('node:events');
 
+// Has to outlast the harness's own WAIT_TIMEOUT_MS, or a harness that reports why it failed is
+// pre-empted by a mocha timeout that reports nothing.
+const HARNESS_TIMEOUT_MS = 60000;
+
 describe('terminal worker shutdown', () => {
 	async function runHarness(mode) {
 		const args = [require.resolve('./fixtures/terminalShutdownHarness.cjs')];
@@ -19,7 +23,7 @@ describe('terminal worker shutdown', () => {
 	}
 
 	it('prevents a concurrent rolling restart from respawning workers during full shutdown', async function () {
-		this.timeout(30000);
+		this.timeout(HARNESS_TIMEOUT_MS);
 		const result = await runHarness();
 		assert.deepEqual(result, {
 			errorCode: 'ERR_HARPER_PROCESS_SHUTTING_DOWN',
@@ -29,17 +33,17 @@ describe('terminal worker shutdown', () => {
 	});
 
 	it('does not respawn a worker that exits unexpectedly after terminal shutdown begins', async function () {
-		this.timeout(30000);
+		this.timeout(HARNESS_TIMEOUT_MS);
 		assert.deepEqual(await runHarness('unexpected'), { starts: 1, workersAfterExit: 0 });
 	});
 
 	it('does not start a non-overlapping replacement after terminal shutdown begins', async function () {
-		this.timeout(30000);
+		this.timeout(HARNESS_TIMEOUT_MS);
 		assert.deepEqual(await runHarness('non-overlapping'), { starts: 1, workersAfterShutdown: 0 });
 	});
 
 	it('ignores a rolling restart requested after terminal shutdown begins', async function () {
-		this.timeout(30000);
+		this.timeout(HARNESS_TIMEOUT_MS);
 		assert.deepEqual(await runHarness('late-restart'), {
 			restartNumberChanged: false,
 			starts: 1,
@@ -50,7 +54,7 @@ describe('terminal worker shutdown', () => {
 	});
 
 	it('allows worker creation after a scoped shutdown', async function () {
-		this.timeout(30000);
+		this.timeout(HARNESS_TIMEOUT_MS);
 		assert.deepEqual(await runHarness('scoped'), { workerCreationAllowed: true });
 	});
 });

--- a/unitTests/testUtils.js
+++ b/unitTests/testUtils.js
@@ -75,9 +75,14 @@ function preTestPrep(testConfigObj) {
 		throw reason;
 	});
 
+	// Set the code rather than calling process.exit() from inside an 'exit' listener: that
+	// re-enters exit and terminates immediately, which skips every listener still queued behind
+	// this one (including mocha.init.js's did-the-run-finish check) and, on Windows, discards
+	// whatever is still pending on the stdout pipe. Assigning process.exitCode here has the same
+	// effect on the process's exit status.
 	process.prependListener('exit', (code) => {
 		if (code === 0) {
-			process.exit(unhandledRejectionExitCode);
+			process.exitCode = unhandledRejectionExitCode;
 		}
 	});
 	// Try to change to bin

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
 const sinon = require('sinon');
 const chai = require('chai');
 const expect = chai.expect;
@@ -42,9 +43,47 @@ const LOG_MSGS_TEST = {
 	TRACE: 'trace log',
 };
 
+// Snapshot of a stream's .write plus the 'error' listener installStdioGuard() stashes on it.
+function captureStdio() {
+	return [process.stdout, process.stderr].map((stream) => ({
+		stream,
+		write: stream.write,
+		handler: stream.harperStdioErrorHandler,
+	}));
+}
+
+function restoreStdio(captured) {
+	for (const { stream, write, handler } of captured) {
+		stream.write = write;
+		if (stream.harperStdioErrorHandler) {
+			stream.removeListener('error', stream.harperStdioErrorHandler);
+			delete stream.harperStdioErrorHandler;
+		}
+		if (handler) {
+			stream.harperStdioErrorHandler = handler;
+			stream.on('error', handler);
+		}
+	}
+}
+
+// Loading this module runs initLogSettings(), which ends in stdioLogging(): that replaces the
+// REAL process.stdout/process.stderr .write with a guard closed over this throwaway instance and
+// adds an 'error' listener to both. Leaving it installed routes mocha's own reporter writes
+// through an instance these tests then deliberately break — and the guard is built to be hostile,
+// rethrowing a write error that is not a broken pipe and noop-ing every write after one that is.
+// mocha's `dot` and `tap` reporters write with process.stdout.write directly, so that rethrow
+// escapes mid-run through the runner's callback chain; `timeout: 0` in .mocharc.json then means
+// nothing ever fails the stalled test, the event loop drains, and the process exits 0 having
+// printed no epilogue — indistinguishable from a pass. So put the real streams back before
+// handing the instance to a test. Tests that need the guard install it on a stream of their own.
 function requireUncached(module) {
-	delete require.cache[require.resolve(module)];
-	return rewire(module);
+	const stdio = captureStdio();
+	try {
+		delete require.cache[require.resolve(module)];
+		return rewire(module);
+	} finally {
+		restoreStdio(stdio);
+	}
 }
 
 let captured_stdout = '';
@@ -1704,85 +1743,100 @@ describe('Test harper_logger module', () => {
 
 		describe('the process.stdout/stderr.write() wrapper installed by stdioLogging() (harper#2106)', () => {
 			let harper_logger;
-			let originalStdoutWrite;
-			let originalStderrWrite;
 
-			// Drives stdioLogging() directly via rewire rather than through initLogSettings()'s
-			// real-filesystem config resolution, which made log_to_file/logConsole depend on
-			// whatever boot properties happen to exist on the machine running this.
+			// These tests drive installStdioGuard() against FAKE streams, never the real
+			// process.stdout/process.stderr, and that is load-bearing rather than tidiness.
+			//
+			// The guard is meant to be hostile: it rethrows a write error that is not a broken-pipe
+			// error, and after a broken-pipe one it routes every later write to a noop. Installed on
+			// the real streams and left there for the duration of a test, that lands on mocha's own
+			// reporter. `dot` and `tap` write with process.stdout.write directly, so the rethrow
+			// escapes mid-run through the runner's callback chain; `timeout: 0` in .mocharc.json
+			// then means nothing ever fails the stalled test, the event loop drains, and the process
+			// exits 0 having printed no epilogue and no failure — a silent pass. (`spec` and `min`
+			// survived it only because Node's console.* swallows stream write errors, and they still
+			// lost the reporter lines for the broken-pipe tests to the noop.)
+			//
+			// installStdioGuard() takes the stream as a parameter, so the same code under test runs
+			// with the assertions pointed at a stream mocha is not holding.
+			function makeFakeStream() {
+				const stream = new EventEmitter();
+				// Stands in for the pristine process.std*.write the guard replaces. The guard never
+				// calls it — it calls the module's nativeStdWrite — so make it a tripwire: a write that
+				// reaches it means the guard was not installed, and the tests below would otherwise
+				// pass vacuously.
+				stream.write = function unguardedWrite() {
+					throw new Error('installStdioGuard() did not replace the write on this stream');
+				};
+				return stream;
+			}
+
+			// Drives stdioLogging()'s guard directly via rewire rather than through
+			// initLogSettings()'s real-filesystem config resolution, which made
+			// log_to_file/logConsole depend on whatever boot properties happen to exist on the
+			// machine running this.
 			function setup(logToFile) {
 				harper_logger = requireUncached(HARPER_LOGGER_MODULE);
 				harper_logger.__set__('log_to_file', logToFile);
 				harper_logger.__set__('logConsole', true);
-				harper_logger.__get__('stdioLogging')();
+				// Nothing in these tests should reach the real stdout; if a write escapes the stubs
+				// below, capture it here rather than letting it interleave with mocha's output.
+				harper_logger.__set__('nativeStdWrite', sinon.stub().returns(true));
+				const installStdioGuard = harper_logger.__get__('installStdioGuard');
+				const fakeStdout = makeFakeStream();
+				const fakeStderr = makeFakeStream();
+				installStdioGuard(fakeStdout);
+				installStdioGuard(fakeStderr);
+				return { fakeStdout, fakeStderr };
 			}
-
-			beforeEach(() => {
-				originalStdoutWrite = process.stdout.write;
-				originalStderrWrite = process.stderr.write;
-			});
-
-			afterEach(() => {
-				// stdioLogging() rebinds the REAL process.stdout/stderr .write (and adds an 'error'
-				// listener) to this module instance - undoing both keeps a broken-pipe simulation
-				// from leaking into the rest of this mocha run.
-				process.stdout.write = originalStdoutWrite;
-				process.stderr.write = originalStderrWrite;
-				for (const stream of [process.stdout, process.stderr]) {
-					if (stream.harperStdioErrorHandler) {
-						stream.removeListener('error', stream.harperStdioErrorHandler);
-						delete stream.harperStdioErrorHandler;
-					}
-				}
-			});
 
 			for (const logToFile of [true, false]) {
 				it(`catches a broken-pipe write inline instead of throwing, regardless of logging.file:${logToFile}`, () => {
-					setup(logToFile);
+					const { fakeStdout, fakeStderr } = setup(logToFile);
 					harper_logger.__set__('nativeStdWrite', function () {
 						throw Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
 					});
 
-					assert.doesNotThrow(() => process.stderr.write('boom\n'));
+					assert.doesNotThrow(() => fakeStderr.write('boom\n'));
 					// the write above disabled stdio itself - a second, independent write is silent too
-					assert.doesNotThrow(() => process.stdout.write('still fine\n'));
+					assert.doesNotThrow(() => fakeStdout.write('still fine\n'));
 
 					const callback = sinon.stub();
-					assert.strictEqual(process.stdout.write('chunk', callback), true);
+					assert.strictEqual(fakeStdout.write('chunk', callback), true);
 					assert.strictEqual(callback.calledOnce, true);
 				});
 			}
 
 			it('does not swallow a write error unrelated to a broken stdio stream', () => {
-				setup(true);
+				const { fakeStderr } = setup(true);
 				harper_logger.__set__('nativeStdWrite', function () {
 					throw Object.assign(new Error('boom'), { code: 'SOMETHING_ELSE' });
 				});
 
-				assert.throws(() => process.stderr.write('boom\n'), /boom/);
+				assert.throws(() => fakeStderr.write('boom\n'), /boom/);
 			});
 
 			it('keeps teeing console output to the log file after a broken pipe disables the native writer', () => {
-				setup(true);
+				const { fakeStderr } = setup(true);
 				const writeToLogFileSpy = sinon.stub();
 				harper_logger.__set__('writeToLogFile', writeToLogFileSpy);
 				harper_logger.__set__('nativeStdWrite', function () {
 					throw Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
 				});
 
-				process.stderr.write('first write, breaks the pipe\n');
-				process.stderr.write('second write, should still reach the file\n');
+				fakeStderr.write('first write, breaks the pipe\n');
+				fakeStderr.write('second write, should still reach the file\n');
 
 				assert.strictEqual(writeToLogFileSpy.callCount, 2);
 				assert.strictEqual(writeToLogFileSpy.secondCall.args[0], 'second write, should still reach the file');
 			});
 
 			// installStdioGuard() stashes its 'error' listener on the stream itself; calling it
-			// directly (rather than process.stderr.emit('error', ...)) avoids altering Node's own
-			// internal stream state for the rest of this mocha run.
+			// directly (rather than fakeStderr.emit('error', ...)) keeps the assertion on the
+			// handler rather than on EventEmitter's unhandled-'error' behaviour.
 			it('catches the ASYNC error event a real closed pipe emits - not just a synchronous write throw', () => {
-				setup(true);
-				const handler = process.stderr.harperStdioErrorHandler;
+				const { fakeStderr } = setup(true);
+				const handler = fakeStderr.harperStdioErrorHandler;
 				assert.strictEqual(typeof handler, 'function');
 
 				assert.doesNotThrow(() => handler(Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })));
@@ -1795,10 +1849,29 @@ describe('Test harper_logger module', () => {
 			});
 
 			it('the async error handler rethrows an error unrelated to a broken stdio stream', () => {
-				setup(true);
-				const handler = process.stderr.harperStdioErrorHandler;
+				const { fakeStderr } = setup(true);
+				const handler = fakeStderr.harperStdioErrorHandler;
 
 				assert.throws(() => handler(Object.assign(new Error('boom'), { code: 'SOMETHING_ELSE' })), /boom/);
+			});
+
+			// The wiring the tests above deliberately do not exercise on the real streams: that
+			// stdioLogging() guards both of them. Safe to run there because it only installs the
+			// pass-through guard - no write is made to throw or to noop - and it is undone
+			// immediately.
+			it('stdioLogging() installs the guard, and its error listener, on both real process streams', () => {
+				const captured = captureStdio();
+				try {
+					harper_logger = requireUncached(HARPER_LOGGER_MODULE);
+					harper_logger.__get__('stdioLogging')();
+
+					for (const { stream, write } of captured) {
+						assert.notStrictEqual(stream.write, write);
+						assert.strictEqual(typeof stream.harperStdioErrorHandler, 'function');
+					}
+				} finally {
+					restoreStdio(captured);
+				}
 			});
 		});
 	});

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -16,6 +16,7 @@ const { createLogger } = harperLoggerModule;
 const { getHttpOptions, handleApplication, logRequest } = require('#src/server/http');
 const { ApplicationScope } = require('#src/components/ApplicationScope');
 const { waitFor } = require('../../waitFor.js');
+const { pinLogConfig } = require('../../logConfigFixture.js');
 
 const HARPER_LOGGER_MODULE = '#js/utility/logging/harper_logger';
 const LOG_DIR_TEST = 'testLogger';
@@ -146,15 +147,28 @@ function setTestLogConfig(level, config_log_path, to_file, to_stream) {
 
 describe('Test harper_logger module', () => {
 	const sandbox = sinon.createSandbox();
+	let restoreLogConfig;
+
+	// Pin the config instead of inheriting whatever Harper install the machine happens to have.
+	// The module-level log_to_file that initLogSettings() resolves at load gates every file write
+	// in createLogger(), so with no boot properties present the HTTP-logger and global-logger tests
+	// below wait forever for a log file nothing is writing, and initLogSettings()'s own test sees
+	// undefined settings because the ENOENT path returns before it reads any config at all.
+	before(() => {
+		restoreLogConfig = pinLogConfig();
+	});
 
 	after(() => {
 		sandbox.restore();
+		restoreLogConfig?.();
 	});
 
 	describe('Test initLogSettings function', () => {
 		const test_error = new Error('no such file or directory test');
+		const afterThisTest = [];
 
 		afterEach(() => {
+			while (afterThisTest.length) afterThisTest.pop()();
 			sandbox.restore();
 			sandbox.resetHistory();
 		});
@@ -179,6 +193,16 @@ describe('Test harper_logger module', () => {
 		});
 
 		it('Test that if error code is not ENOENT error is handled correctly', () => {
+			// This asserts the path where there is nothing to fall back to, so ROOTPATH has to be
+			// absent: initLogSettings() deliberately SWALLOWS a failure to read the boot properties
+			// when ROOTPATH names a directory holding a config (which is how pinLogConfig() above
+			// works, and how a developer with ROOTPATH exported would run).
+			const originalRootPath = process.env.ROOTPATH;
+			delete process.env.ROOTPATH;
+			afterThisTest.push(() => {
+				if (originalRootPath !== undefined) process.env.ROOTPATH = originalRootPath;
+			});
+
 			test_error.code = 'EACCES';
 			const harper_logger = requireUncached(HARPER_LOGGER_MODULE);
 			const properties_reader_stub = sandbox.stub().throws(test_error);
@@ -1782,6 +1806,10 @@ describe('Test harper_logger module', () => {
 				// Nothing in these tests should reach the real stdout; if a write escapes the stubs
 				// below, capture it here rather than letting it interleave with mocha's output.
 				harper_logger.__set__('nativeStdWrite', sinon.stub().returns(true));
+				// logConsole above makes the guard tee to writeToLogFile, which is only assigned when
+				// the resolved config gives the logger a path. Stub it so the tee is exercised here on
+				// any machine rather than throwing 'writeToLogFile is not a function'.
+				harper_logger.__set__('writeToLogFile', sinon.stub());
 				const installStdioGuard = harper_logger.__get__('installStdioGuard');
 				const fakeStdout = makeFakeStream();
 				const fakeStderr = makeFakeStream();

--- a/unitTests/utility/logging/logRotator.test.js
+++ b/unitTests/utility/logging/logRotator.test.js
@@ -9,6 +9,7 @@ const { readFileSync } = require('fs');
 const hdb_logger = require('#src/utility/logging/harper_logger');
 const { logRotator: log_rotator } = require('#src/utility/logging/logRotator');
 const assert = require('assert');
+const { pinLogConfig } = require('../../logConfigFixture.js');
 const LOG_DIR_NAME_TEST = 'testLogger';
 const LOG_NAME_TEST = 'hdb.log';
 const LOG_DIR_TEST = path.join(__dirname, LOG_DIR_NAME_TEST);
@@ -17,6 +18,7 @@ const TEST_TIMEOUT = 10000;
 
 describe('Test logRotator module', () => {
 	let logger;
+	let restoreLogConfig;
 	async function callLogger() {
 		for (let i = 1; i < 21; i++) {
 			logger.error('This log is coming from the logRotator unit test. Log number:', i);
@@ -27,6 +29,11 @@ describe('Test logRotator module', () => {
 	}
 
 	before(() => {
+		// Every assertion here reads the log file back, and createLogger() only writes one when the
+		// logger's config says logging.file is on. Without this the suite depends on the machine
+		// having Harper installed: green on a developer box, ENOENT on the log it just wrote
+		// everywhere else.
+		restoreLogConfig = pinLogConfig({ level: 'error' });
 		fs.mkdirpSync(LOG_DIR_TEST);
 		logger = hdb_logger.createLogger({
 			stdStreams: false,
@@ -41,6 +48,7 @@ describe('Test logRotator module', () => {
 	});
 
 	after(() => {
+		restoreLogConfig?.();
 		try {
 			fs.removeSync(LOG_DIR_TEST);
 		} catch {}

--- a/unitTests/windowsGate.mjs
+++ b/unitTests/windowsGate.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/*
+ * The Windows unit-test gate — `npm run test:unit:windows`, run in CI by the
+ * `unit-test-windows` job in .github/workflows/unit-test.yml.
+ *
+ * Two things this does that a plain `mocha` invocation cannot.
+ *
+ * It runs GROUPS in separate processes. Handed the whole scoped set at once, mocha on
+ * Windows terminates part-way through with exit code 0 and no epilogue. One process
+ * per directory keeps each run small enough to finish.
+ *
+ * It requires each group to print a summary line. That early termination is silent —
+ * exit 0, no "N passing" — so a bare `mocha` step would report a green gate having
+ * executed a fraction of the tests. A group that exits without a summary fails here,
+ * as does one that exits non-zero or outruns GROUP_TIMEOUT_MS.
+ *
+ * SCOPE. GROUPS covers the part of the unit tree verified green on Windows, not the
+ * whole thing: the suites in EXCLUDED fail there for environmental or test-design
+ * reasons that reproduce on `main`, so gating on everything would land red and stay
+ * red. Everything else under a GROUPS directory is picked up automatically — a new
+ * suite is gated on Windows the day it is added, which is the point: a platform-gated
+ * fix and the test written to prove it now both run somewhere.
+ *
+ * MAINTENANCE. Shrink EXCLUDED as its entries are fixed; widen GROUPS as more of the
+ * tree is verified. Every EXCLUDED entry states why it is there — do not add one
+ * without a reason, and do not add one for a suite that merely looks risky, only for
+ * one observed to fail. Confirm a fix with `npx mocha <suite>` on Windows, then
+ * confirm it again inside its group (several of the entries below pass alone and fail
+ * with their neighbours) before deleting its line.
+ */
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+/** One mocha process per entry. Whole directories, so new suites are picked up. */
+const GROUPS = [
+	'unitTests/agent/**/*.test.js',
+	'unitTests/buildTools/**/*.test.js',
+	'unitTests/components/**/*.test.js',
+	'unitTests/config/**/*.test.js',
+	'unitTests/server/**/*.test.js',
+	'unitTests/sqlEngine/**/*.test.js',
+	'unitTests/utility/**/*.test.js',
+	'unitTests/validation/**/*.test.js',
+	// Individually verified files from directories not yet covered wholesale.
+	'unitTests/resources/blob.test.js',
+];
+
+const EXCLUDED = [
+	// --- Product bug: chokidar's `persistent: false` error hole --------------------
+	// `after each` dies with an uncaught `EPERM: operation not permitted, watch` out
+	// of `FSWatcher._handle.onchange`. 39 passing / 2 failing; reproduces on `main`.
+	'unitTests/components/EntryHandler.test.js',
+
+	// --- Hangs, never exits (leaked handle) ----------------------------------------
+	// Both produce no output at all and have to be killed rather than failing an
+	// assertion, so they take their whole group down with them.
+	'unitTests/components/OptionsWatcher.test.js',
+	'unitTests/components/applicationSpawn.test.js',
+
+	// --- Exits 0 having run nothing ------------------------------------------------
+	// Terminates during file load with an EACCES-tagged error and never prints an
+	// epilogue, so mocha reports success having executed zero of its tests. This
+	// suite is why the summary-line check above exists.
+	'unitTests/utility/logging/harper_logger.test.js',
+
+	// --- Windows worker cold start outruns the condition-wait ----------------------
+	// Both tests spawn an `eval: true` Worker that requires
+	// #src/server/threads/manageThreads; on Windows that boot plus module load
+	// regularly exceeds waitFor()'s 2000ms default, so the suite is flaky — it passes
+	// when the module graph is warm in the OS file cache and fails when it is not.
+	// Needs an explicit timeout rather than the default.
+	'unitTests/server/threads/threadInfoTimeout.test.js',
+
+	// --- Unix-domain-socket assumptions --------------------------------------------
+	// `listen EACCES` binding a `.sock` path under the temp dir. Needs a Windows
+	// named-pipe path or a platform skip.
+	'unitTests/server/threads/threadServerListenOnPorts.test.js',
+	'unitTests/server/udsMirror.test.js',
+
+	// --- Path, shell, and toolchain assumptions ------------------------------------
+	// POSIX path separators, `git`/`ssh`/tarball shell invocations, npm-pack layout,
+	// and system introspection with no Windows analogue.
+	'unitTests/components/ComponentV1.test.js',
+	'unitTests/components/componentLoader.test.js',
+	'unitTests/components/credentials.test.js',
+	'unitTests/components/extractApplicationSwap.test.js',
+	'unitTests/components/gitCredentials.test.js',
+	'unitTests/components/gitSSHMaterialization.test.js',
+	'unitTests/components/packageComponent.test.js',
+	'unitTests/components/packageComponentOperation.test.js',
+	'unitTests/components/prepareApplicationSerialization.test.js',
+	'unitTests/utility/environment/systemInformation.test.js',
+	'unitTests/validation/configValidator.test.js',
+	'unitTests/validation/fileLoadValidator.test.js',
+
+	// --- Native/HTTP layer ---------------------------------------------------------
+	// uWebSockets.js is not exercised on Windows, and Headers.test.js exits non-zero
+	// after its own assertions pass (30 passing / 0 failing).
+	'unitTests/server/serverHelpers/Headers.test.js',
+	'unitTests/server/serverHelpers/uwsServer.test.js',
+];
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const MOCHA = join(repoRoot, 'node_modules', 'mocha', 'bin', 'mocha.js');
+const SUMMARY = /\b(\d+) passing\b/;
+const GROUP_TIMEOUT_MS = Number(process.env.HARPER_WINDOWS_GATE_GROUP_TIMEOUT_MS ?? 600_000);
+
+// No --config: mocha discovers .mocharc.json itself, so the gate inherits the same
+// root config (and unitTests/mocha.init.js) as every other unit-test run.
+function runGroup(pattern) {
+	return new Promise((settle) => {
+		const args = [MOCHA, '--reporter', 'dot', pattern];
+		for (const excluded of EXCLUDED) args.push('--exclude', excluded);
+
+		const startedAt = Date.now();
+		const child = spawn(process.execPath, args, { cwd: repoRoot, stdio: ['ignore', 'pipe', 'pipe'] });
+
+		let output = '';
+		const capture = (chunk) => {
+			output += chunk;
+			process.stdout.write(chunk);
+		};
+		child.stdout.on('data', capture);
+		child.stderr.on('data', capture);
+
+		let timedOut = false;
+		const timer = setTimeout(() => {
+			timedOut = true;
+			child.kill('SIGKILL');
+		}, GROUP_TIMEOUT_MS);
+
+		child.on('close', (code) => {
+			clearTimeout(timer);
+			const passing = SUMMARY.exec(output)?.[1];
+			let reason;
+			if (timedOut) reason = `timed out after ${GROUP_TIMEOUT_MS}ms`;
+			else if (passing === undefined) reason = `exited ${code} without reporting a summary`;
+			else if (code !== 0) reason = `exited ${code}`;
+			settle({ pattern, seconds: Math.round((Date.now() - startedAt) / 1000), passing, reason });
+		});
+	});
+}
+
+const results = [];
+for (const pattern of GROUPS) {
+	console.log(`\n=== ${pattern} ===`);
+	results.push(await runGroup(pattern));
+}
+
+console.log('\n=== Windows unit-test gate ===');
+for (const { pattern, seconds, passing, reason } of results) {
+	const cells = [`${String(seconds).padStart(4)}s`, `${(passing ?? '?').padStart(4)} passing`, pattern];
+	console.log(`${reason ? 'FAIL' : 'ok  '}  ${cells.join('  ')}${reason ? `  — ${reason}` : ''}`);
+}
+
+const failed = results.filter((result) => result.reason);
+if (failed.length) {
+	console.error(`\n${failed.length} of ${results.length} group(s) failed.`);
+	process.exit(1);
+}
+console.log(
+	`\nAll ${results.length} groups passed (${results.reduce((sum, result) => sum + Number(result.passing), 0)} tests).`
+);

--- a/unitTests/windowsGate.mjs
+++ b/unitTests/windowsGate.mjs
@@ -5,14 +5,17 @@
  *
  * Two things this does that a plain `mocha` invocation cannot.
  *
- * It runs GROUPS in separate processes. Handed the whole scoped set at once, mocha on
- * Windows terminates part-way through with exit code 0 and no epilogue. One process
- * per directory keeps each run small enough to finish.
+ * It runs GROUPS in separate processes, so one suite that hangs or takes its process
+ * down cannot cost the run every group behind it, and each group gets its own
+ * GROUP_TIMEOUT_MS.
  *
- * It requires each group to print a summary line. That early termination is silent —
- * exit 0, no "N passing" — so a bare `mocha` step would report a green gate having
- * executed a fraction of the tests. A group that exits without a summary fails here,
- * as does one that exits non-zero or outruns GROUP_TIMEOUT_MS.
+ * It requires each group to print a summary line. A mocha run can stop advancing with
+ * nothing failed — `timeout: 0` in .mocharc.json means no test ever times out, so the
+ * event loop just drains and the process exits 0 having printed no epilogue. A bare
+ * `mocha` step would report a green gate having executed a fraction of the tests. A
+ * group that exits without a summary fails here, as does one that exits non-zero or
+ * outruns GROUP_TIMEOUT_MS. (unitTests/mocha.init.js now also fails such a run from the
+ * inside; this check is the backstop for a process that never gets that far.)
  *
  * SCOPE. GROUPS covers the part of the unit tree verified green on Windows, not the
  * whole thing: the suites in EXCLUDED fail there for environmental or test-design
@@ -26,7 +29,10 @@
  * without a reason, and do not add one for a suite that merely looks risky, only for
  * one observed to fail. Confirm a fix with `npx mocha <suite>` on Windows, then
  * confirm it again inside its group (several of the entries below pass alone and fail
- * with their neighbours) before deleting its line.
+ * with their neighbours) before deleting its line. Run it under `--reporter dot`, the
+ * reporter this gate uses: unlike `spec`, it writes with process.stdout.write directly
+ * rather than through console.*, so it does not paper over a suite that leaves stdout
+ * broken.
  */
 
 import { spawn } from 'node:child_process';
@@ -58,12 +64,6 @@ const EXCLUDED = [
 	// assertion, so they take their whole group down with them.
 	'unitTests/components/OptionsWatcher.test.js',
 	'unitTests/components/applicationSpawn.test.js',
-
-	// --- Exits 0 having run nothing ------------------------------------------------
-	// Terminates during file load with an EACCES-tagged error and never prints an
-	// epilogue, so mocha reports success having executed zero of its tests. This
-	// suite is why the summary-line check above exists.
-	'unitTests/utility/logging/harper_logger.test.js',
 
 	// --- Windows worker cold start outruns the condition-wait ----------------------
 	// Both tests spawn an `eval: true` Worker that requires

--- a/unitTests/windowsGate.mjs
+++ b/unitTests/windowsGate.mjs
@@ -158,8 +158,11 @@ for (const { pattern, seconds, passing, reason } of results) {
 const failed = results.filter((result) => result.reason);
 if (failed.length) {
 	console.error(`\n${failed.length} of ${results.length} group(s) failed.`);
-	process.exit(1);
+	// Not process.exit(): the group table above is the whole point of the run, and a piped stdout
+	// on Windows can still be draining it. Nothing is left to keep the loop alive here anyway.
+	process.exitCode = 1;
+} else {
+	console.log(
+		`\nAll ${results.length} groups passed (${results.reduce((sum, result) => sum + Number(result.passing), 0)} tests).`
+	);
 }
-console.log(
-	`\nAll ${results.length} groups passed (${results.reduce((sum, result) => sum + Number(result.passing), 0)} tests).`
-);

--- a/unitTests/windowsGate.mjs
+++ b/unitTests/windowsGate.mjs
@@ -126,20 +126,32 @@ function runGroup(pattern) {
 		child.stderr.on('data', capture);
 
 		let timedOut = false;
-		const timer = setTimeout(() => {
-			timedOut = true;
-			child.kill('SIGKILL');
-		}, GROUP_TIMEOUT_MS);
-
-		child.on('close', (code) => {
+		let settled = false;
+		let timer;
+		const finish = (reason, code) => {
+			if (settled) return;
+			settled = true;
 			clearTimeout(timer);
 			const passing = SUMMARY.exec(output)?.[1];
-			let reason;
-			if (timedOut) reason = `timed out after ${GROUP_TIMEOUT_MS}ms`;
-			else if (passing === undefined) reason = `exited ${code} without reporting a summary`;
-			else if (code !== 0) reason = `exited ${code}`;
+			if (!reason) {
+				if (timedOut) reason = `timed out after ${GROUP_TIMEOUT_MS}ms`;
+				else if (passing === undefined) reason = `exited ${code} without reporting a summary`;
+				else if (code !== 0) reason = `exited ${code}`;
+			}
 			settle({ pattern, seconds: Math.round((Date.now() - startedAt) / 1000), passing, reason });
-		});
+		};
+
+		timer = setTimeout(() => {
+			timedOut = true;
+			child.kill('SIGKILL');
+			// 'close' needs the stdio pipes at EOF, not just the child dead, and a group can leave a
+			// grandchild holding them — a leaked test harness, which SIGKILL on Windows does not reach.
+			// Settling anyway costs this group's tail output; not settling costs the whole gate's table.
+			setTimeout(() => finish('timed out and left a descendant holding its output'), 5000).unref();
+		}, GROUP_TIMEOUT_MS);
+
+		child.on('error', (error) => finish(`could not be spawned: ${error.message}`));
+		child.on('close', (code) => finish(undefined, code));
 	});
 }
 
@@ -158,8 +170,8 @@ for (const { pattern, seconds, passing, reason } of results) {
 const failed = results.filter((result) => result.reason);
 if (failed.length) {
 	console.error(`\n${failed.length} of ${results.length} group(s) failed.`);
-	// Not process.exit(): the group table above is the whole point of the run, and a piped stdout
-	// on Windows can still be draining it. Nothing is left to keep the loop alive here anyway.
+	// The group table above is the point of the run and a piped stdout on Windows may still be
+	// draining it; nothing here holds the event loop open, so the code applies on its own.
 	process.exitCode = 1;
 } else {
 	console.log(

--- a/unitTests/windowsGate.mjs
+++ b/unitTests/windowsGate.mjs
@@ -122,8 +122,10 @@ function runGroup(pattern) {
 			output += chunk;
 			process.stdout.write(chunk);
 		};
-		child.stdout.on('data', capture);
-		child.stderr.on('data', capture);
+		// Optional: a spawn that fails on fd exhaustion can return before its stdio is wired, and
+		// throwing here would take the gate down in place of the 'error' listener below.
+		child.stdout?.on('data', capture);
+		child.stderr?.on('data', capture);
 
 		let timedOut = false;
 		let settled = false;
@@ -134,8 +136,8 @@ function runGroup(pattern) {
 			clearTimeout(timer);
 			// A descendant that outlived the group still holds these, and anything it writes from
 			// here on would interleave through later groups and through the summary table.
-			child.stdout.destroy();
-			child.stderr.destroy();
+			child.stdout?.destroy();
+			child.stderr?.destroy();
 			const passing = SUMMARY.exec(output)?.[1];
 			if (!reason) {
 				if (timedOut) reason = `timed out after ${GROUP_TIMEOUT_MS}ms`;

--- a/unitTests/windowsGate.mjs
+++ b/unitTests/windowsGate.mjs
@@ -132,6 +132,10 @@ function runGroup(pattern) {
 			if (settled) return;
 			settled = true;
 			clearTimeout(timer);
+			// A descendant that outlived the group still holds these, and anything it writes from
+			// here on would interleave through later groups and through the summary table.
+			child.stdout.destroy();
+			child.stderr.destroy();
 			const passing = SUMMARY.exec(output)?.[1];
 			if (!reason) {
 				if (timedOut) reason = `timed out after ${GROUP_TIMEOUT_MS}ms`;


### PR DESCRIPTION
Stacked on #2361 — its commit is cherry-picked here as the first of three, because `unitTests/windowsGate.mjs` does not exist on `main` yet and this PR edits it. Basing this PR on that branch instead would have dragged in 7 unrelated `main` commits (it is that far behind), so the base is `main` and the duplicated commit collapses when #2361 merges. **Review the second and third commits.**

`unitTests/utility/logging/harper_logger.test.js` did not run on Windows, and it failed silently rather than loudly:

```bash
npx mocha --reporter dot unitTests/utility/logging/harper_logger.test.js
```

exited 0, printed no epilogue, and ran none of its tests. Every runner reads that as a pass, and it took the whole `unitTests/utility/**` gate group down with it — which is why #2361 refuses to trust a mocha process that exits without printing a summary.

## Two things it was not

**Not the load-time error it looked like.** The `EACCES`-tagged `Error: no such file or directory test` on stderr is the fixture error the `initLogSettings` test deliberately provokes, printed by the logger's own `console.error(err)`. Its stack points at line 116 because that is where the `Error` was *constructed* — in a `describe` body, which runs during `loadFilesAsync` — not where it was thrown.

**Not Windows-specific.** The same suite/reporter combination stalls identically on Linux. The reporter decides, not the platform, which is why the Ubuntu jobs never caught it.

## What was wrong

The stdio tests installed harper's `process.stdout`/`process.stderr` write guard from a freshly rewired module instance and then made that instance's `nativeStdWrite` throw or noop. The guard is built to be hostile — it rethrows a write error that is not a broken pipe, and routes every write after a broken-pipe one to a noop — and it was installed on the **real** streams, so for the duration of those tests it was mocha's own reporter that ran into it.

`dot` and `tap` write with `process.stdout.write` directly, so the rethrow escaped mid-run through the runner's callback chain. `timeout: 0` in `.mocharc.json` then meant nothing ever failed the stalled test: the event loop drained and the process exited 0. `spec` and `min` survived only because Node's `console.*` swallows stream write errors — and they still lost five reporter lines to the noop, reporting 104 passing with 99 printed.

## Second defect, found because the first one stopped hiding it

With the run failing loudly, CI reported 15 failures where it had reported a green silent pass.

`harper_logger` resolves its config once, at module load, from whatever Harper install the machine has: `getPropsFilePath()` → `~/.harperdb/hdb_boot_properties.file` → `settings_path` → the config's `logging` section. The module-level `log_to_file` that falls out of that gates every file write in `createLogger()`, so with no boot properties present `initLogSettings()` takes its ENOENT path, `log_to_file` is false, and `createLogger({ path })` silently writes nothing to that path.

Both logging suites assert on what lands in a log file, so both were green on a developer box with Harper installed and red on a clean checkout — 7 failures in `harper_logger.test.js` and 6 in `logRotator.test.js`. Only `harper_logger.test.js` was excluded from the gate, and it aborted the process before `logRotator.test.js` ever ran, so `logRotator`'s half of this had never been seen.

## Changes

- The stdio tests drive `installStdioGuard()` against **fake streams**; it already takes the stream as a parameter, so the same code is under test without mocha's streams involved. One new test covers the wiring they no longer exercise there — that `stdioLogging()` guards both real process streams — installing only the pass-through guard and undoing it immediately.
- `requireUncached()` restores the real stdout/stderr afterwards. Loading the module runs `initLogSettings()`, which ends in `stdioLogging()`, so every one of the six loads in that file was leaving a guard closed over a throwaway instance installed for the rest of the mocha process.
- **`unitTests/logConfigFixture.js`** writes a config to a temp `ROOTPATH` and forces a re-init — `initLogSettings()` tolerates unreadable boot properties when `ROOTPATH` names a directory holding a config — then restores env, config, and the stdio guard. Two details are load-bearing and commented in the file: the pinned log root defaults to a throwaway temp dir (pinning it to the directory `logRotator.test.js` rotates makes the suite's own logger and the main one the same file logger, since `getFileLogger()` keys by path, and `moveLogFile()`'s closing `notify()` then recreates the log the test just asserted was gone); and the fixture re-points `require(...).externalLogger`, because `harper_logger` ends with `module.exports = { ... externalLogger: exports.externalLogger }`, a snapshot taken just after the load-time init that a re-init cannot reach.
- **`unitTests/mocha.init.js`** fails a run that starts and never finishes, on fd 2 with `writeSync`, instead of letting it exit 0. Root hooks bracket the run, so a stall is detectable from the inside. This is what turned the silent pass into the 15-failure report above.
- **`unitTests/testUtils.js`** sets `process.exitCode` rather than calling `process.exit()` from inside an `'exit'` listener, which skipped every listener queued behind it (the check above included) and discarded whatever was still pending on the stdout pipe.
- The suite comes off `EXCLUDED` in `unitTests/windowsGate.mjs`. Its header and the AGENTS.md note described the silent termination as something mocha does to a large scoped set on Windows; both now describe what it actually was.

## The two groups that were still red — same root cause, twice more

The `unit-test-windows` job stayed red on `unitTests/components/**` and `unitTests/server/**`. Both
turned out to be the ambient-config dependence above, at two more sites, and both reproduce on
Linux on a checkout with no Harper installed. **The difference between the two CI jobs is one
step:** the Ubuntu `unit-test` job runs `harper install` before its suites, and the Windows gate
does not — so a suite that reads whatever config the machine happens to have is green on Ubuntu and
red on Windows.

### `components/**` — the spawn allowlist

`Global Variable Isolation in testJSWithDeps > should enforce process spawning restrictions` asserts
that `spawn('npm', ['build'])` with no process name is rejected *for the missing name*. With no
config, `applications.allowedSpawnCommands` is empty and it is rejected as a disallowed command
instead — a message that does not contain "name", which is exactly what the assertion checks.

No hook could pin that value, because [`ALLOWED_COMMANDS` was a module-load snapshot](https://github.com/HarperFast/harper/pull/2367/changes?w=1#diff-017d60e3f7f4b41769872ae398a2c11a80a5c783da018b471d1c0d2b0cb7dddcR1091):
`componentLoader` imports `jsLoader` statically, and in a group run some earlier test file has
already loaded it before mocha reaches this file's `before()`. So the allowlist and the hdb base
path are now [read on each spawn call](https://github.com/HarperFast/harper/pull/2367/changes?w=1#diff-017d60e3f7f4b41769872ae398a2c11a80a5c783da018b471d1c0d2b0cb7dddcR1091) — identical behaviour whenever the config is
resolved, still denying when it is not (`Array.isArray` first, so a non-list value fails closed the
way iterating it into a `Set` used to), and the suite [pins the shipped default itself](https://github.com/HarperFast/harper/pull/2367/changes?w=1#diff-022716dfd5af8765a1504f667093003c0dca7d6d2a12e2bea5884a9296526859R13).

### `server/**` — a rejection nobody was watching

`terminalShutdown.test.js`'s two failing modes both call `restartWorkers()`, which loads the root
components, whose `loadCertificates()` reads the config **file** rather than the in-memory config
`initTestEnvironment()` sets up. With no install it rejects with `ENOENT` in **541 ms**. The three
modes that never call it passed, which is why exactly those two failed.

The harness could not say so:

- The rejection sat unhandled behind a `waitFor` that spun to its 5s deadline and reported the
  condition it was watching — "replacement worker was not created" — rather than the ENOENT.
- Then the harness *hung*: the worker it had already started holds the event loop open, so
  `process.exitCode = 1` never got to apply, and mocha reported a bare 30s timeout with none of the
  above in it.

So the harness [writes its own config to a temp `ROOTPATH`](https://github.com/HarperFast/harper/pull/2367/changes?w=1#diff-73d8cf4523ec3c1c94169ea7215f3d5d0dac53b7d1c27317c11e755100836bf9R17) (the lever
`harper --ROOTPATH` uses to run without boot properties), [races the restart's rejection against the
wait](https://github.com/HarperFast/harper/pull/2367/changes?w=1#diff-73d8cf4523ec3c1c94169ea7215f3d5d0dac53b7d1c27317c11e755100836bf9R41), and [exits on failure with the error on stdout](https://github.com/HarperFast/harper/pull/2367/changes?w=1#diff-73d8cf4523ec3c1c94169ea7215f3d5d0dac53b7d1c27317c11e755100836bf9R177), which the caller puts
into the assertion message. The waits are 20s rather than 5s — they bound a hang, they are not an
assertion about how fast a cold runner starts a worker.

### And the gate itself

Three fixes to `windowsGate.mjs`, all about not losing the group table the job exists to produce:
a group settles on `'close'`, which needs its stdio pipes at EOF and not just the child dead, so a
leaked descendant (this very harness, which `SIGKILL` on Windows does not reach) would hang the
whole gate — it now [settles 5s after the kill](https://github.com/HarperFast/harper/pull/2367/changes?w=1#diff-fc246680a36d8be12666c7cbd9aa797681fe0925748e86ced7b9d304d1734fa8R156) and
[destroys the pipes](https://github.com/HarperFast/harper/pull/2367/changes?w=1#diff-fc246680a36d8be12666c7cbd9aa797681fe0925748e86ced7b9d304d1734fa8R139) so an orphan cannot write through later groups; a
[spawn that fails outright](https://github.com/HarperFast/harper/pull/2367/changes?w=1#diff-fc246680a36d8be12666c7cbd9aa797681fe0925748e86ced7b9d304d1734fa8R159) records a group failure instead of throwing out of the run;
and the final `process.exit(1)` is now `process.exitCode`, so a piped stdout on Windows finishes
draining the table. Both temp-tree removals ([harness](https://github.com/HarperFast/harper/pull/2367/changes?w=1#diff-73d8cf4523ec3c1c94169ea7215f3d5d0dac53b7d1c27317c11e755100836bf9R22), [fixture](https://github.com/HarperFast/harper/pull/2367/changes?w=1#diff-241e6ceec57b2413e580377f3c36bb9bdcaa755fdc702c36106ddd8055b697b1R83)) are guarded,
because Windows refuses to remove a tree while a handle is open under it and the logger closes its
fd on a 10s timer — an unguarded `rmSync` in an `exit`/`after` hook would redden a run that passed.

## Verification

Windows 11 / Node v24.14.0, run both with this machine's Harper install and with `USERPROFILE`/`HOME`
pointed at an empty directory to stand in for a clean runner:

| | ambient config | clean machine |
| --- | --- | --- |
| `harper_logger.test.js`, `dot` / `spec` / `tap` | 105 passing, all 105 lines printed | 105 passing |
| `unitTests/utility/logging/*` | 140 passing | 140 passing |
| `unitTests/utility/**` gate group, `dot` | 665 passing, 0 failing | 665 passing, 0 failing |

Before: no epilogue at all, exit 0, zero tests.

On CI (`workflow_dispatch` on this branch, since the workflow's `push` trigger only covers `main` and
release branches):

- **Ubuntu, Node 24 — pass.**
- Windows gate group table: `unitTests/utility/**` went from `FAIL — 652 passing, 15 failing` to
  **`ok — 665 passing`**.

Linux was also confirmed for the failure mechanism itself, not just the fix: in a minimal mocha
project, `dot`/`tap` stall exactly as on Windows while `spec`/`min` complete, and the new
`mocha.init.js` check converts the stall to exit 1.

For the two groups fixed here, the same clean-machine condition reproduces on Linux (this box's boot
properties name a config file that does not exist), so both were confirmed failing before and passing
after, on the mechanism rather than on a rerun:

| | before | after |
| --- | --- | --- |
| `globalIsolation.test.js` | 12 passing, **1 failing** | 13 passing |
| `terminalShutdown.test.js` | 3 passing, **2 failing**, 42s | 5 passing, 2s |
| harness, `non-overlapping` mode | 20s, no output | `{"starts":1,"workersAfterShutdown":0}`, 0.8s |
| `npm run test:unit:windows` | 2 of 9 groups failed | **all 9 groups passed, 3452 tests** |

Also run on this checkout, all passing: `test:unit:security` (667), `test:unit:resources` (1766 — one
pre-existing failure in `requestPathRetryExhaustion.test.js`, confirmed identical with these changes
reverted), `unitTests/bin` (248), `dataLayer` (252), `build-tools` (16), `install` (9),
`sqlTranslator` (67), `upgrade` (19). `test:unit:main` as a single mocha run cannot start on a
machine with no Harper install — `security/auth.ts` fails at load — which is itself the ambient
dependence this PR is about; it was run per-directory instead.

The gate's failure path was checked directly rather than inferred:
`HARPER_WINDOWS_GATE_GROUP_TIMEOUT_MS=1 npm run test:unit:windows` still prints the full table and
exits 1.

## For the human reviewer

- **`security/jsLoader.ts` is the only production change**, and it is in a security guard, so it is
  the thing to look hardest at. Reading the allowlist per call means a runtime `set_configuration`
  now takes effect without a restart; that is arguably more correct, but the semantics do ship.
  Everything else here is test and CI code.
- **The same module-load-snapshot bug is still live at two higher-stakes sites in that file** —
  `APPLICATIONS_LOCKDOWN` and `ALLOWED_NODE_BUILTIN_MODULES`. If config is unresolved when
  `jsLoader` loads, `applications.lockdown` reads `undefined`, the guard short-circuits, and
  applications load with `freezeIntrinsics()`/`preventFunctionConstructor()` never run, silently;
  `ALLOWED_NODE_BUILTIN_MODULES` falls open to "allow everything". Deliberately not fixed here —
  it is pre-existing and a production behaviour change that wants its own PR.
- Declined from the pre-push review, all nits: `taskkill /pid <pid> /T /F` to reap a timed-out
  group's descendant tree on win32; bounding the gate's `output` accumulator; adding a unit test for
  `windowsGate.mjs` itself; a defensive copy of the allowlist (`env.get` returns the live value
  either way, so the copy changes nothing); and `rmSync`'s `maxRetries` instead of a silent catch.
- Also declined, raised by both the Claude PR bot and the cross-model review:
  `captureStdio`/`restoreStdio` in `harper_logger.test.js` duplicate the identically shaped pair
  inside `logConfigFixture.js`. Worth extracting; it is a refactor of a passing suite, not part of
  this fix.
- The workflow comment asking for `unit-test-windows` to be made a **required status check** cannot
  enforce itself and goes invisible on merge. It needs a human to set the branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=claude; ran=gemini; adjudicated=domain; declined=codex,cursor-grok,cursor-composer; rounds=6 @ 1dc4b9e2fb35</sub>

<sub>Human-Review-Need: 4 (decisions: settle-after-sigkill-grace, snapshot-fix-scope, spawn-allowlist-read-per-call, mocharc-timeout-zero, windows-build-continue-on-error, gate-scope-allowlist) @ 1dc4b9e2fb35</sub>
