### PR TITLE
Keep resolved attribute values out of durable records, at every layer that writes them

### DIFF
--- a/integrationTests/resources/cached-computed-attribute/config.yaml
+++ b/integrationTests/resources/cached-computed-attribute/config.yaml
@@ -1,0 +1,5 @@
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/resources/cached-computed-attribute/resources.js
+++ b/integrationTests/resources/cached-computed-attribute/resources.js
@@ -1,0 +1,129 @@
+// Sources and probes for the harper#2359 suite. `colliding-*` ids get a source payload carrying a
+// value under the computed attribute's own name.
+const { CachedProduct } = tables;
+
+class ProductOrigin extends Resource {
+	get() {
+		const id = this.getId();
+		const record = { id, price: 100, discount: 40 };
+		if (String(id).startsWith('colliding')) record.salePrice = 999;
+		return record;
+	}
+	put() {}
+}
+
+CachedProduct.sourcedFrom(ProductOrigin);
+
+// Plants a record the way 5.2.0-5.2.6 stored one: the durable projection disabled for exactly that
+// write, so the computed attribute's value becomes a stored field. `validate` rejects a
+// user-supplied computed property outright, so no public write path can produce this record.
+export class PoisonedRecord extends Resource {
+	async put(data) {
+		const body = await data;
+		const store = CachedProduct.primaryStore;
+		const resolvedNames = store.encoder.resolvedAttributeNames;
+		try {
+			store.encoder.resolvedAttributeNames = undefined;
+			await store.put(this.getId(), { id: this.getId(), ...body });
+		} finally {
+			store.encoder.resolvedAttributeNames = resolvedNames;
+		}
+	}
+}
+
+// Reports whether a record has reached the table's own store, so a test can wait for the cache-fill
+// write to commit instead of assuming a re-read is served from storage.
+export class StoredState extends Resource {
+	get() {
+		const id = this.getId();
+		const store = String(id).startsWith('item-') ? tables.CachedItem.primaryStore : CachedProduct.primaryStore;
+		return { stored: store.getEntry(id) != null };
+	}
+}
+
+// Reports the keys actually stored for a record, read with the computed accessor and the projection
+// removed so that materialization cannot discard a resolver-owned key before it is observed. This is
+// the only way to see the durable bytes: every ordinary read path drops such a key on the way out.
+export class StoredKeys extends Resource {
+	get() {
+		const store = CachedProduct.primaryStore;
+		const prototype = store.encoder.structPrototype;
+		const descriptor = Object.getOwnPropertyDescriptor(prototype, 'salePrice');
+		const resolved = store.encoder.resolvedAttributeNames;
+		try {
+			delete prototype.salePrice;
+			store.encoder.resolvedAttributeNames = undefined;
+			const id = this.getId();
+			// A range read rather than a point read: the point read is served from the record cache, whose
+			// entry is the already-materialized record.
+			const [entry] = store.getRange({ start: id, end: `${id}￿` }).asArray;
+			return { keys: entry?.value ? Object.keys(entry.value) : null };
+		} finally {
+			if (descriptor) Object.defineProperty(prototype, 'salePrice', descriptor);
+			store.encoder.resolvedAttributeNames = resolved;
+		}
+	}
+}
+
+// PlainProduct has no source, so invalidation is reached explicitly here.
+export class PlainProductResource extends tables.PlainProduct {
+	static async post(target) {
+		await this.invalidate(target);
+		return { status: 'invalidated' };
+	}
+}
+
+// Plants a record with a stored value under an @enumerable relationship name, as an affected release
+// could have done through the same response projection.
+export class PoisonedRelationship extends Resource {
+	async put(data) {
+		const body = await data;
+		await tables.Item.primaryStore.put(this.getId(), { id: this.getId(), ...body });
+	}
+}
+
+// Raw stored keys for Item, read with the relationship accessor removed so materialization cannot
+// discard or re-derive anything before it is observed.
+export class ItemKeys extends Resource {
+	get() {
+		const store = tables.Item.primaryStore;
+		const prototype = store.encoder.structPrototype;
+		const descriptor = Object.getOwnPropertyDescriptor(prototype, 'cat');
+		const resolved = store.encoder.resolvedAttributeNames;
+		try {
+			delete prototype.cat;
+			store.encoder.resolvedAttributeNames = undefined;
+			const id = this.getId();
+			const [entry] = store.getRange({ start: id, end: `${id}￿` }).asArray;
+			return { keys: entry?.value ? Object.keys(entry.value) : null, cat: entry?.value?.cat ?? null };
+		} finally {
+			if (descriptor) Object.defineProperty(prototype, 'cat', descriptor);
+			store.encoder.resolvedAttributeNames = resolved;
+		}
+	}
+}
+
+class CachedItemOrigin extends Resource {
+	get() {
+		const id = this.getId();
+		// relobj-* ids return the related object instead of the foreign key
+		if (String(id).startsWith('item-relobj')) return { id, label: 'from source', cat: { slug: 'a', name: 'A' } };
+		// malformed relationship shapes alongside a good foreign key: derivation must not wipe it
+		if (String(id).startsWith('item-relscalar')) return { id, label: 'from source', catId: 'a', cat: 'a' };
+		if (String(id).startsWith('item-relnopk')) return { id, label: 'from source', catId: 'a', cat: { name: 'A' } };
+		return { id, label: 'from source', catId: 'no-such-cat' };
+	}
+	put() {}
+}
+tables.CachedItem.sourcedFrom(CachedItemOrigin);
+
+// The Item-table variant of RangeScan: a stored value under the writable `cat` relationship must
+// neither crash materialization (stored null) nor rewrite the foreign key (stored scalar) on the
+// store's own getRange path.
+export class RangeScanItem extends Resource {
+	get() {
+		const id = this.getId();
+		const [entry] = tables.Item.primaryStore.getRange({ start: id, end: `${id}￿` }).asArray;
+		return entry?.value ? { catId: entry.value.catId, ownKeys: Object.keys(entry.value) } : null;
+	}
+}

--- a/integrationTests/resources/cached-computed-attribute/schema.graphql
+++ b/integrationTests/resources/cached-computed-attribute/schema.graphql
@@ -1,0 +1,45 @@
+# Tables for the harper#2359 suite. Expirations are long so a second read is served from storage
+# rather than refetched — the read that has to survive.
+type CachedProduct @table(expiration: 3600) @export {
+	id: ID @primaryKey
+	price: Float
+	discount: Float
+	salePrice: Float @computed(from: "price - (discount || 0)")
+}
+
+# The same computed shape without a cache source: covers re-encoding an existing record (a partial
+# update reads, merges and writes the record back) on a table whose encoder applies the projection.
+#
+# `salePrice` is @indexed here too, which reaches the defect by a second route needing no cache source
+# and no replication: invalidation preserves a partial record holding every indexed attribute's value
+# so the row stays searchable, and for an indexed computed attribute that means storing the computed
+# value.
+type PlainProduct @table @export {
+	id: ID @primaryKey
+	price: Float
+	discount: Float
+	label: String
+	salePrice: Float @computed(from: "price - (discount || 0)") @indexed
+}
+
+# An @enumerable relationship: the same #1484 response projection surfaces it, so an affected release
+# could have stored a value under this name too. Unlike a computed attribute it has a writable setter.
+type Cat @table @export {
+	slug: ID @primaryKey
+	name: String
+}
+type Item @table @export {
+	id: ID @primaryKey
+	label: String
+	catId: ID @indexed
+	cat: Cat @relationship(from: "catId") @enumerable
+}
+
+# A cached table whose @enumerable relationship has a dangling foreign key: the cache-fill record is
+# struct-prototyped, which is the route that reaches the response projection during a durable encode.
+type CachedItem @table(expiration: 3600) @export {
+	id: ID @primaryKey
+	label: String
+	catId: ID @indexed
+	cat: Cat @relationship(from: "catId") @enumerable
+}

--- a/integrationTests/resources/cachedComputedAttribute.test.ts
+++ b/integrationTests/resources/cachedComputedAttribute.test.ts
@@ -1,0 +1,273 @@
+/**
+ * harper#2359 — a cache table with a scalar `@computed` attribute. A source-filled record was durably
+ * encoded through the response projection that surfaces computed values, so the computed value became
+ * a stored field; materializing it then assigned that value through the computed accessor, which has
+ * no setter, and every read, query, invalidate and delete of the record threw. Affects 5.2.0-5.2.6.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { resolve } from 'node:path';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'cached-computed-attribute');
+
+suite('cache table with a computed attribute', (ctx: ContextWithHarper) => {
+	let request: (path: string, init?: RequestInit) => Promise<Response>;
+
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH);
+		const { admin, httpURL } = ctx.harper;
+		const authorization = 'Basic ' + Buffer.from(`${admin.username}:${admin.password}`).toString('base64');
+		request = (path, init = {}) =>
+			fetch(`${httpURL}${path}`, { ...init, headers: { authorization, ...(init.headers ?? {}) } });
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	// The fixture reports whether the record is present in the table's own store, which is only true
+	// once the cache-fill write has committed.
+	async function waitForStoredRecord(id: string) {
+		for (let attempt = 0; attempt < 100; attempt++) {
+			const response = await request(`/StoredState/${id}`);
+			if (response.status === 200 && ((await response.json()) as any).stored === true) return;
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		throw new Error(`the cache-fill write for ${id} never reached the store`);
+	}
+
+	test('a source-filled record stays readable after the cache fill', async () => {
+		const fill = await request('/CachedProduct/plain-1');
+		strictEqual(fill.status, 200);
+		strictEqual(((await fill.json()) as any).salePrice, 60);
+
+		// The cache write commits behind the fill response, so wait for the record to be readable from
+		// storage rather than assuming the next read is: an immediate re-read that raced the commit
+		// would be another source fetch, and would pass without ever exercising the failing path.
+		await waitForStoredRecord('plain-1');
+
+		const cached = await request('/CachedProduct/plain-1');
+		const body = await cached.text();
+		strictEqual(cached.status, 200, `cached read failed: ${body}`);
+		strictEqual(JSON.parse(body).salePrice, 60);
+	});
+
+	test('the durable record carries no computed value', async () => {
+		await request('/CachedProduct/durable-1');
+		await waitForStoredRecord('durable-1');
+
+		const stored = await request('/StoredKeys/durable-1');
+		strictEqual(stored.status, 200);
+		const keys = ((await stored.json()) as any).keys as string[];
+		ok(Array.isArray(keys), `expected stored keys, got ${JSON.stringify(keys)}`);
+		ok(keys.includes('price'), `expected the stored fields, got ${JSON.stringify(keys)}`);
+		ok(!keys.includes('salePrice'), `the computed value must not be stored: ${JSON.stringify(keys)}`);
+	});
+
+	test('the cached record is reachable by query, invalidation and re-read', async () => {
+		strictEqual((await request('/CachedProduct/plain-2')).status, 200);
+		// The cache write commits behind the fill response; the query below reads the store.
+		await waitForStoredRecord('plain-2');
+
+		const query = await request('/CachedProduct/?price=100');
+		strictEqual(query.status, 200);
+		const rows = (await query.json()) as any[];
+		const row = rows.find((candidate) => candidate.id === 'plain-2');
+		ok(row, `queried record missing: ${JSON.stringify(rows).slice(0, 400)}`);
+		// A materialization failure inside a query surfaces as an error object in an HTTP 200 result
+		// set rather than as a failed request, so the row itself has to be checked.
+		ok(!('error' in row), `query returned an error row: ${JSON.stringify(row)}`);
+		strictEqual(row.salePrice, 60);
+
+		const invalidated = await request('/CachedProduct/plain-2', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ action: 'invalidate' }),
+		});
+		ok(invalidated.status < 500, `invalidation failed: ${invalidated.status} ${await invalidated.text()}`);
+		strictEqual((await request('/CachedProduct/plain-2')).status, 200);
+	});
+
+	test('a record stored by an affected release is readable again, with the resolver authoritative', async () => {
+		const planted = await request('/PoisonedRecord/legacy-1', {
+			method: 'PUT',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ price: 100, discount: 40, salePrice: 999 }),
+		});
+		ok(planted.status < 300, `planting failed: ${planted.status} ${await planted.text()}`);
+
+		// Contamination cannot be observed through a read (materialization is what discards the key);
+		// the planted-bytes probe below is what proves the record really is contaminated.
+		const read = await request('/CachedProduct/legacy-1');
+		const body = await read.text();
+		strictEqual(read.status, 200, `a record stored by an affected release must still read: ${body}`);
+		strictEqual(JSON.parse(body).salePrice, 60, 'the resolver, not the stored value, must be authoritative');
+
+		const query = await request('/CachedProduct/?price=100');
+		strictEqual(query.status, 200);
+		const row = ((await query.json()) as any[]).find((candidate) => candidate.id === 'legacy-1');
+		ok(row, 'the record must be queryable');
+		ok(!('error' in row), `query returned an error row: ${JSON.stringify(row)}`);
+		strictEqual(row.salePrice, 60);
+
+		// Non-vacuity for the durable-record probe: it must be able to see a stored computed value.
+		const stored = await request('/StoredKeys/legacy-1');
+		strictEqual(stored.status, 200);
+		ok(
+			((await stored.json()) as any).keys?.includes('salePrice'),
+			'the planted record must actually carry the stored computed value'
+		);
+	});
+
+	test('re-encoding an existing record keeps every stored field', async () => {
+		const put = await request('/PlainProduct/plain-update', {
+			method: 'PUT',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ price: 100, discount: 40, label: 'keep me' }),
+		});
+		ok(put.status < 300, `put failed: ${put.status} ${await put.text()}`);
+
+		// A partial update reads, merges and writes the record back, so the projection sees a record
+		// instance rather than a request body — the case where projecting by own keys would encode an
+		// empty record.
+		const patch = await request('/PlainProduct/plain-update', {
+			method: 'PATCH',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ discount: 25 }),
+		});
+		ok(patch.status < 300, `patch failed: ${patch.status} ${await patch.text()}`);
+
+		const read = await request('/PlainProduct/plain-update');
+		strictEqual(read.status, 200);
+		const record = (await read.json()) as any;
+		strictEqual(record.price, 100, 'an untouched stored field must survive the re-encode');
+		strictEqual(record.label, 'keep me', 'an untouched stored field must survive the re-encode');
+		strictEqual(record.discount, 25);
+		strictEqual(record.salePrice, 75);
+	});
+
+	test('invalidating a row with an indexed computed attribute leaves it readable', async () => {
+		const put = await request('/PlainProduct/invalidated-1', {
+			method: 'PUT',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ price: 100, discount: 40, label: 'invalidate me' }),
+		});
+		ok(put.status < 300, `put failed: ${put.status} ${await put.text()}`);
+
+		// Invalidation preserves every indexed attribute's value in the partial record so the row stays
+		// searchable, which for an indexed computed attribute means storing the computed value — the
+		// same collision as a cache fill, reached with no cache source and no replication.
+		const invalidated = await request('/PlainProductResource/invalidated-1', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: '{}',
+		});
+		ok(invalidated.status < 300, `invalidation failed: ${invalidated.status} ${await invalidated.text()}`);
+
+		// Invalidation reduces the row to a stub, so what is under test is that reading it works at all
+		// rather than what it still contains.
+		const read = await request('/PlainProduct/invalidated-1');
+		const body = await read.text();
+		strictEqual(read.status, 200, `an invalidated row must still read: ${body}`);
+		ok(!body.includes('attribute.set'), `the invalidated row failed to materialize: ${body}`);
+	});
+
+	test('a cache fill with a dangling @enumerable relationship stays readable', async () => {
+		// The relationship half of the defect, present since 5.1.0: the cache-fill record is
+		// struct-prototyped, so its durable encode used to run the response projection and bake the
+		// resolved relationship value in; a dangling foreign key resolves to undefined, and the stored
+		// undefined then crashed the relationship setter on every later materialization.
+		const fill = await request('/CachedItem/item-dangling-1');
+		strictEqual(fill.status, 200);
+		await waitForStoredRecord('item-dangling-1');
+
+		const cached = await request('/CachedItem/item-dangling-1');
+		const body = await cached.text();
+		strictEqual(cached.status, 200, `cached read failed: ${body}`);
+		strictEqual(JSON.parse(body).catId, 'no-such-cat');
+
+		const query = await request('/CachedItem/?catId=no-such-cat');
+		strictEqual(query.status, 200);
+		const row = ((await query.json()) as any[]).find((candidate) => candidate.id === 'item-dangling-1');
+		ok(row, 'the record must be queryable');
+		ok(!('error' in row), `query returned an error row: ${JSON.stringify(row)}`);
+	});
+
+	test('a source returning the related object gets its foreign key derived', async () => {
+		const fill = await request('/CachedItem/item-relobj-1');
+		strictEqual(fill.status, 200);
+		await waitForStoredRecord('item-relobj-1');
+
+		const cached = await request('/CachedItem/item-relobj-1');
+		const body = await cached.text();
+		strictEqual(cached.status, 200, `cached read failed: ${body}`);
+		strictEqual(JSON.parse(body).catId, 'a', 'the foreign key must be derived from the related object');
+	});
+
+	test('a malformed relationship value from a source never wipes the foreign key', async () => {
+		for (const id of ['item-relscalar-1', 'item-relnopk-1']) {
+			strictEqual((await request(`/CachedItem/${id}`)).status, 200);
+			await waitForStoredRecord(id);
+
+			const cached = await request(`/CachedItem/${id}`);
+			const body = await cached.text();
+			strictEqual(cached.status, 200, `${id} cached read failed: ${body}`);
+			strictEqual(JSON.parse(body).catId, 'a', `${id} must keep the source's foreign key`);
+		}
+	});
+
+	test('a record stored with a value under a relationship name still materializes, keeping its foreign key', async () => {
+		// Shapes an affected release could have persisted under an @enumerable relationship name.
+		// null is what the projection wrote for a dangling foreign key; the scalar shape used to
+		// destroy the foreign key by deriving it from the stale stored value.
+		for (const [id, stored] of [
+			['rel-null', null],
+			['rel-object', { slug: 'a', name: 'A' }],
+			['rel-scalar', 'a'],
+		] as const) {
+			const planted = await request(`/PoisonedRelationship/${id}`, {
+				method: 'PUT',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ label: 'L', catId: 'a', cat: stored }),
+			});
+			ok(planted.status < 300, `planting ${id} failed: ${planted.status} ${await planted.text()}`);
+
+			const read = await request(`/Item/${id}`);
+			const body = await read.text();
+			strictEqual(read.status, 200, `${id} must still read: ${body}`);
+			strictEqual(JSON.parse(body).catId, 'a', `${id} must keep its foreign key`);
+
+			// The store's own getRange promotion — the path full-copy replication iterates — drives the
+			// writable relationship setter unless the colliding key is skipped: a stored null crashes it
+			// and a stored scalar rewrites the foreign key.
+			const ranged = await request(`/RangeScanItem/${id}`);
+			const rangedText = await ranged.text();
+			strictEqual(ranged.status, 200, `${id} range materialization failed: ${rangedText}`);
+			strictEqual(JSON.parse(rangedText)?.catId, 'a', `${id} must keep its foreign key on the range path`);
+		}
+	});
+
+	test('a source value under a computed attribute never outranks the resolver', async () => {
+		const fill = await request('/CachedProduct/colliding-1');
+		strictEqual(fill.status, 200);
+		strictEqual(
+			((await fill.json()) as any).salePrice,
+			60,
+			'the cache-fill response must report the resolver, not the value the source supplied'
+		);
+
+		await waitForStoredRecord('colliding-1');
+		const cached = await request('/CachedProduct/colliding-1');
+		strictEqual(cached.status, 200);
+		strictEqual(((await cached.json()) as any).salePrice, 60, 'the read must report the resolver');
+
+		// The durable bytes themselves, not just the read: with the read-side discard in place the
+		// resolver wins either way, so only the stored keys prove the write side dropped the value.
+		const stored = await request('/StoredKeys/colliding-1');
+		strictEqual(stored.status, 200);
+		const keys = ((await stored.json()) as any).keys as string[];
+		ok(keys?.includes('price'), `expected stored fields: ${JSON.stringify(keys)}`);
+		ok(!keys.includes('salePrice'), `the source value must not be stored: ${JSON.stringify(keys)}`);
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
 				"ses": "^1.15.0",
 				"stream-chain": "2.2.5",
 				"stream-json": "1.9.1",
-				"structon": "1.0.8",
+				"structon": "1.1.0",
 				"systeminformation": "^5.31.4",
 				"tar-fs": "^3.1.2",
 				"tar-stream": "^3.1.8",
@@ -14292,9 +14292,9 @@
 			}
 		},
 		"node_modules/structon": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/structon/-/structon-1.0.8.tgz",
-			"integrity": "sha512-EB4CW5ylIIm04qY+PFQ1MJffh/GZqIqkpfCZDPfrLIdIdv3XZ7aSH7hIu535KQMPbIn3U7JhIydnpj4boZ1/IA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/structon/-/structon-1.1.0.tgz",
+			"integrity": "sha512-QveeRWPoVevondkGanTbYjxfPvrPtfSKLUXIt3rUM5EK8p4K4lJceNc0juernn+YlfhpCZDpIcJEr3oZxGcimw==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
 				"msgpackr": ">=2.0.1"

--- a/package.json
+++ b/package.json
@@ -244,7 +244,7 @@
 		"ses": "^1.15.0",
 		"stream-chain": "2.2.5",
 		"stream-json": "1.9.1",
-		"structon": "1.0.8",
+		"structon": "1.1.0",
 		"systeminformation": "^5.31.4",
 		"tar-fs": "^3.1.2",
 		"tar-stream": "^3.1.8",

--- a/resources/DESIGN.md
+++ b/resources/DESIGN.md
@@ -166,6 +166,11 @@ Tests: `../unitTests/resources/defineResource.test.js`, `../unitTests/resources/
 
 ## Conventions
 
+- A record's `toJSON` is a response projection, not durable state. `recordUpdater` (and the cache-fill
+  and audit paths feeding it) projects records to stored fields via `storedFieldsOnly`, so no durable
+  form carries a resolver-owned (`@computed`/`@relationship`) name; materialization skips such names
+  when promoting a decoded record (`assignStoredFields`), which is what keeps rows written by affected
+  releases readable. See harper#2359 and `integrationTests/resources/cachedComputedAttribute.test.ts`.
 - **Never** remove `transactional()` from a static method on `Resource` — it owns transaction context lifetime.
 - New `Resource` subclasses should override **instance** methods (`get`, `put`, ...) for behavior; static methods are the protocol entry points and stay generic.
 - **Overriding a static entry point takes over its whole contract.** Assigning `static post`/`put`/`patch` on a subclass shadows the `transactional()`-wrapped static, so none of that wrapper runs — including the `when(data, ...)` that resolves `data` and the `allowCreate`/`allowUpdate` gate. That is by design (it is how `login.ts` implements a deliberately pre-authentication endpoint), and it means an override owns two obligations the wrapper would otherwise have met:

--- a/resources/PrimaryRocksDatabase.ts
+++ b/resources/PrimaryRocksDatabase.ts
@@ -3,7 +3,7 @@ import { RocksDatabase, type RocksDatabaseOptions, constants, type Store, Transa
 const FRESH_VERSION_FLAG = constants.FRESH_VERSION_FLAG;
 import { WeakLRUCache } from 'weak-lru-cache';
 import { when } from '../utility/when.ts';
-import { entryMap, METADATA, type Entry } from './RecordEncoder.ts';
+import { assignStoredFields, entryMap, METADATA, type Entry } from './RecordEncoder.ts';
 
 /**
  * RocksDatabase subclass that owns all primary-store behaviour for Harper tables:
@@ -87,7 +87,7 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 			if (entry.value.constructor === Object && this.#enc.structPrototype) {
 				const originalValue = entry.value;
 				entry.value = new this.#enc.structPrototype.constructor();
-				Object.assign(entry.value, originalValue);
+				assignStoredFields(entry.value, originalValue, this.#enc);
 			}
 			if (typeof entry.value === 'object' && entry.value !== null) {
 				entryMap.set(entry.value, entry);
@@ -191,7 +191,7 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 			if (entry.value?.constructor === Object && enc.structPrototype) {
 				const originalValue = entry.value;
 				entry.value = new enc.structPrototype.constructor();
-				for (const key in originalValue) entry.value[key] = originalValue[key];
+				assignStoredFields(entry.value, originalValue, enc);
 			}
 			return entry;
 		});

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -6,7 +6,7 @@
  */
 
 import { Encoder } from 'msgpackr';
-import { createStructon } from 'structon';
+import { createStructon, SOURCE_SYMBOL } from 'structon';
 import {
 	HAS_PREVIOUS_RESIDENCY_ID,
 	HAS_CURRENT_RESIDENCY_ID,
@@ -150,6 +150,72 @@ let timestampNextEncoding = 0,
 	additionalAuditRefsNextEncoding: Array<{ version: number; nodeId: number }> | undefined;
 // tracking metadata with a singleton works better than trying to alter response of getEntry/get and coordinating that across caching layers
 export let lastMetadata: Entry | null = null;
+/**
+ * A resolver owns its attribute's name, so no durable form of a record may carry a value under it.
+ * A value gets there either through the response `toJSON` the table installs on the record prototype
+ * (msgpackr consults an instance's toJSON when it encodes one) or as an own key from a source or
+ * peer payload.
+ */
+export function storedFieldsOnly(encoder: any, record: any) {
+	if (record === null || typeof record !== 'object') return record;
+	// Optional: this also runs for a store whose encode hook was grafted onto a foreign encoder
+	// (copyDb's migration target), which carries no table schema.
+	const resolved = encoder?.resolvedAttributeNames;
+	if (resolved === undefined) return record;
+	const resolvedList = encoder.resolvedAttributeNamesList ?? Array.from(resolved);
+	// A typed-struct instance keeps its stored fields as accessors on a structon-generated child
+	// prototype carrying structon's own toJSON, so it never reaches the response projection — and
+	// copying its own keys would encode an empty record.
+	let project =
+		encoder.surfacedToJSON !== undefined &&
+		record.toJSON === encoder.surfacedToJSON &&
+		record[SOURCE_SYMBOL] === undefined;
+	if (!project && typeof record.toJSON === 'function' && record[SOURCE_SYMBOL] === undefined) {
+		// A class instance with its own serialization: the encoder will consult that toJSON, so the
+		// projection has to run on its OUTPUT, or the serialized form smuggles resolver-owned keys past
+		// a check that only saw the instance. A non-object (or self) result is left for the encoder,
+		// which invokes toJSON again — serializers are assumed pure.
+		const json = record.toJSON();
+		if (json !== record && json !== null && typeof json === 'object') record = json;
+	}
+	if (!project) {
+		for (let i = 0; i < resolvedList.length; i++) {
+			if (Object.hasOwn(record, resolvedList[i])) {
+				project = true;
+				break;
+			}
+		}
+	}
+	if (!project) return record;
+	const stored = {};
+	for (const key of Object.keys(record)) {
+		if (resolved.has(key)) continue;
+		// '__proto__' as an own key must stay a data property: plain assignment would run the inherited
+		// setter, dropping the field from the durable write and swapping the temporary's prototype.
+		if (key === '__proto__')
+			Object.defineProperty(stored, key, { value: record[key], enumerable: true, writable: true, configurable: true });
+		else stored[key] = record[key];
+	}
+	return stored;
+}
+
+/**
+ * A resolver-owned name is skipped rather than assigned during record-instance promotion: through a
+ * read-only resolver the assignment throws, and through a writable one (a many-to-one
+ * `@relationship`) it would derive a foreign key from the stale stored value.
+ */
+export function assignStoredFields(target: any, source: any, encoder: any) {
+	const resolved = encoder?.resolvedAttributeNames;
+	if (resolved === undefined) return Object.assign(target, source);
+	for (const key in source) {
+		if (resolved.has(key)) continue;
+		if (key === '__proto__')
+			Object.defineProperty(target, key, { value: source[key], enumerable: true, writable: true, configurable: true });
+		else target[key] = source[key];
+	}
+	return target;
+}
+
 export class RecordEncoder extends StructonEncoder {
 	rootStore: any;
 	declare saveStructures: any;
@@ -160,6 +226,11 @@ export class RecordEncoder extends StructonEncoder {
 	declare maxOwnStructures: number;
 	randomAccessStructure = false;
 	structureUpdate?: any;
+	// Set by TableResource.updatedAttributes. Undefined for a store with no resolved attributes, which
+	// is what keeps the projection off that store's writes entirely.
+	resolvedAttributeNames?: Set<string>;
+	resolvedAttributeNamesList?: string[];
+	surfacedToJSON?: () => any;
 	isRocksDB: boolean;
 	name: string;
 	useVersions: boolean;
@@ -614,7 +685,7 @@ export function handleLocalTimeForGets(store, rootStore) {
 					// if an object was deserialized as a plain object, give it the right prototype for computed properties to be accessible
 					const originalValue = entry.value;
 					entry.value = new store.encoder.structPrototype.constructor();
-					Object.assign(entry.value, originalValue);
+					assignStoredFields(entry.value, originalValue, store.encoder);
 				}
 				entryMap.set(entry.value, entry); // allow the record to access the entry
 			}
@@ -666,7 +737,7 @@ export function handleLocalTimeForGets(store, rootStore) {
 					// if an object was deserialized as a plain object, give it the right prototype for computed properties to be accessible
 					const originalValue = entry.value;
 					entry.value = new store.encoder.structPrototype.constructor();
-					for (const key in originalValue) entry.value[key] = originalValue[key];
+					assignStoredFields(entry.value, originalValue, store.encoder);
 				}
 			}
 			return entry;
@@ -783,6 +854,10 @@ export function recordUpdater(store, tableId, auditStore) {
 		// harper#1309: reset so a record===undefined call (delete/no-op) cannot carry stale bytes
 		// into the audit encodedRecord or write-size analytics of this call.
 		lastValueEncoding = undefined;
+		// Every durable form of the record — the stored value, the audit entry's encodedRecord and so the
+		// transaction log and replication payload — comes from this record, so projecting it here covers
+		// them all; nested values keep their own toJSON serialization.
+		record = storedFieldsOnly(store.encoder, record);
 		const isRocksDB = store instanceof RocksDatabase;
 		// determine if and how we apply the local timestamp
 		if (isRocksDB) {
@@ -884,6 +959,10 @@ export function recordUpdater(store, tableId, auditStore) {
 			if (audit) {
 				const username = typeof options?.user === 'string' ? options.user : options?.user?.username;
 				if (auditRecord) {
+					// The audit encodedRecord is durable record state too (it is the transaction log and the
+					// replication payload), so it takes the same projection — except for message/publish
+					// entries, whose auditRecord IS the published payload and must reach subscribers verbatim.
+					if (type !== 'message' && type !== 'publish') auditRecord = storedFieldsOnly(store.encoder, auditRecord);
 					encodeBlobsWithFilePath(() => store.encoder.encode(auditRecord), id, store.rootStore);
 					if (blobsWereEncoded) {
 						extendedType |= HAS_BLOBS;

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -207,7 +207,10 @@ export function storedFieldsOnly(encoder: any, record: any) {
 export function assignStoredFields(target: any, source: any, encoder: any) {
 	const resolved = encoder?.resolvedAttributeNames;
 	if (resolved === undefined) return Object.assign(target, source);
-	for (const key in source) {
+	// Own keys, matching the Object.assign fallback above and storedFieldsOnly: a decoded plain
+	// object has no inherited enumerables of its own, so walking the chain could only ever pick up
+	// somebody else's (a polluted Object.prototype included).
+	for (const key of Object.keys(source)) {
 		if (resolved.has(key)) continue;
 		if (key === '__proto__')
 			Object.defineProperty(target, key, { value: source[key], enumerable: true, writable: true, configurable: true });

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -82,6 +82,7 @@ import {
 	type Entry,
 	type StructureCounts,
 	entryMap,
+	storedFieldsOnly,
 } from './RecordEncoder.ts';
 import { recordAction, recordActionBinary } from './analytics/write.ts';
 import { rebuildUpdateBefore } from './crdt.ts';
@@ -535,6 +536,18 @@ export function makeTable(options) {
 	// it, so such a table takes the guarded serialization path rather than the raw fast path.
 	let hasSurfacedComputed = false;
 	let runningRecordExpiration: boolean;
+	const reportedResolverCollisions = new Set<string>();
+	// Reached from record materialization, so it can never be the reason a record fails to load: the
+	// name is marked before the log call, and a throwing log sink is swallowed.
+	function reportResolverCollision(name: string) {
+		if (reportedResolverCollisions.has(name)) return;
+		reportedResolverCollisions.add(name);
+		try {
+			logger.warn?.(
+				`Table "${tableName}" has a stored value under "${name}", which is a computed attribute; the stored value is being discarded and the computed value used instead`
+			);
+		} catch {}
+	}
 	const isRocksDB = primaryStore instanceof RocksDatabase;
 	type BigInt64ArrayAndMaxSafeId = BigInt64Array & { maxSafeId: number };
 	let idIncrementer: BigInt64ArrayAndMaxSafeId;
@@ -5072,6 +5085,9 @@ export function makeTable(options) {
 			for (const attribute of this.attributes) {
 				if (attribute.isPrimaryKey) primaryKeyAttribute = attribute;
 				attribute.resolve = null; // reset this
+				// Also the setter, or a reload that turns a @relationship into a @computed keeps the
+				// relationship's setter and writes a foreign key from a computed assignment.
+				attribute.set = null;
 				const relationship = attribute.relationship;
 				const computed = attribute.computed;
 				// Register the default embedder unless an author override is set. Sits outside
@@ -5233,14 +5249,19 @@ export function makeTable(options) {
 			enumerableAttributeNames = [];
 			enumerableRelationDefs.clear();
 			hasSurfacedComputed = false;
+			const resolvedAttributeNames: string[] = [];
 			for (const attribute of attributes) {
 				const name = attribute.name;
 				if (attribute.resolve) {
+					resolvedAttributeNames.push(name);
 					Object.defineProperty(primaryStore.encoder.structPrototype, name, {
 						get() {
 							return attribute.resolve(this, contextStorage.getStore()); // it is only possible to get the context from ALS, we don't have a direct reference to the current context
 						},
 						set(related) {
+							// A read-only resolver must never be the reason a record fails to materialize — the
+							// same reason the one-to-many branch above installs a no-op.
+							if (!attribute.set) return reportResolverCollision(name);
 							return attribute.set(this, related);
 						},
 						configurable: true,
@@ -5266,6 +5287,12 @@ export function makeTable(options) {
 			if (enumerableAttributeNames.length > 0)
 				installEnumerableToJSON(primaryStore.encoder.structPrototype, this, hasSurfacedComputed);
 			else if (primaryStore.encoder.structPrototype.toJSON) delete primaryStore.encoder.structPrototype.toJSON;
+			// Undefined rather than an empty set for a table with no resolved attributes: that is the
+			// check which keeps the projection off an unaffected store's write path.
+			primaryStore.encoder.resolvedAttributeNames =
+				resolvedAttributeNames.length > 0 ? new Set(resolvedAttributeNames) : undefined;
+			primaryStore.encoder.resolvedAttributeNamesList = resolvedAttributeNames;
+			primaryStore.encoder.surfacedToJSON = primaryStore.encoder.structPrototype.toJSON;
 		}
 		// #section: computed-history
 		static setComputedAttribute(attribute_name, resolver) {
@@ -6140,6 +6167,31 @@ export function makeTable(options) {
 						// before stamping the primary key and created/updated times below (records are immutable —
 						// 5.2 record caching relies on it — so we must not write through the frozen object).
 						if (isFrozenRecordObject(updatedRecord)) updatedRecord = { ...updatedRecord };
+						// A writable resolver (a relationship) keeps its meaning for source payloads: a source
+						// returning the related object instead of the foreign key gets the key derived, the way
+						// the promotion setter used to. Derivation runs against a probe first — a malformed
+						// value (a scalar, an object without the related primary key) derives undefined, and
+						// applying that would durably wipe the foreign key. The projection then drops the
+						// resolver-owned key itself, so the cache-fill response cannot be the one read
+						// reporting the source's value.
+						const resolvedNames = primaryStore.encoder.resolvedAttributeNamesList;
+						if (resolvedNames) {
+							for (const name of resolvedNames) {
+								if (Object.hasOwn(updatedRecord, name)) {
+									const resolvedAttribute = findAttribute(attributes, name);
+									if (resolvedAttribute?.set && updatedRecord[name] != null) {
+										const probe = {};
+										resolvedAttribute.set(probe, updatedRecord[name]);
+										for (const key in probe) {
+											const derived = probe[key];
+											const usable = Array.isArray(derived) ? derived.every((one) => one != null) : derived != null;
+											if (usable) updatedRecord[key] = derived;
+										}
+									}
+								}
+							}
+						}
+						updatedRecord = storedFieldsOnly(primaryStore.encoder, updatedRecord);
 						if (primaryKey && updatedRecord[primaryKey] !== id) updatedRecord[primaryKey] = id;
 					}
 					resolved = true;

--- a/resources/graphql.ts
+++ b/resources/graphql.ts
@@ -351,4 +351,4 @@ async function processGraphQLSchema(gqlContent, urlPath, filePath, resources) {
 }
 
 // useful for testing
-export const loadGQLSchema = (content) => processGraphQLSchema(content, null, null, new Resources());
+export const loadGQLSchema = (content) => processGraphQLSchema(content, null, '<inline-schema>', new Resources());

--- a/resources/tracked.ts
+++ b/resources/tracked.ts
@@ -45,6 +45,10 @@ export function assignTrackedAccessors(Target, typeDef, useFullPropertyProxy = f
 					return attribute.resolve(this, this.getContext?.());
 				},
 				set(related) {
+					// Unlike the struct-prototype accessor (which tolerates a stored collision so a record can
+					// still load), this is a user assignment to a resolved attribute, and a read-only resolver
+					// (a scalar @computed has no attribute.set) has nowhere to put it (harper#2359).
+					if (!attribute.set) throw new ClientError(`${name} is a computed attribute and can not be assigned`);
 					return attribute.set(this, related);
 				},
 				configurable: true,

--- a/unitTests/apiTests/computedDurableEncoding-test.mjs
+++ b/unitTests/apiTests/computedDurableEncoding-test.mjs
@@ -1,0 +1,160 @@
+'use strict';
+
+// harper#2359: a resolved attribute owns its name, so no durable encoding may carry a value under it,
+// and a record that already does must still materialize with the resolver authoritative. FourProp
+// supplies `nameTitle` (@computed @enumerable, so the response projection surfaces it) and
+// `ageInMonths` (@computed).
+import assert from 'node:assert';
+import { setupTestApp } from './setupTestApp.mjs';
+import { storedFieldsOnly } from '#src/resources/RecordEncoder';
+
+const RESOLVED = ['nameTitle', 'ageInMonths'];
+
+// Asserting the projection rather than encoded bytes keeps the test off the shared, reused encode
+// buffer; the wiring into real encodes is covered by integrationTests/resources/cachedComputedAttribute.test.ts.
+function durableProjection(store, record) {
+	return storedFieldsOnly(store.encoder, record);
+}
+
+describe('resolved attributes stay out of durable encodings', function () {
+	before(async function () {
+		await setupTestApp();
+	});
+
+	it('the response projection surfaces a computed attribute but the durable encoding does not', () => {
+		const store = tables.FourProp.primaryStore;
+		const record = new store.encoder.structPrototype.constructor();
+		Object.assign(record, { id: 'durable-2359', name: 'name', title: 'title', age: 3 });
+
+		// Establishes the premise: this record reaches the encoder carrying the projection that adds the
+		// computed value (the contamination route), not merely a plain object.
+		assert.ok(Object.keys(record.toJSON()).includes('nameTitle'));
+
+		const keys = Object.keys(durableProjection(store, record));
+		for (const name of RESOLVED) assert.ok(!keys.includes(name), `${name} must not be durably encoded`);
+		assert.ok(keys.includes('name'));
+		assert.ok(keys.includes('title'));
+	});
+
+	it('a class instance smuggling a resolver-owned key through its own toJSON is projected', () => {
+		const store = tables.FourProp.primaryStore;
+		class Row {
+			constructor() {
+				this.id = 'tojson-2359';
+				this.name = 'n';
+			}
+			toJSON() {
+				return { ...this, nameTitle: 'SMUGGLED' };
+			}
+		}
+		const projected = durableProjection(store, new Row());
+		assert.ok(!Object.hasOwn(projected, 'nameTitle'), 'the toJSON output must be projected too');
+		assert.strictEqual(projected.name, 'n', 'the serialized shape must otherwise be preserved');
+
+		class CleanRow {
+			constructor() {
+				this.id = 'tojson-clean';
+			}
+			toJSON() {
+				return { id: this.id, extra: 'serialized' };
+			}
+		}
+		const clean = durableProjection(store, new CleanRow());
+		assert.strictEqual(clean.extra, 'serialized', 'a clean toJSON serialization must be honored');
+	});
+
+	it('an own __proto__ key survives the projection as a data property', () => {
+		const store = tables.FourProp.primaryStore;
+		const record = { id: 'proto-2359', name: 'n', title: 't', age: 1, nameTitle: 'FORGED' };
+		Object.defineProperty(record, '__proto__', { value: { injected: true }, enumerable: true, configurable: true });
+		const projected = durableProjection(store, record);
+		assert.notStrictEqual(projected, record, 'the colliding key must force a projection');
+		const descriptor = Object.getOwnPropertyDescriptor(projected, '__proto__');
+		assert.ok(descriptor && 'value' in descriptor, '__proto__ must be an own data property');
+		assert.deepStrictEqual(descriptor.value, { injected: true });
+		assert.strictEqual(Object.getPrototypeOf(projected), Object.prototype, 'the prototype must not be swapped');
+		assert.ok(!('injected' in Object.getPrototypeOf(projected)), 'no pollution of the prototype');
+	});
+
+	it('an own key colliding with a resolved attribute is dropped from the durable encoding', () => {
+		const store = tables.FourProp.primaryStore;
+		const keys = Object.keys(
+			durableProjection(store, { id: 'durable-own-2359', name: 'name', title: 'title', age: 3, nameTitle: 'WRONG' })
+		);
+		assert.ok(!keys.includes('nameTitle'));
+		assert.ok(keys.includes('name'));
+	});
+
+	it('assigning a computed attribute on a resource instance throws a client error', () => {
+		const instance = Object.create(tables.FourProp.prototype);
+		assert.throws(() => {
+			instance.nameTitle = 'assigned';
+		}, /computed attribute/);
+	});
+
+	it('a relationship attribute is resolver-owned, and a table with no resolved attributes is untouched', () => {
+		const resolved = tables.FourProp.primaryStore.encoder.resolvedAttributeNames;
+		for (const name of RESOLVED) assert.ok(resolved.has(name), `${name} must be resolver-owned`);
+		assert.ok(tables.Related.primaryStore.encoder.resolvedAttributeNames.has('subObject'));
+		// The undefined (not empty-set) marker is what keeps the projection off an unaffected table's
+		// write path entirely.
+		assert.strictEqual(tables.VariedProps.primaryStore.encoder.resolvedAttributeNames, undefined);
+	});
+});
+
+describe('the audit encodedRecord takes the durable projection', function () {
+	before(async function () {
+		await setupTestApp();
+	});
+
+	// The explicit auditRecord branch is fed by partial updates (the patch body — which replication
+	// can deliver contaminated from an affected peer) and by the residency path (the record instance,
+	// whose toJSON is the response projection). Neither feed is reachable from a single-node public
+	// write (validate rejects a user-supplied computed property), so the branch is driven directly and
+	// the payload is captured at the encoder, which the projection runs before; the write is then
+	// allowed to fail downstream where it wants a live transaction.
+	it('a record-type audit payload is projected; a message payload is not', async () => {
+		const { recordUpdater } = await import('#src/resources/RecordEncoder');
+		const table = tables.FourProp;
+		const encoder = table.primaryStore.encoder;
+		const update = recordUpdater(table.primaryStore, table.tableId, table.auditStore);
+
+		const capturedAuditPayload = (id, type, auditRecord) => {
+			const encoded = [];
+			const realEncode = encoder.encode;
+			encoder.encode = function (record, options) {
+				encoded.push(record);
+				return realEncode.call(this, record, options);
+			};
+			try {
+				update(id, { id, name: 'n', title: 't', age: 1 }, null, Date.now(), -1, true, {}, type, false, auditRecord);
+			} catch {
+				// the audit write wants a live transaction; everything under test ran before it
+			} finally {
+				encoder.encode = realEncode;
+			}
+			return encoded.find((candidate) => candidate && Object.hasOwn(candidate, 'probe'));
+		};
+
+		const recordPayload = capturedAuditPayload(`audit-rec-${Date.now()}`, 'put', {
+			probe: true,
+			name: 'patched',
+			nameTitle: 'FORGED',
+		});
+		assert.ok(recordPayload, 'the record-type audit payload must be encoded');
+		assert.strictEqual(recordPayload.name, 'patched');
+		assert.ok(!Object.hasOwn(recordPayload, 'nameTitle'), 'resolver-owned keys must be projected out');
+
+		const messagePayload = capturedAuditPayload(`audit-msg-${Date.now()}`, 'message', {
+			probe: true,
+			body: 'hello',
+			nameTitle: 'part of the payload',
+		});
+		assert.ok(messagePayload, 'the message payload must be encoded');
+		assert.strictEqual(
+			messagePayload.nameTitle,
+			'part of the payload',
+			'a published payload must reach subscribers verbatim'
+		);
+	});
+});


### PR DESCRIPTION
Fixes #2359.

A table with a scalar `@computed` attribute and a cache source stored the computed value as a stored
field, and then could not read the record back — read, query, invalidate and **delete** all failed
with `TypeError: attribute.set is not a function`, on a single node with no replication. Version
bisect: 5.1.26 passes, 5.2.0 fails, 5.2.6 fails. The same mechanism has affected `@enumerable`
`@relationship` attributes **since 5.1.0**: a dangling foreign key crashes materialization the same
way, and a scalar collision silently destroys the foreign key.

## Routes in

1. **Cache fill** — `sourcedFrom` + scalar `@computed` (the 5.2.0 regression, from #1484's response
   projection) or `@enumerable @relationship` (since 5.1.0, from `getFromSource`'s `setPrototypeOf`).
2. **Invalidation** — `_writeInvalidate` preserves `getProperty(name)` for every indexed attribute;
   for `@computed @indexed` that stores the computed value. No cache source or replication needed.
3. **Initial-copy replication** — the surface #2359 was filed for.

## Mechanism

msgpackr consults an instance's `toJSON` when encoding it, and structon's struct writer additionally
walked the prototype chain — so a durable encode of any struct-prototyped record ran the **response**
projection and persisted resolved values as stored fields. Materialization then assigned those back
through the resolver accessors: a computed attribute has no setter (throw → record unreachable); a
relationship setter dereferences the stale value (`null` → crash; scalar → FK derived from garbage).

## The change — the invariant at every layer that owns it

**No durable form of a record carries a value under a resolver-owned name, and a stored collision can
never prevent materialization nor outrank its resolver.**

- **Write, harper layer:** [`recordUpdater` projects the record](https://github.com/HarperFast/harper/pull/2368/changes?w=1#diff-d175bc619774c0fb18833823092f139f0ba6a0eb4503f49159fd5c2e0e324f38R860) to
  [its stored fields](https://github.com/HarperFast/harper/pull/2368/changes?w=1#diff-d175bc619774c0fb18833823092f139f0ba6a0eb4503f49159fd5c2e0e324f38R159) — and [the audit entry's own record](https://github.com/HarperFast/harper/pull/2368/changes?w=1#diff-d175bc619774c0fb18833823092f139f0ba6a0eb4503f49159fd5c2e0e324f38R965), gated so
  message/publish payloads stay verbatim — before anything durable is written. Every durable form derives from that one value — stored bytes, the audit entry's
  `encodedRecord`, the transaction log, the replication payload — and message payloads are untouched
  because they do not pass through it. This also covers own-key contamination from source and peer
  payloads, which no encoder option can see.
- **Write, library layer (defense in depth):** structon 1.1.0 gains own-property write guards
  matching msgpackr's own object writers ([HarperFast/structon#9](https://github.com/HarperFast/structon/pull/9)),
  closing the prototype-walk route for every struct encode. msgpackr 2.1.0 adds a `useToJSON` option
  ([kriszyp/msgpackr#201](https://github.com/kriszyp/msgpackr/pull/201)); harper deliberately does
  **not** set it after review flagged the collateral — an encoder-wide opt-out also silences the
  legitimate `toJSON` of nested values (`URL`, getter-backed classes), turning them into `{}` in
  storage. The record boundary is `recordUpdater`'s projection; the option stays available for
  encoders whose payloads are pure state.
- **Read:** the four paths that promote a plain decode to a record instance
  [skip resolver-owned names](https://github.com/HarperFast/harper/pull/2368/changes?w=1#diff-d175bc619774c0fb18833823092f139f0ba6a0eb4503f49159fd5c2e0e324f38R207) instead of assigning through the accessors, and
  [the accessor itself drops such an assignment](https://github.com/HarperFast/harper/pull/2368/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R5264) (warning once per table, log failures
  swallowed). This is what makes the rows already written by
  5.1.0–5.2.6 readable again — they are otherwise unreadable **and undeletable**, so a write-side-only
  fix cannot recover them.
- A schema reload [clears `attribute.set` alongside `attribute.resolve`](https://github.com/HarperFast/harper/pull/2368/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R5090), so a
  `@relationship` → `@computed` change cannot retain the stale setter. A user assignment to a
  computed attribute [throws a `ClientError`](https://github.com/HarperFast/harper/pull/2368/changes?w=1#diff-381599071d5ae8eee33664333b602287bdc8b9bc12f79b48fcf57acf92b63066R51) naming the attribute instead of a `TypeError`.

`@indexed @computed` stays correct: `updateIndices` derives index values from `propertyResolvers`,
never from the encoded record, so stripping the stored copy changes no index entry.

## Dependencies and rollout

structon **1.1.0** is published and pinned by this PR — its own-property write guards are live at the
encoder, and every suite was re-run against the genuine npm artifact. msgpackr deliberately stays at
**2.0.5**: rocksdb-js pins that version exactly, so bumping harper's pin forks the msgpackr instance
and splits the module-level `addExtension` registry (blob/bigint extensions invisible to rocksdb-js's
copy) — and nothing here needs 2.1.0, since harper does not set the new option. The harper-layer
projection is independently sufficient, so a structon rollback degrades to defense-in-depth loss, not
a regression. An un-upgraded 5.2.x peer keeps producing contaminated payloads; an upgraded node
tolerates them on read and strips them on write, and contaminated bytes leave storage on each row's
next rewrite (no scrub).

## For the human reviewer

- **Relationship to #2360:** built independently before finding it; supersedes its write side (which
  covers only read-only resolvers, leaving the relationship crash live — measured on its head:
  `GET /CachedItem/x1` → 500 after a cache fill with a dangling FK) and generalizes its decode-side
  cleanup to all resolver-owned names. Its `readOnlyResolverNames` decode filter and this PR's
  materialization skip solve the same recovery problem in different places; happy to converge on
  either placement in review.
- **A source returning a related object instead of its foreign key** keeps working: the writable
  resolver's setter derives the key before the projection drops the resolver-owned name, preserving
  the promotion-setter behavior sources relied on. [Derivation runs against a probe first](https://github.com/HarperFast/harper/pull/2368/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R6183), so a
  malformed value (a scalar, an object without the related primary key) cannot wipe a foreign key the
  source also supplied. A read-only (computed) collision from a source is still dropped silently —
  surfacing it to the app author is an open question for review.
- **Cross-model review history:** the planning review rejected the first design (a global durable-
  encode scope flag) as taxing every encode and missing plain-object contamination — this design is
  the result. Round-1 code review majors, both real and both fixed with probes that fail without the
  fix: the fourth plain-object promotion site (`PrimaryRocksDatabase.getRange`, the path full-copy
  replication iterates — a stored `null` under a writable relationship crashed it, a scalar rewrote
  the FK) and the explicit `auditRecord` branch bypassing the projection (patch bodies and the
  residency path feed it; now projected, gated so message/publish payloads stay verbatim). Earlier
  rounds: writable-relationship collisions moved the read-side fix from the accessor to the repair
  sites; the stale `attribute.set` reset. Rejected with facts: a claimed empty-record data loss for
  typed structs (structon keeps decoded fields on its own child prototype, verified by test), and a
  claimed missing `ClientError` import (line 1 of tracked.ts).

## Verification

- **Fails-on-base** against clean-built `origin/main`: 6 of the 9 integration tests fail with the
  production errors (`attribute.set is not a function`; relationship variants with `getId`
  TypeErrors); the other 3 are guard/behavior-preservation tests, green on both.
- `integrationTests/resources/cachedComputedAttribute.test.ts` — 11 tests over REST: cache fill,
  raw-stored-bytes probe (with a non-vacuity check that the probe can see a planted collision),
  legacy-record recovery, invalidation route, re-encode of an existing record, dangling-FK
  relationship fill, a source returning the related object (FK derived) and malformed relationship
  shapes (FK never wiped), planted relationship collisions asserted on both the point-read and the
  store `getRange` paths, source-collision echo with the durable stored keys asserted directly.
- `unitTests/apiTests/computedDurableEncoding-test.mjs` — projection contract, class-`toJSON`
  smuggling, the own-`__proto__` data-property guarantee, `ClientError`, resolver-name wiring, and
  the audit-branch gate (record payload projected, message payload verbatim), driven directly through
  `recordUpdater` with the payload captured at the encoder. The audit test pins the projection at the
  encoder seam, not a committed audit entry — a Pro-side replication round trip is the end-to-end
  check for that half and belongs with #2359's Pro work.
- Gates: `test:unit:apitests`, `test:unit:resources`, `test:integration:all` (results in PR checks;
  local runs recorded in the review artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=unknown; ran=none; rounds=1 @ 62c3b11f34d1</sub>

<sub>Human-Review-Need: 4 @ 62c3b11f34d1</sub>
