### PR TITLE
Report incomplete PR descriptions before review

### DIFF
--- a/.github/actions/review-coverage/README.md
+++ b/.github/actions/review-coverage/README.md
@@ -1,0 +1,13 @@
+# PR description checks
+
+This action independently reports cross-model review coverage and PR-description format. Format checking is off for consumers unless `format_mode` is set to `report` or `enforce`.
+
+For a non-bot Harper organization member changing more than two lines, the description must contain:
+
+- summary prose before the sections;
+- exactly one `## Verification` section with executed evidence or a not-observable rationale; and
+- at least one line-anchored link into the current PR diff. Every PR-diff link in the body must point to this repository and PR and resolve inside a current diff hunk.
+
+If any AI field is present, the body must also have one `## For the human reviewer` section before Verification, one valid `Complexity: easy|medium|complicated` field, and one pinned `<sub>Review-Coverage: … @ <sha></sub>` and `<sub>Human-Review-Need: 0-4 @ <sha></sub>` footer.
+
+Drafts are reported but do not fail enforcement. Bot, external-author, and at-most-two-line PRs are exempt. To repair a line link, hash the changed file path with SHA-256 and use `https://github.com/<owner>/<repo>/pull/<number>/changes?w=1#diff-<hash>R<line>` (`L<line>` for the old side).

--- a/.github/actions/review-coverage/README.md
+++ b/.github/actions/review-coverage/README.md
@@ -8,6 +8,8 @@ For a non-bot Harper organization member changing more than two lines, the descr
 - exactly one `## Verification` section with executed evidence or a not-observable rationale; and
 - at least one line-anchored link into the current PR diff. Every PR-diff link in the body must point to this repository and PR and resolve inside a current diff hunk.
 
-If any AI field is present, the body must also have one `## For the human reviewer` section before Verification, one valid `Complexity: easy|medium|complicated` field, and one pinned `<sub>Review-Coverage: … @ <sha></sub>` and `<sub>Human-Review-Need: 0-4 @ <sha></sub>` footer.
+If any AI field is present, the body must also have one `## For the human reviewer` section before Verification, one valid `Complexity: easy|medium|complicated` field, and one `<sub>Review-Coverage: … @ <sha></sub>` and `<sub>Human-Review-Need: 0-4 @ <sha></sub>` footer pinned to the current head.
 
-Drafts are reported but do not fail enforcement. Bot, external-author, and at-most-two-line PRs are exempt. To repair a line link, hash the changed file path with SHA-256 and use `https://github.com/<owner>/<repo>/pull/<number>/changes?w=1#diff-<hash>R<line>` (`L<line>` for the old side).
+Drafts are reported but do not fail enforcement. Bot, external-author, and at-most-two-line PRs are exempt. Repair a link by copying a line link from the PR's Files changed page.
+
+GitHub may omit patches or fail to return a complete file list. Report mode records that as unverifiable and stays green. Enforce mode fails closed; do not enable it until the action runs from a trusted host rather than the PR checkout.

--- a/.github/actions/review-coverage/action.yml
+++ b/.github/actions/review-coverage/action.yml
@@ -7,7 +7,7 @@
 #   - uses: HarperFast/harper/.github/actions/review-coverage@<full sha> # main
 #
 name: review-coverage
-description: Report (or enforce) cross-model review coverage named in the PR description
+description: Report cross-model coverage and PR-description format
 inputs:
   mode:
     description: report (always green, informational) or enforce (red when under-reported)
@@ -15,6 +15,15 @@ inputs:
   required:
     description: how many distinct cross-model review families the description must name
     default: '2'
+  format_mode:
+    description: off, report (always green), or enforce PR-description format
+    default: off
+  pr_files:
+    description: normalized PR-files API artifact used for current line-link validation
+    default: ''
+  pr_files_ready:
+    description: true only when the PR-files artifact was produced successfully
+    default: 'false'
 runs:
   using: node24
   main: ci-review-coverage.mjs

--- a/.github/actions/review-coverage/action.yml
+++ b/.github/actions/review-coverage/action.yml
@@ -24,6 +24,9 @@ inputs:
   pr_files_ready:
     description: true only when the PR-files artifact was produced successfully
     default: 'false'
+  pr_files_superseded:
+    description: true when the event head was replaced before collection completed
+    default: 'false'
 runs:
   using: node24
   main: ci-review-coverage.mjs

--- a/.github/actions/review-coverage/ci-review-coverage.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.mjs
@@ -9,24 +9,45 @@
 // Run from the JavaScript action in this directory, or locally:
 //   node .github/actions/review-coverage/ci-review-coverage.mjs --event <payload.json> [--mode enforce]
 
-import { appendFileSync, readFileSync } from 'node:fs';
+import { appendFileSync, readFileSync, statSync } from 'node:fs';
 import { evaluateCiCoverage } from './evaluateCiCoverage.mjs';
+import { evaluatePrFormat } from './evaluatePrFormat.mjs';
+import { classifyPullRequest } from './prExemption.mjs';
 import { COVERAGE_REQUIRED } from './reviewGate.mjs';
+
+const MAX_PR_FILES_BYTES = 4 * 1024 * 1024;
 
 function arg(name, fallback = '') {
 	const i = process.argv.indexOf(`--${name}`);
 	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
 }
 
-function main(mode) {
+function readPrFiles(pr, formatMode) {
+	if (formatMode === 'off' || classifyPullRequest(pr).exempt) return null;
+	const ready = arg('pr-files-ready', process.env.INPUT_PR_FILES_READY || '').toLowerCase() === 'true';
+	const file = arg('pr-files', process.env.INPUT_PR_FILES || '');
+	if (!ready || !file) return null;
+	const size = statSync(file).size;
+	if (size > MAX_PR_FILES_BYTES) throw new Error(`normalized PR-files artifact exceeds ${MAX_PR_FILES_BYTES} bytes`);
+	return JSON.parse(readFileSync(file, 'utf8'));
+}
+
+function main(mode, formatMode) {
 	const eventPath = arg('event', process.env.GITHUB_EVENT_PATH ?? '');
 	if (!eventPath) throw new Error('no event payload (--event or GITHUB_EVENT_PATH)');
-	const pr = JSON.parse(readFileSync(eventPath, 'utf8')).pull_request;
+	const event = JSON.parse(readFileSync(eventPath, 'utf8'));
+	const pr = event.pull_request;
 	if (!pr) throw new Error('event payload has no pull_request');
 	const rawRequired = arg('required', process.env.INPUT_REQUIRED || process.env.REVIEW_COVERAGE_REQUIRED || '');
 	const required = rawRequired === '' ? COVERAGE_REQUIRED : Number(rawRequired);
 	if (!Number.isInteger(required) || required < 0) throw new Error(`invalid required '${rawRequired}'`);
 	const r = evaluateCiCoverage(pr, { mode, required });
+	const format = evaluatePrFormat(pr, {
+		mode: formatMode,
+		repo: String(event.repository?.full_name ?? ''),
+		number: Number(event.number ?? pr.number),
+		prFiles: readPrFiles(pr, formatMode),
+	});
 
 	const lines = [
 		`### Cross-model review coverage — ${r.pass ? (r.exempt ? '✅ exempt' : r.compliant ? '✅' : '⚠️ report-only') : '❌'}`,
@@ -39,6 +60,20 @@ function main(mode) {
 				? ''
 				: `Per team policy, a substantive PR is queued for human review only after ${required} cross-model reviews are run and reported in the description (\`## Review coverage\` naming each model — see harper-engineering-guidelines). The dispatch review gate enforces this when the fleet's review finds issues; this check just makes the reporting visible early.`,
 	].filter(Boolean);
+	if (formatMode !== 'off') {
+		lines.push(
+			'',
+			`### PR description format — ${format.exempt ? '✅ exempt' : format.compliant ? '✅' : format.draft ? '⚠️ draft' : '⚠️'}`,
+			'',
+			format.exempt
+				? `_${format.exempt}_`
+				: format.compliant
+					? `${format.links.lineAnchored.length} current line-anchored PR-diff link(s); required structure present.`
+					: format.problems.map((problem) => `- ${problem}`).join('\n'),
+			'',
+			'See `.github/actions/review-coverage/README.md` for the format and remediation.'
+		);
+	}
 	if (process.env.GITHUB_STEP_SUMMARY) {
 		try {
 			appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n') + '\n');
@@ -47,6 +82,10 @@ function main(mode) {
 		}
 	}
 	console.log(`review-coverage [${mode}]: ${r.exempt ? r.summary : r.detail}`);
+	if (formatMode !== 'off')
+		console.log(
+			`pr-format [${formatMode}]: ${format.exempt ? `exempt: ${format.exempt}` : format.compliant ? 'compliant' : format.problems.join('; ')}`
+		);
 	if (r.pass && !r.exempt && !r.compliant)
 		console.error(
 			`::warning::${r.detail} — the dispatch gate will block at review time if the fleet's review finds issues`
@@ -57,21 +96,31 @@ function main(mode) {
 		);
 		process.exitCode = 1;
 	}
+	if (!format.pass) {
+		for (const problem of format.problems) console.error(`::error::PR description: ${problem}`);
+		process.exitCode = 1;
+	} else if (!format.compliant && !format.exempt) {
+		for (const problem of format.problems) console.error(`::warning::PR description: ${problem}`);
+	}
 }
 
 const mode = arg('mode', process.env.INPUT_MODE || process.env.REVIEW_COVERAGE_MODE || 'report').toLowerCase();
-if (mode !== 'report' && mode !== 'enforce') {
+const formatMode = arg('format-mode', process.env.INPUT_FORMAT_MODE || 'off').toLowerCase();
+if (!['report', 'enforce'].includes(mode)) {
 	console.error(`::error::review-coverage: unknown mode '${mode}' (report|enforce)`);
+	process.exitCode = 1;
+} else if (!['off', 'report', 'enforce'].includes(formatMode)) {
+	console.error(`::error::review-coverage: unknown format mode '${formatMode}' (off|report|enforce)`);
 	process.exitCode = 1;
 } else {
 	try {
-		main(mode);
+		main(mode, formatMode);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		console.error(
-			`review-coverage: ${message}${mode === 'enforce' ? '' : ' (passing — report mode fails only on policy)'}`
+			`review-coverage: ${message}${mode === 'enforce' || formatMode === 'enforce' ? '' : ' (passing — report mode fails only on policy)'}`
 		);
-		if (mode === 'enforce') {
+		if (mode === 'enforce' || formatMode === 'enforce') {
 			console.error(`::error::review-coverage could not evaluate this PR (${message}) — enforce mode fails closed`);
 			process.exitCode = 1;
 		}

--- a/.github/actions/review-coverage/ci-review-coverage.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.mjs
@@ -10,6 +10,7 @@
 //   node .github/actions/review-coverage/ci-review-coverage.mjs --event <payload.json> [--mode enforce]
 
 import { appendFileSync, readFileSync, statSync } from 'node:fs';
+import { validateNormalizedPrFiles } from './collectPrFiles.mjs';
 import { evaluateCiCoverage } from './evaluateCiCoverage.mjs';
 import { evaluatePrFormat } from './evaluatePrFormat.mjs';
 import { classifyPullRequest } from './prExemption.mjs';
@@ -29,7 +30,7 @@ function readPrFiles(pr, formatMode, superseded) {
 	if (!ready || !file) return null;
 	const size = statSync(file).size;
 	if (size > MAX_PR_FILES_BYTES) throw new Error(`normalized PR-files artifact exceeds ${MAX_PR_FILES_BYTES} bytes`);
-	return JSON.parse(readFileSync(file, 'utf8'));
+	return validateNormalizedPrFiles(JSON.parse(readFileSync(file, 'utf8')));
 }
 
 function main(mode, formatMode) {

--- a/.github/actions/review-coverage/ci-review-coverage.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.mjs
@@ -22,8 +22,8 @@ function arg(name, fallback = '') {
 	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
 }
 
-function readPrFiles(pr, formatMode) {
-	if (formatMode === 'off' || classifyPullRequest(pr).exempt) return null;
+function readPrFiles(pr, formatMode, superseded) {
+	if (formatMode === 'off' || superseded || classifyPullRequest(pr).exempt) return null;
 	const ready = arg('pr-files-ready', process.env.INPUT_PR_FILES_READY || '').toLowerCase() === 'true';
 	const file = arg('pr-files', process.env.INPUT_PR_FILES || '');
 	if (!ready || !file) return null;
@@ -42,10 +42,11 @@ function main(mode, formatMode) {
 	const required = rawRequired === '' ? COVERAGE_REQUIRED : Number(rawRequired);
 	if (!Number.isInteger(required) || required < 0) throw new Error(`invalid required '${rawRequired}'`);
 	const r = evaluateCiCoverage(pr, { mode, required });
+	const superseded = arg('pr-files-superseded', process.env.INPUT_PR_FILES_SUPERSEDED || '').toLowerCase() === 'true';
 	let prFiles = null;
 	let evidenceProblem = '';
 	try {
-		prFiles = readPrFiles(pr, formatMode);
+		prFiles = readPrFiles(pr, formatMode, superseded);
 	} catch (error) {
 		evidenceProblem = `PR-files evidence is unavailable (${error instanceof Error ? error.message : String(error)})`;
 	}
@@ -55,6 +56,7 @@ function main(mode, formatMode) {
 		number: Number(event.number ?? pr.number),
 		prFiles,
 		evidenceProblem,
+		superseded,
 	});
 
 	const lines = [

--- a/.github/actions/review-coverage/ci-review-coverage.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.mjs
@@ -42,11 +42,19 @@ function main(mode, formatMode) {
 	const required = rawRequired === '' ? COVERAGE_REQUIRED : Number(rawRequired);
 	if (!Number.isInteger(required) || required < 0) throw new Error(`invalid required '${rawRequired}'`);
 	const r = evaluateCiCoverage(pr, { mode, required });
+	let prFiles = null;
+	let evidenceProblem = '';
+	try {
+		prFiles = readPrFiles(pr, formatMode);
+	} catch (error) {
+		evidenceProblem = `PR-files evidence is unavailable (${error instanceof Error ? error.message : String(error)})`;
+	}
 	const format = evaluatePrFormat(pr, {
 		mode: formatMode,
 		repo: String(event.repository?.full_name ?? ''),
 		number: Number(event.number ?? pr.number),
-		prFiles: readPrFiles(pr, formatMode),
+		prFiles,
+		evidenceProblem,
 	});
 
 	const lines = [

--- a/.github/actions/review-coverage/ci-review-coverage.test.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.test.mjs
@@ -144,6 +144,12 @@ test('the CLI runs through a symlinked entrypoint', () => {
 		fileURLToPath(new URL('./evaluateCiCoverage.mjs', import.meta.url)),
 		path.join(dir, 'evaluateCiCoverage.mjs')
 	);
+	symlinkSync(
+		fileURLToPath(new URL('./evaluatePrFormat.mjs', import.meta.url)),
+		path.join(dir, 'evaluatePrFormat.mjs')
+	);
+	symlinkSync(fileURLToPath(new URL('./prExemption.mjs', import.meta.url)), path.join(dir, 'prExemption.mjs'));
+	symlinkSync(fileURLToPath(new URL('./prFormatLinks.mjs', import.meta.url)), path.join(dir, 'prFormatLinks.mjs'));
 	symlinkSync(fileURLToPath(new URL('./reviewGate.mjs', import.meta.url)), path.join(dir, 'reviewGate.mjs'));
 	writeFileSync(file, JSON.stringify({ pull_request: pr() }));
 	try {
@@ -178,6 +184,57 @@ test('the JavaScript action uses a pinned runtime and receives action inputs', (
 		});
 		assert.strictEqual(result.status, 1);
 		assert.match(result.stderr, /2 cross-model reviews reported .*policy asks for 3/);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('format mode off never reads a PR-files artifact', () => {
+	const dir = mkdtempSync(path.join(tmpdir(), 'rc-off-'));
+	const file = path.join(dir, 'event.json');
+	writeFileSync(file, JSON.stringify({ pull_request: pr() }));
+	try {
+		const result = spawnSync(process.execPath, [SCRIPT], {
+			encoding: 'utf8',
+			env: {
+				...CLEAN_ENV,
+				GITHUB_EVENT_PATH: file,
+				INPUT_FORMAT_MODE: 'off',
+				INPUT_PR_FILES_READY: 'true',
+				INPUT_PR_FILES: path.join(dir, 'missing.json'),
+			},
+		});
+		assert.strictEqual(result.status, 0);
+		assert.doesNotMatch(result.stderr, /missing\.json/);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('an oversized normalized PR-files artifact is bounded before parsing', () => {
+	const dir = mkdtempSync(path.join(tmpdir(), 'rc-large-'));
+	const event = path.join(dir, 'event.json');
+	const prFiles = path.join(dir, 'pr-files.json');
+	writeFileSync(event, JSON.stringify({ pull_request: pr() }));
+	writeFileSync(prFiles, Buffer.alloc(4 * 1024 * 1024 + 1));
+	try {
+		const execute = (formatMode) =>
+			spawnSync(process.execPath, [SCRIPT], {
+				encoding: 'utf8',
+				env: {
+					...CLEAN_ENV,
+					GITHUB_EVENT_PATH: event,
+					INPUT_FORMAT_MODE: formatMode,
+					INPUT_PR_FILES_READY: 'true',
+					INPUT_PR_FILES: prFiles,
+				},
+			});
+		const report = execute('report');
+		assert.strictEqual(report.status, 0);
+		assert.match(report.stderr, /artifact exceeds 4194304 bytes/);
+		const enforce = execute('enforce');
+		assert.strictEqual(enforce.status, 1);
+		assert.match(enforce.stderr, /enforce mode fails closed/);
 	} finally {
 		rmSync(dir, { recursive: true, force: true });
 	}

--- a/.github/actions/review-coverage/ci-review-coverage.test.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.test.mjs
@@ -103,6 +103,7 @@ import path from 'node:path';
 import { normalizePrFiles } from './collectPrFiles.mjs';
 
 const SCRIPT = fileURLToPath(new URL('./ci-review-coverage.mjs', import.meta.url));
+const COLLECTOR = fileURLToPath(new URL('./collectPrFiles.mjs', import.meta.url));
 const CLEAN_ENV = { ...process.env };
 delete CLEAN_ENV.GITHUB_ENV;
 delete CLEAN_ENV.GITHUB_OUTPUT;
@@ -150,6 +151,7 @@ test('the CLI runs through a symlinked entrypoint', () => {
 		fileURLToPath(new URL('./evaluatePrFormat.mjs', import.meta.url)),
 		path.join(dir, 'evaluatePrFormat.mjs')
 	);
+	symlinkSync(COLLECTOR, path.join(dir, 'collectPrFiles.mjs'));
 	symlinkSync(fileURLToPath(new URL('./prExemption.mjs', import.meta.url)), path.join(dir, 'prExemption.mjs'));
 	symlinkSync(fileURLToPath(new URL('./prFormatLinks.mjs', import.meta.url)), path.join(dir, 'prFormatLinks.mjs'));
 	symlinkSync(fileURLToPath(new URL('./reviewGate.mjs', import.meta.url)), path.join(dir, 'reviewGate.mjs'));
@@ -298,6 +300,46 @@ test('the action consumes a produced PR-files artifact end to end', () => {
 		});
 		assert.strictEqual(result.status, 0);
 		assert.match(result.stdout, /pr-format \[report\]: compliant/);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('the collector CLI writes a normalized stdin artifact', () => {
+	const dir = mkdtempSync(path.join(tmpdir(), 'rc-collector-'));
+	const output = path.join(dir, 'pr-files.json');
+	try {
+		const result = spawnSync(process.execPath, [COLLECTOR, output], {
+			encoding: 'utf8',
+			input: JSON.stringify([[{ filename: 'new.js', patch: '@@ -0,0 +1,2 @@\n+a\n+b' }]]),
+		});
+		assert.strictEqual(result.status, 0);
+		assert.deepStrictEqual(JSON.parse(readFileSync(output, 'utf8')).files[0].ranges, { L: [], R: [[1, 2]] });
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('a schema-invalid artifact becomes unavailable evidence without hiding coverage', () => {
+	const dir = mkdtempSync(path.join(tmpdir(), 'rc-schema-'));
+	const event = path.join(dir, 'event.json');
+	const prFiles = path.join(dir, 'pr-files.json');
+	writeFileSync(event, JSON.stringify({ pull_request: pr() }));
+	writeFileSync(prFiles, JSON.stringify({ version: 1, complete: true, files: {} }));
+	try {
+		const result = spawnSync(process.execPath, [SCRIPT], {
+			encoding: 'utf8',
+			env: {
+				...CLEAN_ENV,
+				GITHUB_EVENT_PATH: event,
+				INPUT_FORMAT_MODE: 'report',
+				INPUT_PR_FILES_READY: 'true',
+				INPUT_PR_FILES: prFiles,
+			},
+		});
+		assert.strictEqual(result.status, 0);
+		assert.match(result.stdout, /review-coverage \[report\]/);
+		assert.match(result.stderr, /invalid normalized PR-files artifact/);
 	} finally {
 		rmSync(dir, { recursive: true, force: true });
 	}

--- a/.github/actions/review-coverage/ci-review-coverage.test.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.test.mjs
@@ -213,6 +213,30 @@ test('format mode off never reads a PR-files artifact', () => {
 	}
 });
 
+test('a superseded action run does not read or warn about PR-files evidence', () => {
+	const dir = mkdtempSync(path.join(tmpdir(), 'rc-superseded-'));
+	const file = path.join(dir, 'event.json');
+	writeFileSync(file, JSON.stringify({ pull_request: pr() }));
+	try {
+		const result = spawnSync(process.execPath, [SCRIPT], {
+			encoding: 'utf8',
+			env: {
+				...CLEAN_ENV,
+				GITHUB_EVENT_PATH: file,
+				INPUT_FORMAT_MODE: 'enforce',
+				INPUT_PR_FILES_SUPERSEDED: 'true',
+				INPUT_PR_FILES_READY: 'true',
+				INPUT_PR_FILES: path.join(dir, 'missing.json'),
+			},
+		});
+		assert.strictEqual(result.status, 0);
+		assert.match(result.stdout, /exempt: superseded by a newer PR head/);
+		assert.doesNotMatch(result.stderr, /PR-files/);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
 test('an oversized normalized PR-files artifact is bounded before parsing', () => {
 	const dir = mkdtempSync(path.join(tmpdir(), 'rc-large-'));
 	const event = path.join(dir, 'event.json');

--- a/.github/actions/review-coverage/ci-review-coverage.test.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.test.mjs
@@ -100,6 +100,8 @@ import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import { normalizePrFiles } from './collectPrFiles.mjs';
+
 const SCRIPT = fileURLToPath(new URL('./ci-review-coverage.mjs', import.meta.url));
 const CLEAN_ENV = { ...process.env };
 delete CLEAN_ENV.GITHUB_ENV;
@@ -232,9 +234,46 @@ test('an oversized normalized PR-files artifact is bounded before parsing', () =
 		const report = execute('report');
 		assert.strictEqual(report.status, 0);
 		assert.match(report.stderr, /artifact exceeds 4194304 bytes/);
+		assert.match(report.stdout, /review-coverage \[report\]/, 'artifact failures must not suppress coverage output');
 		const enforce = execute('enforce');
 		assert.strictEqual(enforce.status, 1);
-		assert.match(enforce.stderr, /enforce mode fails closed/);
+		assert.match(enforce.stderr, /PR-files evidence is unavailable/);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('the action consumes a produced PR-files artifact end to end', () => {
+	const dir = mkdtempSync(path.join(tmpdir(), 'rc-artifact-'));
+	const event = path.join(dir, 'event.json');
+	const prFiles = path.join(dir, 'pr-files.json');
+	const hash = 'db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356ba';
+	const link = `https://github.com/HarperFast/harper/pull/2338/changes?w=1#diff-${hash}R211`;
+	writeFileSync(
+		event,
+		JSON.stringify({
+			number: 2338,
+			repository: { full_name: 'HarperFast/harper' },
+			pull_request: pr({ body: `Summary with [current code](${link}).\n\n## Verification\n\nFocused test passed.` }),
+		})
+	);
+	writeFileSync(
+		prFiles,
+		JSON.stringify(normalizePrFiles([[{ filename: 'resources/auditStore.ts', patch: '@@ -200,21 +205,62 @@' }]]))
+	);
+	try {
+		const result = spawnSync(process.execPath, [SCRIPT], {
+			encoding: 'utf8',
+			env: {
+				...CLEAN_ENV,
+				GITHUB_EVENT_PATH: event,
+				INPUT_FORMAT_MODE: 'report',
+				INPUT_PR_FILES_READY: 'true',
+				INPUT_PR_FILES: prFiles,
+			},
+		});
+		assert.strictEqual(result.status, 0);
+		assert.match(result.stdout, /pr-format \[report\]: compliant/);
 	} finally {
 		rmSync(dir, { recursive: true, force: true });
 	}

--- a/.github/actions/review-coverage/collectPrFiles.mjs
+++ b/.github/actions/review-coverage/collectPrFiles.mjs
@@ -36,6 +36,28 @@ export function normalizePrFiles(pages) {
 	};
 }
 
+export function validateNormalizedPrFiles(value) {
+	if (value?.version !== 1 || typeof value.complete !== 'boolean' || !Array.isArray(value.files))
+		throw new Error('invalid normalized PR-files artifact');
+	if (value.files.length > MAX_FILES) throw new Error(`normalized PR-files artifact exceeds ${MAX_FILES} files`);
+	for (const file of value.files) {
+		if (
+			typeof file?.path !== 'string' ||
+			typeof file.patchAvailable !== 'boolean' ||
+			!['L', 'R'].every(
+				(side) =>
+					Array.isArray(file.ranges?.[side]) &&
+					file.ranges[side].every(
+						(range) =>
+							Array.isArray(range) && range.length === 2 && range.every((line) => Number.isInteger(line) && line >= 0)
+					)
+			)
+		)
+			throw new Error('invalid normalized PR-files entry');
+	}
+	return value;
+}
+
 function parseRanges(patch) {
 	const ranges = { L: [], R: [] };
 	for (const line of patch.split('\n')) {

--- a/.github/actions/review-coverage/collectPrFiles.mjs
+++ b/.github/actions/review-coverage/collectPrFiles.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import { renameSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+export const MAX_INPUT_BYTES = 16 * 1024 * 1024;
+export const MAX_FILES = 3000;
+
+export async function readBounded(input, maxBytes = MAX_INPUT_BYTES) {
+	const chunks = [];
+	let bytes = 0;
+	for await (const chunk of input) {
+		bytes += chunk.length;
+		if (bytes > maxBytes) throw new Error(`PR-files response exceeds ${maxBytes} bytes`);
+		chunks.push(chunk);
+	}
+	return Buffer.concat(chunks).toString('utf8');
+}
+
+export function normalizePrFiles(pages) {
+	if (!Array.isArray(pages) || pages.some((page) => !Array.isArray(page)))
+		throw new Error('expected --slurp paginated arrays');
+	const files = pages.flat();
+	if (files.length > MAX_FILES) throw new Error(`PR-files response exceeds ${MAX_FILES} files`);
+	return {
+		version: 1,
+		complete: files.length < MAX_FILES,
+		files: files.map((file) => {
+			if (!file || typeof file.filename !== 'string') throw new Error('PR-files entry has no filename');
+			return {
+				path: file.filename,
+				patchAvailable: typeof file.patch === 'string',
+				ranges: typeof file.patch === 'string' ? parseRanges(file.patch) : { L: [], R: [] },
+			};
+		}),
+	};
+}
+
+function parseRanges(patch) {
+	const ranges = { L: [], R: [] };
+	for (const line of patch.split('\n')) {
+		const hunk = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/.exec(line);
+		if (!hunk) continue;
+		for (const [side, startIndex, countIndex] of [
+			['L', 1, 2],
+			['R', 3, 4],
+		]) {
+			const start = Number(hunk[startIndex]);
+			const count = hunk[countIndex] === undefined ? 1 : Number(hunk[countIndex]);
+			if (count > 0) ranges[side].push([start, start + count - 1]);
+		}
+	}
+	return ranges;
+}
+
+async function main() {
+	const output = process.argv[2];
+	if (!output) throw new Error('output path is required');
+	const normalized = normalizePrFiles(JSON.parse(await readBounded(process.stdin)));
+	writeFileSync(`${output}.tmp`, JSON.stringify(normalized));
+	renameSync(`${output}.tmp`, output);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+	main().catch((error) => {
+		console.error(`collect-pr-files: ${error.message}`);
+		process.exitCode = 1;
+	});
+}

--- a/.github/actions/review-coverage/evaluateCiCoverage.mjs
+++ b/.github/actions/review-coverage/evaluateCiCoverage.mjs
@@ -1,18 +1,8 @@
-import { COVERAGE_REQUIRED, isTrivialChange, reportedCrossModelReviews } from './reviewGate.mjs';
-
-const NON_MEMBER_ASSOCIATIONS = new Set([
-	'COLLABORATOR',
-	'CONTRIBUTOR',
-	'FIRST_TIME_CONTRIBUTOR',
-	'FIRST_TIMER',
-	'MANNEQUIN',
-	'NONE',
-]);
+import { COVERAGE_REQUIRED, reportedCrossModelReviews } from './reviewGate.mjs';
+import { classifyPullRequest } from './prExemption.mjs';
 
 /** `pass` in the return value already accounts for report versus enforce mode. */
 export function evaluateCiCoverage(pr, { mode = 'report', required = COVERAGE_REQUIRED } = {}) {
-	const login = String(pr?.user?.login ?? '');
-	const assoc = String(pr?.author_association ?? '');
 	const body = String(pr?.body ?? '');
 	const { count, families } = reportedCrossModelReviews(body);
 	const plural = count === 1 ? 'review' : 'reviews';
@@ -31,18 +21,8 @@ export function evaluateCiCoverage(pr, { mode = 'report', required = COVERAGE_RE
 				? `Human-Review-Need: ${footer[1]} @ head`
 				: `Human-Review-Need footer is STALE (reviewed @ ${footer[2].slice(0, 7)}, head is ${head.slice(0, 7)})`;
 
-	// Missing size fields would otherwise read as 0+0 and silently exempt every PR.
-	const sized = Number.isFinite(pr?.additions) && Number.isFinite(pr?.deletions);
-	const exempt =
-		login.endsWith('[bot]') || pr?.user?.type === 'Bot'
-			? 'bot author'
-			: NON_MEMBER_ASSOCIATIONS.has(assoc)
-				? `author is not an org member (${assoc}) — always human review`
-				: sized && isTrivialChange(pr?.additions, pr?.deletions)
-					? 'trivial change (≤2 lines)'
-					: pr?.draft
-						? 'draft — checked again at ready-for-review'
-						: '';
+	const classification = classifyPullRequest(pr);
+	const exempt = classification.exempt || (classification.draft ? 'draft — checked again at ready-for-review' : '');
 	const compliant = count >= required;
 	const pass = mode !== 'enforce' || Boolean(exempt) || compliant;
 	const summary = exempt ? `exempt: ${exempt}` : coverage;

--- a/.github/actions/review-coverage/evaluatePrFormat.mjs
+++ b/.github/actions/review-coverage/evaluatePrFormat.mjs
@@ -1,5 +1,5 @@
 import { classifyPullRequest } from './prExemption.mjs';
-import { checkBodyLinks, stripFencedBlocks } from './prFormatLinks.mjs';
+import { checkBodyLinks, inspectBodyText } from './prFormatLinks.mjs';
 
 const MAX_BODY_LENGTH = 65_536;
 
@@ -7,7 +7,7 @@ function matches(prose, pattern) {
 	return [...prose.matchAll(pattern)];
 }
 
-export function evaluatePrFormat(pr, { mode = 'report', repo, number, prFiles = null } = {}) {
+export function evaluatePrFormat(pr, { mode = 'report', repo, number, prFiles = null, evidenceProblem = '' } = {}) {
 	const classification = classifyPullRequest(pr);
 	if (mode === 'off' || classification.exempt)
 		return {
@@ -18,9 +18,11 @@ export function evaluatePrFormat(pr, { mode = 'report', repo, number, prFiles = 
 		};
 
 	const body = String(pr?.body ?? '');
-	const prose = stripFencedBlocks(body);
+	const inspected = inspectBodyText(body);
+	const prose = inspected.prose;
 	const problems = [];
 	if (body.length > MAX_BODY_LENGTH) problems.push(`description exceeds ${MAX_BODY_LENGTH} characters`);
+	if (inspected.unterminatedFence) problems.push('description has an unterminated fenced code block');
 	const firstHeading = prose.search(/^##\s+/m);
 	const summary = (firstHeading < 0 ? prose : prose.slice(0, firstHeading)).replace(/<[^>]+>/g, '').trim();
 	if (!summary) problems.push('description needs summary prose before its sections');
@@ -38,7 +40,7 @@ export function evaluatePrFormat(pr, { mode = 'report', repo, number, prFiles = 
 
 	const links = checkBodyLinks({ body, prFiles, repo, number });
 	problems.push(...links.problems.map(({ message }) => message));
-	const aiMarkers = /(?:Complexity:|Review-Coverage:|Human-Review-Need:)/i.test(prose);
+	const aiMarkers = /^(?:Complexity:|\s*(?:<sub>)?(?:Review-Coverage:|Human-Review-Need:))/m.test(prose);
 	if (aiMarkers) {
 		const reviewer = matches(prose, /^## For the human reviewer\s*$/gim);
 		if (reviewer.length !== 1)
@@ -61,18 +63,26 @@ export function evaluatePrFormat(pr, { mode = 'report', repo, number, prFiles = 
 			problems.push(
 				`AI-shaped description needs exactly one valid Complexity field (found ${complexityFields.length})`
 			);
-		const coverageFields = matches(prose, /Review-Coverage:/g);
+		const coverageFields = matches(prose, /^\s*(?:<sub>)?Review-Coverage:/gm);
 		const coverage = matches(prose, /^\s*<sub>Review-Coverage:[^\n]*@\s*[0-9a-f]{6,40}<\/sub>\s*$/gim);
 		if (coverageFields.length !== 1 || coverage.length !== 1)
 			problems.push(
 				`AI-shaped description needs exactly one pinned Review-Coverage footer (found ${coverageFields.length})`
 			);
-		const needFields = matches(prose, /Human-Review-Need:/g);
+		const needFields = matches(prose, /^\s*(?:<sub>)?Human-Review-Need:/gm);
 		const need = matches(prose, /^\s*<sub>Human-Review-Need:\s*[0-4]\s*@\s*[0-9a-f]{6,40}<\/sub>\s*$/gim);
 		if (needFields.length !== 1 || need.length !== 1)
 			problems.push(
 				`AI-shaped description needs exactly one pinned Human-Review-Need footer (found ${needFields.length})`
 			);
+		const head = String(pr?.head?.sha ?? '').toLowerCase();
+		for (const [label, field] of [
+			['Review-Coverage', coverage[0]],
+			['Human-Review-Need', need[0]],
+		]) {
+			const pin = field?.[0].match(/@\s*([0-9a-f]{6,40})<\/sub>/i)?.[1].toLowerCase();
+			if (pin && !head.startsWith(pin)) problems.push(`${label} footer is not pinned to the current head`);
+		}
 		if (
 			verification.length === 1 &&
 			complexity.length === 1 &&
@@ -88,6 +98,7 @@ export function evaluatePrFormat(pr, { mode = 'report', repo, number, prFiles = 
 	}
 
 	if (links.unverifiable) problems.push('current PR-diff links could not be fully verified');
+	if (evidenceProblem) problems.push(evidenceProblem);
 	const compliant = problems.length === 0;
 	return {
 		pass: mode !== 'enforce' || classification.draft || compliant,

--- a/.github/actions/review-coverage/evaluatePrFormat.mjs
+++ b/.github/actions/review-coverage/evaluatePrFormat.mjs
@@ -1,0 +1,100 @@
+import { classifyPullRequest } from './prExemption.mjs';
+import { checkBodyLinks, stripFencedBlocks } from './prFormatLinks.mjs';
+
+const MAX_BODY_LENGTH = 65_536;
+
+function matches(prose, pattern) {
+	return [...prose.matchAll(pattern)];
+}
+
+export function evaluatePrFormat(pr, { mode = 'report', repo, number, prFiles = null } = {}) {
+	const classification = classifyPullRequest(pr);
+	if (mode === 'off' || classification.exempt)
+		return {
+			pass: true,
+			exempt: mode === 'off' ? 'format check disabled' : classification.exempt,
+			compliant: true,
+			problems: [],
+		};
+
+	const body = String(pr?.body ?? '');
+	const prose = stripFencedBlocks(body);
+	const problems = [];
+	if (body.length > MAX_BODY_LENGTH) problems.push(`description exceeds ${MAX_BODY_LENGTH} characters`);
+	const firstHeading = prose.search(/^##\s+/m);
+	const summary = (firstHeading < 0 ? prose : prose.slice(0, firstHeading)).replace(/<[^>]+>/g, '').trim();
+	if (!summary) problems.push('description needs summary prose before its sections');
+
+	const verification = matches(prose, /^## Verification\s*$/gim);
+	if (verification.length !== 1)
+		problems.push(`description needs exactly one ## Verification section (found ${verification.length})`);
+	else {
+		const content = prose
+			.slice(verification[0].index + verification[0][0].length)
+			.split(/^(?:##\s+|Complexity:|\s*<sub>(?:Review-Coverage:|Human-Review-Need:))/m)[0]
+			.trim();
+		if (!content) problems.push('## Verification needs executed evidence or a not-observable rationale');
+	}
+
+	const links = checkBodyLinks({ body, prFiles, repo, number });
+	problems.push(...links.problems.map(({ message }) => message));
+	const aiMarkers = /(?:Complexity:|Review-Coverage:|Human-Review-Need:)/i.test(prose);
+	if (aiMarkers) {
+		const reviewer = matches(prose, /^## For the human reviewer\s*$/gim);
+		if (reviewer.length !== 1)
+			problems.push(
+				`AI-shaped description needs exactly one ## For the human reviewer section (found ${reviewer.length})`
+			);
+		else if (verification.length === 1 && reviewer[0].index > verification[0].index)
+			problems.push('## For the human reviewer must precede ## Verification');
+		else {
+			const content = prose
+				.slice(reviewer[0].index + reviewer[0][0].length)
+				.split(/^##\s+/m)[0]
+				.trim();
+			if (!content)
+				problems.push('## For the human reviewer needs a decision ledger or the no-open-judgment-calls statement');
+		}
+		const complexityFields = matches(prose, /^Complexity:/gim);
+		const complexity = matches(prose, /^Complexity:\s*(easy|medium|complicated)\s*$/gim);
+		if (complexityFields.length !== 1 || complexity.length !== 1)
+			problems.push(
+				`AI-shaped description needs exactly one valid Complexity field (found ${complexityFields.length})`
+			);
+		const coverageFields = matches(prose, /Review-Coverage:/g);
+		const coverage = matches(prose, /^\s*<sub>Review-Coverage:[^\n]*@\s*[0-9a-f]{6,40}<\/sub>\s*$/gim);
+		if (coverageFields.length !== 1 || coverage.length !== 1)
+			problems.push(
+				`AI-shaped description needs exactly one pinned Review-Coverage footer (found ${coverageFields.length})`
+			);
+		const needFields = matches(prose, /Human-Review-Need:/g);
+		const need = matches(prose, /^\s*<sub>Human-Review-Need:\s*[0-4]\s*@\s*[0-9a-f]{6,40}<\/sub>\s*$/gim);
+		if (needFields.length !== 1 || need.length !== 1)
+			problems.push(
+				`AI-shaped description needs exactly one pinned Human-Review-Need footer (found ${needFields.length})`
+			);
+		if (
+			verification.length === 1 &&
+			complexity.length === 1 &&
+			coverage.length === 1 &&
+			need.length === 1 &&
+			!(
+				verification[0].index < complexity[0].index &&
+				complexity[0].index < coverage[0].index &&
+				coverage[0].index < need[0].index
+			)
+		)
+			problems.push('AI fields must follow Verification in Complexity, Review-Coverage, Human-Review-Need order');
+	}
+
+	if (links.unverifiable) problems.push('current PR-diff links could not be fully verified');
+	const compliant = problems.length === 0;
+	return {
+		pass: mode !== 'enforce' || classification.draft || compliant,
+		exempt: '',
+		draft: classification.draft,
+		compliant,
+		problems,
+		links,
+	};
+}

--- a/.github/actions/review-coverage/evaluatePrFormat.mjs
+++ b/.github/actions/review-coverage/evaluatePrFormat.mjs
@@ -7,12 +7,16 @@ function matches(prose, pattern) {
 	return [...prose.matchAll(pattern)];
 }
 
-export function evaluatePrFormat(pr, { mode = 'report', repo, number, prFiles = null, evidenceProblem = '' } = {}) {
+export function evaluatePrFormat(
+	pr,
+	{ mode = 'report', repo, number, prFiles = null, evidenceProblem = '', superseded = false } = {}
+) {
 	const classification = classifyPullRequest(pr);
-	if (mode === 'off' || classification.exempt)
+	if (mode === 'off' || classification.exempt || superseded)
 		return {
 			pass: true,
-			exempt: mode === 'off' ? 'format check disabled' : classification.exempt,
+			exempt:
+				mode === 'off' ? 'format check disabled' : superseded ? 'superseded by a newer PR head' : classification.exempt,
 			compliant: true,
 			problems: [],
 		};
@@ -23,6 +27,7 @@ export function evaluatePrFormat(pr, { mode = 'report', repo, number, prFiles = 
 	const problems = [];
 	if (body.length > MAX_BODY_LENGTH) problems.push(`description exceeds ${MAX_BODY_LENGTH} characters`);
 	if (inspected.unterminatedFence) problems.push('description has an unterminated fenced code block');
+	if (inspected.unterminatedComment) problems.push('description has an unterminated HTML comment');
 	const firstHeading = prose.search(/^##\s+/m);
 	const summary = (firstHeading < 0 ? prose : prose.slice(0, firstHeading)).replace(/<[^>]+>/g, '').trim();
 	if (!summary) problems.push('description needs summary prose before its sections');
@@ -33,14 +38,15 @@ export function evaluatePrFormat(pr, { mode = 'report', repo, number, prFiles = 
 	else {
 		const content = prose
 			.slice(verification[0].index + verification[0][0].length)
-			.split(/^(?:##\s+|Complexity:|\s*<sub>(?:Review-Coverage:|Human-Review-Need:))/m)[0]
+			.split(/^(?:##\s+|Complexity:|\s*<sub>(?:Review-Coverage:|Human-Review-Need:))/im)[0]
+			.replace(/<[^>]+>/g, '')
 			.trim();
 		if (!content) problems.push('## Verification needs executed evidence or a not-observable rationale');
 	}
 
 	const links = checkBodyLinks({ body, prFiles, repo, number });
 	problems.push(...links.problems.map(({ message }) => message));
-	const aiMarkers = /^(?:Complexity:|\s*(?:<sub>)?(?:Review-Coverage:|Human-Review-Need:))/m.test(prose);
+	const aiMarkers = /^(?:Complexity:|\s*(?:<sub>)?(?:Review-Coverage:|Human-Review-Need:))/im.test(prose);
 	if (aiMarkers) {
 		const reviewer = matches(prose, /^## For the human reviewer\s*$/gim);
 		if (reviewer.length !== 1)
@@ -63,17 +69,17 @@ export function evaluatePrFormat(pr, { mode = 'report', repo, number, prFiles = 
 			problems.push(
 				`AI-shaped description needs exactly one valid Complexity field (found ${complexityFields.length})`
 			);
-		const coverageFields = matches(prose, /^\s*(?:<sub>)?Review-Coverage:/gm);
+		const coverageFields = matches(prose, /^\s*(?:<sub>)?Review-Coverage:/gim);
 		const coverage = matches(prose, /^\s*<sub>Review-Coverage:[^\n]*@\s*[0-9a-f]{6,40}<\/sub>\s*$/gim);
 		if (coverageFields.length !== 1 || coverage.length !== 1)
 			problems.push(
-				`AI-shaped description needs exactly one pinned Review-Coverage footer (found ${coverageFields.length})`
+				`AI-shaped description needs exactly one valid pinned Review-Coverage footer (found ${coverageFields.length} field(s), ${coverage.length} valid)`
 			);
-		const needFields = matches(prose, /^\s*(?:<sub>)?Human-Review-Need:/gm);
+		const needFields = matches(prose, /^\s*(?:<sub>)?Human-Review-Need:/gim);
 		const need = matches(prose, /^\s*<sub>Human-Review-Need:\s*[0-4]\s*@\s*[0-9a-f]{6,40}<\/sub>\s*$/gim);
 		if (needFields.length !== 1 || need.length !== 1)
 			problems.push(
-				`AI-shaped description needs exactly one pinned Human-Review-Need footer (found ${needFields.length})`
+				`AI-shaped description needs exactly one valid pinned Human-Review-Need footer (found ${needFields.length} field(s), ${need.length} valid)`
 			);
 		const head = String(pr?.head?.sha ?? '').toLowerCase();
 		for (const [label, field] of [

--- a/.github/actions/review-coverage/evaluatePrFormat.mjs
+++ b/.github/actions/review-coverage/evaluatePrFormat.mjs
@@ -38,7 +38,7 @@ export function evaluatePrFormat(
 	else {
 		const content = prose
 			.slice(verification[0].index + verification[0][0].length)
-			.split(/^(?:##\s+|Complexity:|\s*<sub>(?:Review-Coverage:|Human-Review-Need:))/im)[0]
+			.split(/^(?:##\s+|[ \t]*Complexity:|[ \t]*<sub>(?:Review-Coverage:|Human-Review-Need:))/im)[0]
 			.replace(/<[^>]+>/g, '')
 			.trim();
 		if (!content) problems.push('## Verification needs executed evidence or a not-observable rationale');
@@ -46,7 +46,7 @@ export function evaluatePrFormat(
 
 	const links = checkBodyLinks({ body, prFiles, repo, number });
 	problems.push(...links.problems.map(({ message }) => message));
-	const aiMarkers = /^(?:Complexity:|\s*(?:<sub>)?(?:Review-Coverage:|Human-Review-Need:))/im.test(prose);
+	const aiMarkers = /^(?:[ \t]*Complexity:|[ \t]*(?:<sub>)?(?:Review-Coverage:|Human-Review-Need:))/im.test(prose);
 	if (aiMarkers) {
 		const reviewer = matches(prose, /^## For the human reviewer\s*$/gim);
 		if (reviewer.length !== 1)
@@ -63,8 +63,8 @@ export function evaluatePrFormat(
 			if (!content)
 				problems.push('## For the human reviewer needs a decision ledger or the no-open-judgment-calls statement');
 		}
-		const complexityFields = matches(prose, /^Complexity:/gim);
-		const complexity = matches(prose, /^Complexity:\s*(easy|medium|complicated)\s*$/gim);
+		const complexityFields = matches(prose, /^[ \t]*Complexity:/gim);
+		const complexity = matches(prose, /^[ \t]*Complexity:\s*(easy|medium|complicated)\s*$/gim);
 		if (complexityFields.length !== 1 || complexity.length !== 1)
 			problems.push(
 				`AI-shaped description needs exactly one valid Complexity field (found ${complexityFields.length})`

--- a/.github/actions/review-coverage/evaluatePrFormat.mjs
+++ b/.github/actions/review-coverage/evaluatePrFormat.mjs
@@ -1,5 +1,5 @@
 import { classifyPullRequest } from './prExemption.mjs';
-import { checkBodyLinks, inspectBodyText } from './prFormatLinks.mjs';
+import { checkBodyLinks, inspectBodyText, stripCodePlaceholders } from './prFormatLinks.mjs';
 
 const MAX_BODY_LENGTH = 65_536;
 
@@ -29,7 +29,9 @@ export function evaluatePrFormat(
 	if (inspected.unterminatedFence) problems.push('description has an unterminated fenced code block');
 	if (inspected.unterminatedComment) problems.push('description has an unterminated HTML comment');
 	const firstHeading = prose.search(/^##\s+/m);
-	const summary = (firstHeading < 0 ? prose : prose.slice(0, firstHeading)).replace(/<[^>]+>/g, '').trim();
+	const summary = stripCodePlaceholders(firstHeading < 0 ? prose : prose.slice(0, firstHeading))
+		.replace(/<[^>]+>/g, '')
+		.trim();
 	if (!summary) problems.push('description needs summary prose before its sections');
 
 	const verification = matches(prose, /^## Verification\s*$/gim);
@@ -56,10 +58,9 @@ export function evaluatePrFormat(
 		else if (verification.length === 1 && reviewer[0].index > verification[0].index)
 			problems.push('## For the human reviewer must precede ## Verification');
 		else {
-			const content = prose
-				.slice(reviewer[0].index + reviewer[0][0].length)
-				.split(/^##\s+/m)[0]
-				.trim();
+			const content = stripCodePlaceholders(
+				prose.slice(reviewer[0].index + reviewer[0][0].length).split(/^##\s+/m)[0]
+			).trim();
 			if (!content)
 				problems.push('## For the human reviewer needs a decision ledger or the no-open-judgment-calls statement');
 		}

--- a/.github/actions/review-coverage/prExemption.mjs
+++ b/.github/actions/review-coverage/prExemption.mjs
@@ -1,0 +1,25 @@
+import { isTrivialChange } from './reviewGate.mjs';
+
+const NON_MEMBER_ASSOCIATIONS = new Set([
+	'COLLABORATOR',
+	'CONTRIBUTOR',
+	'FIRST_TIME_CONTRIBUTOR',
+	'FIRST_TIMER',
+	'MANNEQUIN',
+	'NONE',
+]);
+
+export function classifyPullRequest(pr) {
+	const login = String(pr?.user?.login ?? '');
+	const association = String(pr?.author_association ?? '');
+	const sized = Number.isFinite(pr?.additions) && Number.isFinite(pr?.deletions);
+	const exempt =
+		login.endsWith('[bot]') || pr?.user?.type === 'Bot'
+			? 'bot author'
+			: NON_MEMBER_ASSOCIATIONS.has(association)
+				? `author is not an org member (${association}) — always human review`
+				: sized && isTrivialChange(pr.additions, pr.deletions)
+					? 'trivial change (≤2 lines)'
+					: '';
+	return { exempt, draft: Boolean(pr?.draft), sized };
+}

--- a/.github/actions/review-coverage/prExemption.mjs
+++ b/.github/actions/review-coverage/prExemption.mjs
@@ -12,6 +12,7 @@ const NON_MEMBER_ASSOCIATIONS = new Set([
 export function classifyPullRequest(pr) {
 	const login = String(pr?.user?.login ?? '');
 	const association = String(pr?.author_association ?? '');
+	// Missing size fields must not read as 0+0 and silently exempt every PR.
 	const sized = Number.isFinite(pr?.additions) && Number.isFinite(pr?.deletions);
 	const exempt =
 		login.endsWith('[bot]') || pr?.user?.type === 'Bot'

--- a/.github/actions/review-coverage/prFormat.test.mjs
+++ b/.github/actions/review-coverage/prFormat.test.mjs
@@ -12,7 +12,7 @@ const REPO = 'HarperFast/harper';
 const NUMBER = 2338;
 const HEAD = '609896d762efe2c9f529a0f9989ce0a53dd29b40';
 const FILE = 'resources/auditStore.ts';
-const HASH = fileAnchorHash(FILE);
+const HASH = 'db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356ba';
 const LINK = `https://github.com/${REPO}/pull/${NUMBER}/changes?w=1#diff-${HASH}R211`;
 const PR_FILES = {
 	version: 1,
@@ -49,10 +49,29 @@ const pr = (over = {}) => ({
 });
 
 test('the remediated #2338 shape passes with a current line anchor', () => {
+	assert.strictEqual(fileAnchorHash(FILE), HASH, "fixture pins GitHub's sha256(path) anchor contract");
 	const result = evaluatePrFormat(pr(), { mode: 'enforce', repo: REPO, number: NUMBER, prFiles: PR_FILES });
 	assert.strictEqual(result.pass, true);
 	assert.strictEqual(result.compliant, true);
 	assert.strictEqual(result.links.lineAnchored.length, 1);
+});
+
+test('ordinary prose and inline examples do not trigger AI-shape fields', () => {
+	const humanBody = [
+		`This lowers algorithmic complexity: fewer branches; the \`Human-Review-Need:\` field is unchanged. [Code](${LINK})`,
+		'',
+		'## Verification',
+		'',
+		'Focused test passed.',
+	].join('\n');
+	const result = evaluatePrFormat(pr({ body: humanBody }), {
+		mode: 'enforce',
+		repo: REPO,
+		number: NUMBER,
+		prFiles: PR_FILES,
+	});
+	assert.strictEqual(result.pass, true);
+	assert.strictEqual(result.compliant, true);
 });
 
 test('the motivating same-head link removal fails independently of footer freshness', () => {
@@ -121,11 +140,41 @@ test('fenced examples do not satisfy the line-link requirement', () => {
 	assert.strictEqual(parseBodyAnchors(fenced).length, 0);
 });
 
+test('inline-code and HTML-comment links do not satisfy the line-link requirement', () => {
+	for (const hidden of [`\`${LINK}\``, `<!-- ${LINK} -->`]) {
+		const result = evaluatePrFormat(
+			pr({ body: body({ link: '' }).replace('continuously.', `continuously. ${hidden}`) }),
+			{
+				mode: 'enforce',
+				repo: REPO,
+				number: NUMBER,
+				prFiles: PR_FILES,
+			}
+		);
+		assert.match(result.problems.join('\n'), /no line-anchored PR-diff link/);
+	}
+});
+
+test('an unterminated fence reports its cause', () => {
+	const result = evaluatePrFormat(pr({ body: `${body()}\n\n\`\`\`md\nexample` }), {
+		mode: 'enforce',
+		repo: REPO,
+		number: NUMBER,
+		prFiles: PR_FILES,
+	});
+	assert.match(result.problems.join('\n'), /unterminated fenced code block/);
+});
+
 test('older files URLs and per-commit paths use the same anchor contract', () => {
 	const url = `https://github.com/${REPO}/pull/${NUMBER}/files/abc123?w=1#diff-${HASH}R211-R220`;
 	const result = checkBodyLinks({ body: url, prFiles: PR_FILES, repo: REPO, number: NUMBER });
 	assert.strictEqual(result.ok, true);
 	assert.strictEqual(result.lineAnchored[0].line, 211);
+});
+
+test('partial or non-resolving anchor URLs are not accepted', () => {
+	for (const malformed of [LINK.replace('/changes?', '/changes-bogus?'), `${LINK}evil`])
+		assert.strictEqual(parseBodyAnchors(malformed).length, 0);
 });
 
 test('PR-files normalization implements unified-diff count semantics', () => {
@@ -156,6 +205,9 @@ test('an omitted patch or incomplete file list is explicitly unverifiable', () =
 			.unverifiable,
 		true
 	);
+	const missing = checkBodyLinks({ body: LINK, prFiles: null, repo: REPO, number: NUMBER });
+	assert.strictEqual(missing.unverifiable, true);
+	assert.doesNotMatch(missing.problems.map(({ message }) => message).join('\n'), /does not match a file/);
 });
 
 test('PR-files input is rejected while streaming beyond the byte cap', async () => {
@@ -176,6 +228,17 @@ test('AI fields require the complete ordered body shape', () => {
 	assert.match(result.problems.join('\n'), /For the human reviewer/);
 	assert.match(result.problems.join('\n'), /valid Complexity/);
 	assert.match(result.problems.join('\n'), /pinned Review-Coverage footer \(found 2\)/);
+});
+
+test('AI footers must be pinned to the current head', () => {
+	const result = evaluatePrFormat(pr({ body: body({ head: 'deadbeef1234' }) }), {
+		mode: 'enforce',
+		repo: REPO,
+		number: NUMBER,
+		prFiles: PR_FILES,
+	});
+	assert.match(result.problems.join('\n'), /Review-Coverage footer is not pinned to the current head/);
+	assert.match(result.problems.join('\n'), /Human-Review-Need footer is not pinned to the current head/);
 });
 
 test('footer text cannot satisfy an empty Verification section', () => {

--- a/.github/actions/review-coverage/prFormat.test.mjs
+++ b/.github/actions/review-coverage/prFormat.test.mjs
@@ -379,6 +379,28 @@ test('HTML-only content cannot satisfy Verification', () => {
 	);
 });
 
+test('visible fenced or indented code can satisfy Verification without exposing Markdown tokens', () => {
+	for (const evidence of ['```text\n80 passing\n```', '    80 passing']) {
+		const result = evaluatePrFormat(pr({ body: body().replace('Focused retention tests passed.', evidence) }), {
+			mode: 'enforce',
+			repo: REPO,
+			number: NUMBER,
+			prFiles: PR_FILES,
+		});
+		assert.strictEqual(result.pass, true, evidence);
+	}
+});
+
+test('an empty fenced block does not satisfy Verification', () => {
+	const result = evaluatePrFormat(pr({ body: body().replace('Focused retention tests passed.', '```text\n```') }), {
+		mode: 'enforce',
+		repo: REPO,
+		number: NUMBER,
+		prFiles: PR_FILES,
+	});
+	assert.match(result.problems.join('\n'), /Verification needs executed evidence/);
+});
+
 test('a lowercase AI field ends an empty Verification section', () => {
 	const broken = body().replace('Focused retention tests passed.\n\nComplexity:', 'complexity:');
 	assert.match(

--- a/.github/actions/review-coverage/prFormat.test.mjs
+++ b/.github/actions/review-coverage/prFormat.test.mjs
@@ -1,0 +1,213 @@
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { Readable } from 'node:stream';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { normalizePrFiles, readBounded } from './collectPrFiles.mjs';
+import { evaluatePrFormat } from './evaluatePrFormat.mjs';
+import { checkBodyLinks, fileAnchorHash, parseBodyAnchors } from './prFormatLinks.mjs';
+
+const REPO = 'HarperFast/harper';
+const NUMBER = 2338;
+const HEAD = '609896d762efe2c9f529a0f9989ce0a53dd29b40';
+const FILE = 'resources/auditStore.ts';
+const HASH = fileAnchorHash(FILE);
+const LINK = `https://github.com/${REPO}/pull/${NUMBER}/changes?w=1#diff-${HASH}R211`;
+const PR_FILES = {
+	version: 1,
+	complete: true,
+	files: [{ path: FILE, patchAvailable: true, ranges: { L: [[200, 220]], R: [[205, 266]] } }],
+};
+const body = ({ link = LINK, head = HEAD.slice(0, 12) } = {}) =>
+	[
+		`Audit retention now runs continuously${link ? ` in [the cleanup loop](${link})` : ''}.`,
+		'',
+		'## For the human reviewer',
+		'',
+		'No open judgment calls.',
+		'',
+		'## Verification',
+		'',
+		'Focused retention tests passed.',
+		'',
+		'Complexity: complicated',
+		'',
+		`<sub>Review-Coverage: authored=codex; ran=claude; rounds=1 @ ${head}</sub>`,
+		'',
+		`<sub>Human-Review-Need: 2 @ ${head}</sub>`,
+	].join('\n');
+const pr = (over = {}) => ({
+	user: { login: 'kriszyp', type: 'User' },
+	author_association: 'MEMBER',
+	body: body(),
+	additions: 160,
+	deletions: 31,
+	draft: false,
+	head: { sha: HEAD },
+	...over,
+});
+
+test('the remediated #2338 shape passes with a current line anchor', () => {
+	const result = evaluatePrFormat(pr(), { mode: 'enforce', repo: REPO, number: NUMBER, prFiles: PR_FILES });
+	assert.strictEqual(result.pass, true);
+	assert.strictEqual(result.compliant, true);
+	assert.strictEqual(result.links.lineAnchored.length, 1);
+});
+
+test('the motivating same-head link removal fails independently of footer freshness', () => {
+	const result = evaluatePrFormat(pr({ body: body({ link: '' }) }), {
+		mode: 'enforce',
+		repo: REPO,
+		number: NUMBER,
+		prFiles: PR_FILES,
+	});
+	assert.strictEqual(result.pass, false);
+	assert.match(result.problems.join('\n'), /no line-anchored PR-diff link/);
+	assert.ok(pr().head.sha.startsWith(HEAD.slice(0, 12)), 'fixture footers remain pinned to the same head');
+});
+
+test('drafts report defects but stay green; ready PRs fail enforce mode', () => {
+	const broken = { body: 'Summary only.', draft: true };
+	const draft = evaluatePrFormat(pr(broken), { mode: 'enforce', repo: REPO, number: NUMBER });
+	assert.strictEqual(draft.pass, true);
+	assert.strictEqual(draft.compliant, false);
+	assert.strictEqual(
+		evaluatePrFormat(pr({ ...broken, draft: false }), { mode: 'enforce', repo: REPO, number: NUMBER }).pass,
+		false
+	);
+});
+
+test('bot, external, and trivial PRs are exempt before PR-files access', () => {
+	for (const candidate of [
+		pr({ user: { login: 'renovate[bot]', type: 'Bot' } }),
+		pr({ author_association: 'CONTRIBUTOR' }),
+		pr({ additions: 1, deletions: 1 }),
+	]) {
+		const result = evaluatePrFormat(candidate, { mode: 'enforce', repo: REPO, number: NUMBER });
+		assert.strictEqual(result.pass, true);
+		assert.ok(result.exempt);
+	}
+});
+
+test('every live anchor must target this PR and a current hunk line', () => {
+	const foreign = body().replace(`/pull/${NUMBER}/`, '/pull/999/');
+	assert.match(
+		evaluatePrFormat(pr({ body: foreign }), {
+			mode: 'enforce',
+			repo: REPO,
+			number: NUMBER,
+			prFiles: PR_FILES,
+		}).problems.join('\n'),
+		/points at HarperFast\/harper#999/
+	);
+	const drifted = body().replace('R211', 'R400');
+	assert.match(
+		evaluatePrFormat(pr({ body: drifted }), {
+			mode: 'enforce',
+			repo: REPO,
+			number: NUMBER,
+			prFiles: PR_FILES,
+		}).problems.join('\n'),
+		/not in a current diff hunk/
+	);
+});
+
+test('fenced examples do not satisfy the line-link requirement', () => {
+	const fenced = body({ link: '' }).replace(
+		'Audit retention now runs continuously.',
+		`Audit retention now runs continuously.\n\n\`\`\`md\n${LINK}\n\`\`\``
+	);
+	assert.strictEqual(parseBodyAnchors(fenced).length, 0);
+});
+
+test('older files URLs and per-commit paths use the same anchor contract', () => {
+	const url = `https://github.com/${REPO}/pull/${NUMBER}/files/abc123?w=1#diff-${HASH}R211-R220`;
+	const result = checkBodyLinks({ body: url, prFiles: PR_FILES, repo: REPO, number: NUMBER });
+	assert.strictEqual(result.ok, true);
+	assert.strictEqual(result.lineAnchored[0].line, 211);
+});
+
+test('PR-files normalization implements unified-diff count semantics', () => {
+	const normalized = normalizePrFiles([
+		[
+			{ filename: 'new.js', patch: '@@ -0,0 +1,3 @@\n+a\n+b\n+c' },
+			{ filename: 'edit.js', patch: '@@ -8 +10 @@\n-old\n+new' },
+			{ filename: 'binary.dat' },
+		],
+	]);
+	assert.deepStrictEqual(normalized.files[0].ranges, { L: [], R: [[1, 3]] });
+	assert.deepStrictEqual(normalized.files[1].ranges, { L: [[8, 8]], R: [[10, 10]] });
+	assert.strictEqual(normalized.files[2].patchAvailable, false);
+});
+
+test('an omitted patch or incomplete file list is explicitly unverifiable', () => {
+	const unavailable = {
+		version: 1,
+		complete: true,
+		files: [{ path: FILE, patchAvailable: false, ranges: { L: [], R: [] } }],
+	};
+	assert.strictEqual(
+		checkBodyLinks({ body: LINK, prFiles: unavailable, repo: REPO, number: NUMBER }).unverifiable,
+		true
+	);
+	assert.strictEqual(
+		checkBodyLinks({ body: LINK, prFiles: { version: 1, complete: false, files: [] }, repo: REPO, number: NUMBER })
+			.unverifiable,
+		true
+	);
+});
+
+test('PR-files input is rejected while streaming beyond the byte cap', async () => {
+	await assert.rejects(readBounded(Readable.from([Buffer.alloc(5), Buffer.alloc(6)]), 10), /exceeds 10 bytes/);
+});
+
+test('AI fields require the complete ordered body shape', () => {
+	const broken = body()
+		.replace('## For the human reviewer', '## Notes')
+		.replace('Complexity: complicated', 'Complexity: enormous')
+		.concat('\nReview-Coverage: duplicate malformed field');
+	const result = evaluatePrFormat(pr({ body: broken }), {
+		mode: 'enforce',
+		repo: REPO,
+		number: NUMBER,
+		prFiles: PR_FILES,
+	});
+	assert.match(result.problems.join('\n'), /For the human reviewer/);
+	assert.match(result.problems.join('\n'), /valid Complexity/);
+	assert.match(result.problems.join('\n'), /pinned Review-Coverage footer \(found 2\)/);
+});
+
+test('footer text cannot satisfy an empty Verification section', () => {
+	const broken = body().replace('Focused retention tests passed.\n\n', '');
+	assert.match(
+		evaluatePrFormat(pr({ body: broken }), {
+			mode: 'enforce',
+			repo: REPO,
+			number: NUMBER,
+			prFiles: PR_FILES,
+		}).problems.join('\n'),
+		/Verification needs executed evidence/
+	);
+});
+
+test('body parsing is bounded at GitHub description size', () => {
+	const result = evaluatePrFormat(pr({ body: `${body()}${'x'.repeat(65_536)}` }), {
+		mode: 'report',
+		repo: REPO,
+		number: NUMBER,
+		prFiles: PR_FILES,
+	});
+	assert.strictEqual(result.pass, true);
+	assert.match(result.problems.join('\n'), /exceeds 65536 characters/);
+});
+
+test('the report workflow keeps the existing check identity and gates PR-files collection', () => {
+	const workflow = readFileSync(fileURLToPath(new URL('../../workflows/review-coverage.yml', import.meta.url)), 'utf8');
+	assert.match(workflow, /jobs:\n\s+coverage:\n\s+runs-on:/);
+	assert.doesNotMatch(workflow, /\n\s+name:\s+report/);
+	assert.match(workflow, /author_association == 'MEMBER'/);
+	assert.match(workflow, /continue-on-error: true/);
+	assert.match(workflow, /persist-credentials: false/);
+	assert.match(workflow, /format_mode: report/);
+});

--- a/.github/actions/review-coverage/prFormat.test.mjs
+++ b/.github/actions/review-coverage/prFormat.test.mjs
@@ -236,6 +236,17 @@ test('older files URLs and per-commit paths use the same anchor contract', () =>
 	const result = checkBodyLinks({ body: url, prFiles: PR_FILES, repo: REPO, number: NUMBER });
 	assert.strictEqual(result.ok, true);
 	assert.strictEqual(result.lineAnchored[0].line, 211);
+	assert.strictEqual(result.lineAnchored[0].endLine, 220);
+});
+
+test('both endpoints of a range link must remain in current hunks', () => {
+	const staleRange = `${LINK}-R400`;
+	const result = checkBodyLinks({ body: staleRange, prFiles: PR_FILES, repo: REPO, number: NUMBER });
+	assert.strictEqual(result.ok, false);
+	assert.match(
+		result.problems.map(({ message }) => message).join('\n'),
+		/auditStore\.tsR400 is not in a current diff hunk/
+	);
 });
 
 test('every recognized PR-diff link needs a line anchor', () => {

--- a/.github/actions/review-coverage/prFormat.test.mjs
+++ b/.github/actions/review-coverage/prFormat.test.mjs
@@ -401,6 +401,29 @@ test('an empty fenced block does not satisfy Verification', () => {
 	assert.match(result.problems.join('\n'), /Verification needs executed evidence/);
 });
 
+test('code-only blocks do not satisfy prose sections', () => {
+	const summaryOnlyCode = body().replace(/^Audit retention[^\n]+/, '```text\nstack trace\n```');
+	assert.match(
+		evaluatePrFormat(pr({ body: summaryOnlyCode }), {
+			mode: 'enforce',
+			repo: REPO,
+			number: NUMBER,
+			prFiles: PR_FILES,
+		}).problems.join('\n'),
+		/needs summary prose/
+	);
+	const reviewerOnlyCode = body().replace('No open judgment calls.', '```text\nreview output\n```');
+	assert.match(
+		evaluatePrFormat(pr({ body: reviewerOnlyCode }), {
+			mode: 'enforce',
+			repo: REPO,
+			number: NUMBER,
+			prFiles: PR_FILES,
+		}).problems.join('\n'),
+		/For the human reviewer needs a decision ledger/
+	);
+});
+
 test('a lowercase AI field ends an empty Verification section', () => {
 	const broken = body().replace('Focused retention tests passed.\n\nComplexity:', 'complexity:');
 	assert.match(

--- a/.github/actions/review-coverage/prFormat.test.mjs
+++ b/.github/actions/review-coverage/prFormat.test.mjs
@@ -155,6 +155,23 @@ test('inline-code and HTML-comment links do not satisfy the line-link requiremen
 	}
 });
 
+test('a stray backtick cannot hide later Markdown blocks', () => {
+	const humanBody = [
+		`Refactors the \` operator handling. [Code](${LINK})`,
+		'',
+		'## Verification',
+		'',
+		'Ran `npm run test:unit`.',
+	].join('\n');
+	const result = evaluatePrFormat(pr({ body: humanBody }), {
+		mode: 'enforce',
+		repo: REPO,
+		number: NUMBER,
+		prFiles: PR_FILES,
+	});
+	assert.strictEqual(result.pass, true);
+});
+
 test('an unterminated fence reports its cause', () => {
 	const result = evaluatePrFormat(pr({ body: `${body()}\n\n\`\`\`md\nexample` }), {
 		mode: 'enforce',
@@ -165,11 +182,43 @@ test('an unterminated fence reports its cause', () => {
 	assert.match(result.problems.join('\n'), /unterminated fenced code block/);
 });
 
+test('an unterminated HTML comment reports its cause', () => {
+	const result = evaluatePrFormat(pr({ body: `${body()}\n\n<!-- unfinished` }), {
+		mode: 'enforce',
+		repo: REPO,
+		number: NUMBER,
+		prFiles: PR_FILES,
+	});
+	assert.match(result.problems.join('\n'), /unterminated HTML comment/);
+});
+
+test('indented-code links do not satisfy the line-link requirement', () => {
+	const indented = body({ link: '' }).replace('continuously.', `continuously.\n\n    ${LINK}`);
+	const result = evaluatePrFormat(pr({ body: indented }), {
+		mode: 'enforce',
+		repo: REPO,
+		number: NUMBER,
+		prFiles: PR_FILES,
+	});
+	assert.match(result.problems.join('\n'), /no line-anchored PR-diff link/);
+});
+
 test('older files URLs and per-commit paths use the same anchor contract', () => {
 	const url = `https://github.com/${REPO}/pull/${NUMBER}/files/abc123?w=1#diff-${HASH}R211-R220`;
 	const result = checkBodyLinks({ body: url, prFiles: PR_FILES, repo: REPO, number: NUMBER });
 	assert.strictEqual(result.ok, true);
 	assert.strictEqual(result.lineAnchored[0].line, 211);
+});
+
+test('every recognized PR-diff link needs a line anchor', () => {
+	const fileOnly = `https://github.com/${REPO}/pull/${NUMBER}/changes#diff-${HASH}`;
+	const result = evaluatePrFormat(pr({ body: `${body()}\n\nSee also ${fileOnly}.` }), {
+		mode: 'enforce',
+		repo: REPO,
+		number: NUMBER,
+		prFiles: PR_FILES,
+	});
+	assert.match(result.problems.join('\n'), /PR-diff link has no line anchor/);
 });
 
 test('partial or non-resolving anchor URLs are not accepted', () => {
@@ -227,7 +276,21 @@ test('AI fields require the complete ordered body shape', () => {
 	});
 	assert.match(result.problems.join('\n'), /For the human reviewer/);
 	assert.match(result.problems.join('\n'), /valid Complexity/);
-	assert.match(result.problems.join('\n'), /pinned Review-Coverage footer \(found 2\)/);
+	assert.match(result.problems.join('\n'), /pinned Review-Coverage footer \(found 2 field\(s\), 1 valid\)/);
+});
+
+test('AI field recognition is case-consistent', () => {
+	const lower = body()
+		.replace('Complexity:', 'complexity:')
+		.replace('Review-Coverage:', 'review-coverage:')
+		.replace('Human-Review-Need:', 'human-review-need:');
+	const result = evaluatePrFormat(pr({ body: lower }), {
+		mode: 'enforce',
+		repo: REPO,
+		number: NUMBER,
+		prFiles: PR_FILES,
+	});
+	assert.strictEqual(result.pass, true);
 });
 
 test('AI footers must be pinned to the current head', () => {
@@ -254,6 +317,43 @@ test('footer text cannot satisfy an empty Verification section', () => {
 	);
 });
 
+test('HTML-only content cannot satisfy Verification', () => {
+	const broken = body().replace('Focused retention tests passed.', '<br>');
+	assert.match(
+		evaluatePrFormat(pr({ body: broken }), {
+			mode: 'enforce',
+			repo: REPO,
+			number: NUMBER,
+			prFiles: PR_FILES,
+		}).problems.join('\n'),
+		/Verification needs executed evidence/
+	);
+});
+
+test('a lowercase AI field ends an empty Verification section', () => {
+	const broken = body().replace('Focused retention tests passed.\n\nComplexity:', 'complexity:');
+	assert.match(
+		evaluatePrFormat(pr({ body: broken }), {
+			mode: 'enforce',
+			repo: REPO,
+			number: NUMBER,
+			prFiles: PR_FILES,
+		}).problems.join('\n'),
+		/Verification needs executed evidence/
+	);
+});
+
+test('a superseded run is neutral even in enforce mode', () => {
+	const result = evaluatePrFormat(pr({ body: '' }), {
+		mode: 'enforce',
+		repo: REPO,
+		number: NUMBER,
+		superseded: true,
+	});
+	assert.strictEqual(result.pass, true);
+	assert.match(result.exempt, /superseded/);
+});
+
 test('body parsing is bounded at GitHub description size', () => {
 	const result = evaluatePrFormat(pr({ body: `${body()}${'x'.repeat(65_536)}` }), {
 		mode: 'report',
@@ -273,4 +373,6 @@ test('the report workflow keeps the existing check identity and gates PR-files c
 	assert.match(workflow, /continue-on-error: true/);
 	assert.match(workflow, /persist-credentials: false/);
 	assert.match(workflow, /format_mode: report/);
+	assert.strictEqual(workflow.match(/live_head=\$\(gh api/g)?.length, 2, 'head is checked before and after collection');
+	assert.match(workflow, /pr_files_superseded:/);
 });

--- a/.github/actions/review-coverage/prFormat.test.mjs
+++ b/.github/actions/review-coverage/prFormat.test.mjs
@@ -172,6 +172,22 @@ test('a stray backtick cannot hide later Markdown blocks', () => {
 	assert.strictEqual(result.pass, true);
 });
 
+test('nested-list and list-continuation links remain visible', () => {
+	for (const evidence of [
+		`- Ran focused tests:\n    - [cleanup loop](${LINK})`,
+		`- Ran focused tests:\n    [cleanup loop](${LINK})`,
+	]) {
+		const humanBody = ['Summary.', '', '## Verification', '', evidence].join('\n');
+		const result = evaluatePrFormat(pr({ body: humanBody }), {
+			mode: 'enforce',
+			repo: REPO,
+			number: NUMBER,
+			prFiles: PR_FILES,
+		});
+		assert.strictEqual(result.pass, true, evidence);
+	}
+});
+
 test('an unterminated fence reports its cause', () => {
 	const result = evaluatePrFormat(pr({ body: `${body()}\n\n\`\`\`md\nexample` }), {
 		mode: 'enforce',
@@ -190,6 +206,18 @@ test('an unterminated HTML comment reports its cause', () => {
 		prFiles: PR_FILES,
 	});
 	assert.match(result.problems.join('\n'), /unterminated HTML comment/);
+});
+
+test('comment and fenced-code tokens do not consume one another', () => {
+	for (const suffix of ['<!-- ```suggestion\nold code\n``` -->', '```md\n<!-- unfinished\n```']) {
+		const result = evaluatePrFormat(pr({ body: `${body()}\n\n${suffix}` }), {
+			mode: 'enforce',
+			repo: REPO,
+			number: NUMBER,
+			prFiles: PR_FILES,
+		});
+		assert.strictEqual(result.pass, true, suffix);
+	}
 });
 
 test('indented-code links do not satisfy the line-link requirement', () => {
@@ -285,6 +313,16 @@ test('AI field recognition is case-consistent', () => {
 		.replace('Review-Coverage:', 'review-coverage:')
 		.replace('Human-Review-Need:', 'human-review-need:');
 	const result = evaluatePrFormat(pr({ body: lower }), {
+		mode: 'enforce',
+		repo: REPO,
+		number: NUMBER,
+		prFiles: PR_FILES,
+	});
+	assert.strictEqual(result.pass, true);
+});
+
+test('ordinary leading whitespace is allowed on Complexity', () => {
+	const result = evaluatePrFormat(pr({ body: body().replace('Complexity:', ' Complexity:') }), {
 		mode: 'enforce',
 		repo: REPO,
 		number: NUMBER,

--- a/.github/actions/review-coverage/prFormatLinks.mjs
+++ b/.github/actions/review-coverage/prFormatLinks.mjs
@@ -18,8 +18,10 @@ function stripInlineCode(body) {
 		while (body[runEnd] === '`') runEnd++;
 		const runLength = runEnd - index;
 		let close = runEnd;
+		const boundary = body.slice(runEnd).search(/\n[ \t]*\n/);
+		const blockEnd = boundary < 0 ? body.length : runEnd + boundary;
 		let matched = false;
-		while (close < body.length) {
+		while (close < blockEnd) {
 			if (body[close] !== '`') {
 				close++;
 				continue;
@@ -42,12 +44,19 @@ function stripInlineCode(body) {
 	return prose;
 }
 
+function stripHtmlComments(body) {
+	let unterminatedComment = false;
+	const prose = body.replace(/<!--[\s\S]*?(?:-->|$)/g, (comment) => {
+		if (!comment.endsWith('-->')) unterminatedComment = true;
+		return comment.replace(/[^\n]/g, ' ');
+	});
+	return { prose, unterminatedComment };
+}
+
 export function inspectBodyText(body) {
 	let fence = null;
 	const prose = [];
-	const visible = String(body)
-		.replace(/\r\n?/g, '\n')
-		.replace(/<!--[\s\S]*?(?:-->|$)/g, (comment) => comment.replace(/[^\n]/g, ' '));
+	const visible = String(body).replace(/\r\n?/g, '\n');
 	for (const line of visible.split('\n')) {
 		let offset = 0;
 		let quoteDepth = 0;
@@ -75,6 +84,7 @@ export function inspectBodyText(body) {
 			}
 		}
 		let content = line.slice(offset);
+		if (/^(?: {4}|\t)/.test(content)) continue;
 		const list = content.match(/^[ \t]*(?:[-+*]|\d+[.)])[ \t]+/)?.[0];
 		if (list) {
 			offset += list.length;
@@ -87,7 +97,9 @@ export function inspectBodyText(body) {
 		}
 		prose.push(line);
 	}
-	return { prose: stripInlineCode(prose.join('\n')), unterminatedFence: Boolean(fence) };
+	// Blanking keeps newlines and offsets stable for section-index comparisons in the evaluator.
+	const inspected = stripHtmlComments(stripInlineCode(prose.join('\n')));
+	return { ...inspected, unterminatedFence: Boolean(fence) };
 }
 
 export function stripFencedBlocks(body) {
@@ -139,7 +151,10 @@ export function checkBodyLinks({ body, prFiles, repo, number }) {
 			else problems.push({ kind: 'unknown-file', message: `${where} does not match a file in the current diff` });
 			continue;
 		}
-		if (anchor.line === null) continue;
+		if (anchor.line === null) {
+			problems.push({ kind: 'no-line', message: `${file.path} PR-diff link has no line anchor` });
+			continue;
+		}
 		if (!file.patchAvailable) {
 			unverifiable = true;
 			continue;

--- a/.github/actions/review-coverage/prFormatLinks.mjs
+++ b/.github/actions/review-coverage/prFormatLinks.mjs
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 
 const ANCHOR_PATTERN =
 	/https:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/pull\/(\d+)\/(?:changes|files)(?:(?:\/[\w.-]+)?(?:\?[^\s)\]#]*)?)#diff-([0-9a-f]{64})(?:([RL])(\d+)(?:-([RL])(\d+))?)?(?![\w-])/g;
+const CODE_MASK = '\ufffc';
 
 export function fileAnchorHash(filePath) {
 	return createHash('sha256').update(filePath, 'utf8').digest('hex');
@@ -59,7 +60,11 @@ function stripInlineAndComments(line, commentOpen) {
 }
 
 function maskCode(line) {
-	return line.replace(/\S/g, 'x');
+	return line.replace(/\S/g, CODE_MASK);
+}
+
+export function stripCodePlaceholders(text) {
+	return text.replaceAll(CODE_MASK, '');
 }
 
 export function inspectBodyText(body) {

--- a/.github/actions/review-coverage/prFormatLinks.mjs
+++ b/.github/actions/review-coverage/prFormatLinks.mjs
@@ -7,29 +7,43 @@ export function fileAnchorHash(filePath) {
 	return createHash('sha256').update(filePath, 'utf8').digest('hex');
 }
 
-function stripInlineCode(body) {
+function stripInlineAndComments(line, commentOpen) {
 	let prose = '';
-	for (let index = 0; index < body.length;) {
-		if (body[index] !== '`') {
-			prose += body[index++];
+	let index = 0;
+	while (index < line.length) {
+		if (commentOpen) {
+			const close = line.indexOf('-->', index);
+			if (close < 0) return { prose: prose + ' '.repeat(line.length - index), commentOpen };
+			prose += ' '.repeat(close + 3 - index);
+			index = close + 3;
+			commentOpen = false;
 			continue;
 		}
-		let runEnd = index;
-		while (body[runEnd] === '`') runEnd++;
-		const runLength = runEnd - index;
+		const comment = line.indexOf('<!--', index);
+		const tick = line.indexOf('`', index);
+		if (comment >= 0 && (tick < 0 || comment < tick)) {
+			prose += line.slice(index, comment);
+			index = comment;
+			commentOpen = true;
+			continue;
+		}
+		if (tick < 0) {
+			prose += line.slice(index);
+			break;
+		}
+		prose += line.slice(index, tick);
+		let runEnd = tick;
+		while (line[runEnd] === '`') runEnd++;
+		const runLength = runEnd - tick;
 		let close = runEnd;
-		const boundary = body.slice(runEnd).search(/\n[ \t]*\n/);
-		const blockEnd = boundary < 0 ? body.length : runEnd + boundary;
 		let matched = false;
-		while (close < blockEnd) {
-			if (body[close] !== '`') {
-				close++;
-				continue;
-			}
+		while (close < line.length) {
+			close = line.indexOf('`', close);
+			if (close < 0) break;
 			let closeEnd = close;
-			while (body[closeEnd] === '`') closeEnd++;
+			while (line[closeEnd] === '`') closeEnd++;
 			if (closeEnd - close === runLength) {
-				prose += body.slice(index, closeEnd).replace(/[^\n]/g, ' ');
+				prose += ' '.repeat(closeEnd - tick);
 				index = closeEnd;
 				matched = true;
 				break;
@@ -37,24 +51,19 @@ function stripInlineCode(body) {
 			close = closeEnd;
 		}
 		if (!matched) {
-			prose += body.slice(index, runEnd);
+			prose += line.slice(tick, runEnd);
 			index = runEnd;
 		}
 	}
-	return prose;
-}
-
-function stripHtmlComments(body) {
-	let unterminatedComment = false;
-	const prose = body.replace(/<!--[\s\S]*?(?:-->|$)/g, (comment) => {
-		if (!comment.endsWith('-->')) unterminatedComment = true;
-		return comment.replace(/[^\n]/g, ' ');
-	});
-	return { prose, unterminatedComment };
+	return { prose, commentOpen };
 }
 
 export function inspectBodyText(body) {
 	let fence = null;
+	let commentOpen = false;
+	let indentedCode = false;
+	let previousBlank = true;
+	let lastNonblankWasList = false;
 	const prose = [];
 	const visible = String(body).replace(/\r\n?/g, '\n');
 	for (const line of visible.split('\n')) {
@@ -83,8 +92,14 @@ export function inspectBodyText(body) {
 				continue;
 			}
 		}
+		if (commentOpen) {
+			const stripped = stripInlineAndComments(line, commentOpen);
+			commentOpen = stripped.commentOpen;
+			prose.push(stripped.prose);
+			previousBlank = stripped.prose.trim() === '';
+			continue;
+		}
 		let content = line.slice(offset);
-		if (/^(?: {4}|\t)/.test(content)) continue;
 		const list = content.match(/^[ \t]*(?:[-+*]|\d+[.)])[ \t]+/)?.[0];
 		if (list) {
 			offset += list.length;
@@ -95,11 +110,27 @@ export function inspectBodyText(body) {
 			fence = { marker: open[1][0], length: open[1].length, quoteDepth, listIndent: list?.length || 0 };
 			continue;
 		}
-		prose.push(line);
+		const blank = content.trim() === '';
+		if (blank) {
+			prose.push('');
+			previousBlank = true;
+			continue;
+		}
+		const indented = /^(?: {4}|\t)/.test(line.slice(offset));
+		if (indentedCode && indented) continue;
+		if (indentedCode) indentedCode = false;
+		if (indented && previousBlank && !lastNonblankWasList && !list) {
+			indentedCode = true;
+			continue;
+		}
+		const stripped = stripInlineAndComments(line, false);
+		commentOpen = stripped.commentOpen;
+		prose.push(stripped.prose);
+		previousBlank = false;
+		lastNonblankWasList = Boolean(list);
 	}
 	// Blanking keeps newlines and offsets stable for section-index comparisons in the evaluator.
-	const inspected = stripHtmlComments(stripInlineCode(prose.join('\n')));
-	return { ...inspected, unterminatedFence: Boolean(fence) };
+	return { prose: prose.join('\n'), unterminatedComment: commentOpen, unterminatedFence: Boolean(fence) };
 }
 
 export function stripFencedBlocks(body) {

--- a/.github/actions/review-coverage/prFormatLinks.mjs
+++ b/.github/actions/review-coverage/prFormatLinks.mjs
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 
 const ANCHOR_PATTERN =
-	/https:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/pull\/(\d+)\/(?:changes|files)(?:(?:\/[\w.-]+)?(?:\?[^\s)\]#]*)?)#diff-([0-9a-f]{64})(?:([RL])(\d+)(?:-[RL]\d+)?)?(?![\w-])/g;
+	/https:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/pull\/(\d+)\/(?:changes|files)(?:(?:\/[\w.-]+)?(?:\?[^\s)\]#]*)?)#diff-([0-9a-f]{64})(?:([RL])(\d+)(?:-([RL])(\d+))?)?(?![\w-])/g;
 
 export function fileAnchorHash(filePath) {
 	return createHash('sha256').update(filePath, 'utf8').digest('hex');
@@ -145,6 +145,8 @@ export function parseBodyAnchors(body) {
 		hash: match[3],
 		side: match[4] ?? null,
 		line: match[5] ? Number(match[5]) : null,
+		endSide: match[6] ?? null,
+		endLine: match[7] ? Number(match[7]) : null,
 	}));
 }
 
@@ -190,11 +192,15 @@ export function checkBodyLinks({ body, prFiles, repo, number }) {
 			unverifiable = true;
 			continue;
 		}
-		if (!withinAnyRange(file.ranges?.[anchor.side] ?? [], anchor.line))
-			problems.push({
-				kind: 'line-not-in-diff',
-				message: `${file.path}${anchor.side}${anchor.line} is not in a current diff hunk`,
-			});
+		for (const [side, line] of [
+			[anchor.side, anchor.line],
+			[anchor.endSide, anchor.endLine],
+		])
+			if (line !== null && !withinAnyRange(file.ranges?.[side] ?? [], line))
+				problems.push({
+					kind: 'line-not-in-diff',
+					message: `${file.path}${side}${line} is not in a current diff hunk`,
+				});
 	}
 	return { ok: problems.length === 0 && !unverifiable, problems, anchors, lineAnchored, unverifiable };
 }

--- a/.github/actions/review-coverage/prFormatLinks.mjs
+++ b/.github/actions/review-coverage/prFormatLinks.mjs
@@ -1,16 +1,54 @@
 import { createHash } from 'node:crypto';
 
 const ANCHOR_PATTERN =
-	/https:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/pull\/(\d+)\/(?:changes|files)[^\s)\]#]*#diff-([0-9a-f]{64})(?:([RL])(\d+))?/g;
+	/https:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/pull\/(\d+)\/(?:changes|files)(?:(?:\/[\w.-]+)?(?:\?[^\s)\]#]*)?)#diff-([0-9a-f]{64})(?:([RL])(\d+)(?:-[RL]\d+)?)?(?![\w-])/g;
 
 export function fileAnchorHash(filePath) {
 	return createHash('sha256').update(filePath, 'utf8').digest('hex');
 }
 
-export function stripFencedBlocks(body) {
+function stripInlineCode(body) {
+	let prose = '';
+	for (let index = 0; index < body.length;) {
+		if (body[index] !== '`') {
+			prose += body[index++];
+			continue;
+		}
+		let runEnd = index;
+		while (body[runEnd] === '`') runEnd++;
+		const runLength = runEnd - index;
+		let close = runEnd;
+		let matched = false;
+		while (close < body.length) {
+			if (body[close] !== '`') {
+				close++;
+				continue;
+			}
+			let closeEnd = close;
+			while (body[closeEnd] === '`') closeEnd++;
+			if (closeEnd - close === runLength) {
+				prose += body.slice(index, closeEnd).replace(/[^\n]/g, ' ');
+				index = closeEnd;
+				matched = true;
+				break;
+			}
+			close = closeEnd;
+		}
+		if (!matched) {
+			prose += body.slice(index, runEnd);
+			index = runEnd;
+		}
+	}
+	return prose;
+}
+
+export function inspectBodyText(body) {
 	let fence = null;
 	const prose = [];
-	for (const line of String(body).replace(/\r\n?/g, '\n').split('\n')) {
+	const visible = String(body)
+		.replace(/\r\n?/g, '\n')
+		.replace(/<!--[\s\S]*?(?:-->|$)/g, (comment) => comment.replace(/[^\n]/g, ' '));
+	for (const line of visible.split('\n')) {
 		let offset = 0;
 		let quoteDepth = 0;
 		while (true) {
@@ -31,7 +69,7 @@ export function stripFencedBlocks(body) {
 				}
 			}
 			if (fence) {
-				const close = content.match(/^[ \t]*(`+|~+)[ \t]*$/);
+				const close = content.match(/^[ \t]{0,3}(`+|~+)[ \t]*$/);
 				if (close && close[1][0] === fence.marker && close[1].length >= fence.length) fence = null;
 				continue;
 			}
@@ -42,14 +80,18 @@ export function stripFencedBlocks(body) {
 			offset += list.length;
 			content = line.slice(offset);
 		}
-		const open = content.match(/^[ \t]*(`{3,}|~{3,})(.*)$/);
+		const open = content.match(/^[ \t]{0,3}(`{3,}|~{3,})(.*)$/);
 		if (open && (open[1][0] === '~' || !open[2].includes('`'))) {
 			fence = { marker: open[1][0], length: open[1].length, quoteDepth, listIndent: list?.length || 0 };
 			continue;
 		}
 		prose.push(line);
 	}
-	return prose.join('\n');
+	return { prose: stripInlineCode(prose.join('\n')), unterminatedFence: Boolean(fence) };
+}
+
+export function stripFencedBlocks(body) {
+	return inspectBodyText(body).prose;
 }
 
 export function parseBodyAnchors(body) {
@@ -77,13 +119,14 @@ export function checkBodyLinks({ body, prFiles, repo, number }) {
 		])
 	);
 	const problems = [];
-	let unverifiable = !prFiles;
+	const identityAvailable = /^[\w.-]+\/[\w.-]+$/.test(repo) && Number.isInteger(number) && number > 0;
+	let unverifiable = !prFiles || !identityAvailable;
 
 	if (lineAnchored.length === 0)
 		problems.push({ kind: 'no-line-anchor', message: 'description has no line-anchored PR-diff link' });
 	for (const anchor of anchors) {
 		const where = `#diff-${anchor.hash.slice(0, 12)}…${anchor.side ?? ''}${anchor.line ?? ''}`;
-		if (anchor.repo.toLowerCase() !== repo.toLowerCase() || anchor.number !== number) {
+		if (identityAvailable && (anchor.repo.toLowerCase() !== repo.toLowerCase() || anchor.number !== number)) {
 			problems.push({
 				kind: 'foreign-pr',
 				message: `${where} points at ${anchor.repo}#${anchor.number}, not ${repo}#${number}`,
@@ -92,7 +135,7 @@ export function checkBodyLinks({ body, prFiles, repo, number }) {
 		}
 		const file = files.get(anchor.hash);
 		if (!file) {
-			if (prFiles && !prFiles.complete) unverifiable = true;
+			if (!prFiles || !prFiles.complete) unverifiable = true;
 			else problems.push({ kind: 'unknown-file', message: `${where} does not match a file in the current diff` });
 			continue;
 		}
@@ -101,7 +144,7 @@ export function checkBodyLinks({ body, prFiles, repo, number }) {
 			unverifiable = true;
 			continue;
 		}
-		if (!withinAnyRange(file.ranges[anchor.side], anchor.line))
+		if (!withinAnyRange(file.ranges?.[anchor.side] ?? [], anchor.line))
 			problems.push({
 				kind: 'line-not-in-diff',
 				message: `${file.path}${anchor.side}${anchor.line} is not in a current diff hunk`,

--- a/.github/actions/review-coverage/prFormatLinks.mjs
+++ b/.github/actions/review-coverage/prFormatLinks.mjs
@@ -58,6 +58,10 @@ function stripInlineAndComments(line, commentOpen) {
 	return { prose, commentOpen };
 }
 
+function maskCode(line) {
+	return line.replace(/\S/g, 'x');
+}
+
 export function inspectBodyText(body) {
 	let fence = null;
 	let commentOpen = false;
@@ -88,7 +92,10 @@ export function inspectBodyText(body) {
 			}
 			if (fence) {
 				const close = content.match(/^[ \t]{0,3}(`+|~+)[ \t]*$/);
-				if (close && close[1][0] === fence.marker && close[1].length >= fence.length) fence = null;
+				if (close && close[1][0] === fence.marker && close[1].length >= fence.length) {
+					fence = null;
+					prose.push(' '.repeat(line.length));
+				} else prose.push(maskCode(line));
 				continue;
 			}
 		}
@@ -108,6 +115,7 @@ export function inspectBodyText(body) {
 		const open = content.match(/^[ \t]{0,3}(`{3,}|~{3,})(.*)$/);
 		if (open && (open[1][0] === '~' || !open[2].includes('`'))) {
 			fence = { marker: open[1][0], length: open[1].length, quoteDepth, listIndent: list?.length || 0 };
+			prose.push(' '.repeat(line.length));
 			continue;
 		}
 		const blank = content.trim() === '';
@@ -117,10 +125,14 @@ export function inspectBodyText(body) {
 			continue;
 		}
 		const indented = /^(?: {4}|\t)/.test(line.slice(offset));
-		if (indentedCode && indented) continue;
+		if (indentedCode && indented) {
+			prose.push(maskCode(line));
+			continue;
+		}
 		if (indentedCode) indentedCode = false;
 		if (indented && previousBlank && !lastNonblankWasList && !list) {
 			indentedCode = true;
+			prose.push(maskCode(line));
 			continue;
 		}
 		const stripped = stripInlineAndComments(line, false);
@@ -184,7 +196,7 @@ export function checkBodyLinks({ body, prFiles, repo, number }) {
 			else problems.push({ kind: 'unknown-file', message: `${where} does not match a file in the current diff` });
 			continue;
 		}
-		if (anchor.line === null) {
+		if (anchor.line == null) {
 			problems.push({ kind: 'no-line', message: `${file.path} PR-diff link has no line anchor` });
 			continue;
 		}
@@ -196,7 +208,7 @@ export function checkBodyLinks({ body, prFiles, repo, number }) {
 			[anchor.side, anchor.line],
 			[anchor.endSide, anchor.endLine],
 		])
-			if (line !== null && !withinAnyRange(file.ranges?.[side] ?? [], line))
+			if (line != null && !withinAnyRange(file.ranges?.[side] ?? [], line))
 				problems.push({
 					kind: 'line-not-in-diff',
 					message: `${file.path}${side}${line} is not in a current diff hunk`,

--- a/.github/actions/review-coverage/prFormatLinks.mjs
+++ b/.github/actions/review-coverage/prFormatLinks.mjs
@@ -1,0 +1,111 @@
+import { createHash } from 'node:crypto';
+
+const ANCHOR_PATTERN =
+	/https:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/pull\/(\d+)\/(?:changes|files)[^\s)\]#]*#diff-([0-9a-f]{64})(?:([RL])(\d+))?/g;
+
+export function fileAnchorHash(filePath) {
+	return createHash('sha256').update(filePath, 'utf8').digest('hex');
+}
+
+export function stripFencedBlocks(body) {
+	let fence = null;
+	const prose = [];
+	for (const line of String(body).replace(/\r\n?/g, '\n').split('\n')) {
+		let offset = 0;
+		let quoteDepth = 0;
+		while (true) {
+			const quote = line.slice(offset).match(/^[ \t]{0,3}>[ \t]?/)?.[0];
+			if (!quote) break;
+			offset += quote.length;
+			quoteDepth++;
+		}
+		if (fence) {
+			let content;
+			if (!fence.quoteDepth && !fence.listIndent) content = line;
+			else if (quoteDepth !== fence.quoteDepth) fence = null;
+			else {
+				content = line.slice(offset);
+				if (fence.listIndent) {
+					if (content.trim() && content.match(/^[ \t]*/)[0].length < fence.listIndent) fence = null;
+					else content = content.slice(Math.min(fence.listIndent, content.length));
+				}
+			}
+			if (fence) {
+				const close = content.match(/^[ \t]*(`+|~+)[ \t]*$/);
+				if (close && close[1][0] === fence.marker && close[1].length >= fence.length) fence = null;
+				continue;
+			}
+		}
+		let content = line.slice(offset);
+		const list = content.match(/^[ \t]*(?:[-+*]|\d+[.)])[ \t]+/)?.[0];
+		if (list) {
+			offset += list.length;
+			content = line.slice(offset);
+		}
+		const open = content.match(/^[ \t]*(`{3,}|~{3,})(.*)$/);
+		if (open && (open[1][0] === '~' || !open[2].includes('`'))) {
+			fence = { marker: open[1][0], length: open[1].length, quoteDepth, listIndent: list?.length || 0 };
+			continue;
+		}
+		prose.push(line);
+	}
+	return prose.join('\n');
+}
+
+export function parseBodyAnchors(body) {
+	return [...stripFencedBlocks(body).matchAll(ANCHOR_PATTERN)].map((match) => ({
+		url: match[0],
+		repo: match[1],
+		number: Number(match[2]),
+		hash: match[3],
+		side: match[4] ?? null,
+		line: match[5] ? Number(match[5]) : null,
+	}));
+}
+
+function withinAnyRange(ranges, line) {
+	return ranges.some(([start, end]) => line >= start && line <= end);
+}
+
+export function checkBodyLinks({ body, prFiles, repo, number }) {
+	const anchors = parseBodyAnchors(body);
+	const lineAnchored = anchors.filter((anchor) => anchor.line !== null);
+	const files = new Map(
+		(prFiles?.files ?? []).map((file) => [
+			fileAnchorHash(file.path),
+			{ path: file.path, ranges: file.ranges, patchAvailable: file.patchAvailable },
+		])
+	);
+	const problems = [];
+	let unverifiable = !prFiles;
+
+	if (lineAnchored.length === 0)
+		problems.push({ kind: 'no-line-anchor', message: 'description has no line-anchored PR-diff link' });
+	for (const anchor of anchors) {
+		const where = `#diff-${anchor.hash.slice(0, 12)}…${anchor.side ?? ''}${anchor.line ?? ''}`;
+		if (anchor.repo.toLowerCase() !== repo.toLowerCase() || anchor.number !== number) {
+			problems.push({
+				kind: 'foreign-pr',
+				message: `${where} points at ${anchor.repo}#${anchor.number}, not ${repo}#${number}`,
+			});
+			continue;
+		}
+		const file = files.get(anchor.hash);
+		if (!file) {
+			if (prFiles && !prFiles.complete) unverifiable = true;
+			else problems.push({ kind: 'unknown-file', message: `${where} does not match a file in the current diff` });
+			continue;
+		}
+		if (anchor.line === null) continue;
+		if (!file.patchAvailable) {
+			unverifiable = true;
+			continue;
+		}
+		if (!withinAnyRange(file.ranges[anchor.side], anchor.line))
+			problems.push({
+				kind: 'line-not-in-diff',
+				message: `${file.path}${anchor.side}${anchor.line} is not in a current diff hunk`,
+			});
+	}
+	return { ok: problems.length === 0 && !unverifiable, problems, anchors, lineAnchored, unverifiable };
+}

--- a/.github/workflows/review-coverage.yml
+++ b/.github/workflows/review-coverage.yml
@@ -39,11 +39,19 @@ jobs:
           [[ "$GH_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]
           [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
           [[ "$EVENT_HEAD" =~ ^[0-9a-f]{40}$ ]]
+          live_head=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          if [[ "$live_head" != "$EVENT_HEAD" ]]; then
+            echo "superseded=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           output="$RUNNER_TEMP/pr-files.json"
           gh api --paginate --slurp "repos/$GH_REPO/pulls/$PR_NUMBER/files?per_page=100" |
             node .github/actions/review-coverage/collectPrFiles.mjs "$output"
           live_head=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER" --jq '.head.sha')
-          [[ "$live_head" == "$EVENT_HEAD" ]]
+          if [[ "$live_head" != "$EVENT_HEAD" ]]; then
+            echo "superseded=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           echo "path=$output" >> "$GITHUB_OUTPUT"
           echo "ready=true" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/review-coverage
@@ -51,3 +59,4 @@ jobs:
           format_mode: report
           pr_files: ${{ steps.pr-files.outputs.path }}
           pr_files_ready: ${{ steps.pr-files.outputs.ready }}
+          pr_files_superseded: ${{ steps.pr-files.outputs.superseded }}

--- a/.github/workflows/review-coverage.yml
+++ b/.github/workflows/review-coverage.yml
@@ -1,9 +1,6 @@
 # PR-description checks (report mode: informational, never blocks).
-# Reports cross-model review coverage and validates the format and current-diff links
-# expected for substantive member-authored PRs. `edited` is required because description
-# repairs and review receipts do not move the commit sha. Enforcement and trusted execution
-# are separate rollout decisions; this pull_request workflow intentionally has read-only
-# permissions and preserves the existing coverage job identity.
+# Read-only permissions and report-only mode are load-bearing while PR code executes here;
+# enforcement requires a later trusted-host workflow.
 name: review-coverage
 on:
   pull_request:
@@ -36,13 +33,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           [[ "$GH_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]
           [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$EVENT_HEAD" =~ ^[0-9a-f]{40}$ ]]
           output="$RUNNER_TEMP/pr-files.json"
           gh api --paginate --slurp "repos/$GH_REPO/pulls/$PR_NUMBER/files?per_page=100" |
             node .github/actions/review-coverage/collectPrFiles.mjs "$output"
+          live_head=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          [[ "$live_head" == "$EVENT_HEAD" ]]
           echo "path=$output" >> "$GITHUB_OUTPUT"
           echo "ready=true" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/review-coverage

--- a/.github/workflows/review-coverage.yml
+++ b/.github/workflows/review-coverage.yml
@@ -1,10 +1,9 @@
-# Cross-model review-coverage check (report mode: informational, never blocks).
-# Parses the PR description with the dispatch human-review gate's own parser and reports
-# how many cross-model reviews it names, plus the Human-Review-Need footer state — so
-# coverage is visible at PR open/edit time, before the fleet's review runs. `edited` is a
-# trigger because reporting coverage is a description edit, which moves no commit sha.
-# Policy: HarperFast/dispatch skills/pr-shepherd/SKILL.md. Flipping to `mode: enforce`
-# is a team policy decision.
+# PR-description checks (report mode: informational, never blocks).
+# Reports cross-model review coverage and validates the format and current-diff links
+# expected for substantive member-authored PRs. `edited` is required because description
+# repairs and review receipts do not move the commit sha. Enforcement and trusted execution
+# are separate rollout decisions; this pull_request workflow intentionally has read-only
+# permissions and preserves the existing coverage job identity.
 name: review-coverage
 on:
   pull_request:
@@ -20,4 +19,34 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/review-coverage
+      - name: Collect current PR file hunks
+        id: pr-files
+        if: >-
+          github.event.pull_request.user.type != 'Bot' &&
+          !endsWith(github.event.pull_request.user.login, '[bot]') &&
+          (github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'OWNER') &&
+          (github.event.pull_request.additions > 2 || github.event.pull_request.deletions > 2 ||
+          (github.event.pull_request.additions == 2 && github.event.pull_request.deletions > 0) ||
+          (github.event.pull_request.deletions == 2 && github.event.pull_request.additions > 0))
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          [[ "$GH_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          output="$RUNNER_TEMP/pr-files.json"
+          gh api --paginate --slurp "repos/$GH_REPO/pulls/$PR_NUMBER/files?per_page=100" |
+            node .github/actions/review-coverage/collectPrFiles.mjs "$output"
+          echo "path=$output" >> "$GITHUB_OUTPUT"
+          echo "ready=true" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/review-coverage
+        with:
+          format_mode: report
+          pr_files: ${{ steps.pr-files.outputs.path }}
+          pr_files_ready: ${{ steps.pr-files.outputs.ready }}


### PR DESCRIPTION
Adds a [report-only PR-description evaluator](https://github.com/HarperFast/harper/pull/2371/changes?w=1#diff-7f8374de25b0bc4e70d218a1eac6dcf2d81a8d220fff27a61cb002b1e748a03aR10) to the [existing review-coverage workflow](https://github.com/HarperFast/harper/pull/2371/changes?w=1#diff-fb73f950853f54ac1a50bd99b3586e9d9dd3d1b0c89055323c49a1555f84b457R22) so substantive engineer-authored PRs expose missing structure and stale or absent current-diff links before review. The current workflow remains informational and read-only; enforcement is explicitly sequenced behind trusted execution.

## For the human reviewer

1. **Trusted enforcement host:** this PR [runs from the PR checkout in report mode](https://github.com/HarperFast/harper/pull/2371/changes?w=1#diff-fb73f950853f54ac1a50bd99b3586e9d9dd3d1b0c89055323c49a1555f84b457R1); a later `pull_request_target` or equivalent base-revision workflow must host the action before `format_mode: enforce` is credible. Reversing this choice means expanding this PR's trust boundary now; declining it leaves the check informational.
2. **Unavailable evidence:** GitHub-omitted patches, incomplete file lists, and collection failures are warnings in report mode but noncompliant in a future enforce mode; [the normalized API artifact is bounded and schema-validated](https://github.com/HarperFast/harper/pull/2371/changes?w=1#diff-884afb2a6459c1b02395c68f3893d3da14e91bd910176f3ad1f74a354f873dc0R39). This is locally reversible; choosing neutral enforcement would let API gaps bypass link freshness.
3. **All links current:** [every recognized PR-diff link must target this PR and resolve to current hunk endpoints](https://github.com/HarperFast/harper/pull/2371/changes?w=1#diff-1ed2bb41b1e69bc34e865ba23a738d2713ab78d6793e12f2dcc5d15678290901R157), rather than accepting one good link alongside stale context. This is a small policy change if the author friction proves too high.
4. **Syntax-only evidence:** [the section evaluator](https://github.com/HarperFast/harper/pull/2371/changes?w=1#diff-7f8374de25b0bc4e70d218a1eac6dcf2d81a8d220fff27a61cb002b1e748a03aR35) proves that Verification and reviewer sections have visible content and correct ordering; it does not decide whether the claimed test or rationale is true. Stronger semantics would need a structured evidence contract, not more Markdown heuristics.

## Verification

- `node --test .github/actions/review-coverage/*.test.mjs` — 83 passed, 0 failed.
- `npx prettier --write .github/actions/review-coverage/*.mjs .github/actions/review-coverage/action.yml .github/workflows/review-coverage.yml` and `npm run lint:required` — passed.
- `npm run build` and `npm run test:unit:resources` — passed; resource suite reported 1,767 passing and 22 pending.
- Live smoke against Harper PR #2338's body and Files API artifact passed; removing its links without changing the head failed as intended. The pinned `resources/auditStore.ts` anchor was also verified against that live PR body.
- The existing `main` CLI accepted the [same-head linkless regression fixture](https://github.com/HarperFast/harper/pull/2371/changes?w=1#diff-19b49b0d7b5ae6ed64e16020249016f4bb13b98235faab83d33e3dea9e571684R77); this branch rejected it.
- `npm run test:integration:all` completed with 1,834 passing, 18 skipped, 3 unrelated runtime failures, and 7 cancellations under the failing QA-720 startup arm. `npm run test:unit:main` was blocked by an existing deploy-by-reference fixture requiring a remote branch and a lingering process-group harness; neither gate touches `.github` code.

Complexity: complicated

<sub>Review-Coverage: authored=codex; ran=claude,gemini; declined=cursor-grok,cursor-composer,domain; rounds=7 @ 5e56d86bd313</sub>

<sub>Human-Review-Need: 3 @ 5e56d86bd313</sub>
