### PR TITLE
Make the HNSW routing test prove the graph and the descent are worth testing

### DIFF
--- a/unitTests/resources/crdt.test.js
+++ b/unitTests/resources/crdt.test.js
@@ -122,6 +122,24 @@ describe('crdt getRecordAtTime', () => {
 		assert.deepStrictEqual(getRecordAtTime(current, 250, store, 1, 'D'), { id: 'D', count: 3 });
 	});
 
+	it('falls back to the reported position when no ref resolves the head', () => {
+		// A ref that names an audit key whose entry carries a different record version resolves nothing,
+		// so the walk has to start from the position the record reports for itself. Only the RocksDB
+		// shape reaches this: LMDB records carry no refs.
+		const events = [
+			{ version: 10, type: 'put', value: { id: 'F', count: 1 }, previousVersion: 0 },
+			{ version: 20, type: 'patch', value: { count: { __op__: 'add', value: 2 } }, previousVersion: 10 },
+			{ txnLogKey: 900, version: 999, type: 'put', value: { id: 'F', count: 999 }, previousVersion: 0 },
+		];
+		const store = makeStore(events);
+		const current = currentEntry({ id: 'F', count: 3 }, 20, {
+			version: 20,
+			nodeId: 1,
+			additionalAuditRefs: [{ version: 900, nodeId: 1 }],
+		});
+		assert.deepStrictEqual(getRecordAtTime(current, 10, store, 1, 'F'), { id: 'F', count: 1 });
+	});
+
 	describe('record deleted then re-inserted under the same key (issue #1330)', () => {
 		// put(n:1) -> patch(n:2) -> patch(n:3) -> delete -> put(n:4, re-insert, current)
 		const events = [

--- a/unitTests/resources/vectorIndex.test.js
+++ b/unitTests/resources/vectorIndex.test.js
@@ -1020,8 +1020,8 @@ describe('HNSW greedy routing above layer 0 (ROUTING_EF)', () => {
 				} finally {
 					customIndex.searchLayer = originalSearchLayer;
 				}
-				// The comparison below cannot catch the optimization being removed: hand the upper
-				// layers the full ef and both of its sides search identically.
+				// Hand the upper layers the full ef and both sides of the greedy-vs-full comparison
+				// below search identically, so only this assertion notices the optimization going away.
 				assert.deepStrictEqual(
 					[...routingEfs],
 					[ROUTING_EF],

--- a/unitTests/resources/vectorIndex.test.js
+++ b/unitTests/resources/vectorIndex.test.js
@@ -935,6 +935,7 @@ describe('HNSW construction ef auto-scale (#2180)', () => {
 describe('HNSW greedy routing above layer 0 (ROUTING_EF)', () => {
 	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
 	const N = 600;
+	const ROUTING_EF = 1; // must track ROUTING_EF in resources/indexes/HierarchicalNavigableSmallWorld.ts
 	// Each graph's level assignment is pinned with a seeded PRNG (mulberry32) so a run is
 	// reproducible: greedy-vs-full equality is only statistically true over random graphs — ~2-3%
 	// of random 600-node graphs legitimately route to a different entry point and change the
@@ -965,7 +966,9 @@ describe('HNSW greedy routing above layer 0 (ROUTING_EF)', () => {
 			],
 		});
 		let seedState = seed;
+		let draws = 0;
 		T.indices.vector.customIndex.random = () => {
+			draws++;
 			seedState = (seedState + 0x6d2b79f5) | 0;
 			let t = Math.imul(seedState ^ (seedState >>> 15), 1 | seedState);
 			t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
@@ -976,6 +979,10 @@ describe('HNSW greedy routing above layer 0 (ROUTING_EF)', () => {
 			const b = ((i * 7) % N) / N;
 			await T.put(i, { vector: [Math.cos(a), Math.sin(a), b, (i % 11) / 11] });
 		}
+		// A seed only names a graph while each node takes exactly one draw: a second consumer of the
+		// stream shifts every level after it and silently re-pins all eight graphs to something the
+		// measurements below were never taken on.
+		assert.strictEqual(draws, N, 'the pinned stream must serve one level draw per node and nothing else');
 		return T;
 	}
 
@@ -993,15 +1000,33 @@ describe('HNSW greedy routing above layer 0 (ROUTING_EF)', () => {
 	// accuracy. Compare against the same graph searched with the full ef at every layer — the
 	// pre-change behaviour — rather than against a fixed expectation.
 	it('returns the same neighbours as searching every layer at the full ef', async () => {
+		const descentSensitive = [];
 		for (const seed of SEEDS) {
 			const label = '0x' + (seed >>> 0).toString(16);
 			const T = await buildGraph(seed);
 			try {
 				const customIndex = T.indices.vector.customIndex;
+				const originalSearchLayer = customIndex.searchLayer;
 				const greedy = [];
-				for (const target of targets) {
-					greedy.push(await topTenIds(T, target));
+				const routingEfs = new Set();
+				customIndex.searchLayer = function (v, epId, ep, ef, level, ...rest) {
+					if (level > 0) routingEfs.add(ef);
+					return originalSearchLayer.call(this, v, epId, ep, ef, level, ...rest);
+				};
+				try {
+					for (const target of targets) {
+						greedy.push(await topTenIds(T, target));
+					}
+				} finally {
+					customIndex.searchLayer = originalSearchLayer;
 				}
+				// The comparison below cannot catch the optimization being removed: hand the upper
+				// layers the full ef and both of its sides search identically.
+				assert.deepStrictEqual(
+					[...routingEfs],
+					[ROUTING_EF],
+					`the layers above 0 must route at ROUTING_EF (seed ${label})`
+				);
 
 				// Every layer at the ef layer 0 actually resolves to — what search() passed down before
 				// greedy descent. Read it from a real query rather than efConstructionSearch, which is
@@ -1009,7 +1034,6 @@ describe('HNSW greedy routing above layer 0 (ROUTING_EF)', () => {
 				// auto-scaled path.
 				const resolvedLayer0Ef = await captureLayer0Ef(T, { limit: 10 });
 				assert(resolvedLayer0Ef > 1, `expected an auto-scaled layer-0 ef, got ${resolvedLayer0Ef} (seed ${label})`);
-				const originalSearchLayer = customIndex.searchLayer;
 				customIndex.searchLayer = function (v, epId, ep, ef, level, ...rest) {
 					return originalSearchLayer.call(this, v, epId, ep, level > 0 ? resolvedLayer0Ef : ef, level, ...rest);
 				};
@@ -1024,10 +1048,32 @@ describe('HNSW greedy routing above layer 0 (ROUTING_EF)', () => {
 				} finally {
 					customIndex.searchLayer = originalSearchLayer;
 				}
+
+				// On many graphs layer 0 alone reaches the true neighbours from wherever it starts, and
+				// there the comparison above passes with the descent deleted outright. That is a
+				// property of the graph, not of this seed list, so the sweep as a whole has to contain
+				// at least one graph the descent decides — otherwise nothing here tests the descent.
+				customIndex.searchLayer = function (v, epId, ep, ef, level, ...rest) {
+					return level > 0 ? [] : originalSearchLayer.call(this, v, epId, ep, ef, level, ...rest);
+				};
+				try {
+					for (let i = 0; i < targets.length; i++) {
+						if ((await topTenIds(T, targets[i])) !== greedy[i]) {
+							descentSensitive.push(label);
+							break;
+						}
+					}
+				} finally {
+					customIndex.searchLayer = originalSearchLayer;
+				}
 			} finally {
 				await T.dropTable();
 			}
 		}
+		assert(
+			descentSensitive.length > 0,
+			'no seed routes differently without the descent: check whether the graph still has a hierarchy worth descending (mL, MAX_LEVEL) before re-picking SEEDS against this control'
+		);
 	});
 });
 


### PR DESCRIPTION
Rebased this PR onto `main` at `3e8e8d183`. `main` now includes the separate LMDB audit-head implementation fix, so this branch contains only the [unresolved-reference regression guard](https://github.com/HarperFast/harper/pull/2373/changes?w=1#diff-c107f30ee51faa2fc3de638ed3e55e83e4ed7321cafb07e6c4e828bd046b028dR125) and the HNSW guards that keep a seeded greedy-routing comparison meaningful: a [one-draw-per-node graph pin](https://github.com/HarperFast/harper/pull/2373/changes?w=1#diff-cad9073daf8c1f98872bbf9e6517826faa9fcc099c2010ba808180e42ff5ca9aR938), an [independent `ROUTING_EF` assertion](https://github.com/HarperFast/harper/pull/2373/changes?w=1#diff-cad9073daf8c1f98872bbf9e6517826faa9fcc099c2010ba808180e42ff5ca9aR1023), and a [descent-sensitivity control](https://github.com/HarperFast/harper/pull/2373/changes?w=1#diff-cad9073daf8c1f98872bbf9e6517826faa9fcc099c2010ba808180e42ff5ca9aR1057).

Fixes #2372

## For the human reviewer

1. The test pins `ROUTING_EF` independently rather than exporting the production-private constant: accidental production drift fails the test, while intentional tuning requires a deliberate paired test update. Exporting it would make the test and implementation drift together; changing this remains local and reversible.
2. The control requires at least one selected graph to depend on descent instead of asserting a broader recall-quality target. That preserves deterministic coverage of the original greedy-vs-full comparison; a recall criterion needs separate calibration and is not part of this rebase.

## Verification

`npm run build` passed. `npm run test:unit:resources` passed. `npm run lint:required` passed. The affected behavior is exercised end-to-end within the resource unit suite through real table inserts and vector searches; no production behavior changed in this rebase.

Complexity: medium

<sub>🤖 Generated with GPT-5 Codex</sub>

<sub>Review-Coverage: authored=codex; ran=gemini,cursor-composer,claude; adjudicated=domain; declined=cursor-grok; rounds=1 @ ef1e0d25d4e5</sub>

<sub>Human-Review-Need: 3 (decisions: independent-routing-expectation, pinned-graph-regression) @ ef1e0d25d4e5</sub>
