### PR TITLE
ci(v5.2): sync the #91 cancellation migration

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -22,11 +22,21 @@ concurrency:
 
 jobs:
   work:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@be549ad08aa6d34b909ea8b542a7ffebdaae1e81 # main 2026-08-25 (#90 cost gates: draft skip, mechanical-diff skip, effort-by-size, debounce; #89 defaults; #88 lenses)
+    # Calling-job permissions ceiling — union of the reusable's
+    # authorize (contents: read) and work (contents/pull-requests/
+    # issues/id-token: write) jobs, so grants don't depend on the
+    # repo's default-workflow-permissions setting (same rationale as
+    # the review callers' blocks).
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@765a51b545f1b2b6c1ffe3b3731baa1512e44dac # main 2026-08-28 (#91 job-level post-authorization cancellation; #90 cost gates; #89 defaults; #88 lenses)
     with:
       # Same SHA as the `uses:` ref above. See the comment in
       # claude-mention.yml for why the duplication is unavoidable.
-      ai-review-prompts-ref: be549ad08aa6d34b909ea8b542a7ffebdaae1e81
+      ai-review-prompts-ref: 765a51b545f1b2b6c1ffe3b3731baa1512e44dac
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -32,11 +32,11 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@765a51b545f1b2b6c1ffe3b3731baa1512e44dac # main 2026-08-28 (#91 job-level post-authorization cancellation; #90 cost gates; #89 defaults; #88 lenses)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@af81872e56dd63da1160adb5eae82d359a456dde # main 2026-09-01 (#94 freshness-gated admission; #91 job-level cancellation; #90 cost gates; #89 defaults; #88 lenses)
     with:
       # Same SHA as the `uses:` ref above. See the comment in
       # claude-mention.yml for why the duplication is unavoidable.
-      ai-review-prompts-ref: 765a51b545f1b2b6c1ffe3b3731baa1512e44dac
+      ai-review-prompts-ref: af81872e56dd63da1160adb5eae82d359a456dde
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -24,7 +24,17 @@ concurrency:
 
 jobs:
   mention:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@be549ad08aa6d34b909ea8b542a7ffebdaae1e81 # main 2026-08-25 (#90 cost gates: draft skip, mechanical-diff skip, effort-by-size, debounce; #89 defaults; #88 lenses)
+    # Calling-job permissions ceiling — union of the reusable's
+    # authorize (contents: read) and work (contents/pull-requests/
+    # issues/id-token: write) jobs, so grants don't depend on the
+    # repo's default-workflow-permissions setting (same rationale as
+    # the review callers' blocks).
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@765a51b545f1b2b6c1ffe3b3731baa1512e44dac # main 2026-08-28 (#91 job-level post-authorization cancellation; #90 cost gates; #89 defaults; #88 lenses)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (parse + auth scripts)
@@ -34,7 +44,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to
       # the CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: be549ad08aa6d34b909ea8b542a7ffebdaae1e81
+      ai-review-prompts-ref: 765a51b545f1b2b6c1ffe3b3731baa1512e44dac
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -34,7 +34,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@765a51b545f1b2b6c1ffe3b3731baa1512e44dac # main 2026-08-28 (#91 job-level post-authorization cancellation; #90 cost gates; #89 defaults; #88 lenses)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@af81872e56dd63da1160adb5eae82d359a456dde # main 2026-09-01 (#94 freshness-gated admission; #91 job-level cancellation; #90 cost gates; #89 defaults; #88 lenses)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (parse + auth scripts)
@@ -44,7 +44,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to
       # the CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 765a51b545f1b2b6c1ffe3b3731baa1512e44dac
+      ai-review-prompts-ref: af81872e56dd63da1160adb5eae82d359a456dde
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -37,7 +37,7 @@ jobs:
     # opt-in label, so a draft opted in via `claude-review` resumes
     # review when it flips ready even with CLAUDE_ALWAYS_ON unset.
     if: ${{ (github.event.action == 'labeled' && github.event.label.name == 'claude-review') || (github.event.action != 'labeled' && vars.CLAUDE_ALWAYS_ON == 'true') || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'claude-review')) }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@765a51b545f1b2b6c1ffe3b3731baa1512e44dac # main 2026-08-28 (#91 job-level post-authorization cancellation; #90 cost gates; #89 defaults; #88 lenses)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@af81872e56dd63da1160adb5eae82d359a456dde # main 2026-09-01 (#94 freshness-gated admission; #91 job-level cancellation; #90 cost gates; #89 defaults; #88 lenses)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -64,7 +64,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 765a51b545f1b2b6c1ffe3b3731baa1512e44dac
+      ai-review-prompts-ref: af81872e56dd63da1160adb5eae82d359a456dde
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,8 +30,9 @@ jobs:
     # always-on toggle". CLAUDE_ALWAYS_ON=true (repo/org variable) → auto-
     # review trusted-author PRs; unset → opt-in via the claude-review
     # label. The reusable's authorize job still owns WHO is admitted.
-    # Note: the `claude-review` label name is matched there too —
-    # `_claude-review.yml`'s authorize `if:`, not in this caller.
+    # Note: the `claude-review` label name is deliberately duplicated —
+    # the caller gate names it (below) AND the reusable's authorize
+    # matches it; renaming the label means changing both.
     # `ready_for_review` is admitted when the PR still carries the
     # opt-in label, so a draft opted in via `claude-review` resumes
     # review when it flips ready even with CLAUDE_ALWAYS_ON unset.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,17 +20,9 @@ on:
     # bot-authored PRs (renovate, dependabot). See ai-review-prompts#38.
     types: [opened, synchronize, reopened, ready_for_review, labeled]
 
-concurrency:
-  # NOTE: this predicate is deliberately NARROWER than the review job's
-  # `if:` — the cancelling set must be a subset of the running set.
-  # ready_for_review runs review (job gate) but never cancel: their
-  # authorization is author-based, so on a bot-authored PR they could
-  # kill a labeler-authorized run and then be rejected themselves.
-  # Ineligible events (per the review job's opt-in gate) get a unique
-  # run_id group so they can never cancel an in-flight eligible review —
-  # workflow-level cancel-in-progress fires before job `if:` is evaluated.
-  group: claude-review-${{ github.event.pull_request.number }}-${{ ((github.event.action == 'labeled' && github.event.label.name == 'claude-review') || (github.event.action != 'labeled' && github.event.action != 'ready_for_review' && vars.CLAUDE_ALWAYS_ON == 'true')) && 'eligible' || github.run_id }}
-  cancel-in-progress: true
+# No concurrency block: cancellation is owned by the reusable's review
+# job (job-level group, engaged only after authorization), so an
+# unauthorized or skipped event can never cancel a legitimate review.
 
 jobs:
   review:
@@ -44,7 +36,7 @@ jobs:
     # opt-in label, so a draft opted in via `claude-review` resumes
     # review when it flips ready even with CLAUDE_ALWAYS_ON unset.
     if: ${{ (github.event.action == 'labeled' && github.event.label.name == 'claude-review') || (github.event.action != 'labeled' && vars.CLAUDE_ALWAYS_ON == 'true') || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'claude-review')) }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@be549ad08aa6d34b909ea8b542a7ffebdaae1e81 # main 2026-08-25 (#90 cost gates: draft skip, mechanical-diff skip, effort-by-size, debounce; #89 defaults; #88 lenses)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@765a51b545f1b2b6c1ffe3b3731baa1512e44dac # main 2026-08-28 (#91 job-level post-authorization cancellation; #90 cost gates; #89 defaults; #88 lenses)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -71,7 +63,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: be549ad08aa6d34b909ea8b542a7ffebdaae1e81
+      ai-review-prompts-ref: 765a51b545f1b2b6c1ffe3b3731baa1512e44dac
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -51,7 +51,7 @@ jobs:
     # `ready_for_review` is admitted when the PR still carries the
     # opt-in label — mirrors claude-review.yml.
     if: ${{ (github.event.action == 'labeled' && github.event.label.name == 'gemini-review') || (github.event.action != 'labeled' && vars.GEMINI_ALWAYS_ON == 'true') || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'gemini-review')) }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@765a51b545f1b2b6c1ffe3b3731baa1512e44dac # main 2026-08-28 (#91 job-level post-authorization cancellation; #90 cost gates; #89 defaults; #88 lenses)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@af81872e56dd63da1160adb5eae82d359a456dde # main 2026-09-01 (#94 freshness-gated admission; #91 job-level cancellation; #90 cost gates; #89 defaults; #88 lenses)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -69,7 +69,7 @@ jobs:
       # duplication is unavoidable: reusable workflows can't introspect
       # their own ref (`github.workflow_ref` resolves to the CALLER's
       # ref in workflow_call context), and `uses: …@<ref>` is literal.
-      ai-review-prompts-ref: 765a51b545f1b2b6c1ffe3b3731baa1512e44dac
+      ai-review-prompts-ref: af81872e56dd63da1160adb5eae82d359a456dde
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -45,8 +45,9 @@ jobs:
     # review trusted-author PRs; unset → opt-in via the gemini-review
     # label. The reusable's authorize job still owns WHO is admitted
     # (CODEOWNERS trust set; the labeler, not the author, on `labeled`).
-    # Note: the `gemini-review` label name is matched there too —
-    # `_gemini-review.yml`'s authorize `if:`, not in this caller.
+    # Note: the `gemini-review` label name is deliberately duplicated —
+    # the caller gate names it (below) AND the reusable's authorize
+    # matches it; renaming the label means changing both.
     # `ready_for_review` is admitted when the PR still carries the
     # opt-in label — mirrors claude-review.yml.
     if: ${{ (github.event.action == 'labeled' && github.event.label.name == 'gemini-review') || (github.event.action != 'labeled' && vars.GEMINI_ALWAYS_ON == 'true') || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'gemini-review')) }}

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -34,19 +34,9 @@ on:
     # lists the union and the `review` job gates on GEMINI_ALWAYS_ON.
     types: [opened, synchronize, reopened, ready_for_review, labeled]
 
-concurrency:
-  # Different group key from claude-review so the two providers can run
-  # in parallel on the same PR. cancel-in-progress is per-group, so a
-  # synchronize push cancels the in-flight Gemini run without touching
-  # the Claude run (and vice versa).
-  # NOTE: this predicate is deliberately NARROWER than the review job's
-  # `if:` — the cancelling set must be a subset of the running set.
-  # ready_for_review runs review (job gate) but never cancel: their
-  # authorization is author-based, so on a bot-authored PR they could
-  # kill a labeler-authorized run and then be rejected themselves.
-  # Ineligible events get a unique run_id group — see claude-review.yml.
-  group: gemini-review-${{ github.event.pull_request.number }}-${{ ((github.event.action == 'labeled' && github.event.label.name == 'gemini-review') || (github.event.action != 'labeled' && github.event.action != 'ready_for_review' && vars.GEMINI_ALWAYS_ON == 'true')) && 'eligible' || github.run_id }}
-  cancel-in-progress: true
+# No concurrency block: cancellation is owned by the reusable's review
+# job (job-level group, engaged only after authorization), so an
+# unauthorized or skipped event can never cancel a legitimate review.
 
 jobs:
   review:
@@ -60,7 +50,7 @@ jobs:
     # `ready_for_review` is admitted when the PR still carries the
     # opt-in label — mirrors claude-review.yml.
     if: ${{ (github.event.action == 'labeled' && github.event.label.name == 'gemini-review') || (github.event.action != 'labeled' && vars.GEMINI_ALWAYS_ON == 'true') || (github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'gemini-review')) }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@be549ad08aa6d34b909ea8b542a7ffebdaae1e81 # main 2026-08-25 (#90 cost gates: draft skip, mechanical-diff skip, effort-by-size, debounce; #89 defaults; #88 lenses)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@765a51b545f1b2b6c1ffe3b3731baa1512e44dac # main 2026-08-28 (#91 job-level post-authorization cancellation; #90 cost gates; #89 defaults; #88 lenses)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -78,7 +68,7 @@ jobs:
       # duplication is unavoidable: reusable workflows can't introspect
       # their own ref (`github.workflow_ref` resolves to the CALLER's
       # ref in workflow_call context), and `uses: …@<ref>` is literal.
-      ai-review-prompts-ref: be549ad08aa6d34b909ea8b542a7ffebdaae1e81
+      ai-review-prompts-ref: 765a51b545f1b2b6c1ffe3b3731baa1512e44dac
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -29,9 +29,9 @@ jobs:
   validate:
     permissions:
       contents: read
-    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@765a51b545f1b2b6c1ffe3b3731baa1512e44dac # main 2026-08-28 (#91 job-level post-authorization cancellation; #90 cost gates; #89 defaults; #88 lenses)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@af81872e56dd63da1160adb5eae82d359a456dde # main 2026-09-01 (#94 freshness-gated admission; #91 job-level cancellation; #90 cost gates; #89 defaults; #88 lenses)
     with:
       # Same SHA as the `uses:` ref above — the reusable uses this
       # to check out the validator script at the matching version.
       # Same SHA-twice pattern as the other caller workflows.
-      ai-review-prompts-ref: 765a51b545f1b2b6c1ffe3b3731baa1512e44dac
+      ai-review-prompts-ref: af81872e56dd63da1160adb5eae82d359a456dde

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -27,7 +27,6 @@ on:
 
 jobs:
   validate:
-    # Explicit ceiling — the reusable only reads workflow files.
     permissions:
       contents: read
     uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@765a51b545f1b2b6c1ffe3b3731baa1512e44dac # main 2026-08-28 (#91 job-level post-authorization cancellation; #90 cost gates; #89 defaults; #88 lenses)

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -27,9 +27,9 @@ on:
 
 jobs:
   validate:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@be549ad08aa6d34b909ea8b542a7ffebdaae1e81 # main 2026-08-25 (#90 cost gates: draft skip, mechanical-diff skip, effort-by-size, debounce; #89 defaults; #88 lenses)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@765a51b545f1b2b6c1ffe3b3731baa1512e44dac # main 2026-08-28 (#91 job-level post-authorization cancellation; #90 cost gates; #89 defaults; #88 lenses)
     with:
       # Same SHA as the `uses:` ref above — the reusable uses this
       # to check out the validator script at the matching version.
       # Same SHA-twice pattern as the other caller workflows.
-      ai-review-prompts-ref: be549ad08aa6d34b909ea8b542a7ffebdaae1e81
+      ai-review-prompts-ref: 765a51b545f1b2b6c1ffe3b3731baa1512e44dac

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -27,6 +27,9 @@ on:
 
 jobs:
   validate:
+    # Explicit ceiling — the reusable only reads workflow files.
+    permissions:
+      contents: read
     uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@765a51b545f1b2b6c1ffe3b3731baa1512e44dac # main 2026-08-28 (#91 job-level post-authorization cancellation; #90 cost gates; #89 defaults; #88 lenses)
     with:
       # Same SHA as the `uses:` ref above — the reusable uses this


### PR DESCRIPTION
Brings the reusable-owned-cancellation migration (#2385) to `v5.2` — byte-identical to main once #2385 merges, so **merge #2385 first**, then this (caller validation compares against the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S94XethbGXpAb4DRKMD4kt

<sub>Review-Coverage: authored=claude; ran=codex; declined=gemini,cursor-grok,cursor-composer,domain; rounds=2 @ cdc52b2619a1</sub>

<sub>Human-Review-Need: 4 @ cdc52b2619a1</sub>
