### PR TITLE
Fix REST query-string parser fall-through from group-by into sort

### DIFF
--- a/resources/search.ts
+++ b/resources/search.ts
@@ -1395,6 +1395,7 @@ function parseBlock(query, expectedEnd) {
 						break;
 					case 'group-by':
 						recordError('group by is not implemented yet');
+						break;
 					case 'sort':
 						query.sort = toSortObject(args);
 						break;

--- a/unitTests/resources/query-parse.test.js
+++ b/unitTests/resources/query-parse.test.js
@@ -174,6 +174,12 @@ describe('Parsing queries', () => {
 		assert.equal(query.conditions.length, 2);
 		assert.deepEqual(query.select, ['name', 'age']);
 	});
+	it('group-by records not-implemented error without falling through into sort', function () {
+		const query = {};
+		parseQuery('group-by(x)', query);
+		assert.match(query.parseError.message, /group by is not implemented yet/);
+		assert.equal(query.sort, undefined);
+	});
 	it('Bracket/array parameter', function () {
 		let query = parseQuery('itemIds[]=1&itemIds[]=2');
 		assert.equal(query.conditions.length, 2);


### PR DESCRIPTION
## Summary

The REST query-string parser's call-function switch had `case 'group-by':` fall through into `case 'sort':` with no `break`. `recordError` (used for the "not implemented" message) is non-fatal — it just appends to `parseErrorMessage`, which is stashed on the target and thrown lazily by `Table.search` — so the fall-through actually ran: `?group-by(x)` recorded the intended not-implemented error **and** assigned `query.sort` from the group-by arguments, and `toSortEntry`'s default branch could append a second, misleading "Unknown sort type" error.

Adds the missing [`break`](https://github.com/HarperFast/harper/pull/2397/changes?w=1#diff-e321acd3b1cfdafa43c8a2aec7d9b2d318880adfe8510b34571460057cc4f003R1397) in `resources/search.ts` so `group-by(x)` only records the not-implemented parse error and leaves `query.sort` unset, with a [regression test](https://github.com/HarperFast/harper/pull/2397/changes?w=1#diff-6b39cba7ed6ac97a42a5604ff43171aaef1f0ff1baab77c50f24a894d34c3fadR178) in `unitTests/resources/query-parse.test.js`.

## For the human reviewer

Pre-push review (codex + gemini + cursor-composer + harper-domain) returned **LGTM**, no in-scope findings on this diff. It surfaced two pre-existing, out-of-scope bugs while tracing the parse-error path — flagged for a follow-up issue, not fixed here:

1. `resources/search.ts:1245` — `new SyntaxViolation((query as any).parseErrorMessage)` reads from `query`, not `currentQuery`. When `parseQuery` is called without a target (both the exported function and `Resource.parseQuery` allow this), `query` is `undefined`, so this throws a `TypeError` instead of the intended `SyntaxViolation`, leaking an internal V8 message fragment into the final 400's text. Pre-existing, not introduced by this change; a reviewer who wants it fixed here rather than filed separately should say so.
2. `resources/RequestTarget.ts` / `resources/Table.ts:3281` — the parse error is stashed on the target but only enforced by `Table.search`. A custom `Resource` subclass implementing its own `search(target)` never checks `target.parseError`, so `GET /MyCustomResource/?group-by(status)` would return 200 with the unsupported clause silently dropped instead of a 400 — the same class of bug this PR fixes for tables, still open for non-table resources.

Also from the review's decision ledger, in case a reviewer wants a different call:
- `group-by` records its own "not implemented" message rather than falling to the generic `unknown query function call` in the `default` arm — message-only choice, trivially reversible.
- `recordError` accumulates and lets the rest of the query parse (rejection is deferred to `Table.search`), rather than failing fast at the clause — this deferral is what leaves non-table resources exposed (finding 2 above).
- The new test proves the parser mutation is gone (`query.sort === undefined`) at the parser level; nothing in this PR adds an API-level test asserting `GET /Table/?group-by(x)` returns 400 end-to-end.

## Verification

- `npm run build` clean.
- `npx mocha unitTests/resources/query-parse.test.js unitTests/resources/query-tier1.test.js` — 66 passing, 1 pending (pre-existing skip), including the new regression test.
- Confirmed the new test fails on unmodified `origin/main`: reverted the fix locally, rebuilt, reran — `query.sort` came back as `{ attribute: 'x', descending: false }` instead of `undefined` — then restored the fix.
- Full `npm run test:unit:resources` (1803 passing, 22 pending, 1 failing) — the one failure (`Caching > Can load cached indexed data`, a fencing-timing assertion) reproduces identically on unmodified `origin/main`; unrelated to this change.
- Not run end-to-end over REST (no integration test targets `group-by`); the parser-level unit test is the verification route for this fix.

Refs: none — no tracking issue; found during a parser read-through.

Complexity: easy

<sub>Review-Coverage: authored=claude; ran=gemini,cursor-composer,codex; adjudicated=domain; declined=cursor-grok; rounds=1 @ ec288e8a910b</sub>

<sub>Human-Review-Need: 3 (decisions: group-by-error-vs-unknown-function, accumulate-vs-throw-on-unsupported-clause, unit-test-only-proof) @ ec288e8a910b</sub>
