### PR TITLE
fix(upgrade): fail the boot when the data-version stamp is not recorded

### DIFF
--- a/bin/upgrade.js
+++ b/bin/upgrade.js
@@ -112,7 +112,7 @@ async function runUpgrade(upgradeObj) {
 
 	// The stamp is what stops these directives running again on data they have already migrated.
 	try {
-		await hdbInfoController.insertHdbUpgradeInfo(upgradeObj[UPGRADE_VERSION]);
+		await hdbInfoController.insertHdbUpgradeInfo(upgradeObj[UPGRADE_VERSION] ?? packageJson.version);
 	} catch (err) {
 		printToLogAndConsole(
 			`The data upgrade completed, but the new data version could not be recorded in the '${hdbTerms.SYSTEM_TABLE_NAMES.INFO_TABLE_NAME}' table, so Harper will not start. Every restart re-runs the upgrade directives against already-upgraded data, so stop any process supervisor that restarts Harper automatically, then check the logs and contact ${hdbTerms.HDB_SUPPORT_ADDRESS}.`,

--- a/bin/upgrade.js
+++ b/bin/upgrade.js
@@ -110,11 +110,16 @@ async function runUpgrade(upgradeObj) {
 		throw err;
 	}
 
+	// The stamp is the only thing stopping these directives from running again on the next boot,
+	// against data they have already migrated, so a boot that cannot record it must not continue.
 	try {
 		await hdbInfoController.insertHdbUpgradeInfo(upgradeObj[UPGRADE_VERSION]);
 	} catch (err) {
-		hdbLogger.error("Error updating the 'hdb_info' system table.");
-		hdbLogger.error(err);
+		printToLogAndConsole(
+			`The data upgrade completed, but the new data version could not be recorded in the '${hdbTerms.SYSTEM_TABLE_NAMES.INFO_TABLE_NAME}' table, so Harper will not start. Restarting re-runs the upgrade directives against already-upgraded data: please check the logs and contact ${hdbTerms.HDB_SUPPORT_ADDRESS} before doing so.`,
+			hdbTerms.LOG_LEVELS.ERROR
+		);
+		throw err;
 	}
 }
 

--- a/bin/upgrade.js
+++ b/bin/upgrade.js
@@ -111,7 +111,7 @@ async function runUpgrade(upgradeObj) {
 	}
 
 	// The stamp is the only thing stopping these directives from running again on the next boot,
-	// against data they have already migrated, so a boot that cannot record it must not continue.
+	// against data they have already migrated.
 	try {
 		await hdbInfoController.insertHdbUpgradeInfo(upgradeObj[UPGRADE_VERSION]);
 	} catch (err) {

--- a/bin/upgrade.js
+++ b/bin/upgrade.js
@@ -110,13 +110,12 @@ async function runUpgrade(upgradeObj) {
 		throw err;
 	}
 
-	// The stamp is the only thing stopping these directives from running again on the next boot,
-	// against data they have already migrated.
+	// The stamp is what stops these directives running again on data they have already migrated.
 	try {
 		await hdbInfoController.insertHdbUpgradeInfo(upgradeObj[UPGRADE_VERSION]);
 	} catch (err) {
 		printToLogAndConsole(
-			`The data upgrade completed, but the new data version could not be recorded in the '${hdbTerms.SYSTEM_TABLE_NAMES.INFO_TABLE_NAME}' table, so Harper will not start. Restarting re-runs the upgrade directives against already-upgraded data: please check the logs and contact ${hdbTerms.HDB_SUPPORT_ADDRESS} before doing so.`,
+			`The data upgrade completed, but the new data version could not be recorded in the '${hdbTerms.SYSTEM_TABLE_NAMES.INFO_TABLE_NAME}' table, so Harper will not start. Every restart re-runs the upgrade directives against already-upgraded data, so stop any process supervisor that restarts Harper automatically, then check the logs and contact ${hdbTerms.HDB_SUPPORT_ADDRESS}.`,
 			hdbTerms.LOG_LEVELS.ERROR
 		);
 		throw err;

--- a/dataLayer/hdbInfoController.ts
+++ b/dataLayer/hdbInfoController.ts
@@ -48,9 +48,7 @@ export class VersionStampNotRecordedError extends Error {
 
 /**
  * An insert whose key already exists is reported as skipped rather than as a failure, so a resolved
- * insert is not by itself evidence that the version was recorded. Boot reads this record to decide
- * whether the upgrade directives still need to run, so anything short of a confirmed insert of the
- * expected id has to fail closed.
+ * insert is not by itself evidence that the version was recorded.
  */
 export function assertVersionRecorded(insertResult: any, expectedId: number, newVersionString: string) {
 	const insertedHashes = insertResult?.inserted_hashes;

--- a/dataLayer/hdbInfoController.ts
+++ b/dataLayer/hdbInfoController.ts
@@ -47,10 +47,9 @@ export class VersionStampNotRecordedError extends Error {
 }
 
 /**
- * An insert whose key already exists is reported as skipped rather than as a failure, so a resolved
- * insert is not by itself evidence that the version was recorded. Ids are compared as strings: the
- * guard is against a write that did not happen, and a boot must not be refused over a hash the
- * storage layer handed back in a different numeric type.
+ * `insert.insert` reports a key that already exists as skipped, not as a failure, so a resolved
+ * insert is not evidence that the version was recorded. Ids compare as strings: the guard is
+ * against a write that did not happen, not against a hash returned in a different type.
  */
 export function assertVersionRecorded(insertResult: any, expectedId: number, newVersionString: string) {
 	const insertedHashes = insertResult?.inserted_hashes;

--- a/dataLayer/hdbInfoController.ts
+++ b/dataLayer/hdbInfoController.ts
@@ -37,6 +37,32 @@ const DEFAULT_DATA_VERSION_NUM = '2.9.9';
 // This value should change as supported versions change.
 const MINIMUM_SUPPORTED_VERSION_NUM = '3.0.0';
 
+export class VersionStampNotRecordedError extends Error {
+	statusCode: number;
+	constructor(message: string) {
+		super(message);
+		this.name = 'VersionStampNotRecordedError';
+		this.statusCode = 500;
+	}
+}
+
+/**
+ * An insert whose key already exists is reported as skipped rather than as a failure, so a resolved
+ * insert is not by itself evidence that the version was recorded. Boot reads this record to decide
+ * whether the upgrade directives still need to run, so anything short of a confirmed insert of the
+ * expected id has to fail closed.
+ */
+export function assertVersionRecorded(insertResult: any, expectedId: number, newVersionString: string) {
+	const insertedHashes = insertResult?.inserted_hashes;
+	if (Array.isArray(insertedHashes) && insertedHashes.length === 1 && insertedHashes[0] === expectedId) return;
+
+	throw new VersionStampNotRecordedError(
+		`Could not record data version ${newVersionString} in '${hdbTerms.SYSTEM_SCHEMA_NAME}.${hdbTerms.SYSTEM_TABLE_NAMES.INFO_TABLE_NAME}': ` +
+			`the insert of ${HDB_INFO_SEARCH_ATTRIBUTE} ${expectedId} reported inserted ${JSON.stringify(insertedHashes ?? null)} ` +
+			`and skipped ${JSON.stringify(insertResult?.skipped_hashes ?? null)}`
+	);
+}
+
 /**
  * * Insert a row into hdbInfo with the initial version data at install.
  *
@@ -91,7 +117,9 @@ export async function insertHdbUpgradeInfo(newVersionString: string) {
 	);
 
 	await pSetSchemaDataToGlobal();
-	return insert.insert(insertObject);
+	const insertResult = await insert.insert(insertObject);
+	assertVersionRecorded(insertResult, newId, newVersionString);
+	return insertResult;
 }
 
 /**

--- a/dataLayer/hdbInfoController.ts
+++ b/dataLayer/hdbInfoController.ts
@@ -48,11 +48,19 @@ export class VersionStampNotRecordedError extends Error {
 
 /**
  * An insert whose key already exists is reported as skipped rather than as a failure, so a resolved
- * insert is not by itself evidence that the version was recorded.
+ * insert is not by itself evidence that the version was recorded. Ids are compared as strings: the
+ * guard is against a write that did not happen, and a boot must not be refused over a hash the
+ * storage layer handed back in a different numeric type.
  */
 export function assertVersionRecorded(insertResult: any, expectedId: number, newVersionString: string) {
 	const insertedHashes = insertResult?.inserted_hashes;
-	if (Array.isArray(insertedHashes) && insertedHashes.length === 1 && insertedHashes[0] === expectedId) return;
+	if (
+		Array.isArray(insertedHashes) &&
+		insertedHashes.length === 1 &&
+		String(insertedHashes[0]) === String(expectedId)
+	) {
+		return;
+	}
 
 	throw new VersionStampNotRecordedError(
 		`Could not record data version ${newVersionString} in '${hdbTerms.SYSTEM_SCHEMA_NAME}.${hdbTerms.SYSTEM_TABLE_NAMES.INFO_TABLE_NAME}': ` +

--- a/integrationTests/upgrade/upgrade-version-stamp.test.ts
+++ b/integrationTests/upgrade/upgrade-version-stamp.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression anchor for harper#2158: an upgrade boot must not report success unless the new data
+ * version was actually recorded in `system.hdb_info`.
+ *
+ * The reported instance ran the 5.2.0 migration on two consecutive boots because the stamp from the
+ * first run was never persisted, and boot reported success anyway. Nothing asserted the stamp
+ * advanced, so the re-run was invisible. This suite asserts the postcondition directly, on the real
+ * boot path:
+ *
+ *   1. a boot records the running version as the latest `data_version_num`;
+ *   2. a boot over a deliberately staled `data_version_num` re-runs the directives AND advances the
+ *      stamp to the running version;
+ *   3. a further boot, with the stamp already current, adds no new record — i.e. the upgrade does
+ *      not re-run, which is the observable the issue reported as broken.
+ *
+ * The stale version is written as a new `hdb_info` row with a higher `info_id`, which is how
+ * `getLatestHdbInfoRecord` picks the current data version — the same "forced re-run on
+ * already-migrated data" the QA finding behind this issue used. It goes through the fixture
+ * component rather than the ops API, which answers 403 for writes to the `system` database.
+ *
+ * Repro: timeout 900 npm run test:integration -- "integrationTests/upgrade/upgrade-version-stamp.test.ts"
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+	setupHarperWithFixture,
+	startHarper,
+	killHarper,
+	teardownHarper,
+	type ContextWithHarper,
+} from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from '../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'upgrade-version-stamp');
+const PACKAGE_VERSION = JSON.parse(readFileSync(resolve(import.meta.dirname, '../../package.json'), 'utf8'))
+	.version as string;
+
+// Older than the 5.2.0 directive, so a boot over it takes bin/upgrade.js's runUpgrade path (the one
+// that stamps) rather than the no-directives-needed path in hdbInfoController.getVersionUpdateInfo.
+const STALE_DATA_VERSION = '5.1.5';
+
+// Re-passed verbatim on every startHarper call: omitting it on a restart wipes config.
+const BOOT_CONFIG = { logging: { console: true, level: 'error' } };
+
+const skipSuite = process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun';
+
+interface InfoRecord {
+	info_id: number;
+	data_version_num: string;
+	hdb_version_num: string;
+}
+
+suite(
+	'upgrade data-version stamp is recorded before boot reports success (#2158)',
+	{ skip: skipSuite },
+	(ctx: ContextWithHarper) => {
+		let client: ReturnType<typeof createApiClient>;
+		let httpURL: string;
+		let recordsAfterUpgradeBoot: InfoRecord[];
+
+		function request(method: string, body?: unknown): Promise<Response> {
+			return fetch(`${httpURL}/VersionStamps/`, {
+				method,
+				headers: { 'Content-Type': 'application/json', 'Authorization': client.headers.Authorization },
+				body: body === undefined ? undefined : JSON.stringify(body),
+			});
+		}
+
+		function refreshClient() {
+			client = createApiClient(ctx.harper);
+			httpURL = ctx.harper.httpURL;
+		}
+
+		async function readStamps(): Promise<InfoRecord[]> {
+			const response = await request('GET');
+			strictEqual(response.status, 200, `/VersionStamps/ should return 200, got ${response.status}`);
+			return ((await response.json()) as { records: InfoRecord[] }).records;
+		}
+
+		function latestOf(records: InfoRecord[]): InfoRecord {
+			ok(records.length > 0, 'system.hdb_info must always hold at least one version record');
+			return records[records.length - 1];
+		}
+
+		async function restartAndWait(): Promise<void> {
+			await killHarper(ctx);
+			await startHarper(ctx, { config: BOOT_CONFIG, env: {} });
+			refreshClient();
+			const deadline = Date.now() + 60_000;
+			while (Date.now() < deadline) {
+				try {
+					if ((await request('GET')).status !== 404) return;
+				} catch {
+					/* not up yet */
+				}
+				await sleep(250);
+			}
+			throw new Error('/VersionStamps/ still 404 after 60s');
+		}
+
+		before(async () => {
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: BOOT_CONFIG, env: {} });
+			refreshClient();
+		});
+
+		after(async () => {
+			await teardownHarper(ctx);
+		});
+
+		test('a boot records the running version as the latest data version', async () => {
+			strictEqual(latestOf(await readStamps()).data_version_num, PACKAGE_VERSION);
+		});
+
+		test('a boot over a stale data version advances the stamp to the running version', async () => {
+			const staleId = latestOf(await readStamps()).info_id + 1;
+			const seeded = await request('POST', { info_id: staleId, version: STALE_DATA_VERSION });
+			strictEqual(seeded.status, 200, `seeding the stale stamp should return 200, got ${seeded.status}`);
+			strictEqual(
+				latestOf(await readStamps()).data_version_num,
+				STALE_DATA_VERSION,
+				'precondition: the instance must look like it is running on stale data before the restart'
+			);
+
+			await restartAndWait();
+
+			recordsAfterUpgradeBoot = await readStamps();
+			const latest = latestOf(recordsAfterUpgradeBoot);
+			strictEqual(latest.data_version_num, PACKAGE_VERSION, 'the upgrade boot must record the running version');
+			ok(latest.info_id > staleId, 'the stamp must be a new record, not the stale one it replaced');
+		});
+
+		test('a further boot with a current stamp does not re-run the upgrade', async () => {
+			await restartAndWait();
+
+			strictEqual(
+				(await readStamps()).length,
+				recordsAfterUpgradeBoot.length,
+				'a boot whose data version is already current must not stamp again'
+			);
+		});
+	}
+);

--- a/integrationTests/upgrade/upgrade-version-stamp.test.ts
+++ b/integrationTests/upgrade/upgrade-version-stamp.test.ts
@@ -37,7 +37,7 @@ import { createApiClient } from '../apiTests/utils/client.mjs';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'upgrade-version-stamp');
 const PACKAGE_VERSION = JSON.parse(readFileSync(resolve(import.meta.dirname, '../../package.json'), 'utf8'))
-	.version as string;
+	?.version as string;
 
 // Older than the 5.2.0 directive, so a boot over it takes bin/upgrade.js's runUpgrade path (the one
 // that stamps) rather than the no-directives-needed path in hdbInfoController.getVersionUpdateInfo.

--- a/integrationTests/upgrade/upgrade-version-stamp.test.ts
+++ b/integrationTests/upgrade/upgrade-version-stamp.test.ts
@@ -93,13 +93,13 @@ suite(
 			const deadline = Date.now() + 60_000;
 			while (Date.now() < deadline) {
 				try {
-					if ((await request('GET')).status !== 404) return;
+					if ((await request('GET')).status === 200) return;
 				} catch {
 					/* not up yet */
 				}
 				await sleep(250);
 			}
-			throw new Error('/VersionStamps/ still 404 after 60s');
+			throw new Error('/VersionStamps/ never returned 200 within 60s of the restart');
 		}
 
 		before(async () => {

--- a/integrationTests/upgrade/upgrade-version-stamp.test.ts
+++ b/integrationTests/upgrade/upgrade-version-stamp.test.ts
@@ -134,6 +134,7 @@ suite(
 		});
 
 		test('a further boot with a current stamp does not re-run the upgrade', async () => {
+			ok(recordsAfterUpgradeBoot, 'this case reads the state the preceding upgrade-boot case leaves behind');
 			await restartAndWait();
 
 			strictEqual(

--- a/integrationTests/upgrade/upgrade-version-stamp.test.ts
+++ b/integrationTests/upgrade/upgrade-version-stamp.test.ts
@@ -8,8 +8,8 @@
  * boot path:
  *
  *   1. a boot records the running version as the latest `data_version_num`;
- *   2. a boot over a deliberately staled `data_version_num` re-runs the directives AND advances the
- *      stamp to the running version;
+ *   2. a boot over a deliberately staled `data_version_num` advances the stamp to the running
+ *      version (the directives run on that boot, but their execution is not itself asserted here);
  *   3. a further boot, with the stamp already current, adds no new record — i.e. the upgrade does
  *      not re-run, which is the observable the issue reported as broken.
  *

--- a/integrationTests/upgrade/upgrade-version-stamp/config.yaml
+++ b/integrationTests/upgrade/upgrade-version-stamp/config.yaml
@@ -1,0 +1,3 @@
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/upgrade/upgrade-version-stamp/resources.js
+++ b/integrationTests/upgrade/upgrade-version-stamp/resources.js
@@ -1,13 +1,9 @@
-// Fixture for upgrade-version-stamp.test.ts (harper#2158).
-//
 // The ops API denies writes to the `system` database (403), so the suite cannot stale
-// `system.hdb_info` the way it needs to in order to make the next boot look like an in-place
-// upgrade. A component resource runs in-process against the table directly, which is the same
-// access the upgrade path itself has.
+// `system.hdb_info` through it to make the next boot look like an in-place upgrade. A component
+// resource reaches the table in-process, which is the access the upgrade path itself has.
 //
-//   GET  /VersionStamps/        — every hdb_info row, oldest info_id first.
-//   POST /VersionStamps/ {info_id, version}
-//                               — write one hdb_info row with a chosen version.
+//   GET  /VersionStamps/                    — every hdb_info row, oldest info_id first.
+//   POST /VersionStamps/ {info_id, version} — write one hdb_info row with a chosen version.
 
 function infoTable() {
 	return databases['system']['hdb_info'];

--- a/integrationTests/upgrade/upgrade-version-stamp/resources.js
+++ b/integrationTests/upgrade/upgrade-version-stamp/resources.js
@@ -1,0 +1,38 @@
+// Fixture for upgrade-version-stamp.test.ts (harper#2158).
+//
+// The ops API denies writes to the `system` database (403), so the suite cannot stale
+// `system.hdb_info` the way it needs to in order to make the next boot look like an in-place
+// upgrade. A component resource runs in-process against the table directly, which is the same
+// access the upgrade path itself has.
+//
+//   GET  /VersionStamps/        — every hdb_info row, oldest info_id first.
+//   POST /VersionStamps/ {info_id, version}
+//                               — write one hdb_info row with a chosen version.
+
+function infoTable() {
+	return databases['system']['hdb_info'];
+}
+
+export class VersionStamps extends Resource {
+	static loadAsInstance = false;
+
+	async get() {
+		const records = [];
+		for await (const record of infoTable().search({ conditions: [] })) {
+			records.push({
+				info_id: record.info_id,
+				data_version_num: record.data_version_num,
+				hdb_version_num: record.hdb_version_num,
+			});
+		}
+		records.sort((a, b) => a.info_id - b.info_id);
+		return { records };
+	}
+
+	async post(query, body) {
+		const b = body || query || {};
+		const info_id = Number(b.info_id);
+		await infoTable().put({ info_id, data_version_num: b.version, hdb_version_num: b.version });
+		return { ok: true, info_id, version: b.version };
+	}
+}

--- a/unitTests/bin/upgrade.test.js
+++ b/unitTests/bin/upgrade.test.js
@@ -89,8 +89,8 @@ describe('Test upgrade.js', () => {
 			processDirectives_stub.resolves();
 		});
 
-		// This assertion is the inverse of the one it replaced: a swallowed stamp failure is what let
-		// boot report success on a stale data version (harper#2158).
+		// The inverse of the assertion it replaced: a swallowed stamp failure let boot report success
+		// on a stale data version.
 		it('Should rethrow an exception from insertHdbUpgradeInfo so boot fails rather than continuing unstamped', async () => {
 			insertHdbUpgradeInfo_stub.throws(test_error);
 

--- a/unitTests/bin/upgrade.test.js
+++ b/unitTests/bin/upgrade.test.js
@@ -68,6 +68,13 @@ describe('Test upgrade.js', () => {
 			expect(insertHdbUpgradeInfo_stub.args[0][0]).to.deep.equal(TEST_CURR_VERS);
 		});
 
+		it('Should fall back to the package version when the upgrade object carries none', async () => {
+			await runUpgrade_rw(new UpgradeObject(TEST_DATA_VERS, undefined));
+
+			expect(insertHdbUpgradeInfo_stub.calledOnce).to.be.true;
+			expect(insertHdbUpgradeInfo_stub.args[0][0]).to.equal(TEST_CURR_VERS);
+		});
+
 		it('Should catch and throw exception from runUpgradeDirectives', async () => {
 			processDirectives_stub.throws(test_error);
 

--- a/unitTests/bin/upgrade.test.js
+++ b/unitTests/bin/upgrade.test.js
@@ -89,26 +89,28 @@ describe('Test upgrade.js', () => {
 			processDirectives_stub.resolves();
 		});
 
-		// Reversed in harper#2158: this used to pin "log and continue", which let boot report success
-		// with a stale data version and re-run the directives on every subsequent boot.
+		// This assertion is the inverse of the one it replaced: a swallowed stamp failure is what let
+		// boot report success on a stale data version (harper#2158).
 		it('Should rethrow an exception from insertHdbUpgradeInfo so boot fails rather than continuing unstamped', async () => {
 			insertHdbUpgradeInfo_stub.throws(test_error);
 
 			let test_result;
 
 			try {
-				await runUpgrade_rw(TEST_UPGRADE_OBJ);
-			} catch (e) {
-				test_result = e;
+				try {
+					await runUpgrade_rw(TEST_UPGRADE_OBJ);
+				} catch (e) {
+					test_result = e;
+				}
+
+				expect(test_result).to.equal(test_error);
+				expect(printToLogAndConsole_stub.calledOnce).to.be.true;
+				expect(printToLogAndConsole_stub.args[0][0]).to.contain('could not be recorded');
+				expect(processDirectives_stub.calledOnce).to.be.true;
+				expect(insertHdbUpgradeInfo_stub.called).to.be.true;
+			} finally {
+				insertHdbUpgradeInfo_stub.resolves();
 			}
-
-			expect(test_result).to.equal(test_error);
-			expect(printToLogAndConsole_stub.calledOnce).to.be.true;
-			expect(printToLogAndConsole_stub.args[0][0]).to.contain('could not be recorded');
-			expect(processDirectives_stub.calledOnce).to.be.true;
-			expect(insertHdbUpgradeInfo_stub.called).to.be.true;
-
-			insertHdbUpgradeInfo_stub.resolves();
 		});
 	});
 

--- a/unitTests/bin/upgrade.test.js
+++ b/unitTests/bin/upgrade.test.js
@@ -89,8 +89,6 @@ describe('Test upgrade.js', () => {
 			processDirectives_stub.resolves();
 		});
 
-		// The inverse of the assertion it replaced: a swallowed stamp failure let boot report success
-		// on a stale data version.
 		it('Should rethrow an exception from insertHdbUpgradeInfo so boot fails rather than continuing unstamped', async () => {
 			insertHdbUpgradeInfo_stub.throws(test_error);
 

--- a/unitTests/bin/upgrade.test.js
+++ b/unitTests/bin/upgrade.test.js
@@ -89,16 +89,26 @@ describe('Test upgrade.js', () => {
 			processDirectives_stub.resolves();
 		});
 
-		it('Should catch an exception from insertHdbUpgradeInfo and continue - i.e. NOT rethrow', async () => {
+		// Reversed in harper#2158: this used to pin "log and continue", which let boot report success
+		// with a stale data version and re-run the directives on every subsequent boot.
+		it('Should rethrow an exception from insertHdbUpgradeInfo so boot fails rather than continuing unstamped', async () => {
 			insertHdbUpgradeInfo_stub.throws(test_error);
 
-			await runUpgrade_rw(TEST_UPGRADE_OBJ);
+			let test_result;
 
-			expect(log_error_stub.calledTwice).to.be.true;
-			expect(log_error_stub.args[0][0]).to.eql("Error updating the 'hdb_info' system table.");
-			expect(log_error_stub.args[1][0]).to.deep.equal(test_error);
+			try {
+				await runUpgrade_rw(TEST_UPGRADE_OBJ);
+			} catch (e) {
+				test_result = e;
+			}
+
+			expect(test_result).to.equal(test_error);
+			expect(printToLogAndConsole_stub.calledOnce).to.be.true;
+			expect(printToLogAndConsole_stub.args[0][0]).to.contain('could not be recorded');
 			expect(processDirectives_stub.calledOnce).to.be.true;
 			expect(insertHdbUpgradeInfo_stub.called).to.be.true;
+
+			insertHdbUpgradeInfo_stub.resolves();
 		});
 	});
 

--- a/unitTests/dataLayer/hdbInfoController.test.js
+++ b/unitTests/dataLayer/hdbInfoController.test.js
@@ -51,7 +51,10 @@ describe.skip('Test hdbInfoController module ', function () {
 		sandbox = sinon.createSandbox();
 		search_stub = sandbox.stub().resolves(INFO_SEARCH_RESULT);
 		hdb_info_controller_rw.__set__('pSearchSearchByValue', search_stub);
-		insert_stub = sandbox.stub(insert, 'insert').resolves();
+		insert_stub = sandbox.stub(insert, 'insert').callsFake(async (insertObject) => ({
+			inserted_hashes: insertObject.records.map((record) => record.info_id),
+			skipped_hashes: [],
+		}));
 		consoleLog_stub = sandbox.stub(console, 'log').returns();
 		consoleError_stub = sandbox.stub(console, 'error').returns();
 		log_info_stub = sandbox.stub(harper_logger, 'info').returns();

--- a/unitTests/dataLayer/hdbInfoVersionStamp.test.js
+++ b/unitTests/dataLayer/hdbInfoVersionStamp.test.js
@@ -36,6 +36,10 @@ describe('hdb_info version stamp verification', () => {
 		assert.throws(() => assertVersionRecorded(undefined, NEW_ID, NEW_VERSION), isStampError);
 	});
 
+	it('accepts an expected info_id the storage layer handed back as a string', () => {
+		assertVersionRecorded({ inserted_hashes: [String(NEW_ID)], skipped_hashes: [] }, NEW_ID, NEW_VERSION);
+	});
+
 	it('rejects an insert that recorded a different info_id than the one derived for this upgrade', () => {
 		assert.throws(
 			() => assertVersionRecorded({ inserted_hashes: [NEW_ID + 1], skipped_hashes: [] }, NEW_ID, NEW_VERSION),

--- a/unitTests/dataLayer/hdbInfoVersionStamp.test.js
+++ b/unitTests/dataLayer/hdbInfoVersionStamp.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const assert = require('node:assert');
+
+const { assertVersionRecorded, VersionStampNotRecordedError } = require('#src/dataLayer/hdbInfoController');
+
+const NEW_ID = 4;
+const NEW_VERSION = '5.2.0';
+
+const isStampError = (error) => {
+	assert.ok(error instanceof VersionStampNotRecordedError, `expected VersionStampNotRecordedError, got ${error}`);
+	assert.strictEqual(error.statusCode, 500);
+	assert.ok(error.message.includes(NEW_VERSION), 'message names the version that was not recorded');
+	assert.ok(error.message.includes(String(NEW_ID)), 'message names the info_id that was attempted');
+	return true;
+};
+
+describe('hdb_info version stamp verification', () => {
+	it('accepts an insert that reports the expected info_id as inserted', () => {
+		assertVersionRecorded({ inserted_hashes: [NEW_ID], skipped_hashes: [] }, NEW_ID, NEW_VERSION);
+	});
+
+	it('rejects an insert whose key already existed and was skipped', () => {
+		assert.throws(
+			() => assertVersionRecorded({ inserted_hashes: [], skipped_hashes: [NEW_ID] }, NEW_ID, NEW_VERSION),
+			isStampError
+		);
+	});
+
+	it('rejects an insert that reports nothing at all', () => {
+		assert.throws(
+			() => assertVersionRecorded({ inserted_hashes: [], skipped_hashes: [] }, NEW_ID, NEW_VERSION),
+			isStampError
+		);
+		assert.throws(() => assertVersionRecorded({}, NEW_ID, NEW_VERSION), isStampError);
+		assert.throws(() => assertVersionRecorded(undefined, NEW_ID, NEW_VERSION), isStampError);
+	});
+
+	it('rejects an insert that recorded a different info_id than the one derived for this upgrade', () => {
+		assert.throws(
+			() => assertVersionRecorded({ inserted_hashes: [NEW_ID + 1], skipped_hashes: [] }, NEW_ID, NEW_VERSION),
+			isStampError
+		);
+	});
+});


### PR DESCRIPTION
An upgrade boot could report success while `system.hdb_info` still held the old data version, so the migration re-ran on every subsequent boot. Two independent paths produced that state; both are closed here, and boot now refuses to continue when the stamp is not confirmed.

**The failure was swallowed.** `runUpgrade` caught everything `insertHdbUpgradeInfo()` threw, logged it, and returned normally — so `bin/run.ts`'s existing "Got an error while trying to upgrade your Harper instance… Exiting Harper." / `process.exit(1)` path never fired. [It now logs what state the instance is in and rethrows](https://github.com/HarperFast/harper/pull/2398/changes?w=1#diff-0eacbdd46d3341512e4b66dda191aa163d06db8b53e41a826bc0d15ca76ad4f6R121).

**The stamp could also no-op with no error at all.** `insertHdbUpgradeInfo` derives the new `info_id` as `max(existing) + 1` from a search whose failures `getAllHdbInfoRecords` swallows into `[]`. On that path `newId` is `1`, which collides with the install record — and `createRecords` sets `requires_no_existing`, so `upsertRecords` pushes a colliding key onto `skipped` rather than writing it. The call then **resolves successfully having written nothing**. [`insertHdbUpgradeInfo` now requires the expected id to come back as inserted](https://github.com/HarperFast/harper/pull/2398/changes?w=1#diff-1d40881acb0308d737478bce63620dd5fac186370bf03bbf6eb529fcfc176c18R126) and [throws `VersionStampNotRecordedError`](https://github.com/HarperFast/harper/pull/2398/changes?w=1#diff-1d40881acb0308d737478bce63620dd5fac186370bf03bbf6eb529fcfc176c18R54) otherwise, which covers all three of its call sites (the upgrade path plus the downgrade-confirmed and no-directives-needed stamps in `getVersionUpdateInfo`). This second path fits the issue report better than the first: the reported boots show the migration notices and no stamp error.

The invariant: **`upgrade()` returns normally only if the new data version is actually recorded**, because the stamp is the only thing stopping a directive re-running against data it has already migrated.

`Framing-Verdict: chosen-approach-sound` (planning review, before implementation).

## Re-deciding the pinned trade-off

[The reversed unit test](https://github.com/HarperFast/harper/pull/2398/changes?w=1#diff-e1f8115a77132ba294cdb599d3da91c2aa2ae0d5a730b8be70126f1370b4b3e1R92) pinned "log and continue" by name. Three facts decided the reversal:

- **The swallow was the outlier, not the policy.** `insertHdbUpgradeInfo`'s other two call sites are already fatal to boot — they run inside `getVersionUpdateInfo`'s try/catch, which `log.fatal`s and rethrows, and `bin/run.ts` exits 1.
- **What was ignored is not bookkeeping.** QA finding F-296 measured that today's re-run is benign (4 record shapes byte-identical by sha256 after a forced re-run, positive control armed) — which is exactly why the swallow survived. It costs nothing until the first non-idempotent directive, at which point it costs data.
- **Failing boot leaves a safe state.** The data is already migrated and the process exits naming the version; booting with a stale stamp leaves an instance that re-migrates on every boot and reports success each time.

## For the human reviewer

Decisions taken during the pre-push review that a reader should weigh rather than assume:

- **An orchestrated restart loop is the accepted cost, and it is not new.** One reviewer called the exit a blocker: a supervisor (systemd, Docker, Kubernetes) will restart Harper immediately, so the "do not restart" advice cannot be honoured unattended. The directives are what mutate data, and they re-run once per boot either way — under today's behaviour the instance *also* comes up and serves traffic while doing it, so this change strictly reduces exposure and makes the loop visible. [The failure message](https://github.com/HarperFast/harper/pull/2398/changes?w=1#diff-0eacbdd46d3341512e4b66dda191aa163d06db8b53e41a826bc0d15ca76ad4f6R117) now tells the operator to stop the supervisor first. Whether a stamp failure should additionally use an exit code or marker that suppresses automatic restart is a design decision left open.
- **A transient search failure now fails boot on a healthy instance.** If `pSearchSearchByValue` throws inside `getAllHdbInfoRecords` during the stamp, `newId` collapses to `1`, the insert is skipped, and boot exits — indistinguishable from a real persistence failure. That is the intended fail-closed direction, but it is a real behaviour change. The latest review round sharpened the consequence: because the guard lives in `insertHdbUpgradeInfo` rather than in `runUpgrade`, it also arms the no-directives stamp in `getVersionUpdateInfo`, where the throw escapes before `bin/run.ts` reaches `upgrade.upgrade()` — so that path gets the generic `UPGRADE_ERR` line, not the supervisor-restart guidance. Making the postcondition state-shaped (re-read the latest record and accept a `data_version_num` that already equals the target) instead of receipt-shaped would remove the false negative; that is a deliberate open decision, not an oversight, and is left for the human reviewer.
- **`insertHdbInstallInfo` was deliberately left alone.** It has the same silent-skip exposure (a re-install where `info_id` 1 exists resolves without writing). Extending the check there needs the install path's re-run semantics traced first, and this change is scoped to the upgrade stamp. Reported separately rather than changed here.
- **The failure path has no end-to-end test, by construction.** Both remaining reviewer findings ask for one. Forcing the stamp to fail requires injecting a storage or search failure at boot, which nothing in the integration harness can do. The unit tests carry that contract; [the integration suite](https://github.com/HarperFast/harper/pull/2398/changes?w=1#diff-996ba1f92c68ff708bbbe38d893ef9984c2f76f1789e1a3201313b714a5435a7R118) anchors the postcondition that had no coverage at all.
- **Two review-bot suggestions were taken, one declined.** Falling back to `packageJson.version` for the stamped version and optional-chaining the test's `package.json` read are in. Adding null guards on `assertVersionRecorded`'s `expectedId`/`newVersionString` was declined: both are computed by the only caller a few lines above, and with the version fallback in place neither can arrive undefined.
- **The original error is not logged twice.** The new message deliberately omits `err`; `bin/run.ts` logs the thrown error on the exit path it reaches.
- **`storage.writeAsync: true` durability is out of scope.** It sets LMDB `noSync`, so a *successfully written* stamp can still be lost to a hard kill — the mechanism the issue title hypothesises. Nothing here syncs the stamp; a storage-engine-specific sync at boot is a separate decision.

## Verification

Re-verified after rebasing onto `main` at `3ea2639ae` (see the rebase note below); the PR's own five commits are unchanged.

- `npm run build` — clean.
- `npm run test:unit:resources` — **1841 passing, 23 pending, 0 failing.** `Caching › Can load cached indexed data` is green again.
- `npm run test:unit:main` — 5129 passing, 195 pending, 1 failing: `configValidator › does not warn when a relative rootPath resolves within the limit`. That case resolves `relative/root` against `process.cwd()`, so it only fails from a deeply nested checkout path; it is green in CI on `main` and on this branch.
- `npx mocha unitTests/bin/upgrade.test.js unitTests/dataLayer/hdbInfoController.test.js unitTests/dataLayer/hdbInfoVersionStamp.test.js` — 10 passing, 19 pending.
- Earlier rounds (pre-rebase, unchanged code): `npm run test:integration -- "integrationTests/upgrade/**/*.test.ts"` — 16 passing, 3 skipped (env-gated on a prior-release install), 0 failing; `integrationTests/server/**` — 189 passing, the 6 failures needing a local Ollama server.
- **Fails on base:** with `bin/upgrade.js` and `dataLayer/hdbInfoController.ts` reverted and `dist` rebuilt, the reversed unit test fails with `expected undefined to equal Error: Oh boy...it is an error`, and the new stamp tests cannot run at all (`assertVersionRecorded is not a function`).

### Why CI was red, and where it stands now

All three `Unit Test (Node.js v22/v24/v26)` jobs failed on the same case, `Caching › Can load cached indexed data` — "the fencing source fill should reach the indexed subscription". That was a **red on `main`**, not a regression here: it is the fence named in the commit message of [`b3235b8c6` "Deliver RocksDB subscription events for source fills whose version differs from the log key"](https://github.com/HarperFast/harper/commit/b3235b8c6e35602421b20a697f44be03269c3b72), which landed after this branch's merge-base. The per-node extras were separate known flakes — `HNSW greedy routing above layer 0` on v22 (open: [#2373](https://github.com/HarperFast/harper/pull/2373)) and an `ENOTEMPTY` teardown on v26 (open: [#2276](https://github.com/HarperFast/harper/pull/2276)).

Checks run against the PR's merge ref, so `main`'s fix reaches this PR whether or not the branch is rebased; the rebase re-triggered CI and makes the local tree match what CI actually tests, which is what the verification above was run against. **All three `Unit Test` jobs now pass at `127d1adbf`.**

**One check is red, and it is `main`'s, not this diff's.** `Unit Test (Windows, Node.js v24)` — the gate added by [#2361](https://github.com/HarperFast/harper/pull/2361) after this branch's base — fails on the `unitTests/config/**` group (1 of 9), on two cases from [#2245](https://github.com/HarperFast/harper/pull/2245): `storage exhaustion during boot (#847) › isStorageExhausted › recognizes EDQUOT by errno when the platform gives no usable code` (`false !== true`) and `› persistConfigDuringBoot › swallows storage exhaustion so startup continues` (`Error: Unknown system error -undefined`) — Windows has no `EDQUOT` errno. The failure is byte-identical on `main`'s own runs ([job on `655787409`](https://github.com/HarperFast/harper/actions/runs/33397431652/job/99505218824)), which have been red on it since the gate landed. Nothing in this diff touches `unitTests/config/` or `config/configUtils.ts`.

`Integration Tests 6/6 (Windows, Node.js v24)` is red for the same reason: `an application with a branched database › keeps the application's own data across a restart` (`a restart must not discard the branch`), from [#2352](https://github.com/HarperFast/harper/pull/2352). It fails on `main`'s own last two Integration runs ([`655787409`](https://github.com/HarperFast/harper/actions/runs/33397431612), [`1db23823b`](https://github.com/HarperFast/harper/actions/runs/33397414407)). Both Windows gates landed on `main` after this branch's base, so this is the first run of #2398 that has ever seen them.

Refs #2158

Complexity: complicated

<sub>Review-Coverage: authored=claude; ran=gemini,cursor-composer,codex; adjudicated=domain; declined=cursor-grok; rounds=5 @ 127d1adbf1fb</sub>

<sub>Human-Review-Need: 3 (decisions: fail-boot-on-unrecorded-stamp, guard-placed-in-controller-not-caller, receipt-vs-state-postcondition, integration-suite-that-passes-on-main) @ 127d1adbf1fb</sub>
