### PR TITLE
Add an integration anchor pinning the transaction-log purge blast radius to audit history only

### DIFF
--- a/integrationTests/database/qa816-purge-blast-radius.test.ts
+++ b/integrationTests/database/qa816-purge-blast-radius.test.ts
@@ -116,6 +116,15 @@ function protectedRows(prefix: string, bucket: string, count: number): SeededRow
 const LEDGER_ROWS = protectedRows('ledger', 'LEDGER', LEDGER_COUNT);
 const QUIET_ROWS = protectedRows('quiet', 'QUIET', QUIET_COUNT);
 const REMOTE_ROWS = protectedRows('remote', 'REMOTE', REMOTE_COUNT);
+const PROTECTED_TABLES = [
+	{ database: PURGED_DB, table: 'Ledger', bucket: 'LEDGER', rows: LEDGER_ROWS },
+	{ database: PURGED_DB, table: 'QuietLedger', bucket: 'QUIET', rows: QUIET_ROWS },
+	{ database: CONTROL_DB, table: 'RemoteLedger', bucket: 'REMOTE', rows: REMOTE_ROWS },
+];
+const CHURN_TABLES = [
+	{ database: PURGED_DB, table: 'Churn' },
+	{ database: CONTROL_DB, table: 'RemoteChurn' },
+];
 const LEDGER_SAMPLE_IDS = Array.from(
 	{ length: LEDGER_SAMPLE_COUNT },
 	(_, i) => LEDGER_ROWS[Math.floor((i * LEDGER_COUNT) / LEDGER_SAMPLE_COUNT)].id
@@ -411,8 +420,7 @@ suite(
 			logging: { auditLog: true, console: true, level: 'error' },
 			storage: { engine: 'rocksdb' },
 		};
-		let churnRows = 0;
-		let remoteChurnRows = 0;
+		const churnCounts = new Map<string, number>();
 		let cutoffTimestamp = Number.NaN;
 		let armed = false;
 		let quietAuditBefore = 0;
@@ -422,79 +430,49 @@ suite(
 			ok(armed, 'PRECONDITION: the seed/arm phase must complete before the purge, read, or restart probes run');
 		}
 
-		/**
-		 * The headline check. Every protected primary row in BOTH databases, value-exact, on three
-		 * independent read surfaces plus a point-read sample — and the churn tables' rows counted, so a
-		 * purge that ate primary data in bulk cannot hide behind the protected tables.
-		 */
 		async function assertPrimaryIntact(label: string): Promise<void> {
-			assertRowSetMatches(label, 'REST collection', LEDGER_ROWS, await restCollection(ctx, 'Ledger', 'LEDGER'));
-			assertRowSetMatches(
-				label,
-				'search_by_value',
-				LEDGER_ROWS,
-				await searchByBucket(ctx, PURGED_DB, 'Ledger', 'LEDGER')
-			);
-			const ledgerScan = await fullScan(ctx, PURGED_DB, 'Ledger', 'records');
-			assertRowSetMatches(label, 'full primary-store scan', LEDGER_ROWS, ledgerScan.records);
-			strictEqual(
-				ledgerScan.totalCount,
-				LEDGER_COUNT,
-				`[${label}] full scan of ${PURGED_DB}.Ledger must total ${LEDGER_COUNT}`
-			);
+			for (const { database, table, bucket, rows } of PROTECTED_TABLES) {
+				assertRowSetMatches(label, `REST collection ${table}`, rows, await restCollection(ctx, table, bucket));
+				assertRowSetMatches(
+					label,
+					`search_by_value ${table}`,
+					rows,
+					await searchByBucket(ctx, database, table, bucket)
+				);
+				const scan = await fullScan(ctx, database, table, 'records');
+				assertRowSetMatches(label, `full primary-store scan ${table}`, rows, scan.records);
+				strictEqual(
+					scan.totalCount,
+					rows.length,
+					`[${label}] full scan of ${database}.${table} must total ${rows.length}`
+				);
+			}
 
 			for (const id of LEDGER_SAMPLE_IDS) {
 				const r = await restJson(ctx, `/Ledger/${id}`);
 				strictEqual(r.status, 200, `[${label}] REST GET /Ledger/${id} expected 200, got ${r.status}`);
-				const expected = LEDGER_ROWS.find((row) => row.id === id);
 				deepStrictEqual(
 					{ id: r.body?.id, bucket: r.body?.bucket, seq: r.body?.seq, payload: r.body?.payload },
-					expected,
+					LEDGER_ROWS.find((row) => row.id === id),
 					`[${label}] REST GET /Ledger/${id} returned a modified row`
 				);
 			}
 
-			assertRowSetMatches(label, 'REST collection', QUIET_ROWS, await restCollection(ctx, 'QuietLedger', 'QUIET'));
-			assertRowSetMatches(
-				label,
-				'search_by_value',
-				QUIET_ROWS,
-				await searchByBucket(ctx, PURGED_DB, 'QuietLedger', 'QUIET')
-			);
-			assertRowSetMatches(
-				label,
-				'full primary-store scan',
-				QUIET_ROWS,
-				(await fullScan(ctx, PURGED_DB, 'QuietLedger', 'records')).records
-			);
-
-			assertRowSetMatches(label, 'REST collection', REMOTE_ROWS, await restCollection(ctx, 'RemoteLedger', 'REMOTE'));
-			assertRowSetMatches(
-				label,
-				'search_by_value',
-				REMOTE_ROWS,
-				await searchByBucket(ctx, CONTROL_DB, 'RemoteLedger', 'REMOTE')
-			);
-			assertRowSetMatches(
-				label,
-				'full primary-store scan',
-				REMOTE_ROWS,
-				(await fullScan(ctx, CONTROL_DB, 'RemoteLedger', 'records')).records
-			);
-
-			strictEqual(
-				(await fullScan(ctx, PURGED_DB, 'Churn', 'count')).totalCount,
-				churnRows,
-				`[${label}] ${PURGED_DB}.Churn must still hold all ${churnRows} churn rows`
-			);
-			strictEqual(
-				(await fullScan(ctx, CONTROL_DB, 'RemoteChurn', 'count')).totalCount,
-				remoteChurnRows,
-				`[${label}] ${CONTROL_DB}.RemoteChurn must still hold all ${remoteChurnRows} churn rows`
-			);
+			// The churn tables carry the bulk of the purged database's bytes, so counting them is what
+			// stops a purge that ate primary data wholesale from hiding behind the small protected sets.
+			for (const { database, table } of CHURN_TABLES) {
+				const expected = churnCounts.get(table) ?? -1;
+				strictEqual(
+					(await fullScan(ctx, database, table, 'count')).totalCount,
+					expected,
+					`[${label}] ${database}.${table} must still hold all ${expected} churn rows`
+				);
+			}
 			findings.push(
-				`[${label}] primary intact: Ledger ${LEDGER_COUNT}/${LEDGER_COUNT}, QuietLedger ${QUIET_COUNT}/${QUIET_COUNT}, ` +
-					`RemoteLedger ${REMOTE_COUNT}/${REMOTE_COUNT}, Churn ${churnRows}, RemoteChurn ${remoteChurnRows}`
+				`[${label}] primary intact: ` +
+					PROTECTED_TABLES.map(({ table, rows }) => `${table} ${rows.length}/${rows.length}`).join(', ') +
+					', ' +
+					CHURN_TABLES.map(({ table }) => `${table} ${churnCounts.get(table)}`).join(', ')
 			);
 		}
 
@@ -554,9 +532,22 @@ suite(
 			'1. seed the protected rows and prove their audit history is there to lose',
 			{ timeout: 300_000 },
 			async () => {
-				await insertRows(ctx, PURGED_DB, 'Ledger', LEDGER_ROWS);
-				await insertRows(ctx, PURGED_DB, 'QuietLedger', QUIET_ROWS);
-				await insertRows(ctx, CONTROL_DB, 'RemoteLedger', REMOTE_ROWS);
+				for (const { database, table, rows } of PROTECTED_TABLES) {
+					await insertRows(ctx, database, table, rows);
+				}
+
+				// Every protected row must land in one un-rotated log file, so the rotation the next test
+				// forces seals ALL of them into a single purge-eligible file. That is what lets test 5
+				// assert the purged database's audit history reaches exactly zero rather than merely
+				// shrinking, which a partial purge would also satisfy.
+				for (const { database, table } of PROTECTED_TABLES) {
+					const log = logOf(await topology(ctx), database, table);
+					strictEqual(
+						log.rotations,
+						0,
+						`ORACLE ARMING: seeding ${database}.${table} must not rotate its log, got rotations=${log.rotations}`
+					);
+				}
 
 				quietAuditBefore = (
 					await idsWithInsertAudit(
@@ -602,10 +593,12 @@ suite(
 			'2. arm both logs: churn each database past a rotation, flush, then take the cutoff',
 			{ timeout: 900_000 },
 			async () => {
-				const purgedChurn = await churnUntilRotation(ctx, PURGED_DB, 'Churn');
-				churnRows = purgedChurn.rows;
-				const controlChurn = await churnUntilRotation(ctx, CONTROL_DB, 'RemoteChurn');
-				remoteChurnRows = controlChurn.rows;
+				const batches: string[] = [];
+				for (const { database, table } of CHURN_TABLES) {
+					const churn = await churnUntilRotation(ctx, database, table);
+					churnCounts.set(table, churn.rows);
+					batches.push(`${database}.${table} ${churn.rows} rows / ${churn.batches} batches`);
+				}
 
 				for (const [database, table] of [
 					[PURGED_DB, 'Ledger'],
@@ -621,10 +614,7 @@ suite(
 				cutoffTimestamp = Date.now();
 				await sleep(250);
 				armed = true;
-				findings.push(
-					`2. churn: ${PURGED_DB}.Churn ${churnRows} rows / ${purgedChurn.batches} batches, ` +
-						`${CONTROL_DB}.RemoteChurn ${remoteChurnRows} rows / ${controlChurn.batches} batches; cutoff=${cutoffTimestamp}`
-				);
+				findings.push(`2. churn: ${batches.join(', ')}; cutoff=${cutoffTimestamp}`);
 			}
 		);
 
@@ -712,9 +702,10 @@ suite(
 					REMOTE_COUNT,
 					`BLAST-RADIUS INVARIANT: a ${PURGED_DB}-scoped purge must not remove any ${CONTROL_DB} audit entry, got ${remoteAfter}/${REMOTE_COUNT}`
 				);
-				ok(
-					ledgerAfter < ledgerAuditBefore,
-					`NON-VACUOUS PRECONDITION: the purge must have removed audit history from ${PURGED_DB}, but the Ledger sample still holds ${ledgerAfter}/${ledgerAuditBefore} pre-cutoff entries`
+				strictEqual(
+					ledgerAfter,
+					0,
+					`NON-VACUOUS PRECONDITION: the purge must have removed every pre-cutoff Ledger audit entry (all ${LEDGER_COUNT} rows were seeded into one un-rotated, later-sealed log file), but the sample still holds ${ledgerAfter}/${ledgerAuditBefore}`
 				);
 			}
 		);

--- a/integrationTests/database/qa816-purge-blast-radius.test.ts
+++ b/integrationTests/database/qa816-purge-blast-radius.test.ts
@@ -1,6 +1,5 @@
 /**
- * QA-816 — permanent anchor for the transaction-log purge blast radius (promoted from dispatch QA
- * finding qa-wave-2026072616).
+ * QA-816 — permanent anchor for the transaction-log purge blast radius.
  *
  * `delete_transaction_logs_before` on RocksDB deletes whole native transaction-log files, and a
  * RocksDB transaction log is per-DATABASE, not per-table: `RocksTransactionLogStore` is
@@ -12,7 +11,7 @@
  * 30/30 — and (b) confined to audit history: 500/500 primary rows survived every read surface
  * across two clean restarts of the purged instance.
  *
- * THE INVARIANT PINNED HERE is (b): a purge may destroy audit history, and only audit history.
+ * The invariant pinned here is (b): a purge may destroy audit history, and only audit history.
  * Every primary record in the purged database survives the purge and every subsequent restart,
  * value-exact on every read surface, and no database other than the purged one loses audit
  * entries. Any future purge change that escalates from audit loss to primary-data loss goes red.
@@ -23,7 +22,7 @@
  * purge granularity would legitimately remove, so it is reported in the findings block and not
  * asserted; only that sibling's PRIMARY rows are asserted intact.
  *
- * ARMING. A purge that deletes nothing would make every survival assertion vacuously true, and a
+ * Arming: a purge that deletes nothing would make every survival assertion vacuously true, and a
  * control database whose entries merely sit in an unsealed active file would "survive" a purge
  * that leaked across databases. So BOTH databases are churned until their shared log rotates and
  * both are flushed before the cutoff is taken: the native purge only deletes log files entirely
@@ -32,7 +31,7 @@
  * is deliberately NOT the arming signal — it counts eligibility under the 3-day retention policy
  * and is 0 for freshly written files regardless of the explicit cutoff the operation passes.
  *
- * PROOF BOUNDARY. Two clean restarts prove persisted reopen/replay behavior. This file does not
+ * Proof boundary: two clean restarts prove persisted reopen/replay behavior. This file does not
  * prove anything about a crash during the purge, writes racing the cutoff, replication, or LMDB.
  * LMDB is excluded by construction: it keeps a log per table, and a database-scoped purge there is
  * a no-op (the purge loop only handles RocksDB tables), so an LMDB arm would assert survival after
@@ -168,7 +167,7 @@ async function restJson(
 ): Promise<{ status: number; body: any }> {
 	const res = await fetch(`${ctx.harper.httpURL}${path}`, {
 		...init,
-		headers: { Authorization: authHeader(ctx), ...(init.headers ?? {}) },
+		headers: { Authorization: authHeader(ctx), ...init.headers },
 		signal: AbortSignal.timeout(timeoutMs),
 	});
 	let body: any = null;

--- a/integrationTests/database/qa816-purge-blast-radius.test.ts
+++ b/integrationTests/database/qa816-purge-blast-radius.test.ts
@@ -1,0 +1,707 @@
+/**
+ * QA-816 — permanent anchor for the transaction-log purge blast radius (promoted from dispatch QA
+ * finding qa-wave-2026072616).
+ *
+ * `delete_transaction_logs_before` on RocksDB deletes whole native transaction-log files, and a
+ * RocksDB transaction log is per-DATABASE, not per-table: `RocksTransactionLogStore` is
+ * constructed once per root database (`resources/auditStore.ts`), and the purge walks the database
+ * and stops after the first RocksDB table because "all tables share the same transaction log
+ * store" (`dataLayer/harperBridge/ResourceBridge.ts`). The live measurement behind this file found
+ * that the resulting audit loss is (a) database-scoped — a quiet table in the SAME database as a
+ * churning sibling lost 30/30 of its audit entries while a table in a different database kept
+ * 30/30 — and (b) confined to audit history: 500/500 primary rows survived every read surface
+ * across two clean restarts of the purged instance.
+ *
+ * THE INVARIANT PINNED HERE is (b): a purge may destroy audit history, and only audit history.
+ * Every primary record in the purged database survives the purge and every subsequent restart,
+ * value-exact on every read surface, and no database other than the purged one loses audit
+ * entries. Any future purge change that escalates from audit loss to primary-data loss goes red.
+ *
+ * Half (a) is asserted only in the direction that stays true under improvement. "A different
+ * database never loses audit entries" is a real invariant and is asserted. "A quiet same-database
+ * sibling loses its audit" is a consequence of one native log per database that a future per-table
+ * purge granularity would legitimately remove, so it is reported in the findings block and not
+ * asserted; only that sibling's PRIMARY rows are asserted intact.
+ *
+ * ARMING. A purge that deletes nothing would make every survival assertion vacuously true, and a
+ * control database whose entries merely sit in an unsealed active file would "survive" a purge
+ * that leaked across databases. So BOTH databases are churned until their shared log rotates and
+ * both are flushed before the cutoff is taken: the native purge only deletes log files entirely
+ * before the last-flushed-to-RocksDB position (`resources/auditStore.ts`, `purgeAgedLogs`), so a
+ * sealed-and-flushed oldest file is what makes each log genuinely purge-eligible. `purgeableFiles`
+ * is deliberately NOT the arming signal — it counts eligibility under the 3-day retention policy
+ * and is 0 for freshly written files regardless of the explicit cutoff the operation passes.
+ *
+ * PROOF BOUNDARY. Two clean restarts prove persisted reopen/replay behavior. This file does not
+ * prove anything about a crash during the purge, writes racing the cutoff, replication, or LMDB.
+ * LMDB is excluded by construction: it keeps a log per table, and a database-scoped purge there is
+ * a no-op (the purge loop only handles RocksDB tables), so an LMDB arm would assert survival after
+ * a purge that never ran. Equality on the read surfaces is value-exact over every seeded field,
+ * not literal on-disk byte identity.
+ *
+ * Reproduction:
+ *   cd <harper checkout> && npm run build && npm run test:integration -- \
+ *     "integrationTests/database/qa816-purge-blast-radius.test.ts"
+ *
+ * Related: rocksdb-js#808 (purge-wedge root cause), harper#846, harper#2049 (the table-scoped
+ * purge refusal that this file's database-scoped call routes around).
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual, deepStrictEqual } from 'node:assert';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+	setupHarperWithFixture,
+	teardownHarper,
+	killHarper,
+	startHarper,
+	type ContextWithHarper,
+} from '@harperfast/integration-testing';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'qa816-purge-blast-radius');
+const PURGED_DB = 'qa816a';
+const CONTROL_DB = 'qa816b';
+const skipSuite = process.env.HARPER_RUNTIME === 'bun';
+
+const LEDGER_COUNT = 500;
+const QUIET_COUNT = 30;
+const REMOTE_COUNT = 30;
+const LEDGER_SAMPLE_COUNT = 8;
+const SEED_BATCH = 250;
+
+const CHURN_PAYLOAD = 'c'.repeat(64 * 1024);
+const CHURN_BATCH = 16;
+const CHURN_BATCH_BYTES = CHURN_BATCH * CHURN_PAYLOAD.length;
+const DEFAULT_MAX_FILE_SIZE = 16 * 1024 * 1024;
+
+interface SeededRow {
+	id: string;
+	bucket: string;
+	seq: number;
+	payload: string;
+}
+
+interface LogInfo {
+	path: string;
+	fileCount: number;
+	oldestSequenceNumber: number;
+	currentSequenceNumber: number;
+	lastFlushedSequence: number;
+	rotations: number;
+	filesPurged: number;
+	entriesWritten: number;
+	maxFileSize: number;
+}
+
+interface TableTopology {
+	database: string;
+	table: string;
+	engineGuess: string;
+	auditStoreId: number;
+	logId: number;
+	log: LogInfo | null;
+}
+
+type Topology = Record<string, TableTopology>;
+
+function protectedRows(prefix: string, bucket: string, count: number): SeededRow[] {
+	return Array.from({ length: count }, (_, i) => ({
+		id: `${prefix}-${i}`,
+		bucket,
+		seq: i,
+		payload: `${prefix}:${i}:${'p'.repeat(48)}`,
+	}));
+}
+
+const LEDGER_ROWS = protectedRows('ledger', 'LEDGER', LEDGER_COUNT);
+const QUIET_ROWS = protectedRows('quiet', 'QUIET', QUIET_COUNT);
+const REMOTE_ROWS = protectedRows('remote', 'REMOTE', REMOTE_COUNT);
+const LEDGER_SAMPLE_IDS = Array.from(
+	{ length: LEDGER_SAMPLE_COUNT },
+	(_, i) => LEDGER_ROWS[Math.floor((i * LEDGER_COUNT) / LEDGER_SAMPLE_COUNT)].id
+);
+const LEDGER_AUDIT_SAMPLE_IDS = Array.from(
+	{ length: 40 },
+	(_, i) => LEDGER_ROWS[Math.floor((i * LEDGER_COUNT) / 40)].id
+);
+
+function authHeader(ctx: ContextWithHarper): string {
+	const { username, password } = ctx.harper.admin;
+	return 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
+}
+
+async function rawOp(
+	ctx: ContextWithHarper,
+	operation: any,
+	timeoutMs = 60_000
+): Promise<{ status: number; body: any; text: string }> {
+	const res = await fetch(ctx.harper.operationsAPIURL, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', 'Authorization': authHeader(ctx) },
+		body: JSON.stringify(operation),
+		signal: AbortSignal.timeout(timeoutMs),
+	});
+	const text = await res.text();
+	let body: any;
+	try {
+		body = JSON.parse(text);
+	} catch {
+		body = text;
+	}
+	return { status: res.status, body, text };
+}
+
+async function restJson(
+	ctx: ContextWithHarper,
+	path: string,
+	init: RequestInit = {},
+	timeoutMs = 120_000
+): Promise<{ status: number; body: any }> {
+	const res = await fetch(`${ctx.harper.httpURL}${path}`, {
+		...init,
+		headers: { Authorization: authHeader(ctx), ...(init.headers ?? {}) },
+		signal: AbortSignal.timeout(timeoutMs),
+	});
+	let body: any = null;
+	try {
+		body = await res.json();
+	} catch {
+		/* non-JSON / empty */
+	}
+	return { status: res.status, body };
+}
+
+async function pollReadiness(ctx: ContextWithHarper): Promise<void> {
+	const deadline = Date.now() + 90_000;
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(`${ctx.harper.httpURL}/Probe/`, {
+				headers: { Authorization: authHeader(ctx) },
+				signal: AbortSignal.timeout(5_000),
+			});
+			if (res.status !== 404) return;
+		} catch {
+			/* not ready */
+		}
+		await sleep(250);
+	}
+	throw new Error('QA-816: Probe route never became ready within 90s');
+}
+
+async function pollJob(ctx: ContextWithHarper, jobId: string, timeoutMs = 120_000): Promise<any> {
+	const deadline = Date.now() + timeoutMs;
+	let last: any;
+	while (Date.now() < deadline) {
+		const r = await rawOp(ctx, { operation: 'get_job', id: jobId });
+		strictEqual(r.status, 200, `get_job(${jobId}) failed with ${r.status}: ${r.text.slice(0, 300)}`);
+		last = Array.isArray(r.body) ? r.body[0] : r.body;
+		ok(last && typeof last === 'object', `get_job(${jobId}) returned a malformed record: ${r.text.slice(0, 300)}`);
+		if (last.status === 'COMPLETE' || last.status === 'ERROR') return last;
+		await sleep(500);
+	}
+	throw new Error(`QA-816: job ${jobId} did not settle within ${timeoutMs}ms; last=${JSON.stringify(last)}`);
+}
+
+async function topology(ctx: ContextWithHarper): Promise<Topology> {
+	const r = await restJson(ctx, '/LogTopology/');
+	strictEqual(r.status, 200, `/LogTopology/ expected 200, got ${r.status}: ${JSON.stringify(r.body)}`);
+	return r.body as Topology;
+}
+
+function logOf(topo: Topology, database: string, table: string): LogInfo {
+	const entry = topo[`${database}.${table}`];
+	ok(entry?.log, `QA-816: no transaction-log stats for ${database}.${table}: ${JSON.stringify(entry)}`);
+	return entry.log;
+}
+
+async function flushDatabase(ctx: ContextWithHarper, database: string): Promise<void> {
+	const r = await restJson(ctx, `/Flush/?database=${database}`, { method: 'POST' });
+	strictEqual(r.status, 200, `/Flush/ ${database} expected 200, got ${r.status}: ${JSON.stringify(r.body)}`);
+	strictEqual(r.body?.flushed, true, `/Flush/ ${database} must actually flush, got ${JSON.stringify(r.body)}`);
+}
+
+/**
+ * Flush until the log's oldest file is both sealed and fully applied to RocksDB — the two
+ * conditions that make it eligible for the native purge. The last-flushed position cannot pass an
+ * unflushed column family, and RocksDB's own size-triggered flushes race the test, so this is
+ * polled rather than asserted after a single flush.
+ */
+async function flushUntilPurgeable(ctx: ContextWithHarper, database: string, table: string): Promise<LogInfo> {
+	const deadline = Date.now() + 60_000;
+	let log: LogInfo;
+	do {
+		await flushDatabase(ctx, database);
+		log = logOf(await topology(ctx), database, table);
+		if (log.oldestSequenceNumber < log.currentSequenceNumber && log.lastFlushedSequence > log.oldestSequenceNumber)
+			return log;
+		await sleep(250);
+	} while (Date.now() < deadline);
+	throw new Error(
+		`ORACLE ARMING: ${database}'s oldest transaction-log file never became sealed and fully flushed within 60s ` +
+			`(oldest=${log.oldestSequenceNumber} current=${log.currentSequenceNumber} lastFlushed=${log.lastFlushedSequence})`
+	);
+}
+
+async function insertRows(ctx: ContextWithHarper, database: string, table: string, rows: SeededRow[]): Promise<void> {
+	for (let start = 0; start < rows.length; start += SEED_BATCH) {
+		const records = rows.slice(start, start + SEED_BATCH);
+		const r = await rawOp(ctx, { operation: 'insert', database, table, records }, 120_000);
+		strictEqual(
+			r.status,
+			200,
+			`insert ${database}.${table}@${start} expected 200, got ${r.status}: ${r.text.slice(0, 300)}`
+		);
+	}
+}
+
+/**
+ * Write fat rows into `table` until its database's shared log rotates at least once, so the
+ * already-seeded protected entries end up in a sealed file. Bounded by the log's own configured
+ * file size rather than a hardcoded byte count, which would go vacuous (or hang) if the rocksdb-js
+ * rotation default moved.
+ */
+async function churnUntilRotation(
+	ctx: ContextWithHarper,
+	database: string,
+	table: string
+): Promise<{ rows: number; batches: number; bytes: number }> {
+	const before = logOf(await topology(ctx), database, table);
+	const maxFileSize = before.maxFileSize > 0 ? before.maxFileSize : DEFAULT_MAX_FILE_SIZE;
+	const batchCap = Math.ceil((maxFileSize * 3) / CHURN_BATCH_BYTES) + 8;
+	let rows = 0;
+	for (let batch = 0; batch < batchCap; batch++) {
+		const records = Array.from({ length: CHURN_BATCH }, (_, i) => ({
+			id: `churn-${rows + i}`,
+			bucket: 'CHURN',
+			seq: rows + i,
+			payload: CHURN_PAYLOAD,
+		}));
+		const r = await rawOp(ctx, { operation: 'insert', database, table, records }, 120_000);
+		strictEqual(
+			r.status,
+			200,
+			`churn insert ${database}.${table}@${rows} expected 200, got ${r.status}: ${r.text.slice(0, 300)}`
+		);
+		rows += CHURN_BATCH;
+		const after = logOf(await topology(ctx), database, table);
+		if (after.rotations > before.rotations) return { rows, batches: batch + 1, bytes: rows * CHURN_PAYLOAD.length };
+	}
+	throw new Error(
+		`QA-816: ${database} transaction log never rotated after ${rows} churn rows (${(rows * CHURN_PAYLOAD.length) / 1024 / 1024}MiB, maxFileSize=${maxFileSize})`
+	);
+}
+
+/** Ids whose audit history still holds an insert entry (optionally, one older than `before`). */
+async function idsWithInsertAudit(
+	ctx: ContextWithHarper,
+	database: string,
+	table: string,
+	ids: string[],
+	before?: number
+): Promise<string[]> {
+	const r = await rawOp(
+		ctx,
+		{ operation: 'read_audit_log', database, table, search_type: 'hash_value', search_values: ids },
+		120_000
+	);
+	strictEqual(
+		r.status,
+		200,
+		`read_audit_log ${database}.${table} expected 200, got ${r.status}: ${r.text.slice(0, 300)}`
+	);
+	return ids.filter((id) => {
+		const entries = Array.isArray(r.body?.[id]) ? r.body[id] : [];
+		return entries.some((entry: any) => {
+			if (entry?.operation !== 'insert') return false;
+			if (before === undefined) return true;
+			const timestamp = Number(entry.timestamp);
+			return Number.isFinite(timestamp) && timestamp < before;
+		});
+	});
+}
+
+function assertRowSetMatches(label: string, surface: string, expected: SeededRow[], actual: any[]): void {
+	const byId = new Map<string, any>();
+	for (const record of actual) {
+		ok(!byId.has(record.id), `[${label}] ${surface} returned duplicate id ${record.id}`);
+		byId.set(record.id, record);
+	}
+	strictEqual(
+		byId.size,
+		expected.length,
+		`[${label}] ${surface} must return exactly ${expected.length} rows, got ${byId.size}`
+	);
+	for (const row of expected) {
+		const record = byId.get(row.id);
+		ok(record, `[${label}] ${surface} lost row ${row.id}`);
+		deepStrictEqual(
+			{ id: record.id, bucket: record.bucket, seq: record.seq, payload: record.payload },
+			row,
+			`[${label}] ${surface} returned a modified row for ${row.id}`
+		);
+	}
+}
+
+async function restCollection(ctx: ContextWithHarper, table: string, bucket: string): Promise<any[]> {
+	const r = await restJson(ctx, `/${table}/?bucket=${bucket}`);
+	strictEqual(r.status, 200, `REST /${table}/?bucket=${bucket} expected 200, got ${r.status}`);
+	ok(
+		Array.isArray(r.body),
+		`REST /${table}/?bucket=${bucket} must return an array, got ${JSON.stringify(r.body)?.slice(0, 200)}`
+	);
+	return r.body;
+}
+
+async function searchByBucket(ctx: ContextWithHarper, database: string, table: string, bucket: string): Promise<any[]> {
+	const r = await rawOp(
+		ctx,
+		{
+			operation: 'search_by_value',
+			database,
+			table,
+			search_attribute: 'bucket',
+			search_value: bucket,
+			get_attributes: ['id', 'bucket', 'seq', 'payload'],
+		},
+		120_000
+	);
+	strictEqual(
+		r.status,
+		200,
+		`search_by_value(${database}.${table}) expected 200, got ${r.status}: ${r.text.slice(0, 300)}`
+	);
+	ok(Array.isArray(r.body), `search_by_value(${database}.${table}) must return an array`);
+	return r.body;
+}
+
+async function fullScan(
+	ctx: ContextWithHarper,
+	database: string,
+	table: string,
+	mode: 'count' | 'records'
+): Promise<{ totalCount: number; records: any[] }> {
+	const r = await restJson(ctx, `/FullScan/?database=${database}&table=${table}&mode=${mode}`);
+	strictEqual(
+		r.status,
+		200,
+		`/FullScan/ ${database}.${table} expected 200, got ${r.status}: ${JSON.stringify(r.body)?.slice(0, 200)}`
+	);
+	return r.body;
+}
+
+suite(
+	'QA-816 purge blast radius: audit-durability-only, never primary data [rocksdb]',
+	{ skip: skipSuite },
+	(ctx: ContextWithHarper) => {
+		const findings: string[] = [];
+		const armConfig = {
+			threads: { count: 1 },
+			logging: { auditLog: true, console: true, level: 'error' },
+			storage: { engine: 'rocksdb' },
+		};
+		let churnRows = 0;
+		let remoteChurnRows = 0;
+		let cutoffTimestamp = Number.NaN;
+		let armed = false;
+		let quietAuditBefore = 0;
+		let ledgerAuditBefore = 0;
+
+		function assertArmed(): void {
+			ok(armed, 'PRECONDITION: the seed/arm phase must complete before the purge, read, or restart probes run');
+		}
+
+		/**
+		 * The headline check. Every protected primary row in BOTH databases, value-exact, on three
+		 * independent read surfaces plus a point-read sample — and the churn tables' rows counted, so a
+		 * purge that ate primary data in bulk cannot hide behind the protected tables.
+		 */
+		async function assertPrimaryIntact(label: string): Promise<void> {
+			assertRowSetMatches(label, 'REST collection', LEDGER_ROWS, await restCollection(ctx, 'Ledger', 'LEDGER'));
+			assertRowSetMatches(
+				label,
+				'search_by_value',
+				LEDGER_ROWS,
+				await searchByBucket(ctx, PURGED_DB, 'Ledger', 'LEDGER')
+			);
+			const ledgerScan = await fullScan(ctx, PURGED_DB, 'Ledger', 'records');
+			assertRowSetMatches(label, 'full primary-store scan', LEDGER_ROWS, ledgerScan.records);
+			strictEqual(
+				ledgerScan.totalCount,
+				LEDGER_COUNT,
+				`[${label}] full scan of ${PURGED_DB}.Ledger must total ${LEDGER_COUNT}`
+			);
+
+			for (const id of LEDGER_SAMPLE_IDS) {
+				const r = await restJson(ctx, `/Ledger/${id}`);
+				strictEqual(r.status, 200, `[${label}] REST GET /Ledger/${id} expected 200, got ${r.status}`);
+				const expected = LEDGER_ROWS.find((row) => row.id === id);
+				deepStrictEqual(
+					{ id: r.body?.id, bucket: r.body?.bucket, seq: r.body?.seq, payload: r.body?.payload },
+					expected,
+					`[${label}] REST GET /Ledger/${id} returned a modified row`
+				);
+			}
+
+			assertRowSetMatches(label, 'REST collection', QUIET_ROWS, await restCollection(ctx, 'QuietLedger', 'QUIET'));
+			assertRowSetMatches(
+				label,
+				'full primary-store scan',
+				QUIET_ROWS,
+				(await fullScan(ctx, PURGED_DB, 'QuietLedger', 'records')).records
+			);
+
+			assertRowSetMatches(label, 'REST collection', REMOTE_ROWS, await restCollection(ctx, 'RemoteLedger', 'REMOTE'));
+			assertRowSetMatches(
+				label,
+				'search_by_value',
+				REMOTE_ROWS,
+				await searchByBucket(ctx, CONTROL_DB, 'RemoteLedger', 'REMOTE')
+			);
+			assertRowSetMatches(
+				label,
+				'full primary-store scan',
+				REMOTE_ROWS,
+				(await fullScan(ctx, CONTROL_DB, 'RemoteLedger', 'records')).records
+			);
+
+			strictEqual(
+				(await fullScan(ctx, PURGED_DB, 'Churn', 'count')).totalCount,
+				churnRows,
+				`[${label}] ${PURGED_DB}.Churn must still hold all ${churnRows} churn rows`
+			);
+			strictEqual(
+				(await fullScan(ctx, CONTROL_DB, 'RemoteChurn', 'count')).totalCount,
+				remoteChurnRows,
+				`[${label}] ${CONTROL_DB}.RemoteChurn must still hold all ${remoteChurnRows} churn rows`
+			);
+			findings.push(
+				`[${label}] primary intact: Ledger ${LEDGER_COUNT}/${LEDGER_COUNT}, QuietLedger ${QUIET_COUNT}/${QUIET_COUNT}, ` +
+					`RemoteLedger ${REMOTE_COUNT}/${REMOTE_COUNT}, Churn ${churnRows}, RemoteChurn ${remoteChurnRows}`
+			);
+		}
+
+		before(async () => {
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: armConfig, env: { HARPER_STORAGE_ENGINE: 'rocksdb' } });
+			await pollReadiness(ctx);
+		});
+
+		after(async () => {
+			try {
+				await teardownHarper(ctx);
+			} finally {
+				// eslint-disable-next-line no-console
+				console.log(`\n=== QA-816 findings ===\n${findings.map((f) => '  ' + f).join('\n')}\n`);
+			}
+		});
+
+		test('0. precondition: one native transaction log per database, shared by its tables', async () => {
+			const topo = await topology(ctx);
+			for (const [key, entry] of Object.entries(topo)) {
+				strictEqual(entry.engineGuess, 'rocksdb', `PRECONDITION: ${key} must be on RocksDB, got ${entry.engineGuess}`);
+			}
+
+			const purged = [topo[`${PURGED_DB}.Ledger`], topo[`${PURGED_DB}.QuietLedger`], topo[`${PURGED_DB}.Churn`]];
+			const control = [topo[`${CONTROL_DB}.RemoteLedger`], topo[`${CONTROL_DB}.RemoteChurn`]];
+			for (const group of [purged, control]) {
+				for (const entry of group.slice(1)) {
+					strictEqual(
+						entry.auditStoreId,
+						group[0].auditStoreId,
+						`PRECONDITION: ${entry.database}.${entry.table} must share ${group[0].table}'s audit store`
+					);
+					strictEqual(
+						entry.logId,
+						group[0].logId,
+						`PRECONDITION: ${entry.database}.${entry.table} must share ${group[0].table}'s native transaction log`
+					);
+				}
+			}
+			ok(
+				purged[0].logId !== control[0].logId,
+				`PRECONDITION: ${PURGED_DB} and ${CONTROL_DB} must not share a transaction log (both logId=${purged[0].logId})`
+			);
+			findings.push(
+				`0. ${PURGED_DB} log=${purged[0].log?.path} (shared by ${purged.length} tables); ` +
+					`${CONTROL_DB} log=${control[0].log?.path} (shared by ${control.length} tables); ` +
+					`maxFileSize=${purged[0].log?.maxFileSize}`
+			);
+		});
+
+		test(
+			'1. seed the protected rows and prove their audit history is there to lose',
+			{ timeout: 300_000 },
+			async () => {
+				await insertRows(ctx, PURGED_DB, 'Ledger', LEDGER_ROWS);
+				await insertRows(ctx, PURGED_DB, 'QuietLedger', QUIET_ROWS);
+				await insertRows(ctx, CONTROL_DB, 'RemoteLedger', REMOTE_ROWS);
+
+				quietAuditBefore = (
+					await idsWithInsertAudit(
+						ctx,
+						PURGED_DB,
+						'QuietLedger',
+						QUIET_ROWS.map((r) => r.id)
+					)
+				).length;
+				ledgerAuditBefore = (await idsWithInsertAudit(ctx, PURGED_DB, 'Ledger', LEDGER_AUDIT_SAMPLE_IDS)).length;
+				const remoteAuditBefore = (
+					await idsWithInsertAudit(
+						ctx,
+						CONTROL_DB,
+						'RemoteLedger',
+						REMOTE_ROWS.map((r) => r.id)
+					)
+				).length;
+
+				findings.push(
+					`1. pre-purge audit: QuietLedger ${quietAuditBefore}/${QUIET_COUNT}, ` +
+						`Ledger sample ${ledgerAuditBefore}/${LEDGER_AUDIT_SAMPLE_IDS.length}, RemoteLedger ${remoteAuditBefore}/${REMOTE_COUNT}`
+				);
+				strictEqual(
+					quietAuditBefore,
+					QUIET_COUNT,
+					'ORACLE ARMING: every QuietLedger row must have audit history before the purge'
+				);
+				strictEqual(
+					ledgerAuditBefore,
+					LEDGER_AUDIT_SAMPLE_IDS.length,
+					'ORACLE ARMING: every sampled Ledger row must have audit history before the purge'
+				);
+				strictEqual(
+					remoteAuditBefore,
+					REMOTE_COUNT,
+					'ORACLE ARMING: every RemoteLedger row must have audit history before the purge'
+				);
+			}
+		);
+
+		test(
+			'2. arm both logs: churn each database past a rotation, flush, then take the cutoff',
+			{ timeout: 900_000 },
+			async () => {
+				const purgedChurn = await churnUntilRotation(ctx, PURGED_DB, 'Churn');
+				churnRows = purgedChurn.rows;
+				const controlChurn = await churnUntilRotation(ctx, CONTROL_DB, 'RemoteChurn');
+				remoteChurnRows = controlChurn.rows;
+
+				for (const [database, table] of [
+					[PURGED_DB, 'Ledger'],
+					[CONTROL_DB, 'RemoteLedger'],
+				] as const) {
+					const log = await flushUntilPurgeable(ctx, database, table);
+					findings.push(
+						`2. ${database} log armed: files=${log.fileCount} oldestSeq=${log.oldestSequenceNumber} ` +
+							`currentSeq=${log.currentSequenceNumber} lastFlushedSeq=${log.lastFlushedSequence} rotations=${log.rotations}`
+					);
+				}
+
+				cutoffTimestamp = Date.now();
+				await sleep(250);
+				armed = true;
+				findings.push(
+					`2. churn: ${PURGED_DB}.Churn ${churnRows} rows / ${purgedChurn.batches} batches, ` +
+						`${CONTROL_DB}.RemoteChurn ${remoteChurnRows} rows / ${controlChurn.batches} batches; cutoff=${cutoffTimestamp}`
+				);
+			}
+		);
+
+		test(`3. purge ${PURGED_DB} and prove the purge was real`, { timeout: 180_000 }, async () => {
+			assertArmed();
+			const ack = await rawOp(ctx, {
+				operation: 'delete_transaction_logs_before',
+				database: PURGED_DB,
+				timestamp: cutoffTimestamp,
+			});
+			strictEqual(
+				ack.status,
+				200,
+				`delete_transaction_logs_before expected 200, got ${ack.status}: ${ack.text.slice(0, 300)}`
+			);
+			ok(ack.body?.job_id, `delete_transaction_logs_before must return a job_id, got ${ack.text.slice(0, 300)}`);
+
+			const job = await pollJob(ctx, ack.body.job_id);
+			findings.push(
+				`3. purge job: status=${job.status} result=${JSON.stringify(job.result)} message=${job.message ?? ''}`
+			);
+			strictEqual(job.status, 'COMPLETE', `purge job must COMPLETE, got ${job.status}: ${job.message}`);
+			ok(
+				job.result && typeof job.result === 'object',
+				`purge job must carry a result object, got ${JSON.stringify(job.result)}`
+			);
+			ok(
+				Number(job.result.entries_deleted) > 0,
+				`NON-VACUOUS PRECONDITION: the purge must delete audit entries, got entries_deleted=${job.result.entries_deleted}`
+			);
+			ok(
+				Number(job.result.log_files_deleted) > 0,
+				`NON-VACUOUS PRECONDITION: the purge must delete log files, got log_files_deleted=${job.result.log_files_deleted}`
+			);
+		});
+
+		test('4. KEY TEST (same process): every primary row survives the purge', { timeout: 300_000 }, async () => {
+			assertArmed();
+			await assertPrimaryIntact('4. POST-PURGE same process');
+		});
+
+		test(
+			'5. restart #1: primary rows survive, and the audit loss is confined to the purged database',
+			{ timeout: 300_000 },
+			async () => {
+				assertArmed();
+				await killHarper(ctx as any);
+				await startHarper(ctx, { config: armConfig, env: { HARPER_STORAGE_ENGINE: 'rocksdb' } });
+				await pollReadiness(ctx);
+
+				await assertPrimaryIntact('5. POST-RESTART-1');
+
+				// Measured after a restart on purpose: an in-process transaction-log read cache can keep
+				// serving purged audit entries until the process restarts (rocksdb-js#808), so a
+				// same-process audit read is not authoritative about what is actually on disk.
+				const remoteAfter = (
+					await idsWithInsertAudit(
+						ctx,
+						CONTROL_DB,
+						'RemoteLedger',
+						REMOTE_ROWS.map((r) => r.id),
+						cutoffTimestamp
+					)
+				).length;
+				const ledgerAfter = (
+					await idsWithInsertAudit(ctx, PURGED_DB, 'Ledger', LEDGER_AUDIT_SAMPLE_IDS, cutoffTimestamp)
+				).length;
+				const quietAfter = (
+					await idsWithInsertAudit(
+						ctx,
+						PURGED_DB,
+						'QuietLedger',
+						QUIET_ROWS.map((r) => r.id),
+						cutoffTimestamp
+					)
+				).length;
+				findings.push(
+					`5. post-restart audit: RemoteLedger ${remoteAfter}/${REMOTE_COUNT} (control, must be whole), ` +
+						`Ledger sample ${ledgerAfter}/${ledgerAuditBefore}, QuietLedger ${quietAfter}/${quietAuditBefore} ` +
+						`(quiet same-database sibling — reported, not asserted)`
+				);
+
+				strictEqual(
+					remoteAfter,
+					REMOTE_COUNT,
+					`BLAST-RADIUS INVARIANT: a ${PURGED_DB}-scoped purge must not remove any ${CONTROL_DB} audit entry, got ${remoteAfter}/${REMOTE_COUNT}`
+				);
+				ok(
+					ledgerAfter < ledgerAuditBefore,
+					`NON-VACUOUS PRECONDITION: the purge must have removed audit history from ${PURGED_DB}, but the Ledger sample still holds ${ledgerAfter}/${ledgerAuditBefore} pre-cutoff entries`
+				);
+			}
+		);
+
+		test('6. restart #2: primary rows still survive a second clean restart', { timeout: 300_000 }, async () => {
+			assertArmed();
+			await killHarper(ctx as any);
+			await startHarper(ctx, { config: armConfig, env: { HARPER_STORAGE_ENGINE: 'rocksdb' } });
+			await pollReadiness(ctx);
+			await assertPrimaryIntact('6. POST-RESTART-2');
+		});
+	}
+);

--- a/integrationTests/database/qa816-purge-blast-radius.test.ts
+++ b/integrationTests/database/qa816-purge-blast-radius.test.ts
@@ -166,26 +166,31 @@ async function restJson(
 	try {
 		body = await res.json();
 	} catch {
-		/* non-JSON / empty */
+		body = null;
 	}
 	return { status: res.status, body };
 }
 
+// Ready means the probe answers 200. A 404 is the fixture still loading; anything else (500 from a
+// half-started server, 401 before auth is up) would otherwise read as "ready" and surface later as
+// an opaque failure in whichever operation ran next.
 async function pollReadiness(ctx: ContextWithHarper): Promise<void> {
 	const deadline = Date.now() + 90_000;
+	let last = 'no response';
 	while (Date.now() < deadline) {
 		try {
 			const res = await fetch(`${ctx.harper.httpURL}/Probe/`, {
 				headers: { Authorization: authHeader(ctx) },
 				signal: AbortSignal.timeout(5_000),
 			});
-			if (res.status !== 404) return;
-		} catch {
-			/* not ready */
+			if (res.status === 200) return;
+			last = `HTTP ${res.status}`;
+		} catch (error) {
+			last = String((error as Error)?.message ?? error);
 		}
 		await sleep(250);
 	}
-	throw new Error('QA-816: Probe route never became ready within 90s');
+	throw new Error(`QA-816: Probe route never answered 200 within 90s; last=${last}`);
 }
 
 async function pollJob(ctx: ContextWithHarper, jobId: string, timeoutMs = 120_000): Promise<any> {
@@ -286,12 +291,19 @@ async function churnUntilRotation(
 		const after = logOf(await topology(ctx), database, table);
 		if (after.rotations > before.rotations) return { rows, batches: batch + 1, bytes: rows * CHURN_PAYLOAD.length };
 	}
+	// Rotation is observed asynchronously, so exhausting the write budget is not yet a failure —
+	// give the already-written bytes a bounded window to show up as a rotation before calling it one.
+	const deadline = Date.now() + 60_000;
+	while (Date.now() < deadline) {
+		await sleep(250);
+		const after = logOf(await topology(ctx), database, table);
+		if (after.rotations > before.rotations) return { rows, batches: batchCap, bytes: rows * CHURN_PAYLOAD.length };
+	}
 	throw new Error(
 		`QA-816: ${database} transaction log never rotated after ${rows} churn rows (${(rows * CHURN_PAYLOAD.length) / 1024 / 1024}MiB, maxFileSize=${maxFileSize})`
 	);
 }
 
-/** Ids whose audit history still holds an insert entry (optionally, one older than `before`). */
 async function idsWithInsertAudit(
 	ctx: ContextWithHarper,
 	database: string,
@@ -445,6 +457,12 @@ suite(
 			assertRowSetMatches(label, 'REST collection', QUIET_ROWS, await restCollection(ctx, 'QuietLedger', 'QUIET'));
 			assertRowSetMatches(
 				label,
+				'search_by_value',
+				QUIET_ROWS,
+				await searchByBucket(ctx, PURGED_DB, 'QuietLedger', 'QUIET')
+			);
+			assertRowSetMatches(
+				label,
 				'full primary-store scan',
 				QUIET_ROWS,
 				(await fullScan(ctx, PURGED_DB, 'QuietLedger', 'records')).records
@@ -500,8 +518,13 @@ suite(
 				strictEqual(entry.engineGuess, 'rocksdb', `PRECONDITION: ${key} must be on RocksDB, got ${entry.engineGuess}`);
 			}
 
-			const purged = [topo[`${PURGED_DB}.Ledger`], topo[`${PURGED_DB}.QuietLedger`], topo[`${PURGED_DB}.Churn`]];
-			const control = [topo[`${CONTROL_DB}.RemoteLedger`], topo[`${CONTROL_DB}.RemoteChurn`]];
+			const lookup = (database: string, table: string): TableTopology => {
+				const entry = topo[`${database}.${table}`];
+				ok(entry, `PRECONDITION: ${database}.${table} is missing from the topology: ${Object.keys(topo).join(', ')}`);
+				return entry;
+			};
+			const purged = [lookup(PURGED_DB, 'Ledger'), lookup(PURGED_DB, 'QuietLedger'), lookup(PURGED_DB, 'Churn')];
+			const control = [lookup(CONTROL_DB, 'RemoteLedger'), lookup(CONTROL_DB, 'RemoteChurn')];
 			for (const group of [purged, control]) {
 				for (const entry of group.slice(1)) {
 					strictEqual(

--- a/integrationTests/database/qa816-purge-blast-radius.test.ts
+++ b/integrationTests/database/qa816-purge-blast-radius.test.ts
@@ -164,19 +164,20 @@ async function restJson(
 	path: string,
 	init: RequestInit = {},
 	timeoutMs = 120_000
-): Promise<{ status: number; body: any }> {
+): Promise<{ status: number; body: any; text: string }> {
 	const res = await fetch(`${ctx.harper.httpURL}${path}`, {
 		...init,
 		headers: { Authorization: authHeader(ctx), ...init.headers },
 		signal: AbortSignal.timeout(timeoutMs),
 	});
+	const text = await res.text();
 	let body: any = null;
 	try {
-		body = await res.json();
+		body = JSON.parse(text);
 	} catch {
 		body = null;
 	}
-	return { status: res.status, body };
+	return { status: res.status, body, text };
 }
 
 // Ready means the probe answers 200. A 404 is the fixture still loading; anything else (500 from a
@@ -201,23 +202,28 @@ async function pollReadiness(ctx: ContextWithHarper): Promise<void> {
 	throw new Error(`QA-816: Probe route never answered 200 within 90s; last=${last}`);
 }
 
+// A job record can be briefly unreadable right after the ack, so a non-200 or malformed tick is a
+// reason to poll again rather than to fail; only the deadline is fatal, and it reports the last tick.
 async function pollJob(ctx: ContextWithHarper, jobId: string, timeoutMs = 120_000): Promise<any> {
 	const deadline = Date.now() + timeoutMs;
-	let last: any;
+	let last = 'no response';
 	while (Date.now() < deadline) {
 		const r = await rawOp(ctx, { operation: 'get_job', id: jobId });
-		strictEqual(r.status, 200, `get_job(${jobId}) failed with ${r.status}: ${r.text.slice(0, 300)}`);
-		last = Array.isArray(r.body) ? r.body[0] : r.body;
-		ok(last && typeof last === 'object', `get_job(${jobId}) returned a malformed record: ${r.text.slice(0, 300)}`);
-		if (last.status === 'COMPLETE' || last.status === 'ERROR') return last;
+		const record = Array.isArray(r.body) ? r.body[0] : r.body;
+		if (r.status === 200 && record && typeof record === 'object') {
+			if (record.status === 'COMPLETE' || record.status === 'ERROR') return record;
+			last = `status=${record.status}`;
+		} else {
+			last = `HTTP ${r.status}: ${r.text.slice(0, 300)}`;
+		}
 		await sleep(500);
 	}
-	throw new Error(`QA-816: job ${jobId} did not settle within ${timeoutMs}ms; last=${JSON.stringify(last)}`);
+	throw new Error(`QA-816: job ${jobId} did not settle within ${timeoutMs}ms; last=${last}`);
 }
 
 async function topology(ctx: ContextWithHarper): Promise<Topology> {
 	const r = await restJson(ctx, '/LogTopology/');
-	strictEqual(r.status, 200, `/LogTopology/ expected 200, got ${r.status}: ${JSON.stringify(r.body)}`);
+	strictEqual(r.status, 200, `/LogTopology/ expected 200, got ${r.status}: ${r.text.slice(0, 300)}`);
 	return r.body as Topology;
 }
 
@@ -229,8 +235,8 @@ function logOf(topo: Topology, database: string, table: string): LogInfo {
 
 async function flushDatabase(ctx: ContextWithHarper, database: string): Promise<void> {
 	const r = await restJson(ctx, `/Flush/?database=${database}`, { method: 'POST' });
-	strictEqual(r.status, 200, `/Flush/ ${database} expected 200, got ${r.status}: ${JSON.stringify(r.body)}`);
-	strictEqual(r.body?.flushed, true, `/Flush/ ${database} must actually flush, got ${JSON.stringify(r.body)}`);
+	strictEqual(r.status, 200, `/Flush/ ${database} expected 200, got ${r.status}: ${r.text.slice(0, 300)}`);
+	strictEqual(r.body?.flushed, true, `/Flush/ ${database} must actually flush, got ${r.text.slice(0, 300)}`);
 }
 
 /**
@@ -365,10 +371,7 @@ function assertRowSetMatches(label: string, surface: string, expected: SeededRow
 async function restCollection(ctx: ContextWithHarper, table: string, bucket: string): Promise<any[]> {
 	const r = await restJson(ctx, `/${table}/?bucket=${bucket}`);
 	strictEqual(r.status, 200, `REST /${table}/?bucket=${bucket} expected 200, got ${r.status}`);
-	ok(
-		Array.isArray(r.body),
-		`REST /${table}/?bucket=${bucket} must return an array, got ${JSON.stringify(r.body)?.slice(0, 200)}`
-	);
+	ok(Array.isArray(r.body), `REST /${table}/?bucket=${bucket} must return an array, got ${r.text.slice(0, 300)}`);
 	return r.body;
 }
 
@@ -401,11 +404,7 @@ async function fullScan(
 	mode: 'count' | 'records'
 ): Promise<{ totalCount: number; records: any[] }> {
 	const r = await restJson(ctx, `/FullScan/?database=${database}&table=${table}&mode=${mode}`);
-	strictEqual(
-		r.status,
-		200,
-		`/FullScan/ ${database}.${table} expected 200, got ${r.status}: ${JSON.stringify(r.body)?.slice(0, 200)}`
-	);
+	strictEqual(r.status, 200, `/FullScan/ ${database}.${table} expected 200, got ${r.status}: ${r.text.slice(0, 300)}`);
 	return r.body;
 }
 
@@ -449,7 +448,11 @@ suite(
 
 			for (const id of LEDGER_SAMPLE_IDS) {
 				const r = await restJson(ctx, `/Ledger/${id}`);
-				strictEqual(r.status, 200, `[${label}] REST GET /Ledger/${id} expected 200, got ${r.status}`);
+				strictEqual(
+					r.status,
+					200,
+					`[${label}] REST GET /Ledger/${id} expected 200, got ${r.status}: ${r.text.slice(0, 300)}`
+				);
 				deepStrictEqual(
 					{ id: r.body?.id, bucket: r.body?.bucket, seq: r.body?.seq, payload: r.body?.payload },
 					LEDGER_ROWS.find((row) => row.id === id),

--- a/integrationTests/database/qa816-purge-blast-radius.test.ts
+++ b/integrationTests/database/qa816-purge-blast-radius.test.ts
@@ -60,15 +60,9 @@ import {
 const FIXTURE_PATH = resolve(import.meta.dirname, 'qa816-purge-blast-radius');
 const PURGED_DB = 'qa816a';
 const CONTROL_DB = 'qa816b';
-// Windows is skipped because the subject operation takes the process down there, not because the
-// suite is slow or flaky. On `Integration Tests 5/6 (Windows, Node.js v24)` of this file's first CI
-// run, tests 0-2 passed, the purge job started (`[job/2] Starting job`), and ~1.4s later the same
-// instance logged `Starting Harper...` / `Harper was not properly shutdown, replaying transaction
-// logs` — Harper died mid-purge and came back, so tests 3 and 4 hit ECONNREFUSED while the later
-// restart arms passed against the recovered instance. Deleting a memory-mapped `.txnlog` file is
-// exactly what Windows refuses, which puts this in rocksdb-js#808's family. Needs triage as a
-// product defect; unskip once that is settled, and do NOT "fix" it by tolerating the restart —
-// tolerating it is what would hide the bug this file exists to catch.
+// Windows is skipped on harper#2401 — the subject operation takes the process down there, which
+// this suite's first CI run is the evidence for. Remove the skip when that issue closes, and do NOT
+// instead make the suite tolerate the restart: tolerating it is what would hide the defect.
 const skipSuite = process.env.HARPER_RUNTIME === 'bun' || process.platform === 'win32';
 
 const LEDGER_COUNT = 500;
@@ -189,15 +183,17 @@ async function restJson(
 	return { status: res.status, body, text };
 }
 
-// Ready means the probe answers 200. A 404 is the fixture still loading; anything else (500 from a
-// half-started server, 401 before auth is up) would otherwise read as "ready" and surface later as
-// an opaque failure in whichever operation ran next.
+// Readiness is probed through `/LogTopology/` rather than a bare liveness route because that
+// endpoint resolves all five fixture tables out of `databases`: an HTTP server that answers before
+// the databases are open would otherwise pass, and flake the first real read instead. Only 200
+// counts — a 404 is the component still loading, and a 500 or 401 from a half-started server would
+// read as ready and resurface later as an opaque failure.
 async function pollReadiness(ctx: ContextWithHarper): Promise<void> {
 	const deadline = Date.now() + 90_000;
 	let last = 'no response';
 	while (Date.now() < deadline) {
 		try {
-			const res = await fetch(`${ctx.harper.httpURL}/Probe/`, {
+			const res = await fetch(`${ctx.harper.httpURL}/LogTopology/`, {
 				headers: { Authorization: authHeader(ctx) },
 				signal: AbortSignal.timeout(5_000),
 			});
@@ -208,7 +204,7 @@ async function pollReadiness(ctx: ContextWithHarper): Promise<void> {
 		}
 		await sleep(250);
 	}
-	throw new Error(`QA-816: Probe route never answered 200 within 90s; last=${last}`);
+	throw new Error(`QA-816: /LogTopology/ never answered 200 within 90s; last=${last}`);
 }
 
 // A job record can be briefly unreadable right after the ack, so a non-200 or malformed tick is a
@@ -217,13 +213,17 @@ async function pollJob(ctx: ContextWithHarper, jobId: string, timeoutMs = 120_00
 	const deadline = Date.now() + timeoutMs;
 	let last = 'no response';
 	while (Date.now() < deadline) {
-		const r = await rawOp(ctx, { operation: 'get_job', id: jobId });
-		const record = Array.isArray(r.body) ? r.body[0] : r.body;
-		if (r.status === 200 && record && typeof record === 'object') {
-			if (record.status === 'COMPLETE' || record.status === 'ERROR') return record;
-			last = `status=${record.status}`;
-		} else {
-			last = `HTTP ${r.status}: ${r.text.slice(0, 300)}`;
+		try {
+			const r = await rawOp(ctx, { operation: 'get_job', id: jobId });
+			const record = Array.isArray(r.body) ? r.body[0] : r.body;
+			if (r.status === 200 && record && typeof record === 'object') {
+				if (record.status === 'COMPLETE' || record.status === 'ERROR') return record;
+				last = `status=${record.status}`;
+			} else {
+				last = `HTTP ${r.status}: ${r.text.slice(0, 300)}`;
+			}
+		} catch (error) {
+			last = String((error as Error)?.message ?? error);
 		}
 		await sleep(500);
 	}
@@ -380,7 +380,7 @@ function assertRowSetMatches(label: string, surface: string, expected: SeededRow
 
 async function restCollection(ctx: ContextWithHarper, table: string, bucket: string): Promise<any[]> {
 	const r = await restJson(ctx, `/${table}/?bucket=${bucket}`);
-	strictEqual(r.status, 200, `REST /${table}/?bucket=${bucket} expected 200, got ${r.status}`);
+	strictEqual(r.status, 200, `REST /${table}/?bucket=${bucket} expected 200, got ${r.status}: ${r.text.slice(0, 300)}`);
 	ok(Array.isArray(r.body), `REST /${table}/?bucket=${bucket} must return an array, got ${r.text.slice(0, 300)}`);
 	return r.body;
 }

--- a/integrationTests/database/qa816-purge-blast-radius.test.ts
+++ b/integrationTests/database/qa816-purge-blast-radius.test.ts
@@ -60,7 +60,16 @@ import {
 const FIXTURE_PATH = resolve(import.meta.dirname, 'qa816-purge-blast-radius');
 const PURGED_DB = 'qa816a';
 const CONTROL_DB = 'qa816b';
-const skipSuite = process.env.HARPER_RUNTIME === 'bun';
+// Windows is skipped because the subject operation takes the process down there, not because the
+// suite is slow or flaky. On `Integration Tests 5/6 (Windows, Node.js v24)` of this file's first CI
+// run, tests 0-2 passed, the purge job started (`[job/2] Starting job`), and ~1.4s later the same
+// instance logged `Starting Harper...` / `Harper was not properly shutdown, replaying transaction
+// logs` — Harper died mid-purge and came back, so tests 3 and 4 hit ECONNREFUSED while the later
+// restart arms passed against the recovered instance. Deleting a memory-mapped `.txnlog` file is
+// exactly what Windows refuses, which puts this in rocksdb-js#808's family. Needs triage as a
+// product defect; unskip once that is settled, and do NOT "fix" it by tolerating the restart —
+// tolerating it is what would hide the bug this file exists to catch.
+const skipSuite = process.env.HARPER_RUNTIME === 'bun' || process.platform === 'win32';
 
 const LEDGER_COUNT = 500;
 const QUIET_COUNT = 30;

--- a/integrationTests/database/qa816-purge-blast-radius.test.ts
+++ b/integrationTests/database/qa816-purge-blast-radius.test.ts
@@ -224,6 +224,7 @@ async function pollJob(ctx: ContextWithHarper, jobId: string, timeoutMs = 120_00
 async function topology(ctx: ContextWithHarper): Promise<Topology> {
 	const r = await restJson(ctx, '/LogTopology/');
 	strictEqual(r.status, 200, `/LogTopology/ expected 200, got ${r.status}: ${r.text.slice(0, 300)}`);
+	ok(r.body && typeof r.body === 'object', `/LogTopology/ must return an object, got ${r.text.slice(0, 300)}`);
 	return r.body as Topology;
 }
 
@@ -405,6 +406,10 @@ async function fullScan(
 ): Promise<{ totalCount: number; records: any[] }> {
 	const r = await restJson(ctx, `/FullScan/?database=${database}&table=${table}&mode=${mode}`);
 	strictEqual(r.status, 200, `/FullScan/ ${database}.${table} expected 200, got ${r.status}: ${r.text.slice(0, 300)}`);
+	ok(
+		typeof r.body?.totalCount === 'number' && Array.isArray(r.body.records),
+		`/FullScan/ ${database}.${table} must return {totalCount, records}, got ${r.text.slice(0, 300)}`
+	);
 	return r.body;
 }
 

--- a/integrationTests/database/qa816-purge-blast-radius/config.yaml
+++ b/integrationTests/database/qa816-purge-blast-radius/config.yaml
@@ -1,0 +1,5 @@
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/database/qa816-purge-blast-radius/resources.js
+++ b/integrationTests/database/qa816-purge-blast-radius/resources.js
@@ -25,6 +25,7 @@ function logStats(auditStore) {
 	const log = auditStore && auditStore.log;
 	if (!log || typeof log.getStats !== 'function') return null;
 	const stats = log.getStats();
+	if (!stats) return null;
 	return {
 		path: stats.path,
 		fileCount: stats.fileCount,
@@ -87,7 +88,7 @@ export class Flush extends Resource {
 		if (!tableNames) throw new Error(`QA-816: unknown database ${databaseName}`);
 		for (const tableName of tableNames) {
 			const table = tableFor(databaseName, tableName);
-			if (typeof table.primaryStore.flush !== 'function')
+			if (typeof table.primaryStore?.flush !== 'function')
 				throw new Error(`QA-816: ${databaseName}.${tableName} primaryStore.flush() unavailable (not RocksDB?)`);
 			await table.primaryStore.flush();
 		}

--- a/integrationTests/database/qa816-purge-blast-radius/resources.js
+++ b/integrationTests/database/qa816-purge-blast-radius/resources.js
@@ -38,13 +38,6 @@ function logStats(auditStore) {
 	};
 }
 
-export class Probe extends Resource {
-	static loadAsInstance = false;
-	async get() {
-		return { ok: true };
-	}
-}
-
 // GET /LogTopology/ -> per-table engine guess plus the identity of the native transaction log
 // each table writes its audit entries to. Identity is reported as an index into a list of
 // distinct objects seen, so the test can assert "these two tables share one log" and "these two

--- a/integrationTests/database/qa816-purge-blast-radius/resources.js
+++ b/integrationTests/database/qa816-purge-blast-radius/resources.js
@@ -102,9 +102,8 @@ export class Flush extends Resource {
 	}
 }
 
-// GET /FullScan/?database=&table=&mode=count|records -> index-independent primary-store scan.
-// `records` returns every row; `count` returns only the total, for the churn tables whose rows are
-// large and whose survival is asserted by count.
+// GET /FullScan/?database=&table=&mode=count|records -> index-independent primary-store scan, so a
+// defect confined to a secondary index cannot hide from the survival check.
 export class FullScan extends Resource {
 	static loadAsInstance = false;
 	async get(query) {

--- a/integrationTests/database/qa816-purge-blast-radius/resources.js
+++ b/integrationTests/database/qa816-purge-blast-radius/resources.js
@@ -1,0 +1,124 @@
+// QA-816 fixture resources. Everything else this suite needs (insert, REST reads,
+// search_by_value, read_audit_log, delete_transaction_logs_before) is a standard Harper surface
+// the test hits directly.
+//
+// The global `tables` object aliases only the `data` database, so every lookup here goes through
+// `databases[<database>][<table>]`.
+
+const DATABASES = {
+	qa816a: ['Ledger', 'QuietLedger', 'Churn'],
+	qa816b: ['RemoteLedger', 'RemoteChurn'],
+};
+
+function tableFor(databaseName, tableName) {
+	const table = databases[databaseName] && databases[databaseName][tableName];
+	if (!table) throw new Error(`QA-816: table ${databaseName}.${tableName} not found`);
+	return table;
+}
+
+function queryValue(query, name) {
+	if (!query) return undefined;
+	return typeof query.get === 'function' ? query.get(name) : query[name];
+}
+
+function logStats(auditStore) {
+	const log = auditStore && auditStore.log;
+	if (!log || typeof log.getStats !== 'function') return null;
+	const stats = log.getStats();
+	return {
+		path: stats.path,
+		fileCount: stats.fileCount,
+		oldestSequenceNumber: stats.oldestSequenceNumber,
+		currentSequenceNumber: stats.currentSequenceNumber,
+		lastFlushedSequence: stats.lastFlushedPosition && stats.lastFlushedPosition.sequence,
+		rotations: stats.totals && stats.totals.rotations,
+		filesPurged: stats.totals && stats.totals.filesPurged,
+		entriesWritten: stats.totals && stats.totals.entriesWritten,
+		maxFileSize: stats.config && stats.config.maxFileSize,
+	};
+}
+
+export class Probe extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		return { ok: true };
+	}
+}
+
+// GET /LogTopology/ -> per-table engine guess plus the identity of the native transaction log
+// each table writes its audit entries to. Identity is reported as an index into a list of
+// distinct objects seen, so the test can assert "these two tables share one log" and "these two
+// do not" directly rather than inferring it from paths.
+export class LogTopology extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		const auditStores = [];
+		const logs = [];
+		const identify = (list, value) => {
+			if (value == null) return -1;
+			let index = list.indexOf(value);
+			if (index === -1) index = list.push(value) - 1;
+			return index;
+		};
+		const result = {};
+		for (const [databaseName, tableNames] of Object.entries(DATABASES)) {
+			for (const tableName of tableNames) {
+				const table = tableFor(databaseName, tableName);
+				const primaryPath = table.primaryStore?.path || table.primaryStore?.rootStore?.path || null;
+				const looksLikeLmdbPath = typeof primaryPath === 'string' && primaryPath.endsWith('.mdb');
+				const hasPurgeLogs = typeof table.primaryStore?.rootStore?.purgeLogs === 'function';
+				result[`${databaseName}.${tableName}`] = {
+					database: databaseName,
+					table: tableName,
+					engineGuess: looksLikeLmdbPath ? 'lmdb' : hasPurgeLogs ? 'rocksdb' : 'unknown',
+					auditStoreId: identify(auditStores, table.auditStore),
+					logId: identify(logs, table.auditStore && table.auditStore.log),
+					log: logStats(table.auditStore),
+				};
+			}
+		}
+		return result;
+	}
+}
+
+// POST /Flush/?database=qa816a -> force that database's memtables to disk. Every table in the
+// database is flushed, not just one: the transaction log's last-flushed position cannot pass an
+// unflushed column family, and the native purge only deletes log files entirely before that
+// position, so a single-table flush leaves the log un-purgeable whenever another table in the
+// database still holds a memtable.
+export class Flush extends Resource {
+	static loadAsInstance = false;
+	async post(query) {
+		const databaseName = String(queryValue(query, 'database') || '');
+		const tableNames = DATABASES[databaseName];
+		if (!tableNames) throw new Error(`QA-816: unknown database ${databaseName}`);
+		for (const tableName of tableNames) {
+			const table = tableFor(databaseName, tableName);
+			if (typeof table.primaryStore.flush !== 'function')
+				throw new Error(`QA-816: ${databaseName}.${tableName} primaryStore.flush() unavailable (not RocksDB?)`);
+			await table.primaryStore.flush();
+		}
+		return { ok: true, flushed: true, database: databaseName, tables: tableNames };
+	}
+}
+
+// GET /FullScan/?database=&table=&mode=count|records -> index-independent primary-store scan.
+// `records` returns every row; `count` returns only the total, for the churn tables whose rows are
+// large and whose survival is asserted by count.
+export class FullScan extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const databaseName = String(queryValue(query, 'database') || '');
+		const tableName = String(queryValue(query, 'table') || '');
+		const mode = String(queryValue(query, 'mode') || 'records');
+		const table = tableFor(databaseName, tableName);
+		let totalCount = 0;
+		const records = [];
+		for await (const record of table.search({})) {
+			totalCount++;
+			if (mode === 'records')
+				records.push({ id: record.id, seq: record.seq, bucket: record.bucket, payload: record.payload });
+		}
+		return { database: databaseName, table: tableName, totalCount, records };
+	}
+}

--- a/integrationTests/database/qa816-purge-blast-radius/schema.graphql
+++ b/integrationTests/database/qa816-purge-blast-radius/schema.graphql
@@ -1,0 +1,39 @@
+# QA-816 — purge blast-radius anchor. Two databases, because a RocksDB transaction log is
+# per-database: `qa816a` is the purge target, `qa816b` is the isolation control. Within each
+# database the `*Churn` table exists only to push the shared log past its rotation size, so the
+# protected tables' audit entries land in a sealed (and therefore purge-eligible) file rather
+# than the active one.
+type Ledger @table(database: "qa816a", audit: true) @export {
+	id: ID @primaryKey
+	bucket: String @indexed
+	seq: Int
+	payload: String
+}
+
+type QuietLedger @table(database: "qa816a", audit: true) @export {
+	id: ID @primaryKey
+	bucket: String @indexed
+	seq: Int
+	payload: String
+}
+
+type Churn @table(database: "qa816a", audit: true) @export {
+	id: ID @primaryKey
+	bucket: String @indexed
+	seq: Int
+	payload: String
+}
+
+type RemoteLedger @table(database: "qa816b", audit: true) @export {
+	id: ID @primaryKey
+	bucket: String @indexed
+	seq: Int
+	payload: String
+}
+
+type RemoteChurn @table(database: "qa816b", audit: true) @export {
+	id: ID @primaryKey
+	bucket: String @indexed
+	seq: Int
+	payload: String
+}


### PR DESCRIPTION
Promotes a measured QA scenario (dispatch QA wave `qa-wave-2026072616`) into a permanent integration anchor for the transaction-log purge blast radius. Test-only — no product code changes.

`delete_transaction_logs_before` on RocksDB deletes whole native transaction-log files, and a RocksDB transaction log is per-**database**, not per-table: `RocksTransactionLogStore` is constructed once per root database, and the purge walks the database and stops after the first RocksDB table because all its tables share one log. The live measurement found the resulting loss is confined to audit history — 500/500 primary rows survived every read surface across two clean restarts of a purged instance, a table in a different database kept 30/30 of its audit entries, and a quiet sibling in the *same* database lost 30/30.

Nothing in the repo today would go red if a purge started removing primary data. This anchors that: **a purge may destroy audit history, and only audit history.**

## What it asserts

The [`assertPrimaryIntact`](https://github.com/HarperFast/harper/pull/2399/changes?w=1#diff-b6efed9d37f5624b79aa1dd396afd5da39b388582a1490e7915ab9da33ad921dR443) helper is the headline check, and every phase runs the same one: the [three protected tables](https://github.com/HarperFast/harper/pull/2399/changes?w=1#diff-b6efed9d37f5624b79aa1dd396afd5da39b388582a1490e7915ab9da33ad921dR121) are compared **value-exact, id-for-id, rejecting duplicates and extras**, on a REST collection query, `search_by_value`, and an [index-independent full primary-store scan](https://github.com/HarperFast/harper/pull/2399/changes?w=1#diff-b6efed9d37f5624b79aa1dd396afd5da39b388582a1490e7915ab9da33ad921dR455), plus a REST point-read sample — immediately after the purge and after each of two clean restarts. The churn tables are counted in the same pass, so a purge that ate primary data wholesale cannot hide behind the small protected sets.

The cross-database half of the blast radius is [asserted outright](https://github.com/HarperFast/harper/pull/2399/changes?w=1#diff-b6efed9d37f5624b79aa1dd396afd5da39b388582a1490e7915ab9da33ad921dR719): a `qa816a`-scoped purge must remove **zero** `qa816b` audit entries.

The same-database quiet-sibling loss is **reported, not asserted**. It is a consequence of one native log per database; per-table purge granularity would be an improvement, and asserting today's collateral loss would make that improvement go red. Only that sibling's *primary* rows are asserted intact.

## Why the arming is elaborate

A purge that deleted nothing would make every survival assertion vacuously true, and a control database whose entries merely sat in an unsealed active file would "survive" a purge that leaked across databases. So both databases are churned past a log rotation and then [flushed until their oldest log file is sealed **and** fully applied to RocksDB](https://github.com/HarperFast/harper/pull/2399/changes?w=1#diff-b6efed9d37f5624b79aa1dd396afd5da39b388582a1490e7915ab9da33ad921dR258) — the native purge only deletes files entirely before the last-flushed-to-RocksDB position. `purge.purgeableFiles` is deliberately not the arming signal: it counts eligibility under the 3-day *retention* policy and is 0 for freshly written files regardless of the explicit cutoff the operation passes.

Seeding additionally [asserts the protected rows land in **one un-rotated log file**](https://github.com/HarperFast/harper/pull/2399/changes?w=1#diff-b6efed9d37f5624b79aa1dd396afd5da39b388582a1490e7915ab9da33ad921dR564), which is what lets the post-restart audit assertion be [exact-zero](https://github.com/HarperFast/harper/pull/2399/changes?w=1#diff-b6efed9d37f5624b79aa1dd396afd5da39b388582a1490e7915ab9da33ad921dR724) rather than merely "fewer" — a purge that silently stopped part-way goes red.

The one-log-per-database precondition is verified directly rather than assumed: a [`/LogTopology/` fixture resource](https://github.com/HarperFast/harper/pull/2399/changes?w=1#diff-4eb06b79f0d12a770b08afcfd336d91a10d83883f0e24fb841b50e208660e88bR45) reports object identity of each table's `auditStore` and its native `TransactionLog`, and test 0 asserts the three `qa816a` tables share one and `qa816b` does not.

## The suite found a Windows defect on its first CI run

Its own first CI run reds `Integration Tests 5/6 (Windows, Node.js v24)` — and the cause is the subject operation, not the test. Tests 0-2 passed, the purge job started, and ~1.4s later the same instance logged `Starting Harper...` / `Harper was not properly shutdown, replaying transaction logs`: Harper died mid-`delete_transaction_logs_before` and self-restarted, so tests 3 and 4 hit ECONNREFUSED while the later restart arms passed against the recovered instance. Deleting a memory-mapped `.txnlog` file is what Windows refuses, which puts it in HarperFast/rocksdb-js#808's family.

Filed as #2401 (P1, Bug, under [Epic] Audit-log subsystem hardening) with the log excerpt, likely mechanism, and next steps. The suite is [skipped on Windows](https://github.com/HarperFast/harper/pull/2399/changes?w=1#diff-b6efed9d37f5624b79aa1dd396afd5da39b388582a1490e7915ab9da33ad921dR66) pointing at that issue — **skipped, not made tolerant**, because tolerating the restart is precisely what would hide the defect this file exists to catch. No data loss accompanied the crash: the same run verified 500/500 rows value-exact afterwards.

## For the human reviewer

Three review findings were consciously declined:

- **"`lastFlushedSequence > oldestSequenceNumber` only proves the flush passed the *start* of the oldest file"** (raised independently by two outside legs). `lastFlushedPosition.sequence` is a log **file** sequence number, not an entry offset — `offset` is the separate within-file field (`@harperfast/rocksdb-js` `TransactionLogStats`). A strictly greater file sequence therefore does mean the whole oldest file precedes the flushed position. The graded leg re-examined and adjudicated this as by-design. Worth a second look if you know the native side differently; note the non-vacuity gate would turn a wrong read here into a loud red, not a silent pass.
- **"`killHarper(ctx as any)` masks a type mismatch that would leave a zombie process."** `killHarper(ctx: StartedHarperTestContext)` does take the test context; the cast is only because the suite's `ctx` is typed `ContextWithHarper`. The adjacent shipped suite uses the identical call, and the restart arms pass. Also adjudicated as not-carried by the graded leg.
- **"Aggregate and remove the comments."** The file header stays: `integrationTests/README.md` requires each test file to begin with a JSDoc comment describing exactly what it tests, and every adjacent promoted anchor carries one. The retained inline comments each state something the code cannot — why rotation is polled rather than asserted, why the churn counts matter, why the un-rotated-file precondition exists, and why the audit read happens after a restart. The graded leg agreed these should stay; the second lens kept asking for them to go. Comments that merely restated control flow were removed.

One open suggestion left for you: the [churn write budget](https://github.com/HarperFast/harper/pull/2399/changes?w=1#diff-b6efed9d37f5624b79aa1dd396afd5da39b388582a1490e7915ab9da33ad921dR299) is derived from the log's own `config.maxFileSize` (16MiB today, and Harper does not expose the knob). A reviewer flagged that a much larger future default would make the churn phase slow rather than fail fast. Left alone as speculative — the bound is derived rather than hardcoded, and both the cap and the phase timeout produce a named diagnostic.

Also worth knowing: the **domain adjudication leg did not run** in any review round. Each pre-push run had to fit inside this environment's 10-minute foreground command cap, and adjudication starts only after the finding legs; the finding legs (Codex graded + Gemini, plus Cursor/Grok in round 1) all completed and their findings were addressed or declined above.

## Verification

- **New suite, green from cold**: 7/7, ~8s, 16 consecutive local runs across the review rounds. `npm run build && npm run test:integration -- --isolation=none "integrationTests/database/qa816-purge-blast-radius.test.ts"`
- **Discrimination measured.** This is an invariant anchor, not a bug fix, so fails-on-base is N/A; instead each assertion class was inverted and confirmed red:
  | inversion | result |
  |---|---|
  | delete one `Ledger` row after the purge | tests 4, 5 and 6 red — `REST collection must return exactly 500 rows, got 499` |
  | purge the control database too | test 5 red — `a qa816a-scoped purge must not remove any qa816b audit entry, got 0/30` |
  | purge with `timestamp: 1` | test 3 red on `entries_deleted=0`, test 5 red on the Ledger audit gate |
- **Full integration suite green locally**, run in three batches to fit the environment's foreground command cap: `database` 362 pass / 0 fail, `apiTests+components+deploy+mcp+mqtt` 255 pass / 0 fail, `resources+security+server+upgrade+*.test.mjs` 1317 pass / 0 fail (6 cancelled — the Ollama suite needs a live local Ollama instance).
- **Unit gates**: `test:unit:main` and `test:unit:resources` each fail one test here, and both fail the same way without this change. CI proves it directly: [the `Unit Test` run on `main` @ e16d9616a](https://github.com/HarperFast/harper/actions/runs/33269006287) fails on all three Node versions with the identical `the fencing source fill should reach the indexed subscription` assertion, and this PR cannot reach it — nothing under `integrationTests/` is in either mocha glob. The second local failure, `configValidator` `getDomainSocketPathLengthWarning`, is environmental: it resolves `relative/root/operations-server` against `process.cwd()`, and this worktree's 79-character path pushes it past the UDS byte limit.
- **Integration CI on this branch**: all 24 integration shards pass, Windows included, with the suite skipped there per #2401.
- `npm run format:check` clean; `oxlint --deny-warnings` clean on the added files.

Refs #846
Refs #2401

Complexity: complicated

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=7 @ dc262df35014</sub>

<sub>Human-Review-Need: 3 @ dc262df35014</sub>
