### PR TITLE
test: anchor #1854's audit:false delete fix at the RocksDB storage layer

### DIFF
--- a/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
+++ b/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
@@ -64,7 +64,7 @@ suite(
 	(ctx: ContextWithHarper) => {
 		let client: ReturnType<typeof createApiClient>;
 		let httpURL: string;
-		let procOutput = '';
+		const procChunks: string[] = [];
 		let rootPath: string;
 		const dbiCache = new Map<string, RocksDatabase>();
 
@@ -79,14 +79,14 @@ suite(
 			client = createApiClient(ctx.harper);
 			httpURL = ctx.harper.httpURL;
 
-			procOutput += ctx.harper.startupOutput?.stdout ?? '';
-			procOutput += ctx.harper.startupOutput?.stderr ?? '';
+			procChunks.push(ctx.harper.startupOutput?.stdout ?? '', ctx.harper.startupOutput?.stderr ?? '');
 			const proc = ctx.harper.process;
-			// setEncoding keeps a multi-byte sequence split across chunk boundaries intact.
+			// setEncoding keeps a multi-byte sequence split across chunk boundaries intact; collecting
+			// chunks instead of concatenating keeps a chatty run from being quadratic.
 			proc?.stdout?.setEncoding('utf8');
 			proc?.stderr?.setEncoding('utf8');
-			proc?.stdout?.on('data', (d: string) => (procOutput += d));
-			proc?.stderr?.on('data', (d: string) => (procOutput += d));
+			proc?.stdout?.on('data', (d: string) => procChunks.push(d));
+			proc?.stderr?.on('data', (d: string) => procChunks.push(d));
 
 			// Workers register routes asynchronously; poll the probe route rather than restarting the
 			// http workers, which races against a pre-installed fixture.
@@ -94,8 +94,10 @@ suite(
 			let ready = false;
 			while (Date.now() < routeDeadline) {
 				try {
+					// Strictly 200: a worker that crashed on a fixture error answers 500, and treating that
+					// as ready turns a startup failure into opaque failures in the arms below.
 					const probe = await fetch(`${httpURL}/Probe/`, { headers: { Authorization: client.headers.Authorization } });
-					if (probe.status !== 404) {
+					if (probe.status === 200) {
 						ready = true;
 						break;
 					}
@@ -147,7 +149,7 @@ suite(
 		}
 
 		function logSources(): Map<string, string> {
-			const sources = new Map<string, string>([['<stdio>', procOutput]]);
+			const sources = new Map<string, string>([['<stdio>', procChunks.join('')]]);
 			if (ctx.harper.logDir) {
 				for (const name of LOG_FILES) {
 					const p = join(ctx.harper.logDir, name);
@@ -329,7 +331,7 @@ suite(
 					// The monitor's decision is asynchronous to the request returning, so wait for the
 					// evidence itself rather than for a fixed settling delay.
 					const logDeadline = Date.now() + 15_000;
-					while (!sawLogSince(mark, OVER_TIME_ABORTED) && Date.now() < logDeadline) await sleep(100);
+					while (!sawLogSince(mark, OVER_TIME_ABORTED) && Date.now() < logDeadline) await sleep(250);
 					ok(
 						sawLogSince(mark, OVER_TIME_ABORTED),
 						`the over-time monitor must have aborted this request's transaction; status=${res.status} body=${body.slice(0, 400)}`

--- a/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
+++ b/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
@@ -18,10 +18,12 @@
  * client surfaces. Those surfaces cannot see half of the damage: `search_by_value` joins each
  * index entry back through its primary record and silently drops the ones whose record is gone,
  * so a dangling entry is invisible to every query API. The oracle here is a second, independent,
- * read-only `@harperfast/rocksdb-js` handle on the on-disk column families, decoding the
+ * read-only `@harperfast/rocksdb-js` handle on the secondary-index column families, decoding the
  * composite `[indexedValue, primaryKey]` index keys itself (the wire format written by
- * resources/RocksIndexStore.ts), with no Harper code in the read path. It also covers the
- * monitor-fired abort (Arm A) alongside #1869's request-thrown abort (Arm B).
+ * resources/RocksIndexStore.ts) rather than asking Harper what they mean. Primary-record liveness
+ * is a direct point lookup by primary key, which no index mediates — `hasLiveRecord()` says why
+ * the raw primary column family cannot answer it. It also covers the monitor-fired abort (Arm A)
+ * alongside #1869's request-thrown abort (Arm B).
  *
  * A RocksDB `readOnly: true` open is a point-in-time snapshot of the SSTs as of that open, not a
  * live view like LMDB's shared mmap, and Harper opens table/index column families with
@@ -36,7 +38,7 @@
  *   npm run test:integration -- "integrationTests/database/delete-index-atomicity-rocksdb.test.ts"
  */
 import { suite, test, before, after } from 'node:test';
-import { ok, strictEqual, notStrictEqual } from 'node:assert';
+import { ok, strictEqual } from 'node:assert';
 import { resolve, join } from 'node:path';
 import { readFileSync, existsSync } from 'node:fs';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -55,7 +57,6 @@ const MAX_TXN_OPEN_MS = 1000;
 // on elapsed wall-clock.
 const HOLD_MS = 15_000;
 const LOG_FILES = ['hdb.log', 'stdout.log', 'stderr.log'];
-const OVER_TIME_ABORTED = /Transaction was open too long and has been aborted/i;
 const skipSuite = process.platform === 'win32';
 
 suite(
@@ -211,7 +212,12 @@ suite(
 		 */
 		async function hasLiveRecord(table: string, id: string): Promise<boolean> {
 			const res = await getJSON(`/${table}/${encodeURIComponent(id)}`);
-			return res.status === 200;
+			if (res.status === 200) return true;
+			if (res.status === 404) return false;
+			// Anything else is the oracle failing, not an answer. Treating it as "absent" would let a
+			// 500 from the just-poisoned thread fabricate a phantom and fail the arm with a message
+			// claiming the index is orphaned.
+			throw new Error(`liveness probe for ${table}/${id} returned ${res.status}: ${(await res.text()).slice(0, 200)}`);
 		}
 		/**
 		 * {category, id} pairs read straight out of the on-disk secondary-index column family.
@@ -294,7 +300,7 @@ suite(
 		// handler — a different path into the same commit branch than #1869's own test covers.
 		for (const table of ['ItemF', 'ItemT']) {
 			test(
-				`Arm A (${table}): monitor-fired abort mid remove/insert/update leaves base and index in agreement`,
+				`Arm A (${table}): monitor-fired abort mid remove/insert/update rolls the delete back`,
 				{ timeout: HOLD_MS + 60_000 },
 				async () => {
 					const removeId = `${table}-rm-base`;
@@ -330,10 +336,15 @@ suite(
 
 					// The monitor's decision is asynchronous to the request returning, so wait for the
 					// evidence itself rather than for a fixed settling delay.
+					// The line names the table and the route it was started from, so the match is evidence
+					// about THIS request rather than about any transaction that outran the 1 s limit.
+					const aborted = new RegExp(
+						`Transaction was open too long and has been aborted[^\\n]*from table: ${table}/ path: /SlowMixedHold/`
+					);
 					const logDeadline = Date.now() + 15_000;
-					while (!sawLogSince(mark, OVER_TIME_ABORTED) && Date.now() < logDeadline) await sleep(250);
+					while (!sawLogSince(mark, aborted) && Date.now() < logDeadline) await sleep(250);
 					ok(
-						sawLogSince(mark, OVER_TIME_ABORTED),
+						sawLogSince(mark, aborted),
 						`the over-time monitor must have aborted this request's transaction; status=${res.status} body=${body.slice(0, 400)}`
 					);
 
@@ -357,6 +368,14 @@ suite(
 							` removeId-still-live=${await hasLiveRecord(table, removeId)}`
 					);
 
+					// The headline post-condition: the aborted delete must have rolled back, so the row it
+					// targeted is still there and still indexed. `phantoms` alone would stay empty if the
+					// row and its index entry both vanished.
+					ok(await hasLiveRecord(table, removeId), `Arm A (${table}): ${removeId} must survive the aborted delete`);
+					ok(
+						indexEntries.some((e) => e.key === 'ARMA-DEL' && e.id === removeId),
+						`Arm A (${table}): ${removeId}'s index entry must survive the aborted delete`
+					);
 					strictEqual(
 						phantoms.length,
 						0,
@@ -374,7 +393,7 @@ suite(
 		// Arm B: #1854's original trigger — a delete followed by a thrown error — observed at the
 		// storage layer, where the phantom the query surfaces cannot show is visible.
 		for (const table of ['ItemF', 'ItemT']) {
-			test(`Arm B (${table}): request-thrown abort after a delete leaves base and index in agreement`, async () => {
+			test(`Arm B (${table}): request-thrown abort after a delete rolls it back`, async () => {
 				const id = `${table}-abort-1`;
 				await seed(table, [{ id, category: 'ARMB' }]);
 
@@ -388,7 +407,7 @@ suite(
 				);
 
 				const res = await postJSON('/DeleteThenAbort/', { table, id });
-				notStrictEqual(res.status, 200, 'DeleteThenAbort handler should surface its deliberate throw as a non-200');
+				ok(res.status >= 400, `DeleteThenAbort must surface its deliberate throw as an error; got ${res.status}`);
 
 				await refreshOracle();
 				const primaryHasId = await hasLiveRecord(table, id);
@@ -398,6 +417,10 @@ suite(
 					`\n[#1854 Arm B ${table}] status=${res.status} primaryHasId=${primaryHasId} indexHasEntry=${indexHasEntry}`
 				);
 
+				// Agreement alone would also be satisfied by both vanishing, which is not what an aborted
+				// delete is allowed to do: the row and its index entry must both still be there.
+				ok(primaryHasId, `Arm B (${table}): ${id} must survive the aborted delete (the removal must roll back)`);
+				ok(indexHasEntry, `Arm B (${table}): ${id}'s index entry must survive the aborted delete`);
 				strictEqual(
 					indexHasEntry,
 					primaryHasId,

--- a/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
+++ b/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
@@ -93,6 +93,7 @@ suite(
 			// http workers, which races against a pre-installed fixture.
 			const routeDeadline = Date.now() + 120_000;
 			let ready = false;
+			let lastProbeError = 'no response yet';
 			while (Date.now() < routeDeadline) {
 				try {
 					// Strictly 200: a worker that crashed on a fixture error answers 500, and treating that
@@ -102,12 +103,13 @@ suite(
 						ready = true;
 						break;
 					}
-				} catch {
-					/* not ready yet */
+					lastProbeError = `status ${probe.status}`;
+				} catch (error) {
+					lastProbeError = String((error as Error)?.message ?? error);
 				}
 				await sleep(250);
 			}
-			ok(ready, 'Probe route should become available before the suite runs');
+			ok(ready, `Probe route should become available before the suite runs; last probe: ${lastProbeError}`);
 
 			// `audit || trackDeletes` is what selects the branch each arm targets (resources/Table.ts),
 			// and `trackDeletes` can be turned on implicitly by adding a subscribed source, so a drift
@@ -179,11 +181,7 @@ suite(
 			return false;
 		}
 
-		/**
-		 * Must precede every raw read: flush the memtables through the fixture so committed writes
-		 * are on disk, then drop every cached handle so the next open is a fresh snapshot rather
-		 * than the stale point-in-time view the previous open captured.
-		 */
+		/** Must precede every raw read; see the file header for why both halves are required. */
 		async function refreshOracle(): Promise<void> {
 			const res = await postJSON('/Flush/', {});
 			strictEqual(res.status, 200, 'flush control should succeed');
@@ -310,8 +308,7 @@ suite(
 						{ id: removeId, category: 'ARMA-DEL' },
 					]);
 
-					// Without a live, indexed row to delete there is no removeEntry() call and the arm
-					// cannot exercise the branch #1869 fixed, whatever it asserts afterwards.
+					// Without a live, indexed row to delete there is no removeEntry() call at all.
 					await refreshOracle();
 					ok(await hasLiveRecord(table, removeId), `${removeId} must exist before the held transaction deletes it`);
 					ok(
@@ -333,6 +330,14 @@ suite(
 						holdMs: HOLD_MS,
 					});
 					const body = await res.text();
+					// End-to-end proof that the transaction was really poisoned rather than merely logged
+					// about: the request fails with the over-time error. A monitor that logged the abort
+					// but left the handle usable would let the marker write and the commit succeed, and
+					// this request would return 200.
+					ok(
+						res.status >= 400 && /exceeding the maximum open-transaction time/.test(body),
+						`the held transaction must have been aborted, so its request must fail with the over-time error; got ${res.status} body=${body.slice(0, 400)}`
+					);
 
 					// The monitor's decision is asynchronous to the request returning, so wait for the
 					// evidence itself rather than for a fixed settling delay.
@@ -351,10 +356,8 @@ suite(
 					await refreshOracle();
 					const phantoms = await findPhantoms(table, 'category');
 					const indexEntries = rawIndexEntries(table, 'category');
-					// The other direction: any row that survived in the primary store must still be
-					// reachable through the index. Whether the update landed depends on which side of the
-					// abort it fell on, and either outcome is consistent as long as some index entry
-					// exists for the surviving row.
+					// Whether the update landed depends on which side of the abort it fell on, so the check
+					// is only that a surviving row is reachable through the index at all.
 					const missing: string[] = [];
 					for (const id of [`${table}-upd-base`, `${table}-ins-1`, `${table}-ins-2`]) {
 						if (!(await hasLiveRecord(table, id))) continue;
@@ -368,9 +371,8 @@ suite(
 							` removeId-still-live=${await hasLiveRecord(table, removeId)}`
 					);
 
-					// The headline post-condition: the aborted delete must have rolled back, so the row it
-					// targeted is still there and still indexed. `phantoms` alone would stay empty if the
-					// row and its index entry both vanished.
+					// `phantoms` alone would stay empty if the row and its index entry both vanished, which
+					// is not something an aborted delete is allowed to do.
 					ok(await hasLiveRecord(table, removeId), `Arm A (${table}): ${removeId} must survive the aborted delete`);
 					ok(
 						indexEntries.some((e) => e.key === 'ARMA-DEL' && e.id === removeId),
@@ -407,7 +409,13 @@ suite(
 				);
 
 				const res = await postJSON('/DeleteThenAbort/', { table, id });
-				ok(res.status >= 400, `DeleteThenAbort must surface its deliberate throw as an error; got ${res.status}`);
+				// Not just any error: the handler's own throw, so a 404 from a mis-registered route cannot
+				// stand in for the abort this arm depends on.
+				const abortBody = await res.text();
+				ok(
+					res.status >= 400 && abortBody.includes(`deliberate abort after delete (table=${table} id=${id})`),
+					`DeleteThenAbort must surface its own deliberate throw; got ${res.status} body=${abortBody.slice(0, 400)}`
+				);
 
 				await refreshOracle();
 				const primaryHasId = await hasLiveRecord(table, id);
@@ -417,8 +425,6 @@ suite(
 					`\n[#1854 Arm B ${table}] status=${res.status} primaryHasId=${primaryHasId} indexHasEntry=${indexHasEntry}`
 				);
 
-				// Agreement alone would also be satisfied by both vanishing, which is not what an aborted
-				// delete is allowed to do: the row and its index entry must both still be there.
 				ok(primaryHasId, `Arm B (${table}): ${id} must survive the aborted delete (the removal must roll back)`);
 				ok(indexHasEntry, `Arm B (${table}): ${id}'s index entry must survive the aborted delete`);
 				strictEqual(

--- a/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
+++ b/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Regression anchor for #1854 (fixed by PR #1869, merged as e755a0d0e): on RocksDB, a delete on
+ * an `audit:false` @indexed table must not commit the base-row removal independently of the
+ * secondary-index removal.
+ *
+ * `_writeDelete()`'s non-audit commit branch (resources/Table.ts) removes the base row with
+ * `removeEntry(primaryStore, existingEntry, ...)` while removing the index entries with
+ * `updateIndices(id, existingRecord, null, transaction && { transaction })`. `removeEntry()`
+ * hands its options straight to `store.remove(key, options)`, so before #1869 — which added the
+ * `isRocksDB && transaction ? { transaction } : undefined` argument — the base-row removal
+ * committed standalone against the raw store. An aborted transaction therefore still durably
+ * removed the row (and unlinked its blob, since the blob-unlink gate keys off the removal's own
+ * commit) while the transaction-scoped index removal rolled back, leaving the secondary index
+ * pointing at a primary key that no longer exists. `audit: true` is unaffected: that branch
+ * removes through `updateRecord()`, which has always threaded `{transaction}`.
+ *
+ * `integrationTests/resources/audit-false-delete-rollback.test.ts` pins the same fix through the
+ * client surfaces. This file pins it at the storage layer instead, because the client surfaces
+ * cannot see half of the damage: `search_by_value` joins each index entry back through its
+ * primary record and silently drops the ones whose record is gone, so a dangling entry is
+ * invisible to every query API. The oracle here is a second, independent, read-only
+ * `@harperfast/rocksdb-js` handle on the on-disk column families, decoding the composite
+ * `[indexedValue, primaryKey]` index keys itself (the wire format written by
+ * resources/RocksIndexStore.ts), with no Harper code in the read path. It also covers the
+ * monitor-fired abort (Arm A) alongside #1869's request-thrown abort (Arm B).
+ *
+ * A RocksDB `readOnly: true` open is a point-in-time snapshot of the SSTs as of that open, not a
+ * live view like LMDB's shared mmap, and Harper opens table/index column families with
+ * `disableWAL` defaulting to true (resources/databases.ts openRocksDatabase), so a committed
+ * write can still sit only in the writer's memtable. An oracle that skips either step reports a
+ * clean run from flush timing rather than from real consistency, so `refreshOracle()` flushes
+ * through the fixture and reopens every handle before each raw read, and the 'oracle proof'
+ * tests below demonstrate — rather than assert — that it detects a phantom the join cannot.
+ *
+ * Reproduction:
+ *   npm run test:integration -- "integrationTests/database/delete-index-atomicity-rocksdb.test.ts"
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual, notStrictEqual } from 'node:assert';
+import { resolve, join } from 'node:path';
+import { readFileSync, existsSync } from 'node:fs';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { RocksDatabase } from '@harperfast/rocksdb-js';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from '../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'delete-index-atomicity-rocksdb');
+const SCHEMA = 'data';
+const MAX_TXN_OPEN_MS = 1000;
+// The monitor ticks once per `storage.maxTransactionOpenTime` and decays a transaction's budget
+// by one interval per tick (resources/DatabaseTransaction.ts startMonitoringTxns), so the abort
+// lands within ~2-3 ticks. This hold is an order of magnitude past that, purely as slack for a
+// loaded runner; the arm asserts on the log line the monitor actually emitted, never on elapsed
+// wall-clock.
+const HOLD_MS = 15_000;
+const skipSuite = process.platform === 'win32';
+
+suite(
+	'#1854 audit:false delete must not orphan secondary-index entries (raw RocksDB oracle)',
+	{ skip: skipSuite },
+	(ctx: ContextWithHarper) => {
+		let client: ReturnType<typeof createApiClient>;
+		let httpURL: string;
+		let procOutput = '';
+		let rootPath: string;
+		const dbiCache = new Map<string, RocksDatabase>();
+
+		before(async () => {
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+				config: {
+					storage: { maxTransactionOpenTime: MAX_TXN_OPEN_MS, debugLongTransactions: true },
+					logging: { console: true, level: 'error' },
+				},
+				env: { HARPER_STORAGE_ENGINE: 'rocksdb' },
+			});
+			client = createApiClient(ctx.harper);
+			httpURL = ctx.harper.httpURL;
+
+			procOutput += ctx.harper.startupOutput?.stdout ?? '';
+			procOutput += ctx.harper.startupOutput?.stderr ?? '';
+			const proc = ctx.harper.process;
+			proc?.stdout?.on('data', (d: Buffer) => (procOutput += d.toString()));
+			proc?.stderr?.on('data', (d: Buffer) => (procOutput += d.toString()));
+
+			// Workers register routes asynchronously; poll the probe route rather than restarting the
+			// http workers, which races against a pre-installed fixture.
+			const routeDeadline = Date.now() + 120_000;
+			let ready = false;
+			while (Date.now() < routeDeadline) {
+				try {
+					const probe = await fetch(`${httpURL}/Probe/`, { headers: { Authorization: client.headers.Authorization } });
+					if (probe.status !== 404) {
+						ready = true;
+						break;
+					}
+				} catch {
+					/* not ready yet */
+				}
+				await sleep(250);
+			}
+			ok(ready, 'Probe route should become available before the suite runs');
+
+			// The audit flag is what selects the branch each arm targets, so a schema drift that
+			// flipped it would turn this anchor green for the wrong reason.
+			const itemF = await (await getJSON('/TableInfo/?table=ItemF')).json();
+			const itemT = await (await getJSON('/TableInfo/?table=ItemT')).json();
+			strictEqual(itemF.audit, false, 'ItemF must be audit:false to reach the branch this anchor pins');
+			strictEqual(itemT.audit, true, 'ItemT must be audit:true to serve as the control arm');
+
+			// The RocksDB root store for a database is a directory (not a single file as on LMDB) at
+			// `{dataRootDir}/database/{name}`, shared by every table and index column family in it.
+			rootPath = join(ctx.harper.dataRootDir, 'database', SCHEMA);
+			const dirDeadline = Date.now() + 30_000;
+			while (!existsSync(rootPath) && Date.now() < dirDeadline) await sleep(200);
+			ok(existsSync(rootPath), `expected RocksDB directory at ${rootPath}`);
+		});
+
+		after(async () => {
+			for (const db of dbiCache.values()) {
+				try {
+					db.close();
+				} catch {
+					/* ignore */
+				}
+			}
+			dbiCache.clear();
+			await teardownHarper(ctx);
+		});
+
+		function postJSON(path: string, body: unknown): Promise<Response> {
+			return fetch(`${httpURL}${path}`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', 'Authorization': client.headers.Authorization },
+				body: JSON.stringify(body),
+			});
+		}
+		function getJSON(path: string): Promise<Response> {
+			return fetch(`${httpURL}${path}`, { headers: { Authorization: client.headers.Authorization } });
+		}
+
+		function sawLog(pattern: RegExp): boolean {
+			let logText = procOutput;
+			if (ctx.harper.logDir) {
+				for (const name of ['hdb.log', 'stdout.log', 'stderr.log']) {
+					const p = join(ctx.harper.logDir, name);
+					if (existsSync(p)) {
+						try {
+							logText += readFileSync(p, 'utf8');
+						} catch {
+							/* ignore */
+						}
+					}
+				}
+			}
+			return pattern.test(logText);
+		}
+
+		/**
+		 * Must precede every raw read: flush the memtables through the fixture so committed writes
+		 * are on disk, then drop every cached handle so the next open is a fresh snapshot rather
+		 * than the stale point-in-time view the previous open captured.
+		 */
+		async function refreshOracle(): Promise<void> {
+			const res = await postJSON('/Flush/', {});
+			strictEqual(res.status, 200, 'flush control should succeed');
+			for (const db of dbiCache.values()) {
+				try {
+					db.close();
+				} catch {
+					/* ignore */
+				}
+			}
+			dbiCache.clear();
+		}
+		function openDbi(name: string): RocksDatabase {
+			if (!dbiCache.has(name)) dbiCache.set(name, RocksDatabase.open(rootPath, { name, readOnly: true }));
+			return dbiCache.get(name)!;
+		}
+		/** Primary keys present in the on-disk primary store, read without consulting any index. */
+		function rawPrimaryKeys(table: string): Set<string> {
+			return new Set([...openDbi(`${table}/`).getKeys()].map(String));
+		}
+		/**
+		 * {category, id} pairs read straight out of the on-disk secondary-index column family.
+		 * RocksIndexStore encodes each entry as an ordered-binary `[indexedValue, primaryKey]` key
+		 * with a null value; the plain RocksDatabase class decodes that key here, with no Harper
+		 * subclass interpreting it.
+		 */
+		function rawIndexEntries(table: string, attribute: string): Array<{ key: string; id: string }> {
+			return [...openDbi(`${table}/${attribute}`).getRange()].map((e: { key: [unknown, unknown] }) => ({
+				key: String(e.key[0]),
+				id: String(e.key[1]),
+			}));
+		}
+		/** Index entries whose id has no primary record — the dangling entries #1854 produced. */
+		function findPhantoms(table: string, attribute: string): Array<{ key: string; id: string }> {
+			const primaryKeys = rawPrimaryKeys(table);
+			return rawIndexEntries(table, attribute).filter((e) => !primaryKeys.has(e.id));
+		}
+
+		test('oracle proof: sees a seeded index entry, and sees it vanish on a normal delete', async () => {
+			await postJSON('/Seed/', { table: 'ItemF', ids: [{ id: 'proof-1', category: 'PROOF' }] });
+			await refreshOracle();
+			let entries = rawIndexEntries('ItemF', 'category').filter((e) => e.key === 'PROOF');
+			let keys = rawPrimaryKeys('ItemF');
+			strictEqual(entries.length, 1, 'oracle should see exactly 1 raw index entry for PROOF after seed');
+			strictEqual(entries[0].id, 'proof-1', 'raw index entry should point at proof-1');
+			ok(keys.has('proof-1'), 'oracle should see proof-1 in the raw primary store after seed');
+
+			const res = await postJSON('/DeleteOne/', { table: 'ItemF', id: 'proof-1' });
+			strictEqual(res.status, 200, 'ordinary delete should succeed');
+
+			await refreshOracle();
+			entries = rawIndexEntries('ItemF', 'category').filter((e) => e.key === 'PROOF');
+			keys = rawPrimaryKeys('ItemF');
+			strictEqual(entries.length, 0, 'oracle should see the PROOF index entry vanish after a normal delete');
+			ok(!keys.has('proof-1'), 'oracle should see proof-1 vanish from the raw primary store after a normal delete');
+		});
+
+		test('oracle proof: detects an injected phantom that the join-based query surface cannot', async () => {
+			const res = await postJSON('/InjectPhantom/', { table: 'ItemF', category: 'GHOST', id: 'ghost-1' });
+			strictEqual(res.status, 200, 'InjectPhantom control should succeed (ghost-1 must not already exist)');
+
+			await refreshOracle();
+			ok(!rawPrimaryKeys('ItemF').has('ghost-1'), 'ghost-1 should never appear in the raw primary store');
+
+			const phantoms = findPhantoms('ItemF', 'category');
+			ok(
+				phantoms.some((p) => p.id === 'ghost-1' && p.key === 'GHOST'),
+				`oracle should detect the injected phantom (GHOST -> ghost-1); phantoms seen: ${JSON.stringify(phantoms)}`
+			);
+
+			const blind = await (await getJSON('/BlindSearch/?table=ItemF&category=GHOST')).json();
+			strictEqual(
+				blind.hits.length,
+				0,
+				'the join-through-primary query surface must see 0 hits for the same phantom, which is why the arms below read raw storage'
+			);
+
+			// Remove the deliberate artifact so the table-wide scans in Arm A/B cannot report it as a
+			// genuine phantom (or have a genuine one masked by it).
+			const cleanup = await postJSON('/RemoveIndexEntry/', { table: 'ItemF', category: 'GHOST', id: 'ghost-1' });
+			strictEqual(cleanup.status, 200, 'positive-control cleanup should succeed');
+			await refreshOracle();
+			ok(
+				findPhantoms('ItemF', 'category').every((p) => p.id !== 'ghost-1'),
+				'ghost-1 phantom should be gone after cleanup'
+			);
+		});
+
+		// Arm A: the abort is fired by the long-transaction monitor mid-transaction, not by the
+		// handler — a different path into the same commit branch than #1869's own test covers.
+		for (const table of ['ItemF', 'ItemT']) {
+			test(
+				`Arm A (${table}): monitor-fired abort mid insert/update/remove leaves base and index in agreement`,
+				{ timeout: HOLD_MS + 60_000 },
+				async () => {
+					await postJSON('/Seed/', {
+						table,
+						ids: [
+							{ id: '__seed__-0', category: '__seed__' },
+							{ id: `${table}-upd-base`, category: 'ARMA-OLD' },
+							{ id: `${table}-rm-base`, category: 'ARMA-DEL' },
+						],
+					});
+
+					const res = await postJSON('/SlowMixedHold/', {
+						table,
+						insertIds: [
+							{ id: `${table}-ins-1`, category: 'ARMA-NEW' },
+							{ id: `${table}-ins-2`, category: 'ARMA-NEW' },
+						],
+						updateId: `${table}-upd-base`,
+						updateCategory: 'ARMA-UPDATED',
+						removeId: `${table}-rm-base`,
+						markerId: `${table}-marker`,
+						holdMs: HOLD_MS,
+					});
+					const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+
+					// The monitor's decision is asynchronous to the request returning, so wait for the
+					// evidence itself rather than for a fixed settling delay.
+					const overTime = /Transaction was open too long and has been (aborted|committed)/i;
+					const logDeadline = Date.now() + 15_000;
+					while (!sawLog(overTime) && Date.now() < logDeadline) await sleep(100);
+					const abortedLine = sawLog(/Transaction was open too long and has been aborted/i);
+					const committedLine = sawLog(/Transaction was open too long and has been committed/i);
+					ok(
+						abortedLine || committedLine,
+						`the over-time monitor must actually have fired for ${table}; status=${res.status} body=${JSON.stringify(body)}`
+					);
+
+					await refreshOracle();
+					const phantoms = findPhantoms(table, 'category');
+					const primaryKeys = rawPrimaryKeys(table);
+					const indexEntries = rawIndexEntries(table, 'category');
+					// The other direction: any row that survived in the primary store must still be
+					// reachable through the index. Both the updated and the pre-image category are listed
+					// because whether the update landed depends on which side of the abort it fell on, and
+					// either outcome is consistent as long as some index entry exists for the surviving row.
+					const missing: string[] = [];
+					for (const id of [`${table}-upd-base`, `${table}-ins-1`, `${table}-ins-2`]) {
+						if (!primaryKeys.has(id)) continue;
+						if (!indexEntries.some((ie) => ie.id === id)) missing.push(`${id} present in primary but not indexed`);
+					}
+
+					console.log(
+						`\n[#1854 Arm A ${table}] status=${res.status} aborted=${abortedLine} committed=${committedLine}\n` +
+							`  phantoms=${phantoms.length}${phantoms.length ? ' ' + JSON.stringify(phantoms) : ''}` +
+							` missing=${missing.length}${missing.length ? ' ' + JSON.stringify(missing) : ''}` +
+							` removeId-still-in-primary=${primaryKeys.has(`${table}-rm-base`)}`
+					);
+
+					strictEqual(
+						phantoms.length,
+						0,
+						`Arm A (${table}): index entries pointing at absent primary records: ${JSON.stringify(phantoms)}`
+					);
+					strictEqual(
+						missing.length,
+						0,
+						`Arm A (${table}): primary records with no index entry: ${JSON.stringify(missing)}`
+					);
+				}
+			);
+		}
+
+		// Arm B: #1854's original trigger — a delete followed by a thrown error — observed at the
+		// storage layer, where the phantom the query surfaces cannot show is visible.
+		for (const table of ['ItemF', 'ItemT']) {
+			test(`Arm B (${table}): request-thrown abort after a delete leaves base and index in agreement`, async () => {
+				const id = `${table}-abort-1`;
+				await postJSON('/Seed/', { table, ids: [{ id, category: 'ARMB' }] });
+
+				const res = await postJSON('/DeleteThenAbort/', { table, id });
+				notStrictEqual(res.status, 200, 'DeleteThenAbort handler should surface its deliberate throw as a non-200');
+
+				await refreshOracle();
+				const primaryHasId = rawPrimaryKeys(table).has(id);
+				const indexHasEntry = rawIndexEntries(table, 'category').some((e) => e.key === 'ARMB' && e.id === id);
+
+				console.log(
+					`\n[#1854 Arm B ${table}] status=${res.status} primaryHasId=${primaryHasId} indexHasEntry=${indexHasEntry}`
+				);
+
+				strictEqual(
+					indexHasEntry,
+					primaryHasId,
+					`Arm B (${table}): base row and index entry must agree on whether id=${id} exists (primaryHasId=${primaryHasId}, indexHasEntry=${indexHasEntry})`
+				);
+			});
+		}
+	}
+);

--- a/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
+++ b/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
@@ -15,12 +15,11 @@
  * removes through `updateRecord()`, which has always threaded `{transaction}`.
  *
  * `integrationTests/resources/audit-false-delete-rollback.test.ts` pins the same fix through the
- * client surfaces. This file pins it at the storage layer instead, because the client surfaces
- * cannot see half of the damage: `search_by_value` joins each index entry back through its
- * primary record and silently drops the ones whose record is gone, so a dangling entry is
- * invisible to every query API. The oracle here is a second, independent, read-only
- * `@harperfast/rocksdb-js` handle on the on-disk column families, decoding the composite
- * `[indexedValue, primaryKey]` index keys itself (the wire format written by
+ * client surfaces. Those surfaces cannot see half of the damage: `search_by_value` joins each
+ * index entry back through its primary record and silently drops the ones whose record is gone,
+ * so a dangling entry is invisible to every query API. The oracle here is a second, independent,
+ * read-only `@harperfast/rocksdb-js` handle on the on-disk column families, decoding the
+ * composite `[indexedValue, primaryKey]` index keys itself (the wire format written by
  * resources/RocksIndexStore.ts), with no Harper code in the read path. It also covers the
  * monitor-fired abort (Arm A) alongside #1869's request-thrown abort (Arm B).
  *
@@ -30,7 +29,8 @@
  * write can still sit only in the writer's memtable. An oracle that skips either step reports a
  * clean run from flush timing rather than from real consistency, so `refreshOracle()` flushes
  * through the fixture and reopens every handle before each raw read, and the 'oracle proof'
- * tests below demonstrate — rather than assert — that it detects a phantom the join cannot.
+ * tests below demonstrate — rather than assert — that it detects a phantom the join cannot, on
+ * both tables.
  *
  * Reproduction:
  *   npm run test:integration -- "integrationTests/database/delete-index-atomicity-rocksdb.test.ts"
@@ -51,9 +51,11 @@ const MAX_TXN_OPEN_MS = 1000;
 // The monitor ticks once per `storage.maxTransactionOpenTime` and decays a transaction's budget
 // by one interval per tick (resources/DatabaseTransaction.ts startMonitoringTxns), so the abort
 // lands within ~2-3 ticks. This hold is an order of magnitude past that, purely as slack for a
-// loaded runner; the arm asserts on the log line the monitor actually emitted, never on elapsed
-// wall-clock.
+// loaded runner; the arm asserts on the log line the monitor emitted for its own request, never
+// on elapsed wall-clock.
 const HOLD_MS = 15_000;
+const LOG_FILES = ['hdb.log', 'stdout.log', 'stderr.log'];
+const OVER_TIME_ABORTED = /Transaction was open too long and has been aborted/i;
 const skipSuite = process.platform === 'win32';
 
 suite(
@@ -80,8 +82,11 @@ suite(
 			procOutput += ctx.harper.startupOutput?.stdout ?? '';
 			procOutput += ctx.harper.startupOutput?.stderr ?? '';
 			const proc = ctx.harper.process;
-			proc?.stdout?.on('data', (d: Buffer) => (procOutput += d.toString()));
-			proc?.stderr?.on('data', (d: Buffer) => (procOutput += d.toString()));
+			// setEncoding keeps a multi-byte sequence split across chunk boundaries intact.
+			proc?.stdout?.setEncoding('utf8');
+			proc?.stderr?.setEncoding('utf8');
+			proc?.stdout?.on('data', (d: string) => (procOutput += d));
+			proc?.stderr?.on('data', (d: string) => (procOutput += d));
 
 			// Workers register routes asynchronously; poll the probe route rather than restarting the
 			// http workers, which races against a pre-installed fixture.
@@ -101,11 +106,13 @@ suite(
 			}
 			ok(ready, 'Probe route should become available before the suite runs');
 
-			// The audit flag is what selects the branch each arm targets, so a schema drift that
-			// flipped it would turn this anchor green for the wrong reason.
+			// `audit || trackDeletes` is what selects the branch each arm targets (resources/Table.ts),
+			// and `trackDeletes` can be turned on implicitly by adding a subscribed source, so a drift
+			// in either would retire this anchor while leaving it green.
 			const itemF = await (await getJSON('/TableInfo/?table=ItemF')).json();
 			const itemT = await (await getJSON('/TableInfo/?table=ItemT')).json();
 			strictEqual(itemF.audit, false, 'ItemF must be audit:false to reach the branch this anchor pins');
+			ok(!itemF.trackDeletes, 'ItemF must not track deletes, which would route it through updateRecord() instead');
 			strictEqual(itemT.audit, true, 'ItemT must be audit:true to serve as the control arm');
 
 			// The RocksDB root store for a database is a directory (not a single file as on LMDB) at
@@ -139,21 +146,34 @@ suite(
 			return fetch(`${httpURL}${path}`, { headers: { Authorization: client.headers.Authorization } });
 		}
 
-		function sawLog(pattern: RegExp): boolean {
-			let logText = procOutput;
+		function logSources(): Map<string, string> {
+			const sources = new Map<string, string>([['<stdio>', procOutput]]);
 			if (ctx.harper.logDir) {
-				for (const name of ['hdb.log', 'stdout.log', 'stderr.log']) {
+				for (const name of LOG_FILES) {
 					const p = join(ctx.harper.logDir, name);
-					if (existsSync(p)) {
-						try {
-							logText += readFileSync(p, 'utf8');
-						} catch {
-							/* ignore */
-						}
+					if (!existsSync(p)) continue;
+					try {
+						sources.set(p, readFileSync(p, 'utf8'));
+					} catch {
+						/* ignore */
 					}
 				}
 			}
-			return pattern.test(logText);
+			return sources;
+		}
+		/**
+		 * With `maxTransactionOpenTime` pinned to a second, any Harper-internal transaction that
+		 * outlives it — during startup, or in an earlier arm — emits the same over-time line, after
+		 * which an unscoped search matches forever and every later arm's monitor proof is vacuous.
+		 * Each arm therefore marks the logs immediately before its own request and matches only what
+		 * was appended after that point.
+		 */
+		function markLogs(): Map<string, number> {
+			return new Map([...logSources()].map(([name, text]) => [name, text.length]));
+		}
+		function sawLogSince(mark: Map<string, number>, pattern: RegExp): boolean {
+			for (const [name, text] of logSources()) if (pattern.test(text.slice(mark.get(name) ?? 0))) return true;
+			return false;
 		}
 
 		/**
@@ -177,9 +197,19 @@ suite(
 			if (!dbiCache.has(name)) dbiCache.set(name, RocksDatabase.open(rootPath, { name, readOnly: true }));
 			return dbiCache.get(name)!;
 		}
-		/** Primary keys present in the on-disk primary store, read without consulting any index. */
-		function rawPrimaryKeys(table: string): Set<string> {
-			return new Set([...openDbi(`${table}/`).getKeys()].map(String));
+		/**
+		 * Whether a live record exists under this primary key, via a direct point lookup that no
+		 * index mediates. The raw primary column family cannot answer this: an audited delete routes
+		 * through `updateRecord(id, null, ...)` (resources/Table.ts) and `RecordEncoder.ts` only skips
+		 * the write when the record is `undefined`, so `null` is stored as a tombstone under the same
+		 * key until cleanup runs — measured here, where ItemT's key survives a committed delete. The
+		 * encoded value's payload offset is variable (version, then a 2- or 4-byte metadata word, then
+		 * optional expiration/residency/node-id fields), so reading liveness out of the raw bytes would
+		 * be a guess. The index side, which is where the query surfaces are blind, stays raw.
+		 */
+		async function hasLiveRecord(table: string, id: string): Promise<boolean> {
+			const res = await getJSON(`/${table}/${encodeURIComponent(id)}`);
+			return res.status === 200;
 		}
 		/**
 		 * {category, id} pairs read straight out of the on-disk secondary-index column family.
@@ -193,78 +223,95 @@ suite(
 				id: String(e.key[1]),
 			}));
 		}
-		/** Index entries whose id has no primary record — the dangling entries #1854 produced. */
-		function findPhantoms(table: string, attribute: string): Array<{ key: string; id: string }> {
-			const primaryKeys = rawPrimaryKeys(table);
-			return rawIndexEntries(table, attribute).filter((e) => !primaryKeys.has(e.id));
+		/** Index entries whose id has no live record — the dangling entries #1854 produced. */
+		async function findPhantoms(table: string, attribute: string): Promise<Array<{ key: string; id: string }>> {
+			const entries = rawIndexEntries(table, attribute);
+			const live = new Map<string, boolean>();
+			for (const e of entries) if (!live.has(e.id)) live.set(e.id, await hasLiveRecord(table, e.id));
+			return entries.filter((e) => !live.get(e.id));
 		}
 
-		test('oracle proof: sees a seeded index entry, and sees it vanish on a normal delete', async () => {
-			await postJSON('/Seed/', { table: 'ItemF', ids: [{ id: 'proof-1', category: 'PROOF' }] });
-			await refreshOracle();
-			let entries = rawIndexEntries('ItemF', 'category').filter((e) => e.key === 'PROOF');
-			let keys = rawPrimaryKeys('ItemF');
-			strictEqual(entries.length, 1, 'oracle should see exactly 1 raw index entry for PROOF after seed');
-			strictEqual(entries[0].id, 'proof-1', 'raw index entry should point at proof-1');
-			ok(keys.has('proof-1'), 'oracle should see proof-1 in the raw primary store after seed');
+		async function seed(table: string, ids: Array<{ id: string; category: string }>): Promise<void> {
+			const res = await postJSON('/Seed/', { table, ids });
+			strictEqual(res.status, 200, `seeding ${table} must succeed, or every assertion below is vacuous`);
+		}
 
-			const res = await postJSON('/DeleteOne/', { table: 'ItemF', id: 'proof-1' });
-			strictEqual(res.status, 200, 'ordinary delete should succeed');
+		// Run against both tables: an audit:true control arm whose oracle has never been shown to
+		// work on that table cannot be trusted to go red.
+		for (const table of ['ItemF', 'ItemT']) {
+			test(`oracle proof (${table}): sees a seeded index entry, and sees it vanish on a normal delete`, async () => {
+				await seed(table, [{ id: 'proof-1', category: 'PROOF' }]);
+				await refreshOracle();
+				let entries = rawIndexEntries(table, 'category').filter((e) => e.key === 'PROOF');
+				strictEqual(entries.length, 1, 'oracle should see exactly 1 raw index entry for PROOF after seed');
+				strictEqual(entries[0].id, 'proof-1', 'raw index entry should point at proof-1');
+				ok(await hasLiveRecord(table, 'proof-1'), 'proof-1 should be a live record after seed');
 
-			await refreshOracle();
-			entries = rawIndexEntries('ItemF', 'category').filter((e) => e.key === 'PROOF');
-			keys = rawPrimaryKeys('ItemF');
-			strictEqual(entries.length, 0, 'oracle should see the PROOF index entry vanish after a normal delete');
-			ok(!keys.has('proof-1'), 'oracle should see proof-1 vanish from the raw primary store after a normal delete');
-		});
+				const res = await postJSON('/DeleteOne/', { table, id: 'proof-1' });
+				strictEqual(res.status, 200, 'ordinary delete should succeed');
 
-		test('oracle proof: detects an injected phantom that the join-based query surface cannot', async () => {
-			const res = await postJSON('/InjectPhantom/', { table: 'ItemF', category: 'GHOST', id: 'ghost-1' });
-			strictEqual(res.status, 200, 'InjectPhantom control should succeed (ghost-1 must not already exist)');
+				await refreshOracle();
+				entries = rawIndexEntries(table, 'category').filter((e) => e.key === 'PROOF');
+				strictEqual(entries.length, 0, 'oracle should see the PROOF index entry vanish after a normal delete');
+				ok(!(await hasLiveRecord(table, 'proof-1')), 'proof-1 should no longer be a live record after a normal delete');
+			});
 
-			await refreshOracle();
-			ok(!rawPrimaryKeys('ItemF').has('ghost-1'), 'ghost-1 should never appear in the raw primary store');
+			test(`oracle proof (${table}): detects an injected phantom that the join-based query surface cannot`, async () => {
+				const res = await postJSON('/InjectPhantom/', { table, category: 'GHOST', id: 'ghost-1' });
+				strictEqual(res.status, 200, 'InjectPhantom control should succeed (ghost-1 must not already exist)');
 
-			const phantoms = findPhantoms('ItemF', 'category');
-			ok(
-				phantoms.some((p) => p.id === 'ghost-1' && p.key === 'GHOST'),
-				`oracle should detect the injected phantom (GHOST -> ghost-1); phantoms seen: ${JSON.stringify(phantoms)}`
-			);
+				await refreshOracle();
+				ok(!(await hasLiveRecord(table, 'ghost-1')), 'ghost-1 should never have been written as a record');
 
-			const blind = await (await getJSON('/BlindSearch/?table=ItemF&category=GHOST')).json();
-			strictEqual(
-				blind.hits.length,
-				0,
-				'the join-through-primary query surface must see 0 hits for the same phantom, which is why the arms below read raw storage'
-			);
+				const phantoms = await findPhantoms(table, 'category');
+				ok(
+					phantoms.some((p) => p.id === 'ghost-1' && p.key === 'GHOST'),
+					`oracle should detect the injected phantom (GHOST -> ghost-1); phantoms seen: ${JSON.stringify(phantoms)}`
+				);
 
-			// Remove the deliberate artifact so the table-wide scans in Arm A/B cannot report it as a
-			// genuine phantom (or have a genuine one masked by it).
-			const cleanup = await postJSON('/RemoveIndexEntry/', { table: 'ItemF', category: 'GHOST', id: 'ghost-1' });
-			strictEqual(cleanup.status, 200, 'positive-control cleanup should succeed');
-			await refreshOracle();
-			ok(
-				findPhantoms('ItemF', 'category').every((p) => p.id !== 'ghost-1'),
-				'ghost-1 phantom should be gone after cleanup'
-			);
-		});
+				const blind = await (await getJSON(`/BlindSearch/?table=${table}&category=GHOST`)).json();
+				strictEqual(
+					blind.hits.length,
+					0,
+					'the join-through-primary query surface must see 0 hits for the same phantom, which is why the arms below read raw storage'
+				);
+
+				// Remove the deliberate artifact so the table-wide scans in Arm A/B cannot report it as
+				// a genuine phantom (or have a genuine one masked by it).
+				const cleanup = await postJSON('/RemoveIndexEntry/', { table, category: 'GHOST', id: 'ghost-1' });
+				strictEqual(cleanup.status, 200, 'positive-control cleanup should succeed');
+				await refreshOracle();
+				ok(
+					(await findPhantoms(table, 'category')).every((p) => p.id !== 'ghost-1'),
+					'ghost-1 phantom should be gone after cleanup'
+				);
+			});
+		}
 
 		// Arm A: the abort is fired by the long-transaction monitor mid-transaction, not by the
 		// handler — a different path into the same commit branch than #1869's own test covers.
 		for (const table of ['ItemF', 'ItemT']) {
 			test(
-				`Arm A (${table}): monitor-fired abort mid insert/update/remove leaves base and index in agreement`,
+				`Arm A (${table}): monitor-fired abort mid remove/insert/update leaves base and index in agreement`,
 				{ timeout: HOLD_MS + 60_000 },
 				async () => {
-					await postJSON('/Seed/', {
-						table,
-						ids: [
-							{ id: '__seed__-0', category: '__seed__' },
-							{ id: `${table}-upd-base`, category: 'ARMA-OLD' },
-							{ id: `${table}-rm-base`, category: 'ARMA-DEL' },
-						],
-					});
+					const removeId = `${table}-rm-base`;
+					await seed(table, [
+						{ id: '__seed__-0', category: '__seed__' },
+						{ id: `${table}-upd-base`, category: 'ARMA-OLD' },
+						{ id: removeId, category: 'ARMA-DEL' },
+					]);
 
+					// Without a live, indexed row to delete there is no removeEntry() call and the arm
+					// cannot exercise the branch #1869 fixed, whatever it asserts afterwards.
+					await refreshOracle();
+					ok(await hasLiveRecord(table, removeId), `${removeId} must exist before the held transaction deletes it`);
+					ok(
+						rawIndexEntries(table, 'category').some((e) => e.key === 'ARMA-DEL' && e.id === removeId),
+						`${removeId} must be indexed before the held transaction deletes it`
+					);
+
+					const mark = markLogs();
 					const res = await postJSON('/SlowMixedHold/', {
 						table,
 						insertIds: [
@@ -273,43 +320,39 @@ suite(
 						],
 						updateId: `${table}-upd-base`,
 						updateCategory: 'ARMA-UPDATED',
-						removeId: `${table}-rm-base`,
+						removeId,
 						markerId: `${table}-marker`,
 						holdMs: HOLD_MS,
 					});
-					const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+					const body = await res.text();
 
 					// The monitor's decision is asynchronous to the request returning, so wait for the
 					// evidence itself rather than for a fixed settling delay.
-					const overTime = /Transaction was open too long and has been (aborted|committed)/i;
 					const logDeadline = Date.now() + 15_000;
-					while (!sawLog(overTime) && Date.now() < logDeadline) await sleep(100);
-					const abortedLine = sawLog(/Transaction was open too long and has been aborted/i);
-					const committedLine = sawLog(/Transaction was open too long and has been committed/i);
+					while (!sawLogSince(mark, OVER_TIME_ABORTED) && Date.now() < logDeadline) await sleep(100);
 					ok(
-						abortedLine || committedLine,
-						`the over-time monitor must actually have fired for ${table}; status=${res.status} body=${JSON.stringify(body)}`
+						sawLogSince(mark, OVER_TIME_ABORTED),
+						`the over-time monitor must have aborted this request's transaction; status=${res.status} body=${body.slice(0, 400)}`
 					);
 
 					await refreshOracle();
-					const phantoms = findPhantoms(table, 'category');
-					const primaryKeys = rawPrimaryKeys(table);
+					const phantoms = await findPhantoms(table, 'category');
 					const indexEntries = rawIndexEntries(table, 'category');
 					// The other direction: any row that survived in the primary store must still be
-					// reachable through the index. Both the updated and the pre-image category are listed
-					// because whether the update landed depends on which side of the abort it fell on, and
-					// either outcome is consistent as long as some index entry exists for the surviving row.
+					// reachable through the index. Whether the update landed depends on which side of the
+					// abort it fell on, and either outcome is consistent as long as some index entry
+					// exists for the surviving row.
 					const missing: string[] = [];
 					for (const id of [`${table}-upd-base`, `${table}-ins-1`, `${table}-ins-2`]) {
-						if (!primaryKeys.has(id)) continue;
+						if (!(await hasLiveRecord(table, id))) continue;
 						if (!indexEntries.some((ie) => ie.id === id)) missing.push(`${id} present in primary but not indexed`);
 					}
 
 					console.log(
-						`\n[#1854 Arm A ${table}] status=${res.status} aborted=${abortedLine} committed=${committedLine}\n` +
+						`\n[#1854 Arm A ${table}] status=${res.status}\n` +
 							`  phantoms=${phantoms.length}${phantoms.length ? ' ' + JSON.stringify(phantoms) : ''}` +
 							` missing=${missing.length}${missing.length ? ' ' + JSON.stringify(missing) : ''}` +
-							` removeId-still-in-primary=${primaryKeys.has(`${table}-rm-base`)}`
+							` removeId-still-live=${await hasLiveRecord(table, removeId)}`
 					);
 
 					strictEqual(
@@ -331,13 +374,22 @@ suite(
 		for (const table of ['ItemF', 'ItemT']) {
 			test(`Arm B (${table}): request-thrown abort after a delete leaves base and index in agreement`, async () => {
 				const id = `${table}-abort-1`;
-				await postJSON('/Seed/', { table, ids: [{ id, category: 'ARMB' }] });
+				await seed(table, [{ id, category: 'ARMB' }]);
+
+				// Both halves of the post-condition are equalities, so a seed that silently did nothing
+				// would satisfy them with `false === false`.
+				await refreshOracle();
+				ok(await hasLiveRecord(table, id), `${id} must exist before the aborted delete`);
+				ok(
+					rawIndexEntries(table, 'category').some((e) => e.key === 'ARMB' && e.id === id),
+					`${id} must be indexed before the aborted delete`
+				);
 
 				const res = await postJSON('/DeleteThenAbort/', { table, id });
 				notStrictEqual(res.status, 200, 'DeleteThenAbort handler should surface its deliberate throw as a non-200');
 
 				await refreshOracle();
-				const primaryHasId = rawPrimaryKeys(table).has(id);
+				const primaryHasId = await hasLiveRecord(table, id);
 				const indexHasEntry = rawIndexEntries(table, 'category').some((e) => e.key === 'ARMB' && e.id === id);
 
 				console.log(

--- a/integrationTests/database/delete-index-atomicity-rocksdb/config.yaml
+++ b/integrationTests/database/delete-index-atomicity-rocksdb/config.yaml
@@ -1,0 +1,5 @@
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/database/delete-index-atomicity-rocksdb/resources.js
+++ b/integrationTests/database/delete-index-atomicity-rocksdb/resources.js
@@ -206,7 +206,13 @@ export class SlowMixedHold extends Resource {
 				elapsedMs: Date.now() - t0,
 			};
 		} finally {
-			await iter.return?.();
+			// The monitor may already have torn the transaction down, in which case closing the
+			// iterator throws; letting that escape would replace the response with an unrelated error.
+			try {
+				await iter.return?.();
+			} catch {
+				/* transaction already gone */
+			}
 		}
 	}
 }

--- a/integrationTests/database/delete-index-atomicity-rocksdb/resources.js
+++ b/integrationTests/database/delete-index-atomicity-rocksdb/resources.js
@@ -1,17 +1,15 @@
-// Workload drivers for delete-index-atomicity-rocksdb.test.ts (regression anchor for #1854).
-// The oracle itself lives outside this process — the test opens the raw RocksDB directory with
-// its own read-only handles. These resources only drive the workload and expose the /Flush/
-// control the oracle needs.
+// Workload drivers for delete-index-atomicity-rocksdb.test.ts. The oracle lives outside this
+// process — the test opens the raw RocksDB directory with its own read-only handles — so these
+// routes only drive the workload and expose the flush the oracle needs.
 //
-// /Flush/ exists because a RocksDB readOnly:true open is a point-in-time snapshot of the SSTs as
-// of that open, not a live view like LMDB's shared mmap, and Harper opens table/index column
-// families with disableWAL defaulting true (resources/databases.ts openRocksDatabase), so a
-// committed write can still sit only in the writer's memtable. Without an explicit flush an
-// external reader reports a clean run from flush timing rather than from real consistency.
-// `flushDatabases()` is not reachable from component code (security/jsLoader.ts exposes a
-// curated allowlist), so this calls `.flush()` on a table's primaryStore instead; RocksDB's
-// flush is atomic across every column family sharing the directory, so one call covers both
-// tables and all their indices.
+// A RocksDB readOnly:true open is a point-in-time snapshot of the SSTs as of that open, not a
+// live view like LMDB's shared mmap, and Harper opens table/index column families with
+// disableWAL defaulting true (resources/databases.ts openRocksDatabase), so a committed write
+// can still sit only in the writer's memtable. Without an explicit flush an external reader
+// reports a clean run from flush timing rather than from real consistency. `flushDatabases()` is
+// not reachable from component code (security/jsLoader.ts exposes a curated allowlist), so
+// /Flush/ calls `.flush()` on a table's primaryStore instead; RocksDB's flush is atomic across
+// every column family sharing the directory, so one call covers both tables and all indices.
 
 function sleep(ms) {
 	return new Promise((r) => setTimeout(r, ms));
@@ -22,7 +20,6 @@ function getTable(name) {
 	return t;
 }
 
-// GET /Probe/ -> readiness poll target.
 export class Probe extends Resource {
 	static loadAsInstance = false;
 	async get() {
@@ -30,19 +27,17 @@ export class Probe extends Resource {
 	}
 }
 
-// GET /TableInfo/?table=X -> lets the test confirm the audit flag the arm depends on actually
-// took effect, so a schema drift cannot turn this anchor quietly green for the wrong reason.
+// Lets the test confirm the flags that select the delete branch each arm targets, so a schema
+// drift cannot turn the anchor quietly green for the wrong reason.
 export class TableInfo extends Resource {
 	static loadAsInstance = false;
 	async get(query) {
 		const name = query?.get ? query.get('table') : query?.table;
 		const t = getTable(name);
-		return { table: name, audit: t.audit, hasAuditStore: !!t.auditStore };
+		return { table: name, audit: t.audit, trackDeletes: !!t.trackDeletes, hasAuditStore: !!t.auditStore };
 	}
 }
 
-// POST /Flush/ -> force every column family to flush its memtable to SST so the external
-// read-only oracle can observe writes already committed in this process.
 export class Flush extends Resource {
 	static loadAsInstance = false;
 	async post() {
@@ -54,7 +49,6 @@ export class Flush extends Resource {
 	}
 }
 
-// POST /Seed/ { table, ids: [{id, category, value}] } -> plain, clean inserts.
 export class Seed extends Resource {
 	static loadAsInstance = false;
 	async post(query, body) {
@@ -68,7 +62,6 @@ export class Seed extends Resource {
 	}
 }
 
-// POST /DeleteOne/ { table, id } -> a single ordinary delete, no abort.
 export class DeleteOne extends Resource {
 	static loadAsInstance = false;
 	async post(query, body) {
@@ -79,10 +72,9 @@ export class DeleteOne extends Resource {
 	}
 }
 
-// POST /InjectPhantom/ { table, category, id } -> oracle positive control. Writes a raw index
-// entry for an id that does not exist in the primary store, bypassing Table.ts's write path
-// entirely, so the test can prove its external oracle actually detects a dangling entry (and
-// that the search_by_value-style join cannot).
+// Oracle positive control: writes a raw index entry for an id that does not exist in the primary
+// store, bypassing Table.ts's write path entirely, so the test can prove its external oracle
+// detects a dangling entry — and that the join-based query surface does not.
 export class InjectPhantom extends Resource {
 	static loadAsInstance = false;
 	async post(query, body) {
@@ -95,9 +87,8 @@ export class InjectPhantom extends Resource {
 	}
 }
 
-// POST /RemoveIndexEntry/ { table, category, id } -> cleanup for InjectPhantom, so the
-// deliberately-injected phantom cannot be mistaken for (or mask) a genuine one in the
-// table-wide scans the later arms run against the same table.
+// Cleanup for InjectPhantom, so the deliberate artifact cannot be mistaken for (or mask) a
+// genuine phantom in the table-wide scans the later arms run against the same table.
 export class RemoveIndexEntry extends Resource {
 	static loadAsInstance = false;
 	async post(query, body) {
@@ -108,9 +99,9 @@ export class RemoveIndexEntry extends Resource {
 	}
 }
 
-// GET /BlindSearch/?table=X&category=Y -> the search_by_value-style join through the primary
-// record, in-process, for direct contrast with the external raw-file oracle: it is structurally
-// blind to a phantom because the join drops entries whose primary record is absent.
+// The search_by_value-style join through the primary record, for direct contrast with the
+// external oracle: it is structurally blind to a phantom because the join drops entries whose
+// primary record is absent.
 export class BlindSearch extends Resource {
 	static loadAsInstance = false;
 	async get(query) {
@@ -125,8 +116,7 @@ export class BlindSearch extends Resource {
 	}
 }
 
-// POST /DeleteThenAbort/ { table, id } -> Arm B: delete inside a transaction that then throws,
-// which is #1854's original trigger shape.
+// Arm B: #1854's original trigger shape.
 export class DeleteThenAbort extends Resource {
 	static loadAsInstance = false;
 	async post(query, body) {
@@ -137,9 +127,8 @@ export class DeleteThenAbort extends Resource {
 	}
 }
 
-// POST /SlowMixedHold/ { table, insertIds, updateId, updateCategory, removeId, markerId, holdMs }
-// Arm A: one long-lived write transaction that inserts, updates an indexed attribute, and
-// removes, then holds an open monitor-tracked read iterator past storage.maxTransactionOpenTime
+// Arm A: one long-lived write transaction that removes, inserts, and updates an indexed
+// attribute, then holds an open monitor-tracked read iterator past storage.maxTransactionOpenTime
 // so the background monitor — not the handler — aborts it mid-transaction. The trailing marker
 // write probes whether the ambient transaction was actually poisoned.
 export class SlowMixedHold extends Resource {
@@ -160,16 +149,29 @@ export class SlowMixedHold extends Resource {
 		const iter = t.search({ conditions: [{ attribute: 'category', value: '__seed__' }] })[Symbol.asyncIterator]();
 		await iter.next();
 
-		const applied = { inserted: [], updated: false, removed: false };
+		const applied = { removed: false, inserted: [], updated: false };
 		let writeError = null;
 		try {
-			for (const row of insertIds) {
+			// The remove goes first: it is the write whose transaction threading #1854 was about, so
+			// no earlier write may fail and skip it, leaving the arm asserting on a workload that
+			// never reached removeEntry().
+			if (removeId) {
 				try {
-					await t.put({ id: row.id, category: row.category, value: 'inserted' });
-					applied.inserted.push(row.id);
+					await t.delete(removeId);
+					applied.removed = true;
 				} catch (e) {
-					writeError = `insert ${row.id}: ${String((e && e.message) || e)}`;
-					break;
+					writeError = `remove ${removeId}: ${String((e && e.message) || e)}`;
+				}
+			}
+			if (!writeError) {
+				for (const row of insertIds) {
+					try {
+						await t.put({ id: row.id, category: row.category, value: 'inserted' });
+						applied.inserted.push(row.id);
+					} catch (e) {
+						writeError = `insert ${row.id}: ${String((e && e.message) || e)}`;
+						break;
+					}
 				}
 			}
 			if (!writeError && updateId) {
@@ -178,14 +180,6 @@ export class SlowMixedHold extends Resource {
 					applied.updated = true;
 				} catch (e) {
 					writeError = `update ${updateId}: ${String((e && e.message) || e)}`;
-				}
-			}
-			if (!writeError && removeId) {
-				try {
-					await t.delete(removeId);
-					applied.removed = true;
-				} catch (e) {
-					writeError = `remove ${removeId}: ${String((e && e.message) || e)}`;
 				}
 			}
 			await sleep(holdMs);

--- a/integrationTests/database/delete-index-atomicity-rocksdb/resources.js
+++ b/integrationTests/database/delete-index-atomicity-rocksdb/resources.js
@@ -1,0 +1,213 @@
+// Workload drivers for delete-index-atomicity-rocksdb.test.ts (regression anchor for #1854).
+// The oracle itself lives outside this process — the test opens the raw RocksDB directory with
+// its own read-only handles. These resources only drive the workload and expose the /Flush/
+// control the oracle needs.
+//
+// /Flush/ exists because a RocksDB readOnly:true open is a point-in-time snapshot of the SSTs as
+// of that open, not a live view like LMDB's shared mmap, and Harper opens table/index column
+// families with disableWAL defaulting true (resources/databases.ts openRocksDatabase), so a
+// committed write can still sit only in the writer's memtable. Without an explicit flush an
+// external reader reports a clean run from flush timing rather than from real consistency.
+// `flushDatabases()` is not reachable from component code (security/jsLoader.ts exposes a
+// curated allowlist), so this calls `.flush()` on a table's primaryStore instead; RocksDB's
+// flush is atomic across every column family sharing the directory, so one call covers both
+// tables and all their indices.
+
+function sleep(ms) {
+	return new Promise((r) => setTimeout(r, ms));
+}
+function getTable(name) {
+	const t = tables[name];
+	if (!t) throw new Error(`delete-index-atomicity-rocksdb: unknown table "${name}"`);
+	return t;
+}
+
+// GET /Probe/ -> readiness poll target.
+export class Probe extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		return { ok: true };
+	}
+}
+
+// GET /TableInfo/?table=X -> lets the test confirm the audit flag the arm depends on actually
+// took effect, so a schema drift cannot turn this anchor quietly green for the wrong reason.
+export class TableInfo extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const name = query?.get ? query.get('table') : query?.table;
+		const t = getTable(name);
+		return { table: name, audit: t.audit, hasAuditStore: !!t.auditStore };
+	}
+}
+
+// POST /Flush/ -> force every column family to flush its memtable to SST so the external
+// read-only oracle can observe writes already committed in this process.
+export class Flush extends Resource {
+	static loadAsInstance = false;
+	async post() {
+		const t = getTable('ItemF');
+		if (typeof t.primaryStore.flush !== 'function')
+			throw new Error('Flush control invalid: primaryStore.flush() not available (not RocksDB?)');
+		await t.primaryStore.flush();
+		return { ok: true };
+	}
+}
+
+// POST /Seed/ { table, ids: [{id, category, value}] } -> plain, clean inserts.
+export class Seed extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const t = getTable(b.table);
+		const rows = b.ids || [];
+		for (const row of rows) {
+			await t.put({ id: row.id, category: row.category, value: row.value ?? 'seed' });
+		}
+		return { ok: true, table: b.table, count: rows.length };
+	}
+}
+
+// POST /DeleteOne/ { table, id } -> a single ordinary delete, no abort.
+export class DeleteOne extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const t = getTable(b.table);
+		await t.delete(b.id);
+		return { ok: true, table: b.table, id: b.id };
+	}
+}
+
+// POST /InjectPhantom/ { table, category, id } -> oracle positive control. Writes a raw index
+// entry for an id that does not exist in the primary store, bypassing Table.ts's write path
+// entirely, so the test can prove its external oracle actually detects a dangling entry (and
+// that the search_by_value-style join cannot).
+export class InjectPhantom extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const t = getTable(b.table);
+		const existing = t.primaryStore.getEntry(b.id);
+		if (existing?.value) throw new Error(`InjectPhantom control invalid: id=${b.id} already exists in primary store`);
+		await t.indices.category.put(b.category, b.id);
+		return { ok: true, table: b.table, category: b.category, id: b.id, injected: true };
+	}
+}
+
+// POST /RemoveIndexEntry/ { table, category, id } -> cleanup for InjectPhantom, so the
+// deliberately-injected phantom cannot be mistaken for (or mask) a genuine one in the
+// table-wide scans the later arms run against the same table.
+export class RemoveIndexEntry extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const t = getTable(b.table);
+		await t.indices.category.remove(b.category, b.id);
+		return { ok: true, table: b.table, category: b.category, id: b.id, removed: true };
+	}
+}
+
+// GET /BlindSearch/?table=X&category=Y -> the search_by_value-style join through the primary
+// record, in-process, for direct contrast with the external raw-file oracle: it is structurally
+// blind to a phantom because the join drops entries whose primary record is absent.
+export class BlindSearch extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const name = query?.get ? query.get('table') : query?.table;
+		const category = query?.get ? query.get('category') : query?.category;
+		const t = getTable(name);
+		const out = [];
+		for await (const r of t.search({ conditions: [{ attribute: 'category', value: category }] })) {
+			out.push({ id: r.id, category: r.category });
+		}
+		return { table: name, category, hits: out };
+	}
+}
+
+// POST /DeleteThenAbort/ { table, id } -> Arm B: delete inside a transaction that then throws,
+// which is #1854's original trigger shape.
+export class DeleteThenAbort extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const t = getTable(b.table);
+		await t.delete(b.id);
+		throw new Error(`deliberate abort after delete (table=${b.table} id=${b.id})`);
+	}
+}
+
+// POST /SlowMixedHold/ { table, insertIds, updateId, updateCategory, removeId, markerId, holdMs }
+// Arm A: one long-lived write transaction that inserts, updates an indexed attribute, and
+// removes, then holds an open monitor-tracked read iterator past storage.maxTransactionOpenTime
+// so the background monitor — not the handler — aborts it mid-transaction. The trailing marker
+// write probes whether the ambient transaction was actually poisoned.
+export class SlowMixedHold extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const t = getTable(b.table);
+		const insertIds = b.insertIds || [];
+		const updateId = b.updateId;
+		const updateCategory = b.updateCategory;
+		const removeId = b.removeId;
+		const markerId = b.markerId;
+		const holdMs = b.holdMs != null ? Number(b.holdMs) : 15_000;
+		const t0 = Date.now();
+
+		// Holding an open iterator over a pre-seeded bucket is what registers a read txn with the
+		// long-transaction monitor; without it the monitor never supervises this transaction.
+		const iter = t.search({ conditions: [{ attribute: 'category', value: '__seed__' }] })[Symbol.asyncIterator]();
+		await iter.next();
+
+		const applied = { inserted: [], updated: false, removed: false };
+		let writeError = null;
+		try {
+			for (const row of insertIds) {
+				try {
+					await t.put({ id: row.id, category: row.category, value: 'inserted' });
+					applied.inserted.push(row.id);
+				} catch (e) {
+					writeError = `insert ${row.id}: ${String((e && e.message) || e)}`;
+					break;
+				}
+			}
+			if (!writeError && updateId) {
+				try {
+					await t.put({ id: updateId, category: updateCategory, value: 'updated' });
+					applied.updated = true;
+				} catch (e) {
+					writeError = `update ${updateId}: ${String((e && e.message) || e)}`;
+				}
+			}
+			if (!writeError && removeId) {
+				try {
+					await t.delete(removeId);
+					applied.removed = true;
+				} catch (e) {
+					writeError = `remove ${removeId}: ${String((e && e.message) || e)}`;
+				}
+			}
+			await sleep(holdMs);
+			let markerError = null;
+			if (markerId) {
+				try {
+					await t.put({ id: markerId, category: 'MARKER', value: 'marker' });
+				} catch (e) {
+					markerError = String((e && e.message) || e);
+				}
+			}
+			return {
+				ok: !writeError,
+				table: b.table,
+				applied,
+				writeError,
+				markerId,
+				markerError,
+				elapsedMs: Date.now() - t0,
+			};
+		} finally {
+			await iter.return?.();
+		}
+	}
+}

--- a/integrationTests/database/delete-index-atomicity-rocksdb/resources.js
+++ b/integrationTests/database/delete-index-atomicity-rocksdb/resources.js
@@ -147,11 +147,11 @@ export class SlowMixedHold extends Resource {
 		// Holding an open iterator over a pre-seeded bucket is what registers a read txn with the
 		// long-transaction monitor; without it the monitor never supervises this transaction.
 		const iter = t.search({ conditions: [{ attribute: 'category', value: '__seed__' }] })[Symbol.asyncIterator]();
-		await iter.next();
 
 		const applied = { removed: false, inserted: [], updated: false };
 		let writeError = null;
 		try {
+			await iter.next();
 			// The remove goes first: it is the write whose transaction threading #1854 was about, so
 			// no earlier write may fail and skip it, leaving the arm asserting on a workload that
 			// never reached removeEntry().
@@ -182,6 +182,11 @@ export class SlowMixedHold extends Resource {
 					writeError = `update ${updateId}: ${String((e && e.message) || e)}`;
 				}
 			}
+			// Fail fast and loudly rather than holding: a workload that never reached the writes still
+			// trips the monitor, and the arm would then find no phantoms and pass without having
+			// exercised the delete at all.
+			if (writeError) throw new Error(`SlowMixedHold: workload write failed before the hold: ${writeError}`);
+
 			await sleep(holdMs);
 			let markerError = null;
 			if (markerId) {

--- a/integrationTests/database/delete-index-atomicity-rocksdb/schema.graphql
+++ b/integrationTests/database/delete-index-atomicity-rocksdb/schema.graphql
@@ -1,14 +1,8 @@
-# Regression anchor for #1854 (fixed by PR #1869) — an aborted delete on an audit:false
-# @indexed table must not leave the secondary index pointing at a primary key that is gone.
-#
-# ItemF: audit:false — reaches Table.ts _writeDelete()'s non-audit commit branch, where
-#   removeEntry(primaryStore, existingEntry) is the only write in the branch that has to be
-#   told about the ambient transaction. Before #1869 it was not, so on RocksDB the base-row
-#   removal committed standalone and survived an abort while updateIndices() — which is
-#   transaction-scoped — rolled back, leaving the index entry dangling.
-# ItemT: audit:true — control arm. That branch removes the record through updateRecord(),
-#   which has always threaded {transaction}, so it must stay consistent either way; a red
-#   ItemT arm means the divergence is not the one this anchor is pinning.
+# ItemF (audit:false) reaches Table.ts _writeDelete()'s non-audit commit branch, where the
+# base-row removal is the one write that has to be told about the ambient transaction; before
+# #1869 it was not. ItemT (audit:true) removes through updateRecord(), which has always threaded
+# {transaction}, and is the control: a red ItemT arm means the divergence is not the one this
+# anchor pins.
 type ItemF @table(audit: false) @export {
 	id: ID! @primaryKey
 	category: String @indexed

--- a/integrationTests/database/delete-index-atomicity-rocksdb/schema.graphql
+++ b/integrationTests/database/delete-index-atomicity-rocksdb/schema.graphql
@@ -1,0 +1,22 @@
+# Regression anchor for #1854 (fixed by PR #1869) — an aborted delete on an audit:false
+# @indexed table must not leave the secondary index pointing at a primary key that is gone.
+#
+# ItemF: audit:false — reaches Table.ts _writeDelete()'s non-audit commit branch, where
+#   removeEntry(primaryStore, existingEntry) is the only write in the branch that has to be
+#   told about the ambient transaction. Before #1869 it was not, so on RocksDB the base-row
+#   removal committed standalone and survived an abort while updateIndices() — which is
+#   transaction-scoped — rolled back, leaving the index entry dangling.
+# ItemT: audit:true — control arm. That branch removes the record through updateRecord(),
+#   which has always threaded {transaction}, so it must stay consistent either way; a red
+#   ItemT arm means the divergence is not the one this anchor is pinning.
+type ItemF @table(audit: false) @export {
+	id: ID! @primaryKey
+	category: String @indexed
+	value: String
+}
+
+type ItemT @table(audit: true) @export {
+	id: ID! @primaryKey
+	category: String @indexed
+	value: String
+}


### PR DESCRIPTION
Promotes a QA-explorer spec (finding P-512 / scenario QA-731) to a committed regression anchor for [#1854](https://github.com/HarperFast/harper/issues/1854), fixed by [#1869 — fix: thread {transaction} into removeEntry for audit:false table deletes](https://github.com/HarperFast/harper/pull/1869). Test-only: four new files, no product code changed.

`_writeDelete()`'s non-audit commit branch removes the base row through `removeEntry()` while removing the index entries through the transaction-scoped `updateIndices()`. Before #1869 the base-row removal was not told about the ambient transaction, so on RocksDB it committed standalone: an aborted transaction still durably removed the row while the index removal rolled back, leaving the secondary index pointing at a primary key that no longer exists.

## Why a second anchor

`integrationTests/resources/audit-false-delete-rollback.test.ts` (shipped with #1869) pins the same fix through the client surfaces. Those surfaces cannot see half of the damage: `search_by_value` joins each index entry back through its primary record and drops the ones whose record is gone, so a dangling entry is invisible to every query API. This anchor reads the secondary-index column families directly with a read-only `@harperfast/rocksdb-js` handle, [decoding the composite `[indexedValue, primaryKey]` keys itself](https://github.com/HarperFast/harper/pull/2400/changes?w=1#diff-5097b51cdc22ddf502301cd56053dc01c2199c4051a6eb408c7b6213fa62a266R226), and adds the monitor-fired abort path (Arm A) alongside #1869's request-thrown abort (Arm B).

Four "oracle proof" tests — two per table — demonstrate rather than assume that the oracle sees an index entry appear and vanish, and detects an injected phantom — [written straight into the index column family](https://github.com/HarperFast/harper/pull/2400/changes?w=1#diff-ab464a4348bd6feff2b58d88e80ec6d2e571aa9558f0a3b0bee7e7728ecfad0aR85), bypassing `Table.ts` — that `BlindSearch` returns zero hits for on the identical on-disk state. The oracle flushes through a fixture control and reopens every handle before each raw read: a RocksDB `readOnly: true` open is a point-in-time snapshot of the SSTs as of that open, and Harper opens these column families with `disableWAL` defaulting true, so without both steps a clean run would be evidence of flush timing rather than of consistency.

## For the human reviewer

- **The oracle is deliberately split, and that is the decision most worth checking.** The index side is raw; primary-record liveness is [a direct point lookup by primary key](https://github.com/HarperFast/harper/pull/2400/changes?w=1#diff-5097b51cdc22ddf502301cd56053dc01c2199c4051a6eb408c7b6213fa62a266R211). It started out reading the raw primary column family, and that made the `audit:true` control arm structurally unable to go red: an audited delete routes through `updateRecord(id, null, …)`, and `RecordEncoder` only skips the write when the record is `undefined`, so `null` lands as a tombstone under the same key until cleanup runs. That is measured, not argued — with a keys-only oracle the `ItemT` proof test fails. Reading liveness out of the raw bytes instead would mean hardcoding a payload offset that is variable (version, then a 2- or 4-byte metadata word, then optional expiration/residency/node-id fields), so a point lookup is the honest primitive. It maps 200/404 and [throws on anything else](https://github.com/HarperFast/harper/pull/2400/changes?w=1#diff-5097b51cdc22ddf502301cd56053dc01c2199c4051a6eb408c7b6213fa62a266R211), because treating a 500 as "absent" would fabricate a phantom. No index mediates it, and the blindness this anchor exists to defeat is entirely on the index side.
- **Why the arms cannot pass vacuously**, since that is the whole value of an anchor and it took four review rounds to close: `SlowMixedHold` [throws before its hold if any write failed](https://github.com/HarperFast/harper/pull/2400/changes?w=1#diff-ab464a4348bd6feff2b58d88e80ec6d2e571aa9558f0a3b0bee7e7728ecfad0aR188), so a request that reaches the hold staged all three; the monitor only aborts *write-bearing* transactions; Arm A [requires a 4xx carrying the over-time error](https://github.com/HarperFast/harper/pull/2400/changes?w=1#diff-5097b51cdc22ddf502301cd56053dc01c2199c4051a6eb408c7b6213fa62a266R338), which only arrives after the hold and the failed commit, so a monitor that logged an abort but left the handle usable would return 200 and fail the arm; and the abort log line is [matched with the table and route it names](https://github.com/HarperFast/harper/pull/2400/changes?w=1#diff-5097b51cdc22ddf502301cd56053dc01c2199c4051a6eb408c7b6213fa62a266R346) (`from table: ItemF/ path: /SlowMixedHold/`) within a [per-request log watermark](https://github.com/HarperFast/harper/pull/2400/changes?w=1#diff-5097b51cdc22ddf502301cd56053dc01c2199c4051a6eb408c7b6213fa62a266R176), so no unrelated transaction outrunning the 1 s limit can supply the evidence. Arm B likewise [requires the fixture's own throw in the body](https://github.com/HarperFast/harper/pull/2400/changes?w=1#diff-5097b51cdc22ddf502301cd56053dc01c2199c4051a6eb408c7b6213fa62a266R416), not merely an error status. Both arms assert the row and its index entry *survive* ([Arm A](https://github.com/HarperFast/harper/pull/2400/changes?w=1#diff-5097b51cdc22ddf502301cd56053dc01c2199c4051a6eb408c7b6213fa62a266R376), [Arm B](https://github.com/HarperFast/harper/pull/2400/changes?w=1#diff-5097b51cdc22ddf502301cd56053dc01c2199c4051a6eb408c7b6213fa62a266R428)), not merely that they agree — agreement is also satisfied by both vanishing.
- **Runtime is ~35 s**, of which 30 s is two deliberate transaction holds. Gemini suggested short-circuiting them by probing the transaction until it throws; I did not, because a probe write re-arms `writeTimeout` and would keep the transaction alive rather than let it be reaped. The QA original held 65 s for parity with its LMDB sibling; 15 s is ~5× the ~2–3 monitor ticks the abort actually needs.
- **Deliberately not merged into the sibling anchor.** This suite pins `HARPER_STORAGE_ENGINE=rocksdb`, `storage.maxTransactionOpenTime: 1000` and `debugLongTransactions`; folding it in would impose those on that file's engine-agnostic probes.
- **`/InjectPhantom/` and `/RemoveIndexEntry/` write raw secondary-index entries, bypassing `Table.ts`.** That is what makes the positive control possible, and it is a pattern worth agreeing on before it gets copied — a deliberate index-corruption injector living in a fixture.
- **Arm A [asserts zero phantoms table-wide](https://github.com/HarperFast/harper/pull/2400/changes?w=1#diff-5097b51cdc22ddf502301cd56053dc01c2199c4051a6eb408c7b6213fa62a266R233)**, not just for the ids it touched, which is why the injected `ghost-1` is cleaned up before the arms run. It catches collateral damage a narrower assertion would miss, at the cost of coupling the tests in file order.
- Two review findings were declined as incorrect rather than fixed: that `getRange()` yields raw `Buffer` keys (`keyEncoding` defaults to `ordered-binary`, and the green runs assert on the decoded `'PROOF'`/`'GHOST'` values), and that the 250 ms log poll is a load risk (it matches on the first call, ~12 s after the abort has already landed). The CLI's `no-restart-test` self-check also fired; it is a false positive here — the diff adds no product recovery path, it tests one.
- The `@ts-expect-error` on the `client.mjs` import reports as unused under `integrationTests/tsconfig.json`, matching every other integration test that imports it.

## Verification

Storage-engine behaviour, so both directions were measured on `e16d9616a` after `npm run build`:

| run | result |
| --- | --- |
| `npm run test:integration -- "integrationTests/database/delete-index-atomicity-rocksdb.test.ts"` on main, cold | **8/8 pass**, ~34.1 s |
| the same file alongside `integrationTests/resources/audit-false-delete-rollback.test.ts` under default (concurrent) isolation | **10/10 pass** |
| the same file with #1869 rewound — `removeEntry(primaryStore, existingEntry, isRocksDB && transaction ? { transaction } : undefined)` → `removeEntry(primaryStore, existingEntry)`, rebuilt | **6/8 — both `ItemF` arms red** |

The rewound failures name the invariant directly, and only on the `audit:false` table:

```
Arm A (ItemF): ItemF-rm-base must survive the aborted delete
Arm B (ItemF): ItemF-abort-1 must survive the aborted delete (the removal must roll back)
```

Both `ItemT` (`audit:true`) control arms and all four oracle-proof tests stayed green in that run, so what the anchor measures is the audit-branch asymmetry #1869 fixed rather than a generic abort bug. `npm run format:check` and `npm run lint:required` are clean repo-wide.

On this PR, every integration shard is green across Node 24, Bun, uWS HTTP and Windows, along with Format Check, lint, coverage and validate. The three `Unit Test` jobs are red on `Caching > Can load cached indexed data` ("the fencing source fill should reach the indexed subscription", `unitTests/resources/caching.test.js:872`). That is **pre-existing on main**, not from this PR: the identical failure is on `e16d9616a` (this branch's base, [run 33269006287](https://github.com/HarperFast/harper/actions/runs/33269006287)) and on `9104b6b07` before it. This diff adds four new files under `integrationTests/` and changes no product code, so the unit suite does not load any of it.

Refs #1854

Complexity: 2

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=4 @ 9c55a45be2e5</sub>

<sub>Human-Review-Need: 3 @ 9c55a45be2e5</sub>
