### PR TITLE
Fix Windows CI flake: process-spawn allowlist read before config loads

### DIFF
--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -973,7 +973,13 @@ const ALLOWED_NODE_BUILTIN_MODULES = env.get(CONFIG_PARAMS.APPLICATIONS_ALLOWEDB
 				return true;
 			},
 		};
-const ALLOWED_COMMANDS = new Set(env.get(CONFIG_PARAMS.APPLICATIONS_ALLOWEDSPAWNCOMMANDS) ?? []);
+// Resolved per call rather than at module load: this module is imported from the component loader,
+// which can be pulled in before the config has been read (and unit tests seed config after import),
+// and a list captured then would be empty for the life of the process.
+function isAllowedCommand(command: string): boolean {
+	const allowed = env.get(CONFIG_PARAMS.APPLICATIONS_ALLOWEDSPAWNCOMMANDS);
+	return Array.isArray(allowed) && allowed.includes(command);
+}
 const child_processConstrained: any = {
 	exec: createSpawn(child_process.exec),
 	execFile: createSpawn(child_process.execFile),
@@ -1131,7 +1137,7 @@ function acquirePidFileLock(
 function createSpawn(spawnFunction: (...args: any) => child_process.ChildProcess, alwaysAllow?: boolean) {
 	const basePath = env.getHdbBasePath();
 	return function (command: string, args?: any, options?: any, callback?: (...args: any[]) => void) {
-		if (!ALLOWED_COMMANDS.has(command.split(' ')[0]) && !alwaysAllow) {
+		if (!alwaysAllow && !isAllowedCommand(command.split(' ')[0])) {
 			throw new Error(`Command ${command} is not allowed`);
 		}
 		const processName = options?.name;

--- a/unitTests/components/globalIsolation.test.js
+++ b/unitTests/components/globalIsolation.test.js
@@ -4,11 +4,27 @@ const { loadComponent, loadedPaths } = require('#src/components/componentLoader'
 const { PACKAGE_ROOT } = require('#src/utility/packageUtils');
 const fs = require('node:fs');
 const env = require('#src/utility/environment/environmentManager');
+const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
 const { ApplicationScope } = require('#src/components/ApplicationScope');
 
 describe('Global Variable Isolation in testJSWithDeps', function () {
 	let mockResources;
 	let pidsDir;
+	let originalAllowedSpawnCommands;
+
+	before(function () {
+		// The spawn allowlist normally comes from the config file of an installed Harper. A clean
+		// machine (CI) has no ~/.harperdb/hdb_boot_properties.file, so env.get() returns undefined and
+		// every command — including the `npm` the process-spawn fixture uses to reach the "name is
+		// required" check — is rejected as disallowed instead. Pin the list so these tests assert on a
+		// fixture rather than on whatever the host machine happens to have installed.
+		originalAllowedSpawnCommands = env.get(CONFIG_PARAMS.APPLICATIONS_ALLOWEDSPAWNCOMMANDS);
+		env.setProperty(CONFIG_PARAMS.APPLICATIONS_ALLOWEDSPAWNCOMMANDS, ['npm', 'node']);
+	});
+
+	after(function () {
+		env.setProperty(CONFIG_PARAMS.APPLICATIONS_ALLOWEDSPAWNCOMMANDS, originalAllowedSpawnCommands);
+	});
 
 	beforeEach(function () {
 		// Create mock resources


### PR DESCRIPTION
## Summary
- `security/jsLoader.ts` captured `applications_allowedSpawnCommands` into a `Set` at module-load time. On a clean machine (no `~/.harperdb/hdb_boot_properties.file`, as on the `windows-latest` runner added in #2361) the config hasn't been read yet when the module is first imported, so the set is permanently empty and every `spawn`/`exec`/`fork` call is rejected as `"not allowed"` instead of reaching the `"must have a process name"` check that `should enforce process spawning restrictions` in `unitTests/components/globalIsolation.test.js` exercises.
- Reproduced locally by pointing `USERPROFILE`/`HOME` at an empty directory (removing `hdb_boot_properties.file` from the picture, same technique used for the logging-suite fixes) — the original test fails there with `AssertionError: Should throw error about missing name`.
- Fix: resolve the allowlist per call (`isAllowedCommand`) instead of once at module load, and pin `applications_allowedSpawnCommands` explicitly in the test's `before`/`after` hooks so the suite asserts against a fixture value rather than whatever config the host machine happens to have installed.

## Test plan
- [x] `unitTests/components/globalIsolation.test.js` — 13/13 passing on a normal dev machine
- [x] Same file — 13/13 passing with `USERPROFILE`/`HOME` pointed at an empty directory (clean-runner repro)
- [x] Original (pre-fix) test file — reproduces the reported failure under the same clean-`HOME` condition
- [x] `npx prettier --check` on both changed files

## Rebase (2026-08-31)
The three red `Unit Test` checks were **not** caused by this PR. They were `main` failing at the
base this branch was cut from: `Caching > Can load cached indexed data` /
"the fencing source fill should reach the indexed subscription"
(`unitTests/resources/caching.test.js`), a regression from #2065 in which a RocksDB source cache
fill is stored at a version that differs from its transaction-log key, so the subscription
listener drops the event. That is now fixed on main by
[#2409](https://github.com/HarperFast/harper/pull/2409) (`b3235b8c6`), and this branch has been
rebased onto it. No code change to this PR — the diff is byte-identical to the pre-rebase one.

### Residual red is also not this PR
Post-rebase CI on `c564250981e2` still shows the three `Unit Test` legs red, with **exactly one
failure each and the same one**: `branch preparation rejects rather than falling back (harper#643)
> does nothing when no databases are declared`, in the LMDB leg
(`HARPER_STORAGE_ENGINE=lmdb npm run test:unit:resources`), throwing `Application 'app' declares
branchedDatabases, which requires the RocksDB storage engine`. That is #2352 (`c50edffc3`), which
landed on main earlier today; `main` itself fails the identical test (run
[33390386458](https://github.com/HarperFast/harper/actions/runs/33390386458) at `b3235b8c6`, and
every main run since `c50edffc3`). It is already fixed by the open
[#2413 "Let an empty branchedDatabases declaration load under LMDB"](https://github.com/HarperFast/harper/pull/2413).
Because this workflow triggers on `pull_request` and checks out the merge ref, **re-running Unit
Test on this PR after #2413 merges is enough — no further rebase needed.**

## Verification (post-rebase, local, Node 24)
- `npm run build` — clean
- `npm run test:unit:resources` — **1841 passing / 23 pending / 0 failing** (was 1802/22/**1 failing**; the caching failure is gone)
- `npx mocha unitTests/components/globalIsolation.test.js` — 13/13 passing
- `npm run test:unit:main` — 5119 passing / 195 pending / 2 failing; both failures are environment-local to this box and untouched by this diff (`unitTests/security/tokenAuthentication.test.js:247` needs an installed instance, which CI provides via `harper install`; `unitTests/validation/configValidator.test.js:332` depends on the worktree path length)

## For the human reviewer
An independent pre-push review (codex + gemini + cursor-grok + harper-domain) ran against the
rebased head `c564250981e2`; adjudicated severity **minor**, no blockers. Nothing was changed in
response, deliberately — this task was scoped to the CI failure. What it surfaced, for triage:

- **Pre-existing, same file, worth a separate issue:** [`ALLOWED_NODE_BUILTIN_MODULES`](https://github.com/HarperFast/harper/blob/c564250981e273bac5a4a40a2ab8d89dea1d5ed3/security/jsLoader.ts#L968-L975) is the fail-open twin of the bug this PR fixes: it is still snapshotted at import, and when config is unread at import it becomes an allow-all `has(){return true}`, so a restrictive operator-configured `applications.allowedBuiltInModules` silently never applies for the life of the process. Two adjacent security knobs now have opposite timing *and* opposite failure directions.
- **Pre-existing:** `createSpawn` still captures `basePath` at module-init, so on the very pre-config import path this change tolerates, the first *allowed* spawn would die in `join(basePath, 'pids')` rather than launch. Latent today (`unitTests/mocha.init.js` sets `HDB_ROOT_KEY` before any import, and production reads config before loading components).
- **Pre-existing:** the allowlist checks only the first space-delimited token while `exec` runs the whole string through a shell, and `fork` is `alwaysAllow`. A guardrail rather than a boundary — app developers are admins in Harper's threat model — but the changed line is where a reader will assume otherwise.
- **Scope note on the test anchor:** the `before`/`after` pin only distinguishes new from old behaviour on a config-less machine. With an installed Harper, `static/defaultConfig.yaml` already supplies `[npm, node]`, so the suite passes with or without the fix locally. It anchors clean CI — which is the flake being fixed — but a green local run does not by itself prove the per-call resolution.
- Open design question the reviewer flagged and this PR does not settle: whether `env.get` should fall back to the shipped `static/defaultConfig.yaml` values for an uninstalled/pre-init process. That is the deeper root cause and affects every config consumer, not just spawn, so "not here" looks right — but it should be a conscious call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=claude; ran=gemini,cursor-grok,codex; adjudicated=domain; declined=cursor-composer; rounds=1 @ c564250981e2</sub>

<sub>Human-Review-Need: 4 (decisions: spawn-policy-read-through, clean-machine-denies-everything, asymmetric-policy-shape, test-pins-process-global-config) @ c564250981e2</sub>
