### PR TITLE
Fix MCP create_* tools being manufactured for Resources with no real create verb

### DIFF
--- a/components/mcp/tools/application.ts
+++ b/components/mcp/tools/application.ts
@@ -3,7 +3,8 @@
  * and registers verb tools (`get_*`, `search_*`, `create_*`, `update_*`,
  * `delete_*`) for each exported Resource that:
  *   1. Has a `'mcp'` exportType not explicitly set to `false`.
- *   2. Implements the corresponding verb on its prototype.
+ *   2. Implements the corresponding verb on its prototype (for `create_*`, an actual
+ *      override, not mere inheritance of the base `Resource.post`).
  *
  * Tool dispatch delegates to the static `Resource.get/post/put/delete/search`
  * methods, which wrap `transactional()` internally. That entry point runs the
@@ -24,9 +25,11 @@ import { createHash } from 'node:crypto';
 import * as env from '../../../utility/environment/environmentManager.ts';
 import { CONFIG_PARAMS } from '../../../utility/hdbTerms.ts';
 import harperLogger from '../../../utility/logging/harper_logger.ts';
+import { Resource } from '../../../resources/Resource.ts';
 import {
 	addTool,
 	clearProfileTools,
+	hasClassLevelVerbs,
 	isAuthenticated,
 	snapshotProfileTools,
 	type AuthedUser,
@@ -687,12 +690,13 @@ function detectVerbs(ResourceClass: ResourceClassLike): VerbAvailability {
 	if (!p || typeof p !== 'object') {
 		return { get: false, search: false, create: false, updatePut: false, updatePatch: false, delete: false };
 	}
+	// `post` is inherited from the base `Resource` prototype whether or not a subclass
+	// overrides it, so `hasClassLevelVerbs` identity-compares instead of a bare `typeof`.
+	// A `create()` override counts too: `loadAsInstance === false` dispatches straight to it.
 	return {
 		get: typeof p.get === 'function',
 		search: typeof p.search === 'function',
-		// Resource.post defaults to no-op on the base class, but `update()` is the
-		// implicit override per the openApi pattern. Treat either as "has create".
-		create: typeof p.post === 'function' || typeof p.update === 'function',
+		create: hasClassLevelVerbs(p, Resource.prototype).post || typeof p.create === 'function',
 		updatePut: typeof p.put === 'function',
 		updatePatch: typeof p.patch === 'function',
 		delete: typeof p.delete === 'function',

--- a/unitTests/components/mcp/tools/application.test.js
+++ b/unitTests/components/mcp/tools/application.test.js
@@ -255,12 +255,15 @@ describe('mcp/tools/application — registration', () => {
 		assert.deepEqual(names.sort(), ['get_ReadOnly', 'search_ReadOnly']);
 	});
 
-	it('manufactures create_ for a real Resource subclass that only overrides update() (Table.ts pattern)', () => {
+	it('manufactures create_ for a real Resource subclass that overrides update() and create(), not post() (Table.ts pattern)', () => {
 		class Writable extends Resource {
 			async get(target) {
 				return { id: target.id, name: 'sample' };
 			}
 			async update(target, record) {
+				return record;
+			}
+			async create(target, record) {
 				return record;
 			}
 		}

--- a/unitTests/components/mcp/tools/application.test.js
+++ b/unitTests/components/mcp/tools/application.test.js
@@ -7,6 +7,7 @@ const {
 	_resetCustomToolWarningsForTest,
 	_resetApplicationToolsRegisteredForTest,
 } = require('#src/components/mcp/tools/application');
+const { Resource } = require('#src/resources/Resource');
 const { listTools, getTool, _resetRegistryForTest } = require('#src/components/mcp/toolRegistry');
 const { listPrompts, _resetPromptRegistryForTest } = require('#src/components/mcp/promptRegistry');
 
@@ -230,6 +231,69 @@ describe('mcp/tools/application — registration', () => {
 			(t) => t.name
 		);
 		assert.deepEqual(names, []);
+	});
+
+	it('does not manufacture create_ for a real Resource subclass that never overrides post/update', () => {
+		// Unlike makeTableResource's plain `class Cls {}`, this inherits `post` from the real
+		// base Resource prototype, so it reproduces the inherited-function bug.
+		class ReadOnly extends Resource {
+			async get(target) {
+				return { id: target.id, name: 'sample' };
+			}
+			async search() {
+				return [{ id: '1' }];
+			}
+		}
+		ReadOnly.databaseName = 'data';
+		ReadOnly.tableName = 'readonly';
+		ReadOnly.primaryKey = 'id';
+		_setResourcesForTest(makeRegistry([['ReadOnly', { Resource: ReadOnly }]]));
+		registerApplicationTools();
+		const names = listTools({ user: SUPER, profile: 'application', sessionId: 's', limit: 200 }).tools.map(
+			(t) => t.name
+		);
+		assert.deepEqual(names.sort(), ['get_ReadOnly', 'search_ReadOnly']);
+	});
+
+	it('manufactures create_ for a real Resource subclass that only overrides update() (Table.ts pattern)', () => {
+		class Writable extends Resource {
+			async get(target) {
+				return { id: target.id, name: 'sample' };
+			}
+			async update(target, record) {
+				return record;
+			}
+		}
+		Writable.databaseName = 'data';
+		Writable.tableName = 'writable';
+		Writable.primaryKey = 'id';
+		_setResourcesForTest(makeRegistry([['Writable', { Resource: Writable }]]));
+		registerApplicationTools();
+		const names = listTools({ user: SUPER, profile: 'application', sessionId: 's', limit: 200 }).tools.map(
+			(t) => t.name
+		);
+		assert.deepEqual(names.sort(), ['create_Writable', 'get_Writable']);
+	});
+
+	it('manufactures create_ for a loadAsInstance: false Resource subclass that only overrides create()', () => {
+		class LoadAsRecord extends Resource {
+			async get(target) {
+				return { id: target.id, name: 'sample' };
+			}
+			async create(target, record) {
+				return record;
+			}
+		}
+		LoadAsRecord.loadAsInstance = false;
+		LoadAsRecord.databaseName = 'data';
+		LoadAsRecord.tableName = 'loadasrecord';
+		LoadAsRecord.primaryKey = 'id';
+		_setResourcesForTest(makeRegistry([['LoadAsRecord', { Resource: LoadAsRecord }]]));
+		registerApplicationTools();
+		const names = listTools({ user: SUPER, profile: 'application', sessionId: 's', limit: 200 }).tools.map(
+			(t) => t.name
+		);
+		assert.deepEqual(names.sort(), ['create_LoadAsRecord', 'get_LoadAsRecord']);
 	});
 
 	describe('exportTypes gating', () => {


### PR DESCRIPTION
MCP's application profile stopped over-manufacturing `create_*` tools for Resources that have no real create verb: [`detectVerbs()` checked `typeof p.post === 'function'`](https://github.com/HarperFast/harper/pull/2405/changes?w=1#diff-061d972b6170c26b6085e634299b8b730c7e09a31580c4a69be199899177e991R699), but every Resource subclass inherits a base `post()`, so the check was true unconditionally and every table got a spurious `create_*` tool exposed to LLM clients.

`detectVerbs` [now reuses `hasClassLevelVerbs`](https://github.com/HarperFast/harper/pull/2405/changes?w=1#diff-061d972b6170c26b6085e634299b8b730c7e09a31580c4a69be199899177e991R32) (already implemented and tested in `toolRegistry.ts`, just unused here), which identity-compares against [`Resource.prototype`](https://github.com/HarperFast/harper/pull/2405/changes?w=1#diff-061d972b6170c26b6085e634299b8b730c7e09a31580c4a69be199899177e991R28) so only a real `post()` override or Table's implicit `update()` override counts — plus a direct instance `create()` override, since a `loadAsInstance === false` Resource's base `post` dispatches straight to it, bypassing `post`/`update` entirely.

## For the human reviewer

1. **Reused `hasClassLevelVerbs` instead of a bespoke predicate.** This keeps `create_*` detection identical to what `resources/openApi.ts`'s own `hasPost` already does (same base-`post`-identity + `update` heuristic), rather than hand-rolling a check scoped exactly to what `makeCreateHandler` can dispatch. Trivially reversible — it's a single expression.
2. **Only `create` routes through the identity-comparing helper; `get`/`search`/`put`/`patch`/`delete` keep bare `typeof` checks.** Safe today because `Resource.prototype` defines no default implementation for any of those, so there's nothing to over-match. If a future default lands on any of them, the same over-manufacture bug would silently return for that verb alone.
3. **Not fixed here (pre-existing, same root cause, different surface):** `components/mcp/resources.ts`'s `hasRestVerbs` has the identical `typeof p.post === 'function'` bug for the `resources/list` / `resources/templates/list` MCP surface, and `resources/openApi.ts`'s `hasPost` doesn't count a direct `create()` override the way this fix does — so a `loadAsInstance: false` resource with only `create()` now gets `create_*` in MCP but no POST in the generated OpenAPI doc. Both are pre-existing, out of scope for this issue, and tracked as separate findings for follow-up.

## Verification

- `npm run build` (tsc) — clean.
- `npx mocha "unitTests/components/mcp/**/*.js"` — 495 passing, including three new regression tests: [a real `Resource` subclass with no `post`/`update`/`create` override gets no `create_*` tool](https://github.com/HarperFast/harper/pull/2405/changes?w=1#diff-44d9e05750ebba44fb54f040106be039bac93dcfff0db410931214c19247a57fR236); [a `Table.ts`-shaped subclass (`update()` + `create()`, no `post()` override) still gets one](https://github.com/HarperFast/harper/pull/2405/changes?w=1#diff-44d9e05750ebba44fb54f040106be039bac93dcfff0db410931214c19247a57fR258); [a `loadAsInstance: false` subclass with only `create()` still gets one](https://github.com/HarperFast/harper/pull/2405/changes?w=1#diff-44d9e05750ebba44fb54f040106be039bac93dcfff0db410931214c19247a57fR281).
- `npm run test:unit:main` — 5115 passing, 2 pre-existing failures unrelated to this change (JWT/RSA key generation, a domain-socket path-length check) — reproduced independent of this diff.
- `npm run test:unit:resources` — 1802 passing, 1 pre-existing timing-flaky failure unrelated to this change (`caching.test.js`'s fencing-source test). CI's `Unit Test` jobs (all three Node versions) fail on this exact same test, already tracked as harper#2404 independent of this branch.
- `oxlint` and `prettier --check` — clean on both changed files.
- Confirmed against the issue's own cited example: `resources/login.ts`'s `Login` class only overrides `static get`/`static post` (no instance-level methods), so its prototype is untouched `Resource.prototype`. Loading it and calling `hasClassLevelVerbs(Login.prototype, Resource.prototype)` directly returns `post: false`, and `Login.prototype.create` is `undefined` — `create_login` is no longer manufactured. REST access to `/login` is unaffected (dispatch calls the static `post` directly, bypassing `detectVerbs` entirely). Two other resources use the identical static-dispatch pattern (`resources/models/v1/chatCompletions.ts`, `resources/models/v1/embeddings.ts`) and lose their spurious `create_*` tools the same way.


Complexity: medium

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=4 @ e7af873b9181</sub>

<sub>Human-Review-Need: 3 @ e7af873b9181</sub>
