### PR TITLE
test: pin that a phantom secondary-index entry is permanent and never served

### DIFF
--- a/integrationTests/database/phantom-index-permanence.test.ts
+++ b/integrationTests/database/phantom-index-permanence.test.ts
@@ -174,6 +174,7 @@ suite(
 
 				const deadline = Date.now() + 120_000;
 				let ready = false;
+				let lastProbeFailure = 'no attempt completed';
 				while (!ready && Date.now() < deadline) {
 					try {
 						const probe = await fetch(`${httpURL}/Probe/`, {
@@ -183,12 +184,15 @@ suite(
 						// An unconsumed undici body holds its socket out of the pool for the whole poll.
 						await probe.text();
 						ready = probe.status === 200;
-					} catch {
-						/* worker routes not registered yet */
+						if (!ready) lastProbeFailure = `HTTP ${probe.status}`;
+					} catch (error) {
+						// Carried into the failure message: a malformed httpURL throws every iteration and
+						// would otherwise read as a plain registration timeout.
+						lastProbeFailure = String(error);
 					}
 					if (!ready) await sleep(250);
 				}
-				ok(ready, 'fixture routes never registered; every assertion below would fail as a confusing 404');
+				ok(ready, `fixture routes never became ready; last probe result: ${lastProbeFailure}`);
 
 				for (let wave = 0; wave < WAVES; wave++) {
 					for (const table of ['Host', 'Companion']) {

--- a/integrationTests/database/phantom-index-permanence.test.ts
+++ b/integrationTests/database/phantom-index-permanence.test.ts
@@ -34,8 +34,8 @@
  * via `getRange()`, which is a raw composite-key scan with no primary join — `search_by_value`
  * is structurally blind here and cannot be used as one.
  *
- * RocksDB only: `flush()`, `compact()` and `rocksdb.levelstats` are RocksDB APIs, and LMDB has no
- * sorted-run structure for compaction to collapse.
+ * RocksDB only: `flush()`, `compact()` and the RocksDB statistics the compaction proof reads are
+ * RocksDB APIs, and LMDB has no on-disk sorted runs for a compaction to rewrite.
  *
  *   npm run test:integration -- "integrationTests/database/phantom-index-permanence.test.ts"
  */
@@ -54,10 +54,8 @@ const PHANTOM_CATEGORY = 'phantom-category';
 const PHANTOM_ID = 'phantom-1';
 const LIVE_ID = 'live-1';
 const STALE_CATEGORY = 'stale-category';
-// Two flushed waves here plus the live row's own flush leave three files in L0 at the moment
-// the compaction proof samples them — enough sorted runs to collapse, and below RocksDB's
-// default level0_file_num_compaction_trigger of 4, so a background compaction is not invited to
-// collapse them first.
+// Enough flushed waves to put the phantom in an SST with other files around it, and few enough to
+// stay under RocksDB's default level0_file_num_compaction_trigger of 4.
 const WAVES = 2;
 const ROWS_PER_WAVE = 6;
 
@@ -127,8 +125,11 @@ suite(
 				})
 				.timeout(REQUEST_TIMEOUT);
 			strictEqual(response.status, 200, `search_by_value must succeed; got ${response.status}`);
-			const rows: any[] = Array.isArray(response.body) ? response.body : [];
-			return rows.map((row) => row.id).sort();
+			ok(
+				Array.isArray(response.body),
+				`search_by_value must return an array of rows, or the "no hits" assertions below pass vacuously; got ${typeof response.body}`
+			);
+			return response.body.map((row: any) => row.id).sort();
 		}
 
 		/** Every enumerated index-backed read surface, for one indexed value. */
@@ -149,80 +150,89 @@ suite(
 			}
 		}
 
-		async function indexSortedRuns(): Promise<number> {
-			const result = await post('/CompactAndStats/', { table: 'Host' });
-			return result.index.totalSortedRuns;
-		}
+		before(
+			async () => {
+				await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+					// One worker, so the flush/compact/index-dump calls and the read surfaces are
+					// structurally the same process rather than incidentally so.
+					config: { threads: { count: 1 }, logging: { console: true, level: 'error' } },
+					env: { HARPER_STORAGE_ENGINE: 'rocksdb' },
+				});
+				client = createApiClient(ctx.harper);
+				httpURL = ctx.harper.httpURL;
+				auth = client.headers.Authorization;
 
-		before(async () => {
-			await setupHarperWithFixture(ctx, FIXTURE_PATH, {
-				config: { logging: { console: true, level: 'error' } },
-				env: { HARPER_STORAGE_ENGINE: 'rocksdb' },
-			});
-			client = createApiClient(ctx.harper);
-			httpURL = ctx.harper.httpURL;
-			auth = client.headers.Authorization;
-
-			const deadline = Date.now() + 120_000;
-			while (Date.now() < deadline) {
-				try {
-					const probe = await fetch(`${httpURL}/Probe/`, {
-						headers: { Authorization: auth },
-						signal: AbortSignal.timeout(2000),
-					});
-					if (probe.status !== 404) break;
-				} catch {
-					/* worker routes not registered yet */
+				const deadline = Date.now() + 120_000;
+				let ready = false;
+				while (!ready && Date.now() < deadline) {
+					try {
+						const probe = await fetch(`${httpURL}/Probe/`, {
+							headers: { Authorization: auth },
+							signal: AbortSignal.timeout(2000),
+						});
+						ready = probe.status !== 404;
+					} catch {
+						/* worker routes not registered yet */
+					}
+					if (!ready) await sleep(250);
 				}
-				await sleep(250);
-			}
+				ok(ready, 'fixture routes never registered; every assertion below would fail as a confusing 404');
 
-			for (let wave = 0; wave < WAVES; wave++) {
-				for (const table of ['Host', 'Companion']) {
-					const rows = Array.from({ length: ROWS_PER_WAVE }, (_, i) => ({
-						id: `${table.toLowerCase()}-${wave}-${i}`,
-						category: `bulk-${wave}`,
-						value: `wave ${wave}`,
-					}));
-					await post('/Seed/', { table, rows });
+				for (let wave = 0; wave < WAVES; wave++) {
+					for (const table of ['Host', 'Companion']) {
+						const rows = Array.from({ length: ROWS_PER_WAVE }, (_, i) => ({
+							id: `${table.toLowerCase()}-${wave}-${i}`,
+							category: `bulk-${wave}`,
+							value: `wave ${wave}`,
+						}));
+						await post('/Seed/', { table, rows });
+					}
+					// Inject before the last flush so the phantom is sealed into an SST and is therefore
+					// data that the compaction below actually has to rewrite.
+					if (wave === WAVES - 1) await post('/InjectPhantom/', { category: PHANTOM_CATEGORY, id: PHANTOM_ID });
+					await post('/FlushAndStats/', { table: 'Host' });
+					await post('/FlushAndStats/', { table: 'Companion' });
 				}
-				// Inject before the last flush so the phantom is sealed into an SST and is therefore
-				// data that the compaction below actually has to rewrite.
-				if (wave === WAVES - 1) await post('/InjectPhantom/', { category: PHANTOM_CATEGORY, id: PHANTOM_ID });
-				await post('/FlushAndStats/', { table: 'Host' });
-				await post('/FlushAndStats/', { table: 'Companion' });
-			}
-		});
+			},
+			{ timeout: 300_000 }
+		);
 
-		after(async () => {
-			await teardownHarper(ctx);
-		});
+		after(
+			async () => {
+				await teardownHarper(ctx);
+			},
+			{ timeout: 60_000 }
+		);
 
-		test('the table is backed by the RocksDB index store', async () => {
+		test('the table is backed by the RocksDB index store', { timeout: 60_000 }, async () => {
 			const info = await get('/EngineInfo/?table=Host');
 			strictEqual(
 				info.indexStoreClass,
 				'RocksIndexStore',
-				`this suite's flush/compact/levelstats machinery is RocksDB-only, but the category index is a ${info.indexStoreClass}`
+				`this suite's flush/compact/statistics machinery is RocksDB-only, but the category index is a ${info.indexStoreClass}`
 			);
 		});
 
-		test('the injected phantom is visible to the raw index oracle and to no read surface', async () => {
-			deepStrictEqual(
-				await rawIndexKeysFor(PHANTOM_CATEGORY),
-				[PHANTOM_ID],
-				'the raw index store must hold the injected entry — otherwise every "not served" assertion below is vacuous'
-			);
-			strictEqual(
-				(await get(`/PrimaryHas/?table=Host&id=${PHANTOM_ID}`)).present,
-				false,
-				'the injected id must have no primary record, or it is not a phantom'
-			);
+		test(
+			'the injected phantom is visible to the raw index oracle and to no read surface',
+			{ timeout: 60_000 },
+			async () => {
+				deepStrictEqual(
+					await rawIndexKeysFor(PHANTOM_CATEGORY),
+					[PHANTOM_ID],
+					'the raw index store must hold the injected entry — otherwise every "not served" assertion below is vacuous'
+				);
+				strictEqual(
+					(await get(`/PrimaryHas/?table=Host&id=${PHANTOM_ID}`)).present,
+					false,
+					'the injected id must have no primary record, or it is not a phantom'
+				);
 
-			assertEverySurface(await allReadSurfaces(PHANTOM_CATEGORY), [], 'phantom alone');
-		});
+				assertEverySurface(await allReadSurfaces(PHANTOM_CATEGORY), [], 'phantom alone');
+			}
+		);
 
-		test('a live row under the same category is served, and only it', async () => {
+		test('a live row under the same category is served, and only it', { timeout: 60_000 }, async () => {
 			await post('/Seed/', { table: 'Host', rows: [{ id: LIVE_ID, category: PHANTOM_CATEGORY, value: 'live' }] });
 
 			deepStrictEqual(
@@ -233,28 +243,41 @@ suite(
 			assertEverySurface(await allReadSurfaces(PHANTOM_CATEGORY), [LIVE_ID], 'phantom beside a live row');
 		});
 
-		test('the phantom is dropped because its primary record is absent, not because the surfaces ignore the raw index', async () => {
-			// Same raw write as the phantom, but for an id that DOES have a primary record. If the read
-			// surfaces served [] here too they would be ignoring the index rather than joining against
-			// the primary, and every zero above would be meaningless.
-			await post('/InjectStaleEntry/', { category: STALE_CATEGORY, id: LIVE_ID });
+		test(
+			'the phantom is dropped because its primary record is absent, not because the surfaces ignore the raw index',
+			{ timeout: 60_000 },
+			async () => {
+				// Same raw write as the phantom, but for an id that DOES have a primary record. If the read
+				// surfaces served [] here too they would be ignoring the index rather than joining against
+				// the primary, and every zero above would be meaningless.
+				await post('/InjectStaleEntry/', { category: STALE_CATEGORY, id: LIVE_ID });
 
-			deepStrictEqual(await rawIndexKeysFor(STALE_CATEGORY), [LIVE_ID], 'the raw index must hold the stale entry');
-			assertEverySurface(
-				await allReadSurfaces(STALE_CATEGORY),
-				[LIVE_ID],
-				'an index entry under a value the record does not hold is served when the primary record exists'
+				deepStrictEqual(await rawIndexKeysFor(STALE_CATEGORY), [LIVE_ID], 'the raw index must hold the stale entry');
+				assertEverySurface(
+					await allReadSurfaces(STALE_CATEGORY),
+					[LIVE_ID],
+					'an index entry under a value the record does not hold is served when the primary record exists'
+				);
+			}
+		);
+
+		test('the phantom survives an explicit compaction of its index column family', { timeout: 60_000 }, async () => {
+			const before = (await post('/FlushAndStats/', { table: 'Host' })).index;
+			const after = (await post('/CompactAndStats/', { table: 'Host' })).index;
+			deepStrictEqual(
+				[...before.errors, ...after.errors],
+				[],
+				'RocksDB statistics must be readable on both sides of the compaction'
 			);
-		});
 
-		test('the phantom survives an explicit compaction of its index column family', async () => {
-			const before = (await post('/FlushAndStats/', { table: 'Host' })).index.totalSortedRuns;
-			strictEqual(typeof before, 'number', 'rocksdb.levelstats must be readable before compaction');
-			ok(before > 1, `the compaction proof needs more than one sorted run to collapse; got ${before}`);
-
-			const after = await indexSortedRuns();
-			strictEqual(typeof after, 'number', 'rocksdb.levelstats must be readable after compaction');
-			ok(after < before, `compaction must have run: sorted runs went ${before} -> ${after}`);
+			// Proven by bytes actually rewritten rather than by a drop in sorted runs: with data this
+			// small RocksDB's own background compaction can collapse the runs first, which would fail a
+			// run-count proof for a reason that has nothing to do with the phantom.
+			ok(
+				after.compactWriteBytes > before.compactWriteBytes,
+				`compact() must have rewritten data: rocksdb.compact.write.bytes ${before.compactWriteBytes} -> ` +
+					`${after.compactWriteBytes} (sorted runs ${before.totalSortedRuns} -> ${after.totalSortedRuns})`
+			);
 
 			deepStrictEqual(
 				await rawIndexKeysFor(PHANTOM_CATEGORY),
@@ -263,7 +286,7 @@ suite(
 			);
 		});
 
-		test('a repeat delete() of the phantom id is a no-op', async () => {
+		test('a repeat delete() of the phantom id is a no-op', { timeout: 60_000 }, async () => {
 			await post('/DeleteOne/', { table: 'Host', id: PHANTOM_ID });
 
 			deepStrictEqual(
@@ -273,7 +296,7 @@ suite(
 			);
 		});
 
-		test('no read surface serves the phantom after compaction and the repeat delete', async () => {
+		test('no read surface serves the phantom after compaction and the repeat delete', { timeout: 60_000 }, async () => {
 			assertEverySurface(await allReadSurfaces(PHANTOM_CATEGORY), [LIVE_ID], 'after compaction and repeat delete');
 		});
 	}

--- a/integrationTests/database/phantom-index-permanence.test.ts
+++ b/integrationTests/database/phantom-index-permanence.test.ts
@@ -21,9 +21,9 @@
  * control below injects the same kind of raw entry for an id that DOES exist, and every surface
  * then serves it under a value the record does not hold. Without that control, the zeros this
  * file asserts would also be satisfied by surfaces that had stopped reading the index at all.
- * The enumerated index-backed surfaces are single-table `search()`, a two-table indexed read in
- * one request (harper#1881's shape), and the ops-API `search_by_value`; they converge on the
- * same join, and no claim is made here about protocols that do not.
+ * The surfaces asserted are single-table `search()`, a two-table indexed read in one request
+ * (harper#1881's shape), the ops-API `search_by_value`, and SQL; they converge on the same join.
+ * A surface that reached the index without that join would not be covered here.
  *
  * Because both producers are fixed, the divergence is injected: the fixture writes the composite
  * index key straight through the table's own index store. The oracle is that same store read back
@@ -77,7 +77,8 @@ suite(
 			});
 			const text = await response.text();
 			ok(response.ok, `POST ${path} must succeed; got ${response.status} ${text.slice(0, 300)}`);
-			return text ? JSON.parse(text) : null;
+			ok(text, `POST ${path} returned ${response.status} with an empty body`);
+			return JSON.parse(text);
 		}
 
 		async function get(path: string): Promise<any> {
@@ -87,10 +88,10 @@ suite(
 			});
 			const text = await response.text();
 			ok(response.ok, `GET ${path} must succeed; got ${response.status} ${text.slice(0, 300)}`);
-			return text ? JSON.parse(text) : null;
+			ok(text, `GET ${path} returned ${response.status} with an empty body`);
+			return JSON.parse(text);
 		}
 
-		/** Raw index-store scan for one indexed value — the only oracle that can see a phantom. */
 		async function rawIndexKeysFor(category: string, table = 'Host'): Promise<string[]> {
 			const entries: IndexEntry[] = await get(`/IndexDump/?table=${table}&category=${encodeURIComponent(category)}`);
 			return entries.map((entry) => entry.primaryKey).sort();
@@ -102,7 +103,6 @@ suite(
 			return result.results;
 		}
 
-		/** The literal ops-API surface, not a fixture re-implementation of it. */
 		async function searchByValueIds(category: string): Promise<string[]> {
 			const response = await client
 				.req()
@@ -123,6 +123,16 @@ suite(
 			return response.body.map((row: any) => row.id).sort();
 		}
 
+		async function sqlIds(category: string): Promise<string[]> {
+			const response = await client
+				.req()
+				.send({ operation: 'sql', sql: `SELECT id FROM data.Host WHERE category = '${category}'` })
+				.timeout(REQUEST_TIMEOUT);
+			strictEqual(response.status, 200, `SQL select must succeed; got ${response.status}`);
+			ok(Array.isArray(response.body), `SQL select must return rows; got ${typeof response.body}`);
+			return response.body.map((row: any) => row.id).sort();
+		}
+
 		/** Every enumerated index-backed read surface, for one indexed value. Companion never holds a
 		 * row under any category this suite queries, so its side of each cross-table read is asserted
 		 * empty here — a phantom leaking across tables would otherwise go unnoticed. */
@@ -140,6 +150,7 @@ suite(
 				comboCompanionFirst: companionFirst.Host,
 				comboHostFirst: hostFirst.Host,
 				searchByValue: await searchByValueIds(category),
+				sql: await sqlIds(category),
 			};
 		}
 
@@ -171,7 +182,7 @@ suite(
 						});
 						// An unconsumed undici body holds its socket out of the pool for the whole poll.
 						await probe.text();
-						ready = probe.status !== 404;
+						ready = probe.status === 200;
 					} catch {
 						/* worker routes not registered yet */
 					}
@@ -248,9 +259,6 @@ suite(
 			'the phantom is dropped because its primary record is absent, not because the surfaces ignore the raw index',
 			{ timeout: 60_000 },
 			async () => {
-				// Same raw write as the phantom, but for an id that DOES have a primary record. If the read
-				// surfaces served [] here too they would be ignoring the index rather than joining against
-				// the primary, and every zero above would be meaningless.
 				await post('/InjectStaleEntry/', { category: STALE_CATEGORY, id: LIVE_ID });
 
 				deepStrictEqual(await rawIndexKeysFor(STALE_CATEGORY), [LIVE_ID], 'the raw index must hold the stale entry');

--- a/integrationTests/database/phantom-index-permanence.test.ts
+++ b/integrationTests/database/phantom-index-permanence.test.ts
@@ -1,0 +1,280 @@
+/**
+ * A phantom secondary-index entry — an index key whose primary record does not exist — is
+ * permanent, and it is never served.
+ *
+ * Two write paths used to create one and both are fixed: harper#1854 (an aborted transaction on
+ * an `audit:false` table committed the primary removal standalone because
+ * `removeEntry(primaryStore, existingEntry)` did not thread `{transaction}`, while the
+ * transaction-scoped index removal rolled back) and harper#1989/#1894 (`updateIndices(id,
+ * existing, null)` resolved a removed record's new value to `null` instead of `undefined`, so an
+ * `indexNulls`-default index re-added a `[null, id]` entry). Those two are anchored by
+ * `integrationTests/resources/audit-false-delete-rollback.test.ts` and
+ * `eviction-index-phantom-null-keys.test.ts` respectively; this file pins what happens to such an
+ * entry if one ever exists again, which is a property of the entry rather than of either bug.
+ *
+ * Nothing reaps one. RocksDB compaction collapses superseded and tombstoned versions, and a
+ * phantom is neither — it is a live key in the index column family, and compaction has no way to
+ * know its primary is gone. A repeat `delete()` cannot repair it either: `updateIndices()`
+ * derives both the old and the new indexed value from a record that is absent, so both resolve to
+ * `undefined` and it `continue`s. Only `runIndexing()`, which clears the index before rebuilding,
+ * removes one.
+ *
+ * What caps the severity is the read path: an index hit is materialized against the primary store
+ * and dropped when no record comes back, so a phantom is never served. That masking is
+ * conditional on the primary being absent rather than a blanket disregard of the raw index — the
+ * control below injects the same kind of raw entry for an id that DOES exist, and every surface
+ * then serves it under a value the record does not hold. Without that control, the zeros this
+ * file asserts would also be satisfied by surfaces that had stopped reading the index at all.
+ * The enumerated index-backed surfaces are single-table `search()`, a two-table indexed read in
+ * one request (harper#1881's shape), and the ops-API `search_by_value`; they converge on the
+ * same join, and no claim is made here about protocols that do not.
+ *
+ * Because both producers are fixed, the divergence is injected: the fixture writes the composite
+ * index key straight through the table's own index store. The oracle is that same store read back
+ * via `getRange()`, which is a raw composite-key scan with no primary join — `search_by_value`
+ * is structurally blind here and cannot be used as one.
+ *
+ * RocksDB only: `flush()`, `compact()` and `rocksdb.levelstats` are RocksDB APIs, and LMDB has no
+ * sorted-run structure for compaction to collapse.
+ *
+ *   npm run test:integration -- "integrationTests/database/phantom-index-permanence.test.ts"
+ */
+import { suite, test, before, after } from 'node:test';
+import { deepStrictEqual, ok, strictEqual } from 'node:assert';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from '../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'phantom-index-permanence');
+const REQUEST_TIMEOUT = 20_000;
+
+const PHANTOM_CATEGORY = 'phantom-category';
+const PHANTOM_ID = 'phantom-1';
+const LIVE_ID = 'live-1';
+const STALE_CATEGORY = 'stale-category';
+// Two flushed waves here plus the live row's own flush leave three files in L0 at the moment
+// the compaction proof samples them — enough sorted runs to collapse, and below RocksDB's
+// default level0_file_num_compaction_trigger of 4, so a background compaction is not invited to
+// collapse them first.
+const WAVES = 2;
+const ROWS_PER_WAVE = 6;
+
+interface IndexEntry {
+	indexedValue: unknown;
+	primaryKey: string;
+}
+
+suite(
+	'phantom secondary-index entry permanence [rocksdb]',
+	{ skip: process.platform === 'win32' },
+	(ctx: ContextWithHarper) => {
+		let client: ReturnType<typeof createApiClient>;
+		let httpURL: string;
+		let auth: string;
+
+		async function post(path: string, body: unknown): Promise<any> {
+			const response = await fetch(`${httpURL}${path}`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', 'Authorization': auth },
+				body: JSON.stringify(body),
+				signal: AbortSignal.timeout(REQUEST_TIMEOUT),
+			});
+			const text = await response.text();
+			ok(response.ok, `POST ${path} must succeed; got ${response.status} ${text.slice(0, 300)}`);
+			return text ? JSON.parse(text) : null;
+		}
+
+		async function get(path: string): Promise<any> {
+			const response = await fetch(`${httpURL}${path}`, {
+				headers: { Authorization: auth },
+				signal: AbortSignal.timeout(REQUEST_TIMEOUT),
+			});
+			const text = await response.text();
+			ok(response.ok, `GET ${path} must succeed; got ${response.status} ${text.slice(0, 300)}`);
+			return text ? JSON.parse(text) : null;
+		}
+
+		/** Raw index-store scan for one indexed value — the only oracle that can see a phantom. */
+		async function rawIndexKeysFor(category: string, table = 'Host'): Promise<string[]> {
+			const entries: IndexEntry[] = await get(`/IndexDump/?table=${table}&category=${encodeURIComponent(category)}`);
+			return entries.map((entry) => entry.primaryKey).sort();
+		}
+
+		async function searchIds(category: string, table = 'Host'): Promise<string[]> {
+			const result = await get(`/Search/?table=${table}&category=${encodeURIComponent(category)}`);
+			return result.ids.sort();
+		}
+
+		async function comboSearchIds(order: string, category: string): Promise<Record<string, string[]>> {
+			const result = await get(`/ComboSearch/?tables=${order}&category=${encodeURIComponent(category)}`);
+			for (const name of Object.keys(result.results)) result.results[name].sort();
+			return result.results;
+		}
+
+		/** The literal ops-API surface, not a fixture re-implementation of it. */
+		async function searchByValueIds(category: string): Promise<string[]> {
+			const response = await client
+				.req()
+				.send({
+					operation: 'search_by_value',
+					schema: 'data',
+					table: 'Host',
+					search_attribute: 'category',
+					search_value: category,
+					get_attributes: ['id'],
+				})
+				.timeout(REQUEST_TIMEOUT);
+			strictEqual(response.status, 200, `search_by_value must succeed; got ${response.status}`);
+			const rows: any[] = Array.isArray(response.body) ? response.body : [];
+			return rows.map((row) => row.id).sort();
+		}
+
+		/** Every enumerated index-backed read surface, for one indexed value. */
+		async function allReadSurfaces(category: string): Promise<Record<string, string[]>> {
+			const companionFirst = await comboSearchIds('Companion,Host', category);
+			const hostFirst = await comboSearchIds('Host,Companion', category);
+			return {
+				search: await searchIds(category),
+				comboCompanionFirst: companionFirst.Host,
+				comboHostFirst: hostFirst.Host,
+				searchByValue: await searchByValueIds(category),
+			};
+		}
+
+		function assertEverySurface(surfaces: Record<string, string[]>, expected: string[], context: string): void {
+			for (const [name, ids] of Object.entries(surfaces)) {
+				deepStrictEqual(ids, expected, `${context}: ${name} must return exactly ${JSON.stringify(expected)}`);
+			}
+		}
+
+		async function indexSortedRuns(): Promise<number> {
+			const result = await post('/CompactAndStats/', { table: 'Host' });
+			return result.index.totalSortedRuns;
+		}
+
+		before(async () => {
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+				config: { logging: { console: true, level: 'error' } },
+				env: { HARPER_STORAGE_ENGINE: 'rocksdb' },
+			});
+			client = createApiClient(ctx.harper);
+			httpURL = ctx.harper.httpURL;
+			auth = client.headers.Authorization;
+
+			const deadline = Date.now() + 120_000;
+			while (Date.now() < deadline) {
+				try {
+					const probe = await fetch(`${httpURL}/Probe/`, {
+						headers: { Authorization: auth },
+						signal: AbortSignal.timeout(2000),
+					});
+					if (probe.status !== 404) break;
+				} catch {
+					/* worker routes not registered yet */
+				}
+				await sleep(250);
+			}
+
+			for (let wave = 0; wave < WAVES; wave++) {
+				for (const table of ['Host', 'Companion']) {
+					const rows = Array.from({ length: ROWS_PER_WAVE }, (_, i) => ({
+						id: `${table.toLowerCase()}-${wave}-${i}`,
+						category: `bulk-${wave}`,
+						value: `wave ${wave}`,
+					}));
+					await post('/Seed/', { table, rows });
+				}
+				// Inject before the last flush so the phantom is sealed into an SST and is therefore
+				// data that the compaction below actually has to rewrite.
+				if (wave === WAVES - 1) await post('/InjectPhantom/', { category: PHANTOM_CATEGORY, id: PHANTOM_ID });
+				await post('/FlushAndStats/', { table: 'Host' });
+				await post('/FlushAndStats/', { table: 'Companion' });
+			}
+		});
+
+		after(async () => {
+			await teardownHarper(ctx);
+		});
+
+		test('the table is backed by the RocksDB index store', async () => {
+			const info = await get('/EngineInfo/?table=Host');
+			strictEqual(
+				info.indexStoreClass,
+				'RocksIndexStore',
+				`this suite's flush/compact/levelstats machinery is RocksDB-only, but the category index is a ${info.indexStoreClass}`
+			);
+		});
+
+		test('the injected phantom is visible to the raw index oracle and to no read surface', async () => {
+			deepStrictEqual(
+				await rawIndexKeysFor(PHANTOM_CATEGORY),
+				[PHANTOM_ID],
+				'the raw index store must hold the injected entry — otherwise every "not served" assertion below is vacuous'
+			);
+			strictEqual(
+				(await get(`/PrimaryHas/?table=Host&id=${PHANTOM_ID}`)).present,
+				false,
+				'the injected id must have no primary record, or it is not a phantom'
+			);
+
+			assertEverySurface(await allReadSurfaces(PHANTOM_CATEGORY), [], 'phantom alone');
+		});
+
+		test('a live row under the same category is served, and only it', async () => {
+			await post('/Seed/', { table: 'Host', rows: [{ id: LIVE_ID, category: PHANTOM_CATEGORY, value: 'live' }] });
+
+			deepStrictEqual(
+				await rawIndexKeysFor(PHANTOM_CATEGORY),
+				[LIVE_ID, PHANTOM_ID].sort(),
+				'the raw index must now hold both the live entry and the phantom'
+			);
+			assertEverySurface(await allReadSurfaces(PHANTOM_CATEGORY), [LIVE_ID], 'phantom beside a live row');
+		});
+
+		test('the phantom is dropped because its primary record is absent, not because the surfaces ignore the raw index', async () => {
+			// Same raw write as the phantom, but for an id that DOES have a primary record. If the read
+			// surfaces served [] here too they would be ignoring the index rather than joining against
+			// the primary, and every zero above would be meaningless.
+			await post('/InjectStaleEntry/', { category: STALE_CATEGORY, id: LIVE_ID });
+
+			deepStrictEqual(await rawIndexKeysFor(STALE_CATEGORY), [LIVE_ID], 'the raw index must hold the stale entry');
+			assertEverySurface(
+				await allReadSurfaces(STALE_CATEGORY),
+				[LIVE_ID],
+				'an index entry under a value the record does not hold is served when the primary record exists'
+			);
+		});
+
+		test('the phantom survives an explicit compaction of its index column family', async () => {
+			const before = (await post('/FlushAndStats/', { table: 'Host' })).index.totalSortedRuns;
+			strictEqual(typeof before, 'number', 'rocksdb.levelstats must be readable before compaction');
+			ok(before > 1, `the compaction proof needs more than one sorted run to collapse; got ${before}`);
+
+			const after = await indexSortedRuns();
+			strictEqual(typeof after, 'number', 'rocksdb.levelstats must be readable after compaction');
+			ok(after < before, `compaction must have run: sorted runs went ${before} -> ${after}`);
+
+			deepStrictEqual(
+				await rawIndexKeysFor(PHANTOM_CATEGORY),
+				[LIVE_ID, PHANTOM_ID].sort(),
+				'compaction must not reap the phantom: it is a live index key, not a tombstone'
+			);
+		});
+
+		test('a repeat delete() of the phantom id is a no-op', async () => {
+			await post('/DeleteOne/', { table: 'Host', id: PHANTOM_ID });
+
+			deepStrictEqual(
+				await rawIndexKeysFor(PHANTOM_CATEGORY),
+				[LIVE_ID, PHANTOM_ID].sort(),
+				'delete() derives index removals from the absent primary record, so it cannot remove the phantom'
+			);
+		});
+
+		test('no read surface serves the phantom after compaction and the repeat delete', async () => {
+			assertEverySurface(await allReadSurfaces(PHANTOM_CATEGORY), [LIVE_ID], 'after compaction and repeat delete');
+		});
+	}
+);

--- a/integrationTests/database/phantom-index-permanence.test.ts
+++ b/integrationTests/database/phantom-index-permanence.test.ts
@@ -2,14 +2,10 @@
  * A phantom secondary-index entry — an index key whose primary record does not exist — is
  * permanent, and it is never served.
  *
- * Two write paths used to create one and both are fixed: harper#1854 (an aborted transaction on
- * an `audit:false` table committed the primary removal standalone because
- * `removeEntry(primaryStore, existingEntry)` did not thread `{transaction}`, while the
- * transaction-scoped index removal rolled back) and harper#1989/#1894 (`updateIndices(id,
- * existing, null)` resolved a removed record's new value to `null` instead of `undefined`, so an
- * `indexNulls`-default index re-added a `[null, id]` entry). Those two are anchored by
- * `integrationTests/resources/audit-false-delete-rollback.test.ts` and
- * `eviction-index-phantom-null-keys.test.ts` respectively; this file pins what happens to such an
+ * Two write paths used to create one and both are fixed — harper#1854 (an aborted `audit:false`
+ * delete escaping its transaction) and harper#1989/#1894 (a removal re-adding a `[null, id]`
+ * entry) — anchored by `integrationTests/resources/audit-false-delete-rollback.test.ts` and
+ * `eviction-index-phantom-null-keys.test.ts` respectively. This file pins what happens to such an
  * entry if one ever exists again, which is a property of the entry rather than of either bug.
  *
  * Nothing reaps one. RocksDB compaction collapses superseded and tombstoned versions, and a
@@ -100,11 +96,6 @@ suite(
 			return entries.map((entry) => entry.primaryKey).sort();
 		}
 
-		async function searchIds(category: string, table = 'Host'): Promise<string[]> {
-			const result = await get(`/Search/?table=${table}&category=${encodeURIComponent(category)}`);
-			return result.ids.sort();
-		}
-
 		async function comboSearchIds(order: string, category: string): Promise<Record<string, string[]>> {
 			const result = await get(`/ComboSearch/?tables=${order}&category=${encodeURIComponent(category)}`);
 			for (const name of Object.keys(result.results)) result.results[name].sort();
@@ -132,12 +123,20 @@ suite(
 			return response.body.map((row: any) => row.id).sort();
 		}
 
-		/** Every enumerated index-backed read surface, for one indexed value. */
+		/** Every enumerated index-backed read surface, for one indexed value. Companion never holds a
+		 * row under any category this suite queries, so its side of each cross-table read is asserted
+		 * empty here — a phantom leaking across tables would otherwise go unnoticed. */
 		async function allReadSurfaces(category: string): Promise<Record<string, string[]>> {
 			const companionFirst = await comboSearchIds('Companion,Host', category);
 			const hostFirst = await comboSearchIds('Host,Companion', category);
+			for (const [order, results] of [
+				['Companion,Host', companionFirst],
+				['Host,Companion', hostFirst],
+			] as const) {
+				deepStrictEqual(results.Companion, [], `${order}: Companion must never match category "${category}"`);
+			}
 			return {
-				search: await searchIds(category),
+				search: (await comboSearchIds('Host', category)).Host,
 				comboCompanionFirst: companionFirst.Host,
 				comboHostFirst: hostFirst.Host,
 				searchByValue: await searchByValueIds(category),

--- a/integrationTests/database/phantom-index-permanence.test.ts
+++ b/integrationTests/database/phantom-index-permanence.test.ts
@@ -170,6 +170,8 @@ suite(
 							headers: { Authorization: auth },
 							signal: AbortSignal.timeout(2000),
 						});
+						// An unconsumed undici body holds its socket out of the pool for the whole poll.
+						await probe.text();
 						ready = probe.status !== 404;
 					} catch {
 						/* worker routes not registered yet */
@@ -262,8 +264,8 @@ suite(
 		);
 
 		test('the phantom survives an explicit compaction of its index column family', { timeout: 60_000 }, async () => {
-			const before = (await post('/FlushAndStats/', { table: 'Host' })).index;
-			const after = (await post('/CompactAndStats/', { table: 'Host' })).index;
+			await post('/FlushAndStats/', { table: 'Host' });
+			const { before, after } = await post('/CompactAndStats/', { table: 'Host' });
 			deepStrictEqual(
 				[...before.errors, ...after.errors],
 				[],

--- a/integrationTests/database/phantom-index-permanence/config.yaml
+++ b/integrationTests/database/phantom-index-permanence/config.yaml
@@ -1,0 +1,5 @@
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/database/phantom-index-permanence/resources.js
+++ b/integrationTests/database/phantom-index-permanence/resources.js
@@ -31,9 +31,11 @@ function qget(query, name) {
 	return typeof query.get === 'function' ? query.get(name) : query[name];
 }
 
-/** L0 file count plus one per non-empty deeper level. NOT a sum of per-level file counts: L0
- * files overlap so each is its own sorted run, while an entire non-L0 level is one run however
- * many files it is split across — a sum reads an L0->L1 merge that splits as "no change". */
+/** Diagnostic only — the compaction proof is the compact.write.bytes delta, because a sorted-run
+ * count can legitimately already be 1 when RocksDB's own background compaction got there first.
+ * L0 files overlap so each is its own sorted run, while an entire non-L0 level is one run however
+ * many files it is split across; a raw sum of per-level file counts reads an L0->L1 merge that
+ * splits across several files as "no change". */
 function totalSortedRuns(levelStats) {
 	if (typeof levelStats !== 'string') return null;
 	let l0 = 0;
@@ -51,22 +53,29 @@ function totalSortedRuns(levelStats) {
 	return sawAnyLevel ? l0 + deeperNonEmptyLevels : null;
 }
 
-// A null totalSortedRuns must reach the test as null, never as 0: a 0 would satisfy an
-// "after < before" compaction proof without any compaction having been measured.
+// Anything unreadable must reach the test as null rather than 0: a 0 would satisfy an
+// "after > before" comparison without any measurement behind it.
 function statsOf(store, label) {
-	if (typeof store?.getDBProperty !== 'function') {
-		return { totalSortedRuns: null, error: `${label}: getDBProperty() unavailable (not RocksDB?)` };
+	const stats = { compactWriteBytes: null, totalSortedRuns: null, errors: [] };
+	if (typeof store?.getStats !== 'function' || typeof store?.getDBProperty !== 'function') {
+		stats.errors.push(`${label}: RocksDB statistics API unavailable`);
+		return stats;
 	}
-	let levelStats;
 	try {
-		levelStats = store.getDBProperty('rocksdb.levelstats');
+		const written = store.getStats(true)?.['rocksdb.compact.write.bytes'];
+		if (typeof written === 'number') stats.compactWriteBytes = written;
+		else stats.errors.push(`${label}: rocksdb.compact.write.bytes was ${typeof written}, not a number`);
 	} catch (error) {
-		return { totalSortedRuns: null, error: `${label}: getDBProperty threw: ${error.message}` };
+		stats.errors.push(`${label}: getStats threw: ${error.message}`);
 	}
-	const runs = totalSortedRuns(levelStats);
-	return runs == null
-		? { totalSortedRuns: null, error: `${label}: could not parse rocksdb.levelstats`, levelStats }
-		: { totalSortedRuns: runs, levelStats };
+	try {
+		const levelStats = store.getDBProperty('rocksdb.levelstats');
+		stats.totalSortedRuns = totalSortedRuns(levelStats);
+		if (stats.totalSortedRuns == null) stats.errors.push(`${label}: could not parse rocksdb.levelstats`);
+	} catch (error) {
+		stats.errors.push(`${label}: getDBProperty threw: ${error.message}`);
+	}
+	return stats;
 }
 
 export class Probe extends Resource {
@@ -206,8 +215,9 @@ export class CompactAndStats extends Resource {
 		if (typeof index.compact !== 'function') {
 			throw new Error('phantom-index-permanence: compact() unavailable on this storage engine');
 		}
-		// bottommost: true because RocksDB otherwise skips the bottommost level, which for this
-		// fixture's data volume is where the compaction under test would have to happen.
+		// bottommost: true rewrites every file in the range whether or not RocksDB considers it
+		// worth doing, so the phantom's file is rewritten even when background compaction has
+		// already merged the range — which is what makes the proof below independent of timing.
 		await index.compact({ bottommost: true });
 		return { table: tableName, index: statsOf(index, `${tableName}.${INDEXED_ATTRIBUTE} index`) };
 	}

--- a/integrationTests/database/phantom-index-permanence/resources.js
+++ b/integrationTests/database/phantom-index-permanence/resources.js
@@ -41,9 +41,9 @@ function totalSortedRuns(levelStats) {
 	let deeperNonEmptyLevels = 0;
 	let sawAnyLevel = false;
 	for (const line of levelStats.split('\n')) {
-		// Level numbers are bare digits on this build; the optional L covers RocksDB builds that
-		// print them as L0/L1.
-		const match = line.match(/^\s*L?(\d+)\s+(\d+)\s/i);
+		// This build prints bare level numbers and a plain file count; the optional L and /N cover
+		// builds that print "L0  2/0" instead.
+		const match = line.match(/^\s*L?(\d+)\s+(\d+)(?:\/\d+)?\s/i);
 		if (!match) continue;
 		sawAnyLevel = true;
 		const level = Number(match[1]);

--- a/integrationTests/database/phantom-index-permanence/resources.js
+++ b/integrationTests/database/phantom-index-permanence/resources.js
@@ -215,11 +215,16 @@ export class CompactAndStats extends Resource {
 		if (typeof index.compact !== 'function') {
 			throw new Error('phantom-index-permanence: compact() unavailable on this storage engine');
 		}
+		const label = `${tableName}.${INDEXED_ATTRIBUTE} index`;
+		// Both samples are taken here rather than by the caller: rocksdb.compact.write.bytes is a
+		// DB-wide lifetime counter, so a sample taken in an earlier request would let a background
+		// compaction of any column family land in between and account for the whole delta.
+		const before = statsOf(index, label);
 		// bottommost: true rewrites every file in the range whether or not RocksDB considers it
 		// worth doing, so the phantom's file is rewritten even when background compaction has
-		// already merged the range — which is what makes the proof below independent of timing.
+		// already merged the range — which is what makes the proof independent of timing.
 		await index.compact({ bottommost: true });
-		return { table: tableName, index: statsOf(index, `${tableName}.${INDEXED_ATTRIBUTE} index`) };
+		return { table: tableName, before, after: statsOf(index, label) };
 	}
 }
 

--- a/integrationTests/database/phantom-index-permanence/resources.js
+++ b/integrationTests/database/phantom-index-permanence/resources.js
@@ -41,7 +41,9 @@ function totalSortedRuns(levelStats) {
 	let deeperNonEmptyLevels = 0;
 	let sawAnyLevel = false;
 	for (const line of levelStats.split('\n')) {
-		const match = line.match(/^\s*(\d+)\s+(\d+)\s/);
+		// Level numbers are bare digits on this build; the optional L covers RocksDB builds that
+		// print them as L0/L1.
+		const match = line.match(/^\s*L?(\d+)\s+(\d+)\s/i);
 		if (!match) continue;
 		sawAnyLevel = true;
 		const level = Number(match[1]);

--- a/integrationTests/database/phantom-index-permanence/resources.js
+++ b/integrationTests/database/phantom-index-permanence/resources.js
@@ -1,0 +1,253 @@
+// Fixture for phantom-index-permanence.test.ts.
+//
+// A "phantom" here is a secondary-index entry whose primary record does not exist. Both write
+// paths that used to produce one are fixed (harper#1854, harper#1989), so the divergence is
+// created synthetically: InjectPhantom writes the composite index key directly through the
+// table's own index store, bypassing Table.delete()/updateIndices() entirely.
+//
+// The oracle is that same server-owned index store read back through getRange() —
+// RocksIndexStore.getRange() is a raw composite-key scan with no join through the primary
+// record, so unlike search_by_value it can see an entry whose primary is absent.
+//
+// Table and attribute names are fixed rather than taken from the request: these endpoints can
+// write raw index keys, and a generic one reused elsewhere could corrupt an unrelated store.
+
+const INDEXED_ATTRIBUTE = 'category';
+
+function getTable(name) {
+	if (name === 'Host') return tables.Host;
+	if (name === 'Companion') return tables.Companion;
+	throw new Error(`phantom-index-permanence: unknown table "${name}" (expected Host or Companion)`);
+}
+
+function getIndex(table, tableName) {
+	const index = table.indices?.[INDEXED_ATTRIBUTE];
+	if (!index) throw new Error(`phantom-index-permanence: no ${INDEXED_ATTRIBUTE} index on ${tableName}`);
+	return index;
+}
+
+function qget(query, name) {
+	if (!query) return undefined;
+	return typeof query.get === 'function' ? query.get(name) : query[name];
+}
+
+/** L0 file count plus one per non-empty deeper level. NOT a sum of per-level file counts: L0
+ * files overlap so each is its own sorted run, while an entire non-L0 level is one run however
+ * many files it is split across — a sum reads an L0->L1 merge that splits as "no change". */
+function totalSortedRuns(levelStats) {
+	if (typeof levelStats !== 'string') return null;
+	let l0 = 0;
+	let deeperNonEmptyLevels = 0;
+	let sawAnyLevel = false;
+	for (const line of levelStats.split('\n')) {
+		const match = line.match(/^\s*(\d+)\s+(\d+)\s/);
+		if (!match) continue;
+		sawAnyLevel = true;
+		const level = Number(match[1]);
+		const files = Number(match[2]);
+		if (level === 0) l0 = files;
+		else if (files > 0) deeperNonEmptyLevels++;
+	}
+	return sawAnyLevel ? l0 + deeperNonEmptyLevels : null;
+}
+
+// A null totalSortedRuns must reach the test as null, never as 0: a 0 would satisfy an
+// "after < before" compaction proof without any compaction having been measured.
+function statsOf(store, label) {
+	if (typeof store?.getDBProperty !== 'function') {
+		return { totalSortedRuns: null, error: `${label}: getDBProperty() unavailable (not RocksDB?)` };
+	}
+	let levelStats;
+	try {
+		levelStats = store.getDBProperty('rocksdb.levelstats');
+	} catch (error) {
+		return { totalSortedRuns: null, error: `${label}: getDBProperty threw: ${error.message}` };
+	}
+	const runs = totalSortedRuns(levelStats);
+	return runs == null
+		? { totalSortedRuns: null, error: `${label}: could not parse rocksdb.levelstats`, levelStats }
+		: { totalSortedRuns: runs, levelStats };
+}
+
+export class Probe extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		return { ok: true };
+	}
+}
+
+// GET /EngineInfo/?table=Host -> the class actually backing the index store, so the suite can
+// assert RocksDB rather than trusting that its HARPER_STORAGE_ENGINE request was honored.
+export class EngineInfo extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const tableName = qget(query, 'table') || 'Host';
+		const table = getTable(tableName);
+		return {
+			table: tableName,
+			indexStoreClass: getIndex(table, tableName).constructor?.name ?? null,
+			primaryStoreClass: table.primaryStore?.constructor?.name ?? null,
+		};
+	}
+}
+
+// POST /Seed/ { table, rows: [{ id, category, value }] } -> ordinary puts through the normal
+// write path.
+export class Seed extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const table = getTable(b.table);
+		for (const row of b.rows || []) {
+			await table.put({ id: row.id, category: row.category, value: row.value ?? 'seed' });
+		}
+		return { ok: true, table: b.table, count: (b.rows || []).length };
+	}
+}
+
+// POST /DeleteOne/ { table, id } -> an ordinary committed delete, no abort.
+export class DeleteOne extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const table = getTable(b.table);
+		await table.delete(b.id);
+		return { ok: true, table: b.table, id: b.id };
+	}
+}
+
+// POST /InjectPhantom/ { category, id } -> write [category, id] straight into Host's category
+// index with no primary record behind it. Refuses if the id does exist, so the fixture cannot
+// quietly produce a live entry and call it a phantom.
+export class InjectPhantom extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const table = tables.Host;
+		if (table.primaryStore.getEntry(b.id)?.value) {
+			throw new Error(`phantom-index-permanence: id "${b.id}" exists in the primary store; it would not be a phantom`);
+		}
+		await getIndex(table, 'Host').put(b.category, b.id);
+		return { ok: true, category: b.category, id: b.id };
+	}
+}
+
+// POST /InjectStaleEntry/ { category, id } -> the contrast to InjectPhantom: an index entry
+// under a value the record does NOT hold, for an id that DOES exist. Refuses if the id is
+// absent, so the two endpoints cannot be confused for one another.
+export class InjectStaleEntry extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const table = tables.Host;
+		if (!table.primaryStore.getEntry(b.id)?.value) {
+			throw new Error(
+				`phantom-index-permanence: id "${b.id}" has no primary record; that would be a phantom, not a stale entry`
+			);
+		}
+		await getIndex(table, 'Host').put(b.category, b.id);
+		return { ok: true, category: b.category, id: b.id };
+	}
+}
+
+// GET /IndexDump/?table=Host&category=X -> raw index-store scan, no join through the primary
+// record. Optionally filtered to one indexed value.
+export class IndexDump extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const tableName = qget(query, 'table') || 'Host';
+		const category = qget(query, 'category');
+		const index = getIndex(getTable(tableName), tableName);
+		const entries = [];
+		for (const entry of index.getRange({ start: null })) {
+			if (category != null && entry.key !== category) continue;
+			entries.push({ indexedValue: entry.key, primaryKey: entry.value });
+		}
+		return entries;
+	}
+}
+
+// GET /PrimaryHas/?table=Host&id=X -> does the primary store hold this record at all?
+export class PrimaryHas extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const tableName = qget(query, 'table') || 'Host';
+		const id = qget(query, 'id');
+		return { table: tableName, id, present: getTable(tableName).primaryStore.getEntry(id)?.value != null };
+	}
+}
+
+// POST /FlushAndStats/ { table } and POST /CompactAndStats/ { table } fold the storage operation
+// and the levelstats read into ONE handler call. Split across two requests, RocksDB's own
+// background compaction can run in between and the stats read then describes a different on-disk
+// state than the one the operation produced.
+export class FlushAndStats extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const tableName = b.table || 'Host';
+		const table = getTable(tableName);
+		const index = getIndex(table, tableName);
+		if (typeof table.primaryStore.flush !== 'function' || typeof index.flush !== 'function') {
+			throw new Error('phantom-index-permanence: flush() unavailable on this storage engine');
+		}
+		await table.primaryStore.flush();
+		await index.flush();
+		return { table: tableName, index: statsOf(index, `${tableName}.${INDEXED_ATTRIBUTE} index`) };
+	}
+}
+
+export class CompactAndStats extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const tableName = b.table || 'Host';
+		const index = getIndex(getTable(tableName), tableName);
+		if (typeof index.compact !== 'function') {
+			throw new Error('phantom-index-permanence: compact() unavailable on this storage engine');
+		}
+		// bottommost: true because RocksDB otherwise skips the bottommost level, which for this
+		// fixture's data volume is where the compaction under test would have to happen.
+		await index.compact({ bottommost: true });
+		return { table: tableName, index: statsOf(index, `${tableName}.${INDEXED_ATTRIBUTE} index`) };
+	}
+}
+
+// GET /Search/?table=Host&category=X -> single-table indexed search(), the shared mechanism REST
+// and search_by_value both resolve through.
+export class Search extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const tableName = qget(query, 'table') || 'Host';
+		const category = qget(query, 'category');
+		const table = getTable(tableName);
+		const ids = [];
+		for await (const record of table.search({ conditions: [{ attribute: INDEXED_ATTRIBUTE, value: category }] })) {
+			ids.push(record.id);
+		}
+		return { table: tableName, category, ids };
+	}
+}
+
+// GET /ComboSearch/?tables=Companion,Host&category=X -> both tables searched by secondary index,
+// in the given order, within ONE request (harper#1881's cross-table read shape).
+export class ComboSearch extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const category = qget(query, 'category');
+		const order = String(qget(query, 'tables') || 'Companion,Host')
+			.split(',')
+			.map((name) => name.trim())
+			.filter(Boolean);
+		const results = {};
+		for (const tableName of order) {
+			const table = getTable(tableName);
+			const ids = [];
+			for await (const record of table.search({ conditions: [{ attribute: INDEXED_ATTRIBUTE, value: category }] })) {
+				ids.push(record.id);
+			}
+			results[tableName] = ids;
+		}
+		return { order, category, results };
+	}
+}

--- a/integrationTests/database/phantom-index-permanence/resources.js
+++ b/integrationTests/database/phantom-index-permanence/resources.js
@@ -1,16 +1,7 @@
 // Fixture for phantom-index-permanence.test.ts.
 //
-// A "phantom" here is a secondary-index entry whose primary record does not exist. Both write
-// paths that used to produce one are fixed (harper#1854, harper#1989), so the divergence is
-// created synthetically: InjectPhantom writes the composite index key directly through the
-// table's own index store, bypassing Table.delete()/updateIndices() entirely.
-//
-// The oracle is that same server-owned index store read back through getRange() —
-// RocksIndexStore.getRange() is a raw composite-key scan with no join through the primary
-// record, so unlike search_by_value it can see an entry whose primary is absent.
-//
-// Table and attribute names are fixed rather than taken from the request: these endpoints can
-// write raw index keys, and a generic one reused elsewhere could corrupt an unrelated store.
+// Table and attribute names are fixed rather than taken from the request: these endpoints write
+// raw index keys, and a generic one reused by another fixture could corrupt an unrelated store.
 
 const INDEXED_ATTRIBUTE = 'category';
 
@@ -31,11 +22,19 @@ function qget(query, name) {
 	return typeof query.get === 'function' ? query.get(name) : query[name];
 }
 
-/** Diagnostic only — the compaction proof is the compact.write.bytes delta, because a sorted-run
- * count can legitimately already be 1 when RocksDB's own background compaction got there first.
- * L0 files overlap so each is its own sorted run, while an entire non-L0 level is one run however
- * many files it is split across; a raw sum of per-level file counts reads an L0->L1 merge that
- * splits across several files as "no change". */
+async function searchIds(tableName, category) {
+	const ids = [];
+	for await (const record of getTable(tableName).search({
+		conditions: [{ attribute: INDEXED_ATTRIBUTE, value: category }],
+	})) {
+		ids.push(record.id);
+	}
+	return ids;
+}
+
+/** Diagnostic only. L0 files overlap so each is its own sorted run, while an entire non-L0 level
+ * is one run however many files it is split across; a raw sum of per-level file counts reads an
+ * L0->L1 merge that splits across several files as "no change". */
 function totalSortedRuns(levelStats) {
 	if (typeof levelStats !== 'string') return null;
 	let l0 = 0;
@@ -53,8 +52,6 @@ function totalSortedRuns(levelStats) {
 	return sawAnyLevel ? l0 + deeperNonEmptyLevels : null;
 }
 
-// Anything unreadable must reach the test as null rather than 0: a 0 would satisfy an
-// "after > before" comparison without any measurement behind it.
 function statsOf(store, label) {
 	const stats = { compactWriteBytes: null, totalSortedRuns: null, errors: [] };
 	if (typeof store?.getStats !== 'function' || typeof store?.getDBProperty !== 'function') {
@@ -62,16 +59,16 @@ function statsOf(store, label) {
 		return stats;
 	}
 	try {
-		const written = store.getStats(true)?.['rocksdb.compact.write.bytes'];
+		// RocksDB omits a counter that is still zero, which is a legitimate reading for the sample
+		// taken before any compaction has run; only an unusable API is an error.
+		const written = store.getStats(true)?.['rocksdb.compact.write.bytes'] ?? 0;
 		if (typeof written === 'number') stats.compactWriteBytes = written;
-		else stats.errors.push(`${label}: rocksdb.compact.write.bytes was ${typeof written}, not a number`);
+		else stats.errors.push(`${label}: rocksdb.compact.write.bytes was a ${typeof written}, not a number`);
 	} catch (error) {
 		stats.errors.push(`${label}: getStats threw: ${error.message}`);
 	}
 	try {
-		const levelStats = store.getDBProperty('rocksdb.levelstats');
-		stats.totalSortedRuns = totalSortedRuns(levelStats);
-		if (stats.totalSortedRuns == null) stats.errors.push(`${label}: could not parse rocksdb.levelstats`);
+		stats.totalSortedRuns = totalSortedRuns(store.getDBProperty('rocksdb.levelstats'));
 	} catch (error) {
 		stats.errors.push(`${label}: getDBProperty threw: ${error.message}`);
 	}
@@ -85,8 +82,8 @@ export class Probe extends Resource {
 	}
 }
 
-// GET /EngineInfo/?table=Host -> the class actually backing the index store, so the suite can
-// assert RocksDB rather than trusting that its HARPER_STORAGE_ENGINE request was honored.
+// The class actually backing the index store, so the suite can assert RocksDB rather than trust
+// that its HARPER_STORAGE_ENGINE request was honored.
 export class EngineInfo extends Resource {
 	static loadAsInstance = false;
 	async get(query) {
@@ -100,8 +97,6 @@ export class EngineInfo extends Resource {
 	}
 }
 
-// POST /Seed/ { table, rows: [{ id, category, value }] } -> ordinary puts through the normal
-// write path.
 export class Seed extends Resource {
 	static loadAsInstance = false;
 	async post(query, body) {
@@ -114,53 +109,51 @@ export class Seed extends Resource {
 	}
 }
 
-// POST /DeleteOne/ { table, id } -> an ordinary committed delete, no abort.
 export class DeleteOne extends Resource {
 	static loadAsInstance = false;
 	async post(query, body) {
 		const b = body || query || {};
-		const table = getTable(b.table);
-		await table.delete(b.id);
+		await getTable(b.table).delete(b.id);
 		return { ok: true, table: b.table, id: b.id };
 	}
 }
 
-// POST /InjectPhantom/ { category, id } -> write [category, id] straight into Host's category
-// index with no primary record behind it. Refuses if the id does exist, so the fixture cannot
-// quietly produce a live entry and call it a phantom.
+/** Writes [category, id] into Host's category index directly, bypassing Table's write path. */
+async function injectIndexEntry(category, id) {
+	await getIndex(tables.Host, 'Host').put(category, id);
+	return { ok: true, category, id };
+}
+
+// InjectPhantom and InjectStaleEntry differ only in which primary state they require, and that is
+// the whole point of having two: a single endpoint taking a flag would let a caller inject the
+// wrong kind of entry and still be believed.
 export class InjectPhantom extends Resource {
 	static loadAsInstance = false;
 	async post(query, body) {
 		const b = body || query || {};
-		const table = tables.Host;
-		if (table.primaryStore.getEntry(b.id)?.value) {
+		if (tables.Host.primaryStore.getEntry(b.id)?.value) {
 			throw new Error(`phantom-index-permanence: id "${b.id}" exists in the primary store; it would not be a phantom`);
 		}
-		await getIndex(table, 'Host').put(b.category, b.id);
-		return { ok: true, category: b.category, id: b.id };
+		return injectIndexEntry(b.category, b.id);
 	}
 }
 
-// POST /InjectStaleEntry/ { category, id } -> the contrast to InjectPhantom: an index entry
-// under a value the record does NOT hold, for an id that DOES exist. Refuses if the id is
-// absent, so the two endpoints cannot be confused for one another.
 export class InjectStaleEntry extends Resource {
 	static loadAsInstance = false;
 	async post(query, body) {
 		const b = body || query || {};
-		const table = tables.Host;
-		if (!table.primaryStore.getEntry(b.id)?.value) {
+		if (!tables.Host.primaryStore.getEntry(b.id)?.value) {
 			throw new Error(
 				`phantom-index-permanence: id "${b.id}" has no primary record; that would be a phantom, not a stale entry`
 			);
 		}
-		await getIndex(table, 'Host').put(b.category, b.id);
-		return { ok: true, category: b.category, id: b.id };
+		return injectIndexEntry(b.category, b.id);
 	}
 }
 
-// GET /IndexDump/?table=Host&category=X -> raw index-store scan, no join through the primary
-// record. Optionally filtered to one indexed value.
+// The raw index scan, with no join through the primary record — the only oracle that can see an
+// entry whose primary is absent. Deliberately scans the whole index rather than seeking to the
+// requested value, so an entry filed under an unexpected key is still observable.
 export class IndexDump extends Resource {
 	static loadAsInstance = false;
 	async get(query) {
@@ -176,7 +169,6 @@ export class IndexDump extends Resource {
 	}
 }
 
-// GET /PrimaryHas/?table=Host&id=X -> does the primary store hold this record at all?
 export class PrimaryHas extends Resource {
 	static loadAsInstance = false;
 	async get(query) {
@@ -186,10 +178,6 @@ export class PrimaryHas extends Resource {
 	}
 }
 
-// POST /FlushAndStats/ { table } and POST /CompactAndStats/ { table } fold the storage operation
-// and the levelstats read into ONE handler call. Split across two requests, RocksDB's own
-// background compaction can run in between and the stats read then describes a different on-disk
-// state than the one the operation produced.
 export class FlushAndStats extends Resource {
 	static loadAsInstance = false;
 	async post(query, body) {
@@ -228,24 +216,8 @@ export class CompactAndStats extends Resource {
 	}
 }
 
-// GET /Search/?table=Host&category=X -> single-table indexed search(), the shared mechanism REST
-// and search_by_value both resolve through.
-export class Search extends Resource {
-	static loadAsInstance = false;
-	async get(query) {
-		const tableName = qget(query, 'table') || 'Host';
-		const category = qget(query, 'category');
-		const table = getTable(tableName);
-		const ids = [];
-		for await (const record of table.search({ conditions: [{ attribute: INDEXED_ATTRIBUTE, value: category }] })) {
-			ids.push(record.id);
-		}
-		return { table: tableName, category, ids };
-	}
-}
-
-// GET /ComboSearch/?tables=Companion,Host&category=X -> both tables searched by secondary index,
-// in the given order, within ONE request (harper#1881's cross-table read shape).
+// Every named table searched by secondary index, in the given order, within one request —
+// harper#1881's cross-table read shape. One table in `tables` is the ordinary single-table search.
 export class ComboSearch extends Resource {
 	static loadAsInstance = false;
 	async get(query) {
@@ -256,12 +228,7 @@ export class ComboSearch extends Resource {
 			.filter(Boolean);
 		const results = {};
 		for (const tableName of order) {
-			const table = getTable(tableName);
-			const ids = [];
-			for await (const record of table.search({ conditions: [{ attribute: INDEXED_ATTRIBUTE, value: category }] })) {
-				ids.push(record.id);
-			}
-			results[tableName] = ids;
+			results[tableName] = await searchIds(tableName, category);
 		}
 		return { order, category, results };
 	}

--- a/integrationTests/database/phantom-index-permanence/resources.js
+++ b/integrationTests/database/phantom-index-permanence/resources.js
@@ -82,8 +82,6 @@ export class Probe extends Resource {
 	}
 }
 
-// The class actually backing the index store, so the suite can assert RocksDB rather than trust
-// that its HARPER_STORAGE_ENGINE request was honored.
 export class EngineInfo extends Resource {
 	static loadAsInstance = false;
 	async get(query) {
@@ -118,7 +116,7 @@ export class DeleteOne extends Resource {
 	}
 }
 
-/** Writes [category, id] into Host's category index directly, bypassing Table's write path. */
+/** Bypasses Table's write path entirely — this is the only way to create the divergence now. */
 async function injectIndexEntry(category, id) {
 	await getIndex(tables.Host, 'Host').put(category, id);
 	return { ok: true, category, id };

--- a/integrationTests/database/phantom-index-permanence/schema.graphql
+++ b/integrationTests/database/phantom-index-permanence/schema.graphql
@@ -1,10 +1,6 @@
-# Two audit:false @indexed tables, the shape both phantom-index findings were reported against
-# (harper#1854, harper#1989).
-#
-#   Host      — holds the injected phantom index entry, plus a live row under the same category.
-#   Companion — never holds a phantom; it occupies the other table slot in the single-request,
-#               two-table indexed read, so that read runs under a realistic multi-sorted-run
-#               precondition on both sides rather than only on Host.
+# Companion never holds a row under any category the suite queries; it exists to occupy the other
+# table slot in the single-request, two-table indexed read, fragmented into sorted runs the same
+# way as Host so that read runs under a realistic precondition on both sides.
 type Host @table(audit: false) @export {
 	id: ID! @primaryKey
 	category: String @indexed

--- a/integrationTests/database/phantom-index-permanence/schema.graphql
+++ b/integrationTests/database/phantom-index-permanence/schema.graphql
@@ -1,0 +1,18 @@
+# Two audit:false @indexed tables, the shape both phantom-index findings were reported against
+# (harper#1854, harper#1989).
+#
+#   Host      — holds the injected phantom index entry, plus a live row under the same category.
+#   Companion — never holds a phantom; it occupies the other table slot in the single-request,
+#               two-table indexed read, so that read runs under a realistic multi-sorted-run
+#               precondition on both sides rather than only on Host.
+type Host @table(audit: false) @export {
+	id: ID! @primaryKey
+	category: String @indexed
+	value: String
+}
+
+type Companion @table(audit: false) @export {
+	id: ID! @primaryKey
+	category: String @indexed
+	value: String
+}


### PR DESCRIPTION
Promotes QA scenario QA-776 to a permanent integration test: a **phantom secondary-index entry** — an index key whose primary record does not exist — is permanent, and it is never served.

Three properties, all previously measured only in a scratch QA run:

- **Compaction does not reap it.** RocksDB compaction collapses superseded and tombstoned versions; a phantom is neither, so there is nothing to reap.
- **A repeat `delete()` does not repair it.** `updateIndices()` derives both the old and the new indexed value from a record that is absent, so both resolve to `undefined` and it `continue`s. Only `runIndexing()`, which clears the index before rebuilding, removes one.
- **No read surface serves it.** An index hit is materialized against the primary store and dropped when no record comes back — asserted across [four read surfaces](https://github.com/HarperFast/harper/pull/2406/changes?w=1#diff-decbeb2ffbe6e39a71577f5a5c29b6b993c2d21b8765a73c7be360d25d63bc26R146).

## Pre-check: F-147 and #1989 are distinct mechanisms, and both are fixed

The dispatch brief asked whether F-147's phantom is the same null-keyed mechanism as [#1989](https://github.com/HarperFast/harper/issues/1989) (F-175), and to pin #1989's shape if so. It is not:

| | #1989 (F-175) | #1854 (F-147) |
|---|---|---|
| entry left behind | a **null-keyed** `[null, id]` entry, *added* by the removal path | the record's **real indexed value** `[value, id]`, *not removed* by the removal path |
| root cause | `updateIndices(id, existing, null)` resolved a removed record's new value to `null` instead of `undefined`, so an `indexNulls`-default index re-added a null-keyed entry | `_writeDelete()`'s non-audit branch called `removeEntry(primaryStore, existingEntry)` with no `{transaction}`, so the primary removal committed standalone while the transaction-scoped index removal rolled back |
| trigger | any removal, engine-independent | an **aborted** transaction on an **`audit:false`** table, RocksDB only |
| status | fixed by #1896; #1989 closed 2026-07-29 as already-fixed | fixed; #1854 closed COMPLETED 2026-07-27 |
| anchor already in repo | `eviction-index-phantom-null-keys.test.ts` | `audit-false-delete-rollback.test.ts` |

What they *do* share is the property this file pins — #1989's body records that the phantom is "not reaped by restart or RocksDB compaction", and QA-776 root-caused why. That permanence is a property of the entry, not of either bug, so the test pins it generically and cites both.

**Consequence:** with both producers fixed, no Harper write path can create a phantom on `main`. QA candidate P-545 was demoted 2026-08-03 for exactly this — its arming step asserted the *buggy* behaviour as a precondition and went red once #1854 landed. This file therefore **injects** the divergence through the table's own index store, and says so rather than implying Harper can still produce one.

## How the assertions are kept from being vacuous

Every claim here is a zero or a negative, so each one is armed by a control that was measured to fire.

- The oracle is the server-owned raw index store read back via `getRange()` — a raw composite-key scan with **no primary join**, so unlike `search_by_value` it can see an entry whose primary is absent. `search_by_value` is structurally blind here and cannot serve as an oracle.
- **The masking is conditional, and that is proven, not assumed.** [`InjectStaleEntry`](https://github.com/HarperFast/harper/pull/2406/changes?w=1#diff-8e3d01c0a35e6847994becfac027894b8fc562f134476baf94fb241a6acca096R139) writes the same kind of raw entry for an id that *does* exist, and every surface then serves it under a value the record does not hold. Without this, the phantom's zeros would equally be satisfied by surfaces that had stopped reading the index at all.
- **The compaction is proven by bytes actually rewritten**, not by a drop in sorted runs: `compact({ bottommost: true })` rewrites every file in range whether or not RocksDB thinks it worthwhile, and both samples of the DB-wide `rocksdb.compact.write.bytes` ticker are taken inside [`CompactAndStats`](https://github.com/HarperFast/harper/pull/2406/changes?w=1#diff-8e3d01c0a35e6847994becfac027894b8fc562f134476baf94fb241a6acca096R195) around that call. Sorted-run counts are diagnostic only — with data this small, background compaction can collapse them first, which would have failed a run-count gate for a reason unrelated to the phantom.

## For the human reviewer

- **The planning gate did not clear on its first pass.** `Framing-Verdict: better-alternative-exists`. The reviewer accepted the layer (test-only) and the rejection of a production reaper, but named a better mechanism: use the server-owned raw index DBI rather than a second external read-only `RocksDatabase` handle, and drop a leg that duplicated `eviction-index-phantom-null-keys.test.ts`. Both were verified against source and adopted, with the task owner's explicit ruling before implementation. `RocksIndexStore.getRange()` is a raw composite-key scan with no primary join, and it is already the oracle the sibling anchor uses.
- **Declined, repeated across rounds: `schema: 'data'` is hardcoded** in the ops-API and SQL calls. This is the convention across the repo's integration tests (`audit-false-delete-rollback.test.ts` and others), and diverging here would make this file the odd one out rather than more robust.
- **Declined: the file header.** Reviewers flagged it as exceeding the zero-new-comments default in every round. Inline comments were trimmed substantially across two passes, but the header is kept: for a promoted QA anchor it is the artifact that says why the test exists and what would make it meaningless, and it matches the sibling anchors' style. Worth a second opinion.
- **Declined: the readiness poll retries to its deadline** rather than failing fast on an unexpected status. It now reports the last status or thrown error, which was the substance of the finding; failing fast on anything but 404 risks turning a transient startup status into a spurious red.
- **Not covered:** surfaces that reach the secondary index without the primary-record join. The four asserted surfaces converge on that join; a future planner optimization that skipped it would not be caught here.
- **Ordered, state-mutating suite.** Each test builds on the on-disk state the previous one left. This is deliberate — the narrative is "one divergence, followed through compaction and a repeat delete" — and matches the sibling storage anchors, but a single failing assertion does require re-running the chain.

## Verification

- New suite green from cold, run repeatedly during development: `npm run test:integration -- "integrationTests/database/phantom-index-permanence.test.ts"` → **7/7 pass, ~4-6 s**.
- **Arming measured, not assumed**, by temporarily removing the mechanism and confirming the red:
  - with `index.compact()` removed → `compact() must have rewritten data: rocksdb.compact.write.bytes 8469 -> 8469` (fails).
  - the stale-entry control passes, i.e. all four surfaces *do* return an injected raw entry whose primary record exists.
- Neighbouring suites, to check for interference: `eviction-index-phantom-null-keys`, `audit-false-delete-rollback` (23/23 pass); `eviction-index-orphan-removal-paths`, `eviction-phantom-null`, `eviction-secondary-index`, `eviction-index-null-reindex`, `longtxn-index-orphan` (20/20 pass).
- **CI: all 24 integration shards pass** (Node v24, Bun, uWS HTTP, and Windows). The new suite is confirmed to have actually executed rather than been collected and skipped — `Integration Tests 3/6 (Node.js v24)` logs `✔ phantom secondary-index entry permanence [rocksdb] (6177ms)`. It self-skips on Windows, where `flush`/`compact`/levelstats have nothing to act on.
- **CI: the three Unit Test jobs are red, and it is not this PR.** All three fail on `caching.test.js` "Can load cached indexed data" — `1802 passing, 1 failing`, byte-identical to the failure this branch reproduces on `main`, and already tracked as [#2404](https://github.com/HarperFast/harper/issues/2404). This diff is four new files under `integrationTests/`, which mocha's `unitTests/**` globs cannot load.
- Locally, `test:unit:main` additionally fails `configValidator` "does not warn when a relative rootPath resolves within the limit" — it resolves against `process.cwd()` and trips on this worktree's 95-character path. Not reproducible in CI, and unrelated.
- `npx prettier --check` clean; `npm run lint:required` (oxlint) clean.
- Promotion-gate criteria met: green on current `main` from cold, no absolute paths, formatter-clean.

Refs #1854
Refs #1989

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=8 @ b5b918a12e19</sub>

<sub>Human-Review-Need: 3 @ b5b918a12e19</sub>
