### PR TITLE
Deliver RocksDB subscription events for source fills whose version differs from the log key

### DIFF
--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -117,7 +117,14 @@ export class RocksTransactionLogStore extends EventEmitter {
 			}
 			entryBinary = createAuditEntry(auditRecord, position);
 		}
-		if (this.listenerCount('aftercommit')) (options.transaction.logEntries ??= []).push(auditRecord);
+		if (this.listenerCount('aftercommit')) {
+			if (!(auditRecord instanceof Uint8Array)) {
+				const txnTimestamp = options.transaction.getTimestamp?.();
+				if (txnTimestamp != null) auditRecord.localTime = txnTimestamp;
+				auditRecord.recordVersion = auditRecord.version;
+			}
+			(options.transaction.logEntries ??= []).push(auditRecord);
+		}
 		// One commit hook per transaction handles both deferred side effects — the `aftercommit` emit and the
 		// per-(log, table) structureVersion watermark advances — so they apply only after a durable commit (never
 		// on an aborted/discarded transaction). This store is the sole setter of transaction.onCommit.
@@ -414,7 +421,10 @@ export class RocksTransactionLogStore extends EventEmitter {
 					position += 8;
 				}
 				const auditRecord = readAuditEntry(data, position, undefined);
+				// version stays the log key (replication resume relies on version === log key);
+				// the record's own version survives as recordVersion
 				auditRecord.version = timestamp;
+				auditRecord.localTime = timestamp;
 				auditRecord.endTxn = endTxn;
 				auditRecord.previousResidencyId = previousResidencyId;
 				auditRecord.previousVersion = previousVersion;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -4247,7 +4247,8 @@ export function makeTable(options) {
 							// been written, so are fresh in memory.
 							const entry: Entry = primaryStore.getEntry(id);
 							if (entry) {
-								if (entry.version !== auditRecord.version) return; // out of order event, with old update, don't send anything
+								// staleness is a record-version comparison; auditRecord.version is the log key on RocksDB
+								if (entry.version !== (auditRecord.recordVersion ?? auditRecord.version)) return; // out of order event, with old update, don't send anything
 								value = entry.value;
 								type = entry.metadataFlags & INVALIDATED ? 'invalidate' : value ? 'put' : 'delete';
 							} else {

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -34,7 +34,8 @@ initSync();
 
 export type AuditRecord = {
 	version: number;
-	localTime: number; // only to be used by LMDB (from the key)
+	recordVersion?: number; // the record's own version; on RocksDB reads `version` becomes the log key, so record identity uses this
+	localTime: number; // log position: LMDB audit-store key; RocksDB transaction-log timestamp
 	type: string;
 	encodedRecord?: Buffer;
 	extendedType?: number;
@@ -635,6 +636,7 @@ export function readAuditEntry(buffer: Uint8Array, start = 0, end = undefined): 
 				return buffer.subarray(recordIdStart, recordIdEnd);
 			},
 			version,
+			recordVersion: version,
 			previousVersion,
 			get user() {
 				try {

--- a/resources/transactionBroadcast.ts
+++ b/resources/transactionBroadcast.ts
@@ -180,6 +180,9 @@ function notifyFromTransactionData(subscriptions, auditLogIterable?, allowYield 
 			const auditRecord = result.value;
 			const timestamp: number = auditRecord.localTime ?? auditRecord.version;
 			subscriptions.lastTxnTime = timestamp;
+			// the transaction extent: RocksDB entries committed together share the log key (record
+			// versions may differ); LMDB's localTime is a per-entry audit key, so version delimits there
+			const txnKey = auditStore.reusableIterable ? timestamp : auditRecord.version;
 			if (ACTIONS_OF_INTEREST.includes(auditRecord.type)) {
 				const tableSubscriptions = subscriptions[auditRecord.tableId];
 				if (tableSubscriptions) {
@@ -204,7 +207,7 @@ function notifyFromTransactionData(subscriptions, auditLogIterable?, allowYield 
 								}
 								try {
 									let beginTxn;
-									if (subscription.supportsTransactions && subscription.txnInProgress !== auditRecord.version) {
+									if (subscription.supportsTransactions && subscription.txnInProgress !== txnKey) {
 										// if the subscriber supports transactions, we mark this as the beginning of a new transaction
 										// tracking the subscription so that we can delimit the transaction on next transaction
 										// (with a beginTxn flag, which may be on an endTxn event)
@@ -214,10 +217,7 @@ function notifyFromTransactionData(subscriptions, auditLogIterable?, allowYield 
 											if (!subscribersWithTxns) subscribersWithTxns = [subscription];
 											else subscribersWithTxns.push(subscription);
 										}
-										// the version defines the extent of a transaction, all audit records with the same version
-										// are part of the same transaction, and when the version changes, we know it is a new
-										// transaction
-										subscription.txnInProgress = auditRecord.version;
+										subscription.txnInProgress = txnKey;
 									}
 									subscription.listener(recordId, auditRecord, timestamp, beginTxn);
 								} catch (error) {

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -586,6 +586,43 @@ describe('Caching', () => {
 		assert.equal(ConflictCachingTable.primaryStore.getEntry(id).version, reportedVersion);
 	});
 
+	it('delivers a subscription event for a fill whose source-reported version predates the log position', async function () {
+		// A dedicated table: ConflictCachingTable's history carries deliberately future-stamped
+		// writes, and a fresh subscriber's catch-up cursor raises startTime to the newest record
+		// time it sees, which would gate off real-time events until wall-clock catches up.
+		const id = 645;
+		let reportedVersion;
+		const ReportedVersionTable = table({
+			table: 'ReportedVersionTable',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
+		ReportedVersionTable.sourcedFrom(
+			class extends Resource {
+				get() {
+					reportedVersion = Date.now() - 1000;
+					this.getContext().lastModified = reportedVersion;
+					return { id: this.getId(), name: 'reported-version-event' };
+				}
+			}
+		);
+		const subscription = await ReportedVersionTable.subscribe({});
+		const events = [];
+		subscription.on('data', (event) => events.push(event));
+		try {
+			await ReportedVersionTable.get(id);
+			await waitFor(() => !ReportedVersionTable.primaryStore.hasLock(id), {
+				message: 'the reported-version fill should finish committing',
+			});
+			assert.equal(ReportedVersionTable.primaryStore.getEntry(id).version, reportedVersion);
+			await waitFor(() => events.some((event) => event.id === id && event.type === 'put'), {
+				message: 'a backdated source-reported fill should still reach the subscription',
+			});
+		} finally {
+			subscription.close();
+		}
+	});
+
 	it('clamps an older source-reported revalidation version instead of using the request timestamp', async function () {
 		const id = 620;
 		await ConflictCachingTable.put(id, { id, name: 'seed-reported-version' });

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -13,9 +13,8 @@ require('#src/server/serverHelpers/serverUtilities');
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 
 function assertChronological(events, msg = 'events out of order') {
-	// Use `version` because lmdb populates localTime on cursor sends but rocksdb doesn't; both
-	// backends set version on the audit record to the commit timestamp, so version is the
-	// portable "time" key.
+	// Use `version`: both backends set it to the commit timestamp on cursor sends (rocksdb now
+	// also populates localTime with the log key, but version remains the portable "time" key).
 	for (let i = 1; i < events.length; i++) {
 		assert.ok(
 			events[i].version >= events[i - 1].version,

--- a/unitTests/resources/transactionBroadcastGrouping.test.js
+++ b/unitTests/resources/transactionBroadcastGrouping.test.js
@@ -1,0 +1,83 @@
+// Transaction delimiting in the broadcaster is engine-aware: RocksDB entries committed together
+// share the log key while their record versions may differ (a source fill's version can be a
+// source-reported lastModified); LMDB's localTime is a per-entry audit key, so there the shared
+// version delimits the transaction. These drive the real same-thread aftercommit path.
+require('../testUtils');
+const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
+const { addSubscription } = require('#src/resources/transactionBroadcast');
+const { waitFor } = require('../waitFor.js');
+
+function makeFakeStores(path, reusableIterable) {
+	const auditStore = new EventEmitter();
+	auditStore.env = {};
+	auditStore.reusableIterable = reusableIterable;
+	const primaryStore = { path, tableId: 1 };
+	return { primaryStore, auditStore };
+}
+
+function subscribeCollecting(table) {
+	const events = [];
+	const subscription = addSubscription(
+		table,
+		null,
+		(recordId, auditRecord, timestamp, beginTxn) => {
+			events.push({ id: recordId, type: auditRecord.type, beginTxn });
+		},
+		0,
+		{ crossThreads: false }
+	);
+	subscription.includeDescendants = true;
+	subscription.supportsTransactions = true;
+	return { events, subscription };
+}
+
+describe('transactionBroadcast transaction grouping', () => {
+	it('groups RocksDB entries by the shared log key even when record versions differ', async function () {
+		const table = makeFakeStores('/fake/broadcast-grouping-rocks', true);
+		const { events, subscription } = subscribeCollecting(table);
+		try {
+			const logKey = Date.now();
+			table.auditStore.emit('aftercommit', [
+				{ type: 'put', tableId: 1, recordId: 'a', version: logKey, recordVersion: logKey, localTime: logKey },
+				// a source fill in the same commit: backdated record version, same log key
+				{
+					type: 'put',
+					tableId: 1,
+					recordId: 'b',
+					version: logKey - 5000,
+					recordVersion: logKey - 5000,
+					localTime: logKey,
+				},
+			]);
+			await waitFor(() => events.length === 3, { message: 'both entries and the end_txn should be delivered' });
+			assert.deepEqual(events, [
+				{ id: 'a', type: 'put', beginTxn: true },
+				{ id: 'b', type: 'put', beginTxn: undefined },
+				{ id: null, type: 'end_txn', beginTxn: true },
+			]);
+		} finally {
+			subscription.end();
+		}
+	});
+
+	it('groups LMDB entries by the shared version across distinct per-entry audit keys', async function () {
+		const table = makeFakeStores('/fake/broadcast-grouping-lmdb', false);
+		const { events, subscription } = subscribeCollecting(table);
+		try {
+			const version = Date.now();
+			table.auditStore.emit('aftercommit', [
+				{ type: 'put', tableId: 1, recordId: 'c', version, localTime: version + 1 },
+				{ type: 'put', tableId: 1, recordId: 'd', version, localTime: version + 2 },
+			]);
+			await waitFor(() => events.length === 3, { message: 'both entries and the end_txn should be delivered' });
+			assert.deepEqual(events, [
+				{ id: 'c', type: 'put', beginTxn: true },
+				{ id: 'd', type: 'put', beginTxn: undefined },
+				{ id: null, type: 'end_txn', beginTxn: true },
+			]);
+		} finally {
+			subscription.end();
+		}
+	});
+});


### PR DESCRIPTION
Fixes the deterministic main-red `Caching > Can load cached indexed data` fence failure (9/9 CI matrix legs since [Fix sourcedFrom cache-fill conflict convergence (#2065)](https://github.com/HarperFast/harper/pull/2065)).

## What was wrong

#2065 deliberately decoupled a source fill's stored record version from its transaction's commit timestamp (fetch-start ordering token, source-reported `lastModified`, or a retained version). On RocksDB, the transaction-log reader then overwrote the decoded record version with the log key, and the subscription listener compared that log key against the stored record version — so every source-fill publication was silently dropped as "out of order". The fill itself committed fine; only its subscription event vanished.

## The fix (stage 0a of the reviewed staged plan)

- [`AuditRecord.recordVersion`](https://github.com/HarperFast/harper/pull/2409/changes?w=1#diff-db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356baR639) carries the decoded entry's own record version through the [RocksDB log-key override](https://github.com/HarperFast/harper/pull/2409/changes?w=1#diff-56c43863dc5f281e19328e36b0082523391cfb5373c0bd88a8d3d94bfa1ab46cR426), and the [listener's staleness check](https://github.com/HarperFast/harper/pull/2409/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R4251) compares record versions, while `version` stays the log key (replication resume cursors rely on `version === log key`).
- Raw same-thread `aftercommit` entries are [stamped with the same two clocks](https://github.com/HarperFast/harper/pull/2409/changes?w=1#diff-56c43863dc5f281e19328e36b0082523391cfb5373c0bd88a8d3d94bfa1ab46cR123) the decoded path reports (`localTime` = the committing transaction's timestamp, explicit `recordVersion`).
- [Transaction delimiting in the broadcaster](https://github.com/HarperFast/harper/pull/2409/changes?w=1#diff-204502f53b351f664fdbba21820d29afa4598b077295f877ca1f275fbd8931e6R185) is engine-aware: RocksDB groups by the shared log key (record versions inside one commit may differ — exactly the fill case); LMDB keeps version grouping since its `localTime` is a per-entry audit key. Look hardest here: the engine split rides the established `reusableIterable` discriminator, and a wrong branch would regroup LMDB transactions.

## For the human reviewer

- **Approved staging (rulings recorded in the dispatch log):** this is stage 0a of a larger, three-round cross-model-reviewed plan. Stage 0b (normalize `version`/`localTime` to LMDB semantics across core + a coordinated harper-pro cursor PR) and the dual-timestamp storage roadmap (rocksdb-js commit stamping, three-clock model) are deliberately NOT in this PR.
- **Deliberately unchanged, with known consequences:** crash replay still re-applies whole transactions at the log key (a replayed fill's version changes across a crash; needs a per-write-version API — follow-up); harper-pro replication still applies the origin's log key as the record version on peers; `event.version` delivered to subscribers remains path-dependent (decoded = log key, raw same-thread = record version — pre-existing, contract decided at 0b); tombstone prune and the blob orphan scan intentionally stay conservative — record versions are legitimately non-unique (`VERSION_NOT_UNIQUE_FLAG`), so a version match is not write identity.
- **Reviewer dissent carried:** the pre-push reviewers preferred normalizing `version` to record semantics now rather than the `recordVersion` alias; the staged ruling keeps main green today and absorbs the alias at 0b.
- **Unrelated known breakage visible in this PR's CI:** the LMDB unit leg fails in `branchDatabase.test.js` ("does nothing when no databases are declared") because `prepareBranches('app', [], …)` hits the RocksDB-engine guard before the empty-declaration no-op — introduced by #2352 on main today, untouched here.

## Verification

- Red-proof: with `resources/{auditStore,RocksTransactionLogStore,Table,transactionBroadcast}.ts` restored to `origin/main` and `dist` rebuilt, both regression anchors fail with the exact CI assertion; with this branch's sources rebuilt, both pass.
- New coverage: a [fresh-table regression](https://github.com/HarperFast/harper/pull/2409/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR589) for a backdated source-reported fill reaching a live subscription, and a [broadcaster-level test](https://github.com/HarperFast/harper/pull/2409/changes?w=1#diff-ffdfe714ba531c816de480ec3929c5847dc848833ba0bc8629ed9ab266488e3c) driving two same-commit entries with divergent record versions through the real same-thread aftercommit path asserting one `beginTxn`/`end_txn` pair on both engine shapes.
- Suites: `test:unit:resources` (RocksDB) 1841 passing; LMDB leg passes except the pre-existing #2352 branchDatabase failure above; `test:unit:main` 5115 passing with one environmental failure (`configValidator` resolves `relative/root` against this deeply nested worktree cwd, exceeding the 107-byte socket-path limit — passes in CI's short cwd); `subscriptionReplay` green on both engines; lint + format clean.
- End-to-end route: subscription delivery is exercised in-process by the unit suites; transport-level (SSE/MQTT) behavior is unchanged by this read-side fix and covered by existing integration suites in CI.

Refs #2065

Signed: Claude Fable 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=claude; ran=gemini; blocked=codex(timeout),claude(fallback)(out-of-budget),domain(timeout); declined=cursor-grok,cursor-composer; rounds=3 @ cad322056c6e</sub>

<sub>Human-Review-Need: 3 @ cad322056c6e</sub>
