### PR TITLE
Let an empty branchedDatabases declaration load under LMDB

### DIFF
--- a/resources/branchDatabase.ts
+++ b/resources/branchDatabase.ts
@@ -250,6 +250,9 @@ export async function prepareBranches(
 				`which cannot carry a scoped databases binding; use the default loader or remove branchedDatabases`
 		);
 	}
+	// An explicitly empty list branches nothing, so it needs no engine capability.
+	if (branchedDatabases !== true && !branchedDatabases.length) return branches;
+
 	if ((process.env.HARPER_STORAGE_ENGINE || env.get(CONFIG_PARAMS.STORAGE_ENGINE)) === 'lmdb') {
 		throw new Error(`Application '${appName}' declares branchedDatabases, which requires the RocksDB storage engine`);
 	}


### PR DESCRIPTION
Main's LMDB unit leg has been red since #2352: `prepareBranches` checked the RocksDB-engine requirement before the empty-declaration no-op, so an application declaring an explicitly empty `branchedDatabases: []` failed to load under LMDB, and main's own pinning test `does nothing when no databases are declared` failed. An explicitly empty list now [returns before the engine guard](https://github.com/HarperFast/harper/pull/2413/changes?w=1#diff-cac868f688668988b75b365b484204e6a54f9fcbb121dab67b3358808b9dacf5R254) — it branches nothing, so it needs no engine capability. Downstream, an empty branch map and an undeclared app are already equivalent (`jsLoader` checks `!branches?.size`), so `[]` now behaves identically to no declaration.

The breakage was masked on #2352's own PR because the (since-fixed, #2409) caching failure short-circuited `test:unit:all` before the LMDB step. The remaining #2352 breakage — the Windows branched-database restart failure, #2410 — is independent and not touched here.

## For the human reviewer

1. **Empty list = no-op, not a config error.** `[]` under LMDB now loads silently as "no branches" instead of refusing on an engine that cannot branch. A user who wrote `[]` expecting isolation gets none with no signal — but `[]` requests nothing, and main's own test pins this as the intended behavior. Reversing is one line but re-breaks that test.
2. **Guard order: the early return sits after the native-loader throw, before the engine throw.** So `[]` is still fatal under the `native` loader while inert under LMDB — an asymmetry the review's one surviving (pre-existing) minor flags. I kept the native refusal deliberately (the [early return](https://github.com/HarperFast/harper/pull/2413/changes?w=1#diff-cac868f688668988b75b365b484204e6a54f9fcbb121dab67b3358808b9dacf5R253) sits below it): that declaration is structurally unusable at any list length and its error tells the operator to remove it. If you rule `[]` should skip both guards, that changes native-loader boot behavior for existing deployments and belongs in its own change.
3. **The no-op lives in `prepareBranches`, not the call site.** Every future caller inherits the semantics and the unit test proves it directly; skipping the call in `componentLoader` instead would leave `prepareBranches` throwing on `[]` for any new caller. Cheap to move now, expensive once a second caller exists.
4. **Coverage is function-level.** Nothing proves an app with `branchedDatabases: []` completes a real component load end to end (integration coverage stops at `true` and `['data']`). Additive test, low stakes for a declaration whose whole behavior is "do nothing" — say the word and I'll add the fixture.

## Verification

- Fails-on-base: with `resources/branchDatabase.ts` restored to origin/main (b3235b8c6) and `dist` force-rebuilt (tsbuildinfo removed), `HARPER_STORAGE_ENGINE=lmdb mocha unitTests/resources/branchDatabase.test.js` fails with the exact CI assertion (`Error: Application 'app' declares branchedDatabases, which requires the RocksDB storage engine` in `does nothing when no databases are declared`); with the fix rebuilt, 14 passing.
- RocksDB leg of the same file: 35 passing. Full `test:unit:resources` (RocksDB): 1841 passing, 0 failures.
- End-to-end route: the unit test is the observable surface — the only production call site is component load (`componentLoader.ts:676`), where an empty list previously threw the load; the behavior is not separately observable beyond the load succeeding (see reviewer item 4).

Complexity: easy

<sub>Review-Coverage: authored=claude; ran=gemini,codex; adjudicated=domain; blocked=cursor-composer(failed); declined=cursor-grok; rounds=2 @ bac37ab63f56</sub>

<sub>Human-Review-Need: 3 (decisions: empty-list-semantics, guard-ordering-vs-native-loader, true-on-empty-instance-asymmetry) @ bac37ab63f56</sub>
