### PR TITLE
Fix a branched database silently discarding its latest writes when restarted after a crash or hard kill

### DIFF
--- a/integrationTests/components/branched-database-crash.test.ts
+++ b/integrationTests/components/branched-database-crash.test.ts
@@ -1,0 +1,107 @@
+/**
+ * A branched database must recover its transaction-log tail after a crash (harper#643).
+ *
+ * A branch's column families write with the WAL disabled, like every store's, so a write's only
+ * durable record until the next memtable flush is the branch's own transaction log. A process that
+ * dies without flushing — a real crash, or Windows' `taskkill /F`, which runs no exit handlers —
+ * must therefore replay that tail when it adopts the branch directory, exactly as a base database
+ * does, or the application's most recent writes silently vanish.
+ *
+ * This is the crash-shaped sibling of branched-database.test.ts's restart test: same fixture, but
+ * the restart is a SIGKILL with the exit-time flush disabled (the crash-replay.test.ts pattern), so
+ * it reproduces on every platform what the Windows integration shard hits implicitly.
+ *
+ * Reproduction:
+ *   npm run test:integration -- "integrationTests/components/branched-database-crash.test.ts"
+ */
+import { suite, test, before, after } from 'node:test';
+import { strictEqual } from 'node:assert';
+import { resolve, join, basename } from 'node:path';
+import { cp, mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+import {
+	startHarper,
+	killHarper,
+	teardownHarper,
+	sendOperation,
+	type ContextWithHarper,
+} from '@harperfast/integration-testing';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'fixtures/branched-database');
+
+const BRANCHED = {
+	config: { 'branched-database': { branchedDatabases: ['data'] } },
+	// Skip the exit-time RocksDB flush so a kill leaves the branch's last writes only in its
+	// transaction log — the state a genuine crash (or a Windows hard kill) leaves behind.
+	env: { HARPER_NO_FLUSH_ON_EXIT: 'true' },
+};
+
+async function crashHarper(ctx: ContextWithHarper): Promise<void> {
+	await new Promise((resolveExit) => {
+		ctx.harper!.process!.on('exit', resolveExit);
+		ctx.harper!.process!.kill('SIGKILL');
+	});
+}
+
+suite('an application with a branched database, across a crash', (ctx: ContextWithHarper) => {
+	before(async () => {
+		// Same two-phase setup as branched-database.test.ts: the base needs the schema before the
+		// branch is taken.
+		const dataRootDir = await mkdtemp(
+			join(process.env.HARPER_INTEGRATION_TEST_INSTALL_PARENT_DIR || tmpdir(), 'harper-integration-test-')
+		);
+		ctx.harper = { dataRootDir } as any;
+		await startHarper(ctx, BRANCHED);
+		await sendOperation(ctx.harper, { operation: 'create_database', database: 'data' });
+		await sendOperation(ctx.harper, {
+			operation: 'create_table',
+			database: 'data',
+			table: 'Branched',
+			primary_key: 'id',
+		});
+		await sendOperation(ctx.harper, {
+			operation: 'insert',
+			database: 'data',
+			table: 'Branched',
+			records: [{ id: 'from-base', note: 'seeded before the branch was taken' }],
+		});
+
+		await killHarper(ctx);
+		await cp(FIXTURE_PATH, join(dataRootDir, 'components', basename(FIXTURE_PATH)), {
+			recursive: true,
+			dereference: true,
+		});
+		await startHarper(ctx, BRANCHED);
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test("keeps the application's own data across a crash", async () => {
+		await sendOperation(ctx.harper, {
+			operation: 'branch_probe',
+			action: 'put',
+			id: 'crash-survivor',
+			note: 'written before the crash',
+		});
+
+		await crashHarper(ctx);
+		await startHarper(ctx, BRANCHED);
+
+		const recovered = await sendOperation(ctx.harper, { operation: 'branch_probe', id: 'crash-survivor' });
+		strictEqual(recovered.found, true, 'a crash must not discard writes the transaction log holds');
+		strictEqual(recovered.note, 'written before the crash');
+
+		// Recovery must have replayed the branch's own log into the branch — never into the base.
+		const inBase = await sendOperation(ctx.harper, {
+			operation: 'search_by_id',
+			database: 'data',
+			table: 'Branched',
+			ids: ['crash-survivor'],
+			get_attributes: ['id'],
+		});
+		strictEqual(inBase.length, 0, 'the base must not see the replayed branch write');
+	});
+});

--- a/resources/branchDatabase.ts
+++ b/resources/branchDatabase.ts
@@ -54,6 +54,12 @@ interface OpenBranch {
 // READY at the same moment and would otherwise each try to open the directory the winner just opened.
 const branchesByPath = new Map<string, Promise<OpenBranch>>();
 
+/**
+ * The claim word is process-local shared memory (in-process only, seeded UNCLAIMED each boot) and
+ * must stay that way: the winner's tail replay runs exactly once per boot because every boot starts
+ * from UNCLAIMED. A durable or cross-process claim would read READY on restart and silently skip
+ * recovery.
+ */
 function claimStateFor(baseName: string, branchPath: string): BigInt64Array {
 	const baseStore = database({ database: baseName, table: undefined });
 	const seed = new BigInt64Array([UNCLAIMED]);
@@ -157,23 +163,26 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 				// exists is always a complete one, never a half-copy to be distrusted.
 				if (!existsSync(branchPath)) await materializeBranch(baseName, branchPath);
 				branch = openBranchDatabase(branchPath, baseName, storeName);
-				// An adopted directory is only complete up to its last memtable flush: its column
-				// families write with the WAL disabled, so anything after that flush exists solely in
-				// the branch's own transaction log — which a process that died without the exit-time
-				// flush (a crash, a Windows hard kill) always leaves behind. Replay that tail, and
-				// finish before READY is published, because READY is what releases the other threads
-				// to open the branch and serve reads from it. The claim makes this thread the sole
-				// elected replayer; a fresh checkpoint has no log, so replay is then a no-op. Skipped
-				// in read-only mode for the same snapshot semantics the base's boot replay uses.
+				// The branch's column families write with the WAL disabled, so writes since its last
+				// memtable flush exist only in its own transaction log — which a process that died
+				// without the exit-time flush (a crash, a Windows hard kill) always leaves behind.
+				// Replay must finish before READY, because READY is what releases the other threads to
+				// serve reads. A fresh checkpoint carries no transaction_logs (verified: the native
+				// checkpoint copies only RocksDB files), so replay after materialize is a no-op; the
+				// read-only skip mirrors the base's boot replay.
 				if (!isReadOnlyMode()) await replayLogs(branch.rootStore as RocksDatabase, branch.tables, true);
 				Atomics.store(claimState, 0, READY);
 			} catch (error) {
 				// Release rather than record the failure. A claim that stays un-releasable turns one
 				// transient error -- a full disk, a rename losing a race -- into a branch that can never
 				// be created again for the life of the process, because the buffer outlives every retry.
-				// The opened branch must go first: it holds the path and store identity, so leaving it
-				// open would make every retry fail with "already open" instead of retrying.
-				branch?.close();
+				// The branch is closed first — it holds the path and store identity a retry needs — and
+				// a close failure must not leave the claim wedged in CREATING for the whole deadline.
+				try {
+					branch?.close();
+				} catch (closeError) {
+					logger.warn(`Error closing branch at ${branchPath} after a failed open`, closeError);
+				}
 				Atomics.store(claimState, 0, UNCLAIMED);
 				throw error;
 			} finally {

--- a/resources/branchDatabase.ts
+++ b/resources/branchDatabase.ts
@@ -5,15 +5,18 @@ import logger from '../utility/logging/harper_logger.ts';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import { commonValidators } from '../validation/common_validators.ts';
 import * as env from '../utility/environment/environmentManager.ts';
+import type { RocksDatabase } from '@harperfast/rocksdb-js';
 import {
 	type BranchDatabase,
 	database,
 	databases,
 	getDatabases,
 	hydrateBranchRelationships,
+	isReadOnlyMode,
 	openBranchDatabase,
 	resolveBranchPath,
 } from './databases.ts';
+import { replayLogs, replayTimeBudgetMs } from './replayLogs.ts';
 
 /**
  * Private per-application forks of a database, for running several variants of an application against
@@ -36,7 +39,8 @@ const READY = 2n;
 
 const MAX_NAME_LENGTH = commonValidators.schema_length.maximum;
 
-/** How long a loser waits for the winner's checkpoint before giving up on the branch. */
+/** How long a loser waits for the winner's checkpoint before giving up on the branch; the
+ *  winner's replay budget is added on top where the deadline is built (`openOrCreate`). */
 const CLAIM_TIMEOUT_MS = 10 * 60 * 1000;
 
 interface OpenBranch {
@@ -133,7 +137,11 @@ function branchStoreName(appName: string, baseName: string): string {
 
 async function openOrCreate(baseName: string, appName: string, branchPath: string): Promise<OpenBranch> {
 	const claimState = claimStateFor(baseName, branchPath);
-	const deadline = Date.now() + CLAIM_TIMEOUT_MS;
+	const storeName = branchStoreName(appName, baseName);
+	// The claim's CREATING window now covers the winner's replay as well as its checkpoint, so
+	// waiters must outlast the replay budget too, or a merely slow (but live) recovery would time
+	// out every other thread's application load minutes before the winner publishes READY.
+	const deadline = Date.now() + CLAIM_TIMEOUT_MS + replayTimeBudgetMs();
 	for (;;) {
 		// The deadline bounds the whole protocol, not just a single wait: an unexpected state word --
 		// a future state, a buffer another version wrote -- must fail this load, never spin forever.
@@ -141,29 +149,43 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 		const previous = Atomics.compareExchange(claimState, 0, UNCLAIMED, CREATING);
 		if (previous === READY) break;
 		if (previous === UNCLAIMED) {
+			let branch: BranchDatabase | undefined;
 			try {
 				// Adopt rather than recreate. The branch outlives the process that first made it, so on
 				// every restart after the first the directory is already here — and `materializeBranch`
 				// only ever publishes by renaming a finished checkpoint into place, so a directory that
 				// exists is always a complete one, never a half-copy to be distrusted.
 				if (!existsSync(branchPath)) await materializeBranch(baseName, branchPath);
+				branch = openBranchDatabase(branchPath, baseName, storeName);
+				// An adopted directory is only complete up to its last memtable flush: its column
+				// families write with the WAL disabled, so anything after that flush exists solely in
+				// the branch's own transaction log — which a process that died without the exit-time
+				// flush (a crash, a Windows hard kill) always leaves behind. Replay that tail, and
+				// finish before READY is published, because READY is what releases the other threads
+				// to open the branch and serve reads from it. The claim makes this thread the sole
+				// elected replayer; a fresh checkpoint has no log, so replay is then a no-op. Skipped
+				// in read-only mode for the same snapshot semantics the base's boot replay uses.
+				if (!isReadOnlyMode()) await replayLogs(branch.rootStore as RocksDatabase, branch.tables, true);
 				Atomics.store(claimState, 0, READY);
 			} catch (error) {
 				// Release rather than record the failure. A claim that stays un-releasable turns one
 				// transient error -- a full disk, a rename losing a race -- into a branch that can never
 				// be created again for the life of the process, because the buffer outlives every retry.
+				// The opened branch must go first: it holds the path and store identity, so leaving it
+				// open would make every retry fail with "already open" instead of retrying.
+				branch?.close();
 				Atomics.store(claimState, 0, UNCLAIMED);
 				throw error;
 			} finally {
 				wakeWaiters(claimState);
 			}
-			break;
+			return { branch, claimState };
 		}
 		// Someone else holds it. A wait that settles on UNCLAIMED means they failed and released, so
 		// take another turn at being the one who creates it.
 		if ((await awaitClaim(claimState, branchPath, deadline)) === READY) break;
 	}
-	return { branch: openBranchDatabase(branchPath, baseName, branchStoreName(appName, baseName)), claimState };
+	return { branch: openBranchDatabase(branchPath, baseName, storeName), claimState };
 }
 
 /** Remove the now-empty `<app>` directory a removed branch leaves behind. */

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -932,11 +932,11 @@ function readRocksMetaDb(
 			rootStore = openRocksDatabase(path, { disableWAL: false, enableStats: true }) as any;
 			rocksdbDatabaseEnvs.set(path, rootStore);
 			initStores(path, rootStore, databaseName, { defaultTable, destination, storeName, openedStores });
-			// A branch (`destination`) is a checkpoint and nothing more, deliberately. Replaying into one
-			// would make its content depend on which thread opened it — `replayLogs` is a no-op off the
-			// main thread, and applications load on workers — and it hands an un-awaited writer to a
-			// store the branch's owner may close moments later, which aborts the process rather than
-			// failing a load. See the contract note on `openBranchDatabase` (harper#643).
+			// A branch (`destination`) recovers its transaction-log tail in `openOrCreate`
+			// (branchDatabase.ts), not here: the branch claim elects exactly one replaying thread —
+			// applications load on workers, where this call would be a no-op — and awaits the replay
+			// before the branch is published to any reader. See the contract note on
+			// `openBranchDatabase` (harper#643).
 			if (!isReadOnlyMode() && !destination) {
 				replayLogs(rootStore, databases[databaseName]);
 			}
@@ -1401,19 +1401,20 @@ function assertLegalBranchName(name: string, description: string): void {
  * `closeBranchDatabases`, which `closeLoadedDatabases` runs at thread teardown so a branch left open
  * on an exiting worker does not leak its handles into the process-global RocksDB registry.
  *
- * NOT YET SAFE FOR SCHEMA MUTATION. A branch's Table classes carry the base's logical name, so a
+ * NOT SAFE FOR SCHEMA MUTATION. A branch's Table classes carry the base's logical name, so a
  * `dropTable()` or equivalent through one resolves against the global schema and would delete the
- * live base Table class. Nothing calls this yet; the scope wiring that first exposes a branch to
- * application code must gate schema operations before it does (harper#643).
+ * live base Table class — which is why schema operations through a branch are refused
+ * (branchGuard.ts).
  *
  * A branch's blob roots start empty, so a row whose blob was written before the checkpoint reads
  * back as a missing file until harper#644 links the base's blob tree into them. Non-blob rows are
  * unaffected, for reads and writes alike.
  *
- * A branch is the checkpoint's SST content plus, on the main thread only, its transaction-log tail:
- * `replayLogs` is a no-op off the main thread and nothing else will ever replay a private store. It
- * is also not awaited, so `close()` can race a replay still writing — neither is a problem while
- * nothing calls this, and both are decisions the scope wiring has to settle (harper#643).
+ * A branch is the checkpoint's SST content plus its own transaction-log tail. This function opens
+ * only the stores; replaying the tail is `openOrCreate`'s job (branchDatabase.ts), where the
+ * cross-thread claim elects exactly one replayer and awaits it before any thread may open the
+ * branch — the same recovery contract a base database gets at boot, without which a process that
+ * died unflushed silently rewinds the branch to its last memtable flush (harper#643).
  */
 export function openBranchDatabase(path: string, databaseName: string, storeName: string): BranchDatabase {
 	assertLegalBranchName(databaseName, 'logical database name');

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -206,6 +206,7 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 						// commit the last transaction since we are starting a new one
 						transaction?.directCommitSync();
 					} catch (error) {
+						// directCommitSync aborts and detaches its transaction on failure; no cleanup here
 						if (electedReplayer) {
 							strictFailure = error;
 							break;
@@ -333,6 +334,7 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 			try {
 				transaction?.directCommitSync();
 			} catch (error) {
+				// directCommitSync aborts and detaches its transaction on failure; no cleanup here
 				if (electedReplayer) strictFailure = error;
 				logger.error('Error committing replay transaction', error);
 			}
@@ -342,10 +344,21 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 			logger.warn(
 				`Skipped ${skipped} unrecoverable audit entries in ${(rootStore as any).databaseName} database during replay`
 			);
-		// we never actually release the lock because we only want to ever run one time
-		// rootStore.unlock('replayLogs');
-		if (strictFailure) reject(strictFailure);
-		else resolve();
+		if (strictFailure) {
+			// A failed strict replay must be re-runnable: the branch claim resets for a retry, so the
+			// lock must not be what survives to wedge it. Only a COMPLETED replay keeps the lock
+			// forever (the once-per-boot guarantee).
+			try {
+				rootStore.unlock('replayLogs');
+			} catch (unlockError) {
+				logger.warn('Error releasing the replay lock after a failed replay', unlockError);
+			}
+			reject(strictFailure);
+		} else {
+			// we never actually release the lock because we only want to ever run one time
+			// rootStore.unlock('replayLogs');
+			resolve();
+		}
 	});
 }
 function asBinary(buffer) {

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -55,7 +55,7 @@ export function replayTimeBudgetMs(): number {
  * construction, and end-of-log is the designed reading of it (see replayLogsGuards.ts).
  */
 export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplayer?: boolean): Promise<void> {
-	if (!isMainThread && !electedReplayer) return; // ideally we don't do it like this, but for now this is predictable
+	if (!isMainThread && !electedReplayer) return Promise.resolve(); // ideally we don't do it like this, but for now this is predictable
 	return new Promise((resolve, reject) => {
 		const acquired = rootStore.tryLock('replayLogs', async () => {
 			resolve();
@@ -95,7 +95,7 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 			tableById.set(table.tableId, table);
 		}
 		// replay all the logs
-		let transaction: DatabaseTransaction;
+		let transaction: DatabaseTransaction | undefined;
 		let lastTimestamp = 0;
 		let writes = 0;
 		let skipped = 0;
@@ -221,7 +221,7 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 					// write batch in half. Re-clone to recover the unreplayed remainder.
 					if (shouldAbortSlowReplay(performance.now() - replayStartTime, replayTimeoutMs)) {
 						const slowMessage = `Aborting transaction-log replay in ${(rootStore as any).databaseName} database: replay has exceeded the wall-clock time limit (${writes} written, ${skipped} skipped). The transaction log contains a pathologically deep out-of-order write history that is too expensive to reconcile during boot (harper#1316). Re-clone this node from a healthy leader to recover the unreplayed data.`;
-						transaction = undefined as any; // already committed above; nothing staged for the new version
+						transaction = undefined; // already committed above; nothing staged for the new version
 						if (electedReplayer) {
 							strictFailure = new Error(slowMessage);
 							break;

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -40,13 +40,33 @@ export function structuresWouldShrink(existing: any, updated: any): boolean {
 	return false;
 }
 
-export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void> {
-	if (!isMainThread) return; // ideally we don't do it like this, but for now this is predictable
-	return new Promise((resolve) => {
+/** The total wall-clock budget (ms) a replay may spend, as configured for this process. */
+export function replayTimeBudgetMs(): number {
+	const configuredReplayTimeout = Number(envGet(CONFIG_PARAMS.REPLICATION_REPLAYTIMEOUT));
+	return configuredReplayTimeout > 0 ? configuredReplayTimeout : REPLAY_WALL_CLOCK_LIMIT_MS;
+}
+
+/**
+ * `electedReplayer` marks a caller that has already won a cross-thread election for this store —
+ * the branch claim (branchDatabase.ts) — and so may replay off the main thread. It also makes the
+ * replay strict: the promise settles (never hangs), and a failure to apply the tail — a commit or
+ * write error, a stall or wall-clock abort — rejects instead of quietly serving a rewound store.
+ * Undecodable/torn entries stay tolerated in both modes: a crash tears the last frame of a log by
+ * construction, and end-of-log is the designed reading of it (see replayLogsGuards.ts).
+ */
+export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplayer?: boolean): Promise<void> {
+	if (!isMainThread && !electedReplayer) return; // ideally we don't do it like this, but for now this is predictable
+	return new Promise((resolve, reject) => {
 		const acquired = rootStore.tryLock('replayLogs', async () => {
 			resolve();
 		});
-		if (!acquired) return;
+		if (!acquired) {
+			// The boot-scan caller keeps the old semantics (settle only if the holder ever unlocks —
+			// nothing awaits it). An elected replayer is the store's sole opener, so a held lock is a
+			// protocol violation; hanging its awaited promise would wedge the claim in CREATING.
+			if (electedReplayer) reject(new Error(`The replay lock for ${(rootStore as any).databaseName} is already held`));
+			return;
+		}
 		// Shed transaction-log files already older than the audit retention window before
 		// replaying. A node that crash-loops during recovery never reaches the steady-state
 		// cleanup loop, so without this its aged backlog only grows and enlarges each subsequent
@@ -89,13 +109,28 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		let lastProgressTime = replayStartTime;
 		// Total wall-clock budget (ms) for replay, configurable via `replication.replayTimeout`;
 		// falls back to the 10-minute default (harper#1316).
-		const configuredReplayTimeout = Number(envGet(CONFIG_PARAMS.REPLICATION_REPLAYTIMEOUT));
-		const replayTimeoutMs = configuredReplayTimeout > 0 ? configuredReplayTimeout : REPLAY_WALL_CLOCK_LIMIT_MS;
+		const replayTimeoutMs = replayTimeBudgetMs();
+		// A strict (elected) replay must not publish a store it knows it left incomplete, so the
+		// first unrecoverable failure is carried out of the loop and rejects below.
+		let strictFailure: Error | undefined;
+		const strictAbort = (error: Error, staged: DatabaseTransaction | undefined): void => {
+			try {
+				staged?.abort();
+			} catch (abortError) {
+				logger.warn('Error aborting a strict replay transaction', abortError);
+			}
+			strictFailure = error;
+		};
 		const txnLog: RocksTransactionLogStore = (rootStore as any).auditStore;
 		for (const auditRecord of txnLog.getRange({ startFromLastFlushed: true, readUncommitted: true }) as any) {
 			if (noProgressRun > 0 && shouldAbortStalledReplay(noProgressRun, performance.now() - lastProgressTime)) {
+				const stallDiagnostic = `Aborting transaction-log replay in ${(rootStore as any).databaseName} database: ${noProgressRun} consecutive audit entries with no successful write (${skipped} skipped as unrecoverable, ${writes} replayed so far). This backlog is making no forward progress and was blocking startup (harper#1266) — typically a peer transaction log whose values reference unresolvable shared structures (harper#1163), or a backlog for a dropped table.`;
+				if (electedReplayer) {
+					strictAbort(new Error(stallDiagnostic), transaction);
+					break;
+				}
 				logger.fatal(
-					`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: ${noProgressRun} consecutive audit entries with no successful write (${skipped} skipped as unrecoverable, ${writes} replayed so far). This backlog is making no forward progress and was blocking startup (harper#1266) — typically a peer transaction log whose values reference unresolvable shared structures (harper#1163), or a backlog for a dropped table. Continuing boot without replaying the remainder; shed or relocate the oversized/undecodable peer transaction log(s), or re-clone this node, to recover the unreplayed data.`
+					`${stallDiagnostic} Continuing boot without replaying the remainder; shed or relocate the oversized/undecodable peer transaction log(s), or re-clone this node, to recover the unreplayed data.`
 				);
 				break;
 			}
@@ -171,6 +206,11 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 						// commit the last transaction since we are starting a new one
 						transaction?.directCommitSync();
 					} catch (error) {
+						// directCommitSync already aborted and detached the failed transaction
+						if (electedReplayer) {
+							strictFailure = error;
+							break;
+						}
 						logger.error('Error committing replay transaction', error);
 					}
 					// Abort if replay has exceeded the total wall-clock budget even while making progress
@@ -181,10 +221,13 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					// is not yet staged, so aborting never tears a same-version (same source-transaction)
 					// write batch in half. Re-clone to recover the unreplayed remainder.
 					if (shouldAbortSlowReplay(performance.now() - replayStartTime, replayTimeoutMs)) {
-						logger.fatal(
-							`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: replay has exceeded the wall-clock time limit (${writes} written, ${skipped} skipped). The transaction log contains a pathologically deep out-of-order write history that is too expensive to reconcile during boot (harper#1316). Re-clone this node from a healthy leader to recover the unreplayed data.`
-						);
+						const slowMessage = `Aborting transaction-log replay in ${(rootStore as any).databaseName} database: replay has exceeded the wall-clock time limit (${writes} written, ${skipped} skipped). The transaction log contains a pathologically deep out-of-order write history that is too expensive to reconcile during boot (harper#1316). Re-clone this node from a healthy leader to recover the unreplayed data.`;
 						transaction = undefined as any; // already committed above; nothing staged for the new version
+						if (electedReplayer) {
+							strictFailure = new Error(slowMessage);
+							break;
+						}
+						logger.fatal(slowMessage);
 						break;
 					}
 					transaction = new DatabaseTransaction();
@@ -274,6 +317,10 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 				noProgressRun = 0;
 				lastProgressTime = performance.now();
 			} catch (err) {
+				if (electedReplayer) {
+					strictAbort(err, transaction);
+					break;
+				}
 				// A write that threw made no forward progress either — count it toward the stall
 				// bound so a continuous stream of throwing writes can't grind the boot thread
 				// indefinitely (and the per-entry error log below can't spam unboundedly). harper#1266
@@ -283,10 +330,13 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 				});
 			}
 		}
-		try {
-			transaction?.directCommitSync();
-		} catch (error) {
-			logger.error('Error committing replay transaction', error);
+		if (!strictFailure) {
+			try {
+				transaction?.directCommitSync();
+			} catch (error) {
+				if (electedReplayer) strictFailure = error;
+				logger.error('Error committing replay transaction', error);
+			}
 		}
 		if (writes > 0) logger.warn(`Replayed ${writes} records in ${(rootStore as any).databaseName} database`);
 		if (skipped > 0)
@@ -295,6 +345,8 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 			);
 		// we never actually release the lock because we only want to ever run one time
 		// rootStore.unlock('replayLogs');
+		if (strictFailure) reject(strictFailure);
+		else resolve();
 	});
 }
 function asBinary(buffer) {

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -61,9 +61,9 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 			resolve();
 		});
 		if (!acquired) {
-			// The boot-scan caller keeps the old semantics (settle only if the holder ever unlocks —
-			// nothing awaits it). An elected replayer is the store's sole opener, so a held lock is a
-			// protocol violation; hanging its awaited promise would wedge the claim in CREATING.
+			// An elected replayer is the store's sole opener, so a held lock is a protocol violation;
+			// hanging its awaited promise would wedge the branch claim in CREATING. The boot-scan
+			// caller keeps the settle-on-unlock semantics (nothing awaits it).
 			if (electedReplayer) reject(new Error(`The replay lock for ${(rootStore as any).databaseName} is already held`));
 			return;
 		}
@@ -110,8 +110,8 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 		// Total wall-clock budget (ms) for replay, configurable via `replication.replayTimeout`;
 		// falls back to the 10-minute default (harper#1316).
 		const replayTimeoutMs = replayTimeBudgetMs();
-		// A strict (elected) replay must not publish a store it knows it left incomplete, so the
-		// first unrecoverable failure is carried out of the loop and rejects below.
+		// Set on the first unrecoverable failure in elected mode; rejects below instead of publishing
+		// a store the replay knows is incomplete.
 		let strictFailure: Error | undefined;
 		const strictAbort = (error: Error, staged: DatabaseTransaction | undefined): void => {
 			try {
@@ -206,7 +206,6 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 						// commit the last transaction since we are starting a new one
 						transaction?.directCommitSync();
 					} catch (error) {
-						// directCommitSync already aborted and detached the failed transaction
 						if (electedReplayer) {
 							strictFailure = error;
 							break;

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -347,13 +347,15 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 		if (strictFailure) {
 			// A failed strict replay must be re-runnable: the branch claim resets for a retry, so the
 			// lock must not be what survives to wedge it. Only a COMPLETED replay keeps the lock
-			// forever (the once-per-boot guarantee).
+			// forever (the once-per-boot guarantee). Reject BEFORE unlocking: unlock wakes tryLock
+			// callbacks — including this holder's own resolve() — and the first settle must be the
+			// rejection, or a failed replay reads as success.
+			reject(strictFailure);
 			try {
 				rootStore.unlock('replayLogs');
 			} catch (unlockError) {
 				logger.warn('Error releasing the replay lock after a failed replay', unlockError);
 			}
-			reject(strictFailure);
 		} else {
 			// we never actually release the lock because we only want to ever run one time
 			// rootStore.unlock('replayLogs');

--- a/unitTests/resources/branchDatabase.test.js
+++ b/unitTests/resources/branchDatabase.test.js
@@ -1,8 +1,9 @@
 require('../testUtils');
 const assert = require('assert');
 const { existsSync } = require('node:fs');
-const { mkdir, rm, writeFile } = require('node:fs/promises');
+const { mkdir, rename, rm, writeFile } = require('node:fs/promises');
 const { join } = require('node:path');
+const { RocksDatabase } = require('@harperfast/rocksdb-js');
 const { setupTestDBPath } = require('../testUtils');
 const { table, databases, database, BRANCH_ROOT_DIR, resolveBranchPath } = require('#src/resources/databases');
 const { getOrCreateBranch, removeBranches } = require('#src/resources/branchDatabase');
@@ -116,12 +117,50 @@ describeUnlessLmdb('branch lifecycle (harper#643)', () => {
 
 	it('settles an elected replay instead of hanging: resolve on completion, reject on a held lock', async function () {
 		// The elected replay promise is awaited inside the branch claim's CREATING window, so it must
-		// always settle — an unresolved promise would wedge the claim and every waiting thread.
-		const rootStore = database({ database: 'lifebase', table: undefined });
-		await replayLogs(rootStore, databases.lifebase, true);
+		// always settle — an unresolved promise would wedge the claim and every waiting thread. Uses
+		// its own database: the replay permanently takes the store's replay lock and applies its log
+		// tail, which must not become shared suite state on lifebase.
+		table({
+			table: 'ReplayProbe',
+			database: 'replaybase',
+			attributes: [{ name: 'id', isPrimaryKey: true }],
+		});
+		const rootStore = database({ database: 'replaybase', table: undefined });
+		await replayLogs(rootStore, databases.replaybase, true);
 		// The completed replay holds the store's replay lock forever (by design: replay runs once per
 		// store per process), so a second elected call must reject rather than hang or run again.
-		await assert.rejects(() => replayLogs(rootStore, databases.lifebase, true), /replay lock/);
+		await assert.rejects(() => replayLogs(rootStore, databases.replaybase, true), /replay lock/);
+	});
+
+	it('fails the load when the adopted branch cannot replay, then adopts cleanly once it can', async function () {
+		// Materialize by hand what a previous boot leaves behind, so this boot's first sight of the
+		// branch is the adopt path.
+		const branchPath = resolveBranchPath('lifebase', 'appAdopt');
+		const staging = `${branchPath}.staging`;
+		await rm(staging, { recursive: true, force: true });
+		await mkdir(join(branchPath, '..'), { recursive: true });
+		await database({ database: 'lifebase', table: undefined }).createCheckpoint(staging);
+		await rename(staging, branchPath);
+
+		// Hold the branch store's replay lock from a second handle on the same directory (handles on
+		// one path share the native store, and the lock table lives on it): the elected replay must
+		// reject — a strict failure after the winner has already opened the branch.
+		const raw = RocksDatabase.open(branchPath);
+		try {
+			assert.ok(
+				raw.tryLock('replayLogs', () => {}),
+				'the probe handle must be able to take the lock'
+			);
+			await assert.rejects(() => getOrCreateBranch('lifebase', 'appAdopt'), /replay lock/);
+
+			// The failed winner must have closed what it opened and released the claim: after the
+			// blocker clears, the same process must be able to adopt the same directory.
+			raw.unlock('replayLogs');
+			const branch = await getOrCreateBranch('lifebase', 'appAdopt');
+			assert.ok(await branch.tables.LifecycleSource.get('a'), 'the adopted branch serves the base rows');
+		} finally {
+			raw.close();
+		}
 	});
 
 	it('releases the claim when the winner cannot open the branch, so a repaired retry works', async function () {

--- a/unitTests/resources/branchDatabase.test.js
+++ b/unitTests/resources/branchDatabase.test.js
@@ -1,9 +1,12 @@
 require('../testUtils');
 const assert = require('assert');
 const { existsSync } = require('node:fs');
+const { mkdir, rm, writeFile } = require('node:fs/promises');
+const { join } = require('node:path');
 const { setupTestDBPath } = require('../testUtils');
-const { table, databases, BRANCH_ROOT_DIR, resolveBranchPath } = require('#src/resources/databases');
+const { table, databases, database, BRANCH_ROOT_DIR, resolveBranchPath } = require('#src/resources/databases');
 const { getOrCreateBranch, removeBranches } = require('#src/resources/branchDatabase');
+const { replayLogs } = require('#src/resources/replayLogs');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
@@ -109,6 +112,29 @@ describeUnlessLmdb('branch lifecycle (harper#643)', () => {
 	it('rejects a path segment that would escape the reserved root', function () {
 		assert.throws(() => resolveBranchPath('lifebase', '..'), /Invalid application name/);
 		assert.throws(() => resolveBranchPath('a/b', 'appA'), /Invalid database name/);
+	});
+
+	it('settles an elected replay instead of hanging: resolve on completion, reject on a held lock', async function () {
+		// The elected replay promise is awaited inside the branch claim's CREATING window, so it must
+		// always settle — an unresolved promise would wedge the claim and every waiting thread.
+		const rootStore = database({ database: 'lifebase', table: undefined });
+		await replayLogs(rootStore, databases.lifebase, true);
+		// The completed replay holds the store's replay lock forever (by design: replay runs once per
+		// store per process), so a second elected call must reject rather than hang or run again.
+		await assert.rejects(() => replayLogs(rootStore, databases.lifebase, true), /replay lock/);
+	});
+
+	it('releases the claim when the winner cannot open the branch, so a repaired retry works', async function () {
+		// A directory that exists is adopted, so plant one that cannot be opened: the winner must
+		// close whatever it opened and release the claim, not leave it wedged in CREATING or READY.
+		const path = resolveBranchPath('lifebase', 'appBroken');
+		await mkdir(path, { recursive: true });
+		await writeFile(join(path, 'CURRENT'), 'not a database\n');
+		await assert.rejects(() => getOrCreateBranch('lifebase', 'appBroken'));
+
+		await rm(path, { recursive: true, force: true });
+		const branch = await getOrCreateBranch('lifebase', 'appBroken');
+		assert.ok(await branch.tables.LifecycleSource.get('a'), 'the retry after repair must serve the base rows');
 	});
 });
 

--- a/unitTests/resources/branchDatabase.test.js
+++ b/unitTests/resources/branchDatabase.test.js
@@ -132,6 +132,39 @@ describeUnlessLmdb('branch lifecycle (harper#643)', () => {
 		await assert.rejects(() => replayLogs(rootStore, databases.replaybase, true), /replay lock/);
 	});
 
+	it('a mid-flight strict replay failure rejects — and still rejects after releasing the lock', async function () {
+		// Releasing the lock wakes tryLock callbacks, including the holder's own resolve(); the
+		// rejection must win the settle or a failed replay reads as success and READY publishes an
+		// incomplete store. A stub store drives the real replay loop into its per-entry failure path.
+		let unlocked = false;
+		const queued = [];
+		const poisonedTable = {
+			tableId: 7,
+			getResource() {
+				throw new Error('poisoned resource');
+			},
+		};
+		const stubStore = {
+			databaseName: 'stub',
+			tryLock(key, onUnlocked) {
+				queued.push(onUnlocked);
+				return true;
+			},
+			unlock() {
+				unlocked = true;
+				for (const onUnlocked of queued) onUnlocked();
+				return true;
+			},
+			auditStore: {
+				getRange() {
+					return [{ type: 'put', tableId: 7, version: 1, extendedType: 17, getValue: () => ({ id: 1 }) }];
+				},
+			},
+		};
+		await assert.rejects(() => replayLogs(stubStore, { Poisoned: poisonedTable }, true), /poisoned resource/);
+		assert.strictEqual(unlocked, true, 'a failed strict replay must release the lock for the retry');
+	});
+
 	it('fails the load when the adopted branch cannot replay, then adopts cleanly once it can', async function () {
 		// Materialize by hand what a previous boot leaves behind, so this boot's first sight of the
 		// branch is the adopt path.


### PR DESCRIPTION
On Windows, a branched database (#2352) silently discarded the application's most recent writes across every restart — `branched-database.test.ts` → "keeps the application's own data across a restart" failed deterministically on the Windows CI shard. The failure is not Windows-cosmetic: the same loss happens on any platform when the process dies without flushing (a crash, a power loss); Windows CI was just the only variant that exercises hard kills on every run.

**Root cause.** A branch's column families write with the RocksDB WAL disabled, like every store's, so a write's only durable record until the next memtable flush is the branch's own transaction log. Base databases replay that log at boot; a branch deliberately skipped it — a contract note written before anything opened branches ("a branch is a checkpoint and nothing more"), plus `replayLogs`' main-thread guard while branches open on worker threads. The restart *adopted* the branch directory correctly and then silently rewound it to its last flush. The platform split is the kill path: the integration harness's graceful phase is `taskkill /T` without `/F`, which cannot terminate a console process, so every Windows kill escalates to a hard kill with no exit-hook flush; POSIX kills run Harper's SIGTERM → `process.exit` → rocksdb `shutdown()` flush, which left nothing to replay and hid the defect.

**Fix.** The existing cross-thread branch claim now elects the replayer. Inside its CREATING window the winner materializes the checkpoint (if the directory is missing), opens the branch, [replays the branch's own transaction-log tail — awaited — and only then publishes READY](https://github.com/HarperFast/harper/pull/2414/changes?w=1#diff-cac868f688668988b75b365b484204e6a54f9fcbb121dab67b3358808b9dacf5R173), so no thread can open the branch and serve pre-replay state, and nothing holds a handle a replay could race. Enforced invariant: **an adopted branch serves no read until its own transaction-log tail has been replayed — the same recovery contract a base database gets at boot** (the [scan-time skip for branch opens](https://github.com/HarperFast/harper/pull/2414/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R935) now documents where recovery lives instead of why it doesn't).

`replayLogs` gains an elected-replayer mode with strict semantics:

- [callable off the main thread](https://github.com/HarperFast/harper/pull/2414/changes?w=1#diff-7f4cbee5cbce369c4f86b2449b8ceaf082fcb125bee915ed2345edc822416c39R57) (the claim is a stronger election than "main thread");
- the promise actually settles — previously it never resolved for anyone (the lock's unlock callback never fires, and the acquiring path never resolved), harmless only because no caller awaited it;
- a commit or write failure, [a stall abort](https://github.com/HarperFast/harper/pull/2414/changes?w=1#diff-7f4cbee5cbce369c4f86b2449b8ceaf082fcb125bee915ed2345edc822416c39R129), or a wall-clock abort **rejects** instead of quietly publishing a store the replay knows is incomplete — the branch's application load fails loudly and the claim is released for retry;
- [a held replay lock rejects immediately](https://github.com/HarperFast/harper/pull/2414/changes?w=1#diff-7f4cbee5cbce369c4f86b2449b8ceaf082fcb125bee915ed2345edc822416c39R67) rather than hanging the awaited promise (and the claim) forever;
- torn-tail decode skips stay tolerated in both modes: a crash tears the last log frame by construction, and end-of-log is the designed reading of it.

Base-database boot replay behavior is unchanged (same tolerate-and-continue policy), a freshly materialized branch has no log so its replay is a no-op, and replay is skipped in read-only mode with the same snapshot semantics the base's boot replay uses. Two hardenings from the planning review: [the claim deadline for waiting threads adds the replay budget](https://github.com/HarperFast/harper/pull/2414/changes?w=1#diff-cac868f688668988b75b365b484204e6a54f9fcbb121dab67b3358808b9dacf5R150) on top of the checkpoint allowance (a slow-but-live recovery must not time out every other thread's application load), and a winner that fails after opening [closes its branch — guarded — before releasing the claim](https://github.com/HarperFast/harper/pull/2414/changes?w=1#diff-cac868f688668988b75b365b484204e6a54f9fcbb121dab67b3358808b9dacf5R182) (leaving it open would make every retry fail with "already open"; a throwing close must not leave the claim wedged in CREATING). No API, config, or on-disk layout change.

Refs #643.

## For the human reviewer

- **Framing-Verdict: chosen-approach-sound (3059fe5373ca)** from the planning round (Codex graded leg). Its two blockers (strict replay completion; close-before-claim-release) and two majors (waiter deadline vs replay budget; replay-lock settlement) are all implemented as described above.
- **Strict-mode severity choice**: an elected replay treats a *thrown* per-entry write, a commit failure, or a stall/wall-clock abort as fatal to the branch open (fail closed), where base replay logs and continues degraded. A branch's log holds only its own local writes, so those failures there are not the peer-log noise the base policy tolerates. Consequence the domain reviewer noted and I kept by design: a *deterministically* doomed replay is retried by each waiting thread in turn until the claim deadline, then every load of that application fails loudly. If you'd rather branches tolerate-and-continue like the base, that is a small policy change in `replayLogs`.
- **The claim word is process-local by invariant** (now [documented at `claimStateFor`](https://github.com/HarperFast/harper/pull/2414/changes?w=1#diff-cac868f688668988b75b365b484204e6a54f9fcbb121dab67b3358808b9dacf5R58)): replay runs exactly once per boot because every boot seeds UNCLAIMED. A reviewer suggestion to make the claim durable/cross-process would silently disable recovery. **Where to look hardest**: the ordering inside the CREATING window — materialize → open → replay → READY — is the whole fix; anything that could publish READY before the awaited replay settles reintroduces the silent rewind.
- **Dead-owner claim recovery is unchanged and remains a pre-existing gap**: a worker thread that dies mid-CREATING leaves waiters to time out with a loud error rather than recover via a lease protocol, and the deadline is now longer (checkpoint allowance + replay budget, ~20 min default). Flagged by both reviews as pre-existing; a lease/heartbeat protocol is real work beyond this fix.
- The elected rejection for stall/wall-clock aborts reuses the base-oriented message wording ("re-clone this node"); branch-specific remediation text was left out to keep the diff narrow.
- Review round 1 (Gemini + Cursor Composer + Harper domain adjudication; the Codex graded leg timed out): adjudicated severity **minor**, all actionable findings addressed in the follow-up commit — guarded the failed-open `close()`, contained a unit test's shared-suite side effect, added the strict-failure-through-adopt test, documented the claim invariant. One Cursor blocker-level concern (READY persisting across process restarts, skipping replay) was adjudicated factually wrong: `getUserSharedBuffer` is in-process memory only. Rounds 3–5 (post-push deltas): two round-3 majors claiming a leaked staged transaction were declined as factually wrong (`directCommitSync` aborts and detaches its own transaction on failure — its catch path is the citation; the one-line note both reviewers tripped over is restored); its real minor became the explicit strict-failure lock release, whose first cut round 4 correctly flagged as a blocker — unlocking before rejecting let the holder's own woken `resolve()` win the settle — now fixed (reject first) and pinned by a stub-store unit test that fails under the buggy ordering.

## Verification

- **Fails on base**: the new [crash-restart assertion](https://github.com/HarperFast/harper/pull/2414/changes?w=1#diff-e547957251adabd2c97fbdece706a556d2a3f49e4e0691fda6782c75a87840a2R94) in `branched-database-crash.test.ts` (SIGKILL + `HARPER_NO_FLUSH_ON_EXIT`, the established `crash-replay.test.ts` pattern — byte-for-byte the state a Windows hard kill leaves) measured **red on c50edffc3** with the exact CI signature (`found=false`, clean startup log), **green with this fix**. This reproduces the Windows failure deterministically on every platform.
- End-to-end route: that crash test, plus the existing restart test on the Windows CI shard of this PR (`Integration Tests 6/6 (Windows, Node.js v24)`) — the environment the task names; no local Windows machine was available, so the shard is the Windows proof.
- All branch + replay integration tests green locally (Linux): `branched-database.test.ts` (5/5, including the restart test), `branched-database-all.test.ts`, `branched-database-schema-gate.test.ts`, `branched-database-crash.test.ts`, `crash-replay.test.ts`, `replay-stress.test.ts`.
- Unit: `test:unit:resources` 1839 passing; `test:unit:main` 5119 passing; new unit tests for elected-replay promise settlement (resolve on completion, reject on a held lock), [a strict replay failure forced *after* the winner opened the branch](https://github.com/HarperFast/harper/pull/2414/changes?w=1#diff-24c1caf834b7f9359787fa243517d214e4d446264f39c87043d313aeb641d9f2R135) (held replay lock via a second handle on the same directory) proving fail-loud plus a clean later adopt, and claim release after a failed winner open (repaired retry succeeds). Three pre-existing local failures are unrelated and fail identically with this diff reverted: `caching.test.js` "Can load cached indexed data" (proven by revert on c50edffc3), `tokenAuthentication.test.js` "rsa_keys is defined" (env), `configValidator.test.js` domain-socket length (assumes a short cwd; this worktree's path is long).
- Measured, not assumed: a native `createCheckpoint` of a store with a populated `transaction_logs/` tree produces a checkpoint with **no** `transaction_logs` — so a freshly materialized branch has no log and its replay is a genuine no-op (the basis for replaying unconditionally on the winner path).

Complexity: medium — one recovery-ordering change inside the branch claim plus strict-mode semantics in `replayLogs`; no schema, API, or layout changes.

---
Written by Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=5 @ d735ac1f85e1</sub>

<sub>Human-Review-Need: 3 @ d735ac1f85e1</sub>
