### PR TITLE
Decode blob content created from a plain Uint8Array as text, not as byte values

### DIFF
--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -1426,7 +1426,6 @@ export type BlobCreationOptions = {
 /**
  * `StorageInfo.contentBuffer` must always hold a `Buffer`: `Buffer.prototype.toString()` decodes
  * UTF-8, while the inherited `Uint8Array.prototype.toString()` joins the byte values with commas.
- * The returned view is zero-copy, so the packed record and the written file are byte-identical.
  */
 function asBuffer(bytes: Uint8Array): Buffer {
 	return Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -64,7 +64,7 @@ type StorageInfo = {
 	store?: any;
 	filePath?: string;
 	recordId?: number;
-	contentBuffer?: any;
+	contentBuffer?: Buffer;
 	source?: Readable;
 	compress?: boolean;
 	flush?: boolean;
@@ -1424,6 +1424,14 @@ export type BlobCreationOptions = {
 	saveBeforeCommit?: boolean; // save the blob before the transaction is committed
 };
 /**
+ * `StorageInfo.contentBuffer` must always hold a `Buffer`: `Buffer.prototype.toString()` decodes
+ * UTF-8, while the inherited `Uint8Array.prototype.toString()` joins the byte values with commas.
+ * The returned view is zero-copy, so the packed record and the written file are byte-identical.
+ */
+function asBuffer(bytes: Uint8Array): Buffer {
+	return Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+/**
  * Create a blob from a readable stream or a buffer by creating a file in the blob storage path with a new unique internal id, that
  * can be saved/stored.
  * @param source
@@ -1442,7 +1450,7 @@ export function createBlob(
 	storageInfoForBlob.set(blob, storageInfo);
 	if (source instanceof Uint8Array) {
 		blob.size = source.length;
-		storageInfo.contentBuffer = source;
+		storageInfo.contentBuffer = asBuffer(source);
 	} else if (source instanceof Readable) {
 		storageInfo.source = source;
 	} else if (typeof source === 'string') storageInfo.contentBuffer = Buffer.from(source);
@@ -2647,7 +2655,7 @@ addExtension({
 			storageInfoForBlob.set(blob, {
 				storageIndex: 0,
 				fileId: null,
-				contentBuffer: blobInfo[1] as any,
+				contentBuffer: asBuffer(blobInfo[1] as Uint8Array),
 			});
 			blob.size = blobInfo[1]?.length;
 		}

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -146,13 +146,9 @@ describe('Blob test', () => {
 		assert(retrievedBytes.equals(random.slice(300, 400)));
 	});
 	it('decodes a blob created from a plain Uint8Array, not just from a Buffer', async () => {
-		// Uint8Array.prototype.toString() joins byte values with commas instead of decoding UTF-8, so a
-		// source that is not already a Buffer has to be normalized when the blob is constructed
 		const text = 'blob contents \u2014 \u2705 '.repeat(4000);
 		const content = Buffer.from(text);
-		assert(content.length > 65536); // over FILE_STORAGE_THRESHOLD, so it is externalized
-		// a non-zero-offset view inside a larger allocation: the normalized Buffer must carry the source's
-		// offset and length across, or the surrounding bytes leak into the blob
+		assert(content.length > 65536); // far enough over FILE_STORAGE_THRESHOLD that raising it cannot make this vacuous
 		const sentinel = Buffer.alloc(64, 0xa5);
 		const backing = Buffer.concat([sentinel, content, sentinel]);
 		const source = new Uint8Array(backing.buffer, backing.byteOffset + sentinel.length, content.length);
@@ -163,7 +159,6 @@ describe('Blob test', () => {
 		const filePath = getFilePathForBlob(blob);
 		assert.notEqual(filePath, null);
 		assert.equal(blob.size, content.length);
-		// the writer still holds the in-memory content, which is the path that produced byte values
 		assert.equal(await blob.text(), text);
 		assert.equal(blob.toJSON(), text);
 		assert.equal(await blob.slice(0, 100).text(), content.subarray(0, 100).toString());
@@ -172,11 +167,9 @@ describe('Blob test', () => {
 		assert.notStrictEqual(record.blob, blob);
 		assert.equal(getFilePathForBlob(record.blob), filePath);
 		assert.equal(await record.blob.text(), text);
-		assert((await record.blob.bytes()).equals(content));
+		assert((await record.blob.bytes()).equals(content)); // the sentinel bytes on either side of the view stayed out
 	});
 	it('decodes a sub-threshold Uint8Array blob that is stored inline in the record', async () => {
-		// under FILE_STORAGE_THRESHOLD the content is packed into the record, so the read back decodes
-		// it from msgpack rather than from a file
 		const text = 'inline blob contents \u2014 \u2705';
 		const blob = await createBlob(new Uint8Array(Buffer.from(text)), { type: 'text/plain' });
 		assert.equal(await blob.text(), text);

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -145,6 +145,35 @@ describe('Blob test', () => {
 		retrievedBytes = await sliced.bytes();
 		assert(retrievedBytes.equals(random.slice(300, 400)));
 	});
+	it('decodes a blob created from a plain Uint8Array, not just from a Buffer', async () => {
+		// Uint8Array.prototype.toString() joins byte values with commas instead of decoding UTF-8, so a
+		// source that is not already a Buffer has to be normalized when the blob is constructed
+		const text = 'blob contents \u2014 \u2705 '.repeat(4000);
+		const content = Buffer.from(text);
+		assert(content.length > 65536); // comfortably over FILE_STORAGE_THRESHOLD, so it is externalized
+		// a non-zero-offset view inside a larger allocation: the normalized Buffer must carry the source's
+		// offset and length across, or the surrounding bytes leak into the blob
+		const sentinel = Buffer.alloc(64, 0xa5);
+		const backing = Buffer.concat([sentinel, content, sentinel]);
+		const source = new Uint8Array(backing.buffer, backing.byteOffset + sentinel.length, content.length);
+		assert(!Buffer.isBuffer(source));
+
+		const blob = await createBlob(source, { type: 'text/plain' });
+		await BlobTest.put({ id: 1, blob });
+		const filePath = getFilePathForBlob(blob);
+		assert.notEqual(filePath, null); // the payload is in a file, not stored inline in the record
+		assert.equal(blob.size, content.length);
+		// the writer still holds the in-memory content, which is the path that produced byte values
+		assert.equal(await blob.text(), text);
+		assert.equal(blob.toJSON(), text);
+		assert.equal(await blob.slice(0, 100).text(), content.subarray(0, 100).toString());
+
+		const record = await BlobTest.get(1);
+		assert.notStrictEqual(record.blob, blob); // a separate instance, reading the stored file
+		assert.equal(getFilePathForBlob(record.blob), filePath);
+		assert.equal(await record.blob.text(), text);
+		assert((await record.blob.bytes()).equals(content)); // none of the surrounding bytes were stored
+	});
 	it('round-trips a compressed blob via bytes() and stream()', async () => {
 		// compressible payload, comfortably over FILE_STORAGE_THRESHOLD so it is file-backed
 		let original = Buffer.from('compressible blob payload '.repeat(2000));

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -150,7 +150,7 @@ describe('Blob test', () => {
 		// source that is not already a Buffer has to be normalized when the blob is constructed
 		const text = 'blob contents \u2014 \u2705 '.repeat(4000);
 		const content = Buffer.from(text);
-		assert(content.length > 65536); // comfortably over FILE_STORAGE_THRESHOLD, so it is externalized
+		assert(content.length > 65536); // over FILE_STORAGE_THRESHOLD, so it is externalized
 		// a non-zero-offset view inside a larger allocation: the normalized Buffer must carry the source's
 		// offset and length across, or the surrounding bytes leak into the blob
 		const sentinel = Buffer.alloc(64, 0xa5);
@@ -161,7 +161,7 @@ describe('Blob test', () => {
 		const blob = await createBlob(source, { type: 'text/plain' });
 		await BlobTest.put({ id: 1, blob });
 		const filePath = getFilePathForBlob(blob);
-		assert.notEqual(filePath, null); // the payload is in a file, not stored inline in the record
+		assert.notEqual(filePath, null);
 		assert.equal(blob.size, content.length);
 		// the writer still holds the in-memory content, which is the path that produced byte values
 		assert.equal(await blob.text(), text);
@@ -169,10 +169,23 @@ describe('Blob test', () => {
 		assert.equal(await blob.slice(0, 100).text(), content.subarray(0, 100).toString());
 
 		const record = await BlobTest.get(1);
-		assert.notStrictEqual(record.blob, blob); // a separate instance, reading the stored file
+		assert.notStrictEqual(record.blob, blob);
 		assert.equal(getFilePathForBlob(record.blob), filePath);
 		assert.equal(await record.blob.text(), text);
-		assert((await record.blob.bytes()).equals(content)); // none of the surrounding bytes were stored
+		assert((await record.blob.bytes()).equals(content));
+	});
+	it('decodes a sub-threshold Uint8Array blob that is stored inline in the record', async () => {
+		// under FILE_STORAGE_THRESHOLD the content is packed into the record, so the read back decodes
+		// it from msgpack rather than from a file
+		const text = 'inline blob contents \u2014 \u2705';
+		const blob = await createBlob(new Uint8Array(Buffer.from(text)), { type: 'text/plain' });
+		assert.equal(await blob.text(), text);
+		await BlobTest.put({ id: 1, blob });
+		const record = await BlobTest.get(1);
+		assert.notStrictEqual(record.blob, blob);
+		assert.equal(getFilePathForBlob(record.blob), null);
+		assert.equal(await record.blob.text(), text);
+		assert.equal(record.blob.toJSON(), text);
 	});
 	it('round-trips a compressed blob via bytes() and stream()', async () => {
 		// compressible payload, comfortably over FILE_STORAGE_THRESHOLD so it is file-backed


### PR DESCRIPTION
A blob whose content came from a plain `Uint8Array` rather than a `Buffer` decoded as `98,97,115,101,...` instead of its text: `createBlob()` stored the source verbatim in `StorageInfo.contentBuffer`, and every in-memory consumer of that field decodes it with `Buffer`-only semantics — `Buffer.prototype.toString()` decodes UTF-8, while the inherited `Uint8Array.prototype.toString()` joins the byte values. So `blob.text()`, `blob.toJSON()` for a `text/*` blob, and `blob.slice().text()` all returned digits for as long as the writer still held the content, including after the payload had been externalized to a file. A plain `Uint8Array` reaches `createBlob()` from ordinary callers: `new TextEncoder().encode(s)`, `await nativeBlob.bytes()`, `await response.bytes()`, anything transferred across a worker.

The fix normalizes at the two boundaries where external bytes enter `contentBuffer` — [`createBlob()`](https://github.com/HarperFast/harper/pull/2415/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR1452) and [the msgpackr blob extension's inline-content decode](https://github.com/HarperFast/harper/pull/2415/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR2657) — with [a zero-copy `Buffer` view that carries the source's `byteOffset` and `byteLength`](https://github.com/HarperFast/harper/pull/2415/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR1430), and [types the field `Buffer`](https://github.com/HarperFast/harper/pull/2415/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR67) so the invariant is stated where it is established. The packed record and the written file are byte-identical.

The originating report attributed this to the file-read path returning a `Uint8Array` on any cold read. That is measurably false on `main`: every branch of the file read returns a `Buffer` (`fsPromises.readFile`, `Buffer.prototype.subarray`, and `zlib.inflate`'s callback), and I confirmed it across Buffer/stream/native-`Blob`/compressed sources at both inline and externalized sizes, read through `Table.get`, a fresh `primaryStore` decode, and `slice()` — all correct. The reported symptom string is reproduced exactly by the `Uint8Array` source instead, and the fix resolves it. The regression tests still cover the externalized path the report asked for, because that is where the writer's handle and the record's handle disagreed.

Found while working on [Branched databases: blob store sharing, allocator, and GC safety](https://github.com/HarperFast/harper/issues/644); pre-existing on `main` and unrelated to branched databases.

## For the human reviewer

1. **Invariant at the boundary, or decoding at the read sites.** The rule "`contentBuffer` is always a `Buffer`" is enforced at the two construction sites and expressed by the field's type, rather than making the two decode sites byte-source-agnostic (`TextDecoder`, or `.toString('utf8')` on a coerced view). Ingress-side is the root-cause fix and costs nothing on reads, but it stays correct only while every future writer honors it — and [the field](https://github.com/HarperFast/harper/pull/2415/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR67) is also written from a `Promise<any>` result, where the type cannot police it. Read-site decoding is unconditionally correct but adds a branch to every read. A reviewer may reasonably read the chosen fix as compensating rather than root-cause; both are one-line changes and the tests carry over either way.
2. **Zero-copy view, or a defensive copy.** [`Buffer.from(bytes.buffer, byteOffset, byteLength)`](https://github.com/HarperFast/harper/pull/2415/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR1430) keeps the caller's backing store aliased by the blob, which is exactly what `contentBuffer = source` did before. That leaves a mutate-after-create edge open: for a file-backed blob the write is async, so a caller that recycles its array after `createBlob()` can change what lands in the file. Copying would close it and change the existing (undocumented) semantics, at one allocation per byte-array blob. I preserved the current behavior rather than widening the fix.
3. **The msgpackr-side call is hardening, not a proven correction.** Nothing in the suite can distinguish [`asBuffer()` at the unpack site](https://github.com/HarperFast/harper/pull/2415/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR2657) from the identity function: `copyBuffers` does `Uint8Array.prototype.slice.call(src, …)`, which returns a `Buffer` whenever `src` is Buffer-backed, and the store read path always is. It is there so the invariant also holds for a non-Buffer transport payload. If you would rather this PR only touched paths it can prove, that call is the one to drop.
4. **`bytes()` return contract.** `Blob.bytes()` now always resolves to a Node `Buffer`, so `Buffer`-only methods (`.equals`, encoding-aware `.toString`) become part of the de-facto public surface even though the web `Blob.bytes()` contract is a plain `Uint8Array`. Consumers will start depending on it and narrowing back later would be breaking. I left the declared return type as `any` because typing it `Promise<Buffer>` breaks `implements Blob` structurally (`Buffer<ArrayBufferLike>` vs `Uint8Array<ArrayBuffer>`).
5. **Charset.** The task asked whether `text()` should honour a charset from `type` (`text/plain; charset=…`). It does not, and this change does not alter that: WHATWG `Blob.text()` always decodes UTF-8 and ignores `type`, and the already-working `Buffer` path did the same. Decoding by charset would be a new feature rather than part of this fix. Say so if you want it anyway.

Gemini raised a `null blobInfo[1]` → `TypeError` at the unpack site in three separate rounds; the adjudicator dropped it each time as unreachable — an empty inline blob packs as a zero-length `Buffer`, a missing one decodes as `undefined` and takes the reference branch, and neither encoder form can emit a literal `null` — so no defensive guard was added.

## Verification

- **Fails on base:** both new tests were run against `main`'s `resources/blob.ts` with the rest of the branch in place — `2 failing`, the first assertion producing the reported `98,108,111,98,...` string — and pass with the fix (`2 passing`).
- `npm run test:unit:resources`: 1870 passing, 0 failing, 23 pending (post-rebase onto `origin/main`).
- `npm run test:unit:backup`: 87 passing, 0 failing.
- `npm run typecheck`, `npm run lint:required`, `npm run format:write`: clean.
- The end-to-end route is the resource layer's own table write/read: both tests go through a real `BlobTest.put()`/`get()`, one externalized to a file and [one inlined into the record](https://github.com/HarperFast/harper/pull/2415/changes?w=1#diff-9b125a1f520c4f030fa53590e672ec5278ebf46b2a2b78a9e6bbd70ea42b9382R180), so the stored bytes and both decode paths are exercised. No HTTP-level route is needed — the defect is entirely below it.
- The larger test uses [a non-zero-offset `Uint8Array` view with 64 sentinel bytes on either side](https://github.com/HarperFast/harper/pull/2415/changes?w=1#diff-9b125a1f520c4f030fa53590e672ec5278ebf46b2a2b78a9e6bbd70ea42b9382R156) and multibyte UTF-8 content, and [asserts the round-tripped bytes equal the source exactly](https://github.com/HarperFast/harper/pull/2415/changes?w=1#diff-9b125a1f520c4f030fa53590e672ec5278ebf46b2a2b78a9e6bbd70ea42b9382R170), so a normalization that dropped `byteOffset`/`byteLength` would persist adjacent memory and fail.
- Four pre-push review rounds ran. Round 3 was a comments-only delta, for which the policy prunes the adjudicator; that left Gemini's twice-dropped major unadjudicated and ratcheted the review-need grade to 4. Round 4 re-ran with the adjudicator on the same head and closed it — `Surviving-Findings: none`, `Adjudicated-Severity: none`, verdict LGTM — but the grade does not ratchet back down.

Complexity: medium

<sub>Review-Coverage: authored=claude; ran=gemini,codex; adjudicated=domain; declined=cursor-grok,cursor-composer; rounds=4 @ 61931d4a7dab</sub>

<sub>Human-Review-Need: 4 (decisions: normalize-at-boundary-vs-decode-site, zero-copy-view-vs-defensive-copy, unpack-call-site-is-defensive-or-corrective) @ 61931d4a7dab</sub>
