### PR TITLE
Gate the EDQUOT storage-exhaustion tests on platforms that define EDQUOT

### DIFF
--- a/unitTests/config/storageExhaustion.test.js
+++ b/unitTests/config/storageExhaustion.test.js
@@ -9,9 +9,17 @@ const { atomicWriteFile, isStorageExhausted, persistConfigDuringBoot } = require
 const { prepareRuntimeEnvConfig, discardConfigState } = require('#src/config/harperConfigEnvVars');
 const hdbTerms = require('#src/utility/hdbTerms');
 
+// Absent from os.constants.errno on platforms with no quota support (win32), where production
+// deliberately declines to synthesize one, so there is no EDQUOT behavior to assert there.
+const PLATFORM_DEFINES_EDQUOT = os.constants.errno.EDQUOT !== undefined;
+
 // A real ENOSPC/EDQUOT needs a volume with no room, which no unit test can arrange portably.
 function storageExhaustedError(errnoName) {
 	const errno = os.constants.errno[errnoName];
+	// Negating an errno the platform does not define yields NaN, which matches nothing in
+	// configUtils, leaving the caller asserting against an error no platform can produce.
+	if (errno === undefined)
+		throw new Error(`os.constants.errno.${errnoName} is undefined on ${process.platform}; gate the caller on it`);
 	// Node has no code mapping for EDQUOT on Linux: the error arrives as `Unknown system error
 	// -122` and only the errno identifies it.
 	return Object.assign(new Error(`Unknown system error -${errno}`), {
@@ -41,8 +49,15 @@ describe('storage exhaustion during boot (#847)', function () {
 		fs.removeSync(testRoot);
 	});
 
+	describe('storageExhaustedError', function () {
+		it('refuses an errno name the platform does not define', function () {
+			assert.throws(() => storageExhaustedError('ENOTAREALERRNO'), /ENOTAREALERRNO is undefined/);
+		});
+	});
+
 	describe('isStorageExhausted', function () {
 		it('recognizes EDQUOT by errno when the platform gives no usable code', function () {
+			if (!PLATFORM_DEFINES_EDQUOT) return this.skip();
 			assert.strictEqual(isStorageExhausted(storageExhaustedError('EDQUOT')), true);
 		});
 
@@ -56,6 +71,21 @@ describe('storage exhaustion during boot (#847)', function () {
 			assert.strictEqual(isStorageExhausted(Object.assign(new Error('gone'), { code: 'ENOENT', errno: -2 })), false);
 			assert.strictEqual(isStorageExhausted(undefined), false);
 		});
+
+		// NaN is SameValueZero-equal to itself, so an errno set built without filtering undefined
+		// out would hold NaN and report exhaustion for any error carrying one.
+		it('does not claim a NaN errno left by an undefined constant', function () {
+			assert.strictEqual(
+				isStorageExhausted(
+					Object.assign(new Error('Unknown system error -undefined'), {
+						errno: NaN,
+						code: 'Unknown system error -undefined',
+						syscall: 'open',
+					})
+				),
+				false
+			);
+		});
 	});
 
 	describe('persistConfigDuringBoot', function () {
@@ -66,10 +96,12 @@ describe('storage exhaustion during boot (#847)', function () {
 			);
 		});
 
+		// ENOSPC carries the same unusable `code` here as a Linux EDQUOT, so it reaches the swallow
+		// through the same errno branch while existing on every platform.
 		it('swallows storage exhaustion so startup continues', function () {
 			assert.strictEqual(
 				persistConfigDuringBoot('artifact', () => {
-					throw storageExhaustedError('EDQUOT');
+					throw storageExhaustedError('ENOSPC');
 				}),
 				false
 			);


### PR DESCRIPTION
`Unit Test (Windows, Node.js v24)` has been red on `main` on every commit since #2245, and this makes it green again. The fix is test-only: the production code in `config/configUtils.ts` is correct and deliberately untouched.

`os.constants.errno.EDQUOT` does not exist on win32, so the suite's `storageExhaustedError` helper fabricated `errno: -undefined` (NaN) and `code: 'Unknown system error -undefined'`. Neither can match — `STORAGE_EXHAUSTED_CODES` holds the literal strings `'ENOSPC'`/`'EDQUOT'`, and `STORAGE_EXHAUSTED_ERRNOS` is correctly just `{-28}` on Windows precisely because `configUtils` filters the undefined constant out before negating it. So `isStorageExhausted` returned `false` and the assertion expecting `true` failed.

On a platform with no quota support the EDQUOT test's premise is void: there is no EDQUOT errno to recognize, and production deliberately declines to synthesize one. So the EDQUOT-by-errno case [now skips there](https://github.com/HarperFast/harper/pull/2416/changes?w=1#diff-6bd15f4bbd0ffcce410fe3f2732622c87a7c5e83d74aa3606bb14bc793f6e01bR60), following the `/dev/full` convention already in this file, rather than hardcoding 122/69 — which would assert an errno the platform can never produce. The `persistConfigDuringBoot` case [keeps running on Windows by throwing `ENOSPC`](https://github.com/HarperFast/harper/pull/2416/changes?w=1#diff-6bd15f4bbd0ffcce410fe3f2732622c87a7c5e83d74aa3606bb14bc793f6e01bR104) instead: it carries the same unusable `code` as a Linux EDQUOT, so it reaches the swallow through the same errno branch and still proves startup continues.

Two robustness additions. The helper [now throws on an errno name the platform does not define](https://github.com/HarperFast/harper/pull/2416/changes?w=1#diff-6bd15f4bbd0ffcce410fe3f2732622c87a7c5e83d74aa3606bb14bc793f6e01bR22), so the next caller gets a message instead of a silent NaN. And a [new case pins that `isStorageExhausted` rejects a NaN errno](https://github.com/HarperFast/harper/pull/2416/changes?w=1#diff-6bd15f4bbd0ffcce410fe3f2732622c87a7c5e83d74aa3606bb14bc793f6e01bR77): without the filter in `configUtils` the set would hold NaN, which is SameValueZero-equal to itself, so an unfiltered set would actively report exhaustion for unrelated failures rather than merely matching nothing.

## For the human reviewer

Mechanics were cleared by codex (LGTM, no findings), cursor-composer (no blockers/concerns/suggestions) and adjudication (severity: none). What is left is scope — every entry below is a deliberate "how much coverage is enough on a platform that cannot produce the error" call, and each is one line to reverse.

1. **No platform now drives a real quota shape through the boot swallow.** `persistConfigDuringBoot` [injects `ENOSPC` on every platform](https://github.com/HarperFast/harper/pull/2416/changes?w=1#diff-6bd15f4bbd0ffcce410fe3f2732622c87a7c5e83d74aa3606bb14bc793f6e01bR104) instead of `EDQUOT`. The branch taken is provably identical (same unusable `code`, same numeric-errno match), but the literal #847 shape — quota, `Unknown system error -122` — is no longer exercised anywhere. The alternative is gating an EDQUOT variant the same way the classifier test is gated, so Linux keeps driving the original shape. I judged the identical branch sufficient; say the word and I will add the gated variant back.
2. **Windows goes quiet rather than asserting.** The EDQUOT case is [`pending` on win32](https://github.com/HarperFast/harper/pull/2416/changes?w=1#diff-6bd15f4bbd0ffcce410fe3f2732622c87a7c5e83d74aa3606bb14bc793f6e01bR60), gated by [the platform probe](https://github.com/HarperFast/harper/pull/2416/changes?w=1#diff-6bd15f4bbd0ffcce410fe3f2732622c87a7c5e83d74aa3606bb14bc793f6e01bR14), which proves nothing on the one platform this PR exists for. The alternative is a positive assertion there — that a win32 EDQUOT-shaped error is *not* storage exhaustion and so the boot write rethrows. I did not, because it pins a number the platform can never emit; it is cheap to convert if you would rather Windows assert than skip.
3. **The NaN guard is load-bearing only on Windows.** On Linux/macOS `EDQUOT` is defined, no NaN can enter the set, and the new case passes even if the production `.filter()` were deleted. Its protection is real only in the Windows gate — which does run this suite. The alternative is testing the set construction directly with a stubbed `os.constants`, which would make it bite everywhere.
4. **[The helper self-test](https://github.com/HarperFast/harper/pull/2416/changes?w=1#diff-6bd15f4bbd0ffcce410fe3f2732622c87a7c5e83d74aa3606bb14bc793f6e01bR53) asserts about the test, not about Harper.** It pins the guard's contract so a future caller gets a message instead of a NaN, at the cost of a test whose failure tells you nothing about the product. Adjudication also asked whether `errno === undefined` should be `typeof errno !== 'number'`, to reject a prototype-shaped name like `'constructor'`. I checked: `os.constants.errno` does not expose `Object.prototype` members, so `constructor` and `toString` both come back `undefined` and the existing check already catches them. Left as-is.
5. **This is verified against a simulated win32 errno table, not the real gate.** Nothing in my worktree can run Windows. The PR is open as a draft precisely so `unit-test-windows` rules on it; I will not flip it to Ready until that check is green.

## Verification

**Route (d), test-only** — this changes a unit test's platform gating; there is no product behavior to observe end-to-end.

macOS cannot reproduce the failure natively (EDQUOT is 69 here), so the win32 errno table was simulated by intercepting `require('node:os')` and removing `EDQUOT` — `os.constants` is non-configurable, so the module load is the only seam.

**Fails on base.** The base suite under that simulation reproduces the CI failure byte-for-byte, down to the line numbers:

```
1) recognizes EDQUOT by errno when the platform gives no usable code:
   AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
    at Context.<anonymous> (…storageExhaustion.test.js:46:11)
2) swallows storage exhaustion so startup continues:
   Error: Unknown system error -undefined
    at storageExhaustedError (…storageExhaustion.test.js:17:23)
19 passing, 1 pending, 2 failing
```

**Passes on this branch** under the same simulation: `22 passing, 2 pending, 0 failing` — the EDQUOT case pends, everything else runs. **Natively on macOS**: `23 passing, 1 pending` (the pending one is the pre-existing `/dev/full` skip).

**The NaN case is not vacuous on Windows.** With `.filter((errno) => errno !== undefined)` removed from the built `configUtils` under the win32 simulation, it is the only test that fails — confirming it guards the production filter this bug is about.

`npm run lint:required` clean; `prettier` reports the file unchanged. Every other suite in the Windows gate's `unitTests/config/**` group passes individually. `unitTests/config/rootConfigWatcher.test.js` hangs on macOS locally, but it is untouched here — identical to `main` — and the Linux and Windows CI runs of that group are unaffected.

**CI on this PR: `Unit Test (Windows, Node.js v24)` passes** — the authoritative confirmation, and the check this PR exists to fix.

One check is red: `Integration Tests 6/6 (Windows, Node.js v24)`. That is the unrelated pre-existing failure tracked as #2410 ("Branched database is discarded on restart on Windows"), not a regression here — it fails identically on the four most recent `main` commits, and this PR touches only a unit test file. Windows integration shards 1-5 all pass.

Complexity: easy

<sub>Review-Coverage: authored=claude; ran=gemini,cursor-composer,codex; adjudicated=domain; declined=cursor-grok; rounds=2 @ 75ee5799583b</sub>

<sub>Human-Review-Need: 3 (decisions: edquot-swallow-coverage-dropped, win32-goes-quiet-vs-asserts, nan-guard-tested-indirectly, helper-self-test-shipped, merge-on-simulated-windows) @ 75ee5799583b</sub>
