### PR TITLE
Add oxlint/prettier ignore for deliberately-broken integration-test fixtures

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -76,5 +76,5 @@
 		"logger": "readonly",
 		"Bun": "readonly"
 	},
-	"ignorePatterns": ["unitTests/security/jsLoader/fixtures", "integrationTests/**/fixture-broken-*"]
+	"ignorePatterns": ["unitTests/security/jsLoader/fixtures", "integrationTests/**/fixture-broken-*/**"]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -76,5 +76,5 @@
 		"logger": "readonly",
 		"Bun": "readonly"
 	},
-	"ignorePatterns": ["unitTests/security/jsLoader/fixtures"]
+	"ignorePatterns": ["unitTests/security/jsLoader/fixtures", "integrationTests/**/fixture-broken-*"]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 # Only list additional files and directories that aren't already in `.gitignore`
 
 unitTests/security/jsLoader/fixtures
+integrationTests/**/fixture-broken-*/**


### PR DESCRIPTION
## Summary

`npm run lint` (`oxlint --deny-warnings .`) runs across the whole repo, so an integration
test that ships a component fixture with a **deliberate** syntax error (to exercise the
loader's parse-error path) currently turns lint red — even though the test itself passes.

Adds a sibling `ignorePatterns` entry to
[`.oxlintrc.json`](https://github.com/HarperFast/harper/pull/2425/changes?w=1#diff-2113aef2ff3d50c021fca1fb6ecf4d4553a0e3f5f51ded7302ad499e43bc2b1eR79),
mirroring the existing `unitTests/security/jsLoader/fixtures` entry: only paths that
announce themselves as intentionally broken (`fixture-broken-*`) are exempted, not
`integrationTests` wholesale.

Pre-push review (round 1) found the initial `integrationTests/**/fixture-broken-*` glob
had two gaps versus that precedent:
- it matched **any** path segment, not just directories, so a colliding test-file name
  (e.g. `fixture-broken-syntax.test.ts`) would have been silently dropped from lint
  coverage instead of just the fixture it's testing;
- the precedent excludes the same path from **both** oxlint and Prettier
  (`.prettierignore`), but only oxlint was mirrored — a broken fixture would pass
  `npm run lint` and then fail the separate Format Check CI job.

Both are fixed in the second commit: the pattern is anchored with a trailing `/**` (only
excludes *descendants* of a `fixture-broken-*` directory, not same-named files), and the
same anchored pattern is mirrored into
[`.prettierignore`](https://github.com/HarperFast/harper/pull/2425/changes?w=1#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98R5).

This unblocks QA promote-candidate P-371, whose `fixture-broken-widget/resources.js`
fixture holds the intentional syntax error.

## For the human reviewer

- No fixture matching `integrationTests/**/fixture-broken-*` exists in this branch yet, so
  neither `npm run lint` nor CI exercises the new pattern end-to-end here — it's proven
  manually (see Verification) and will be self-proving once P-371's fixture lands. If that
  fixture ends up named differently (e.g. `broken-fixture-*`), the pattern will need to
  follow.
- Design assessment (from the task): lint-config only, no product code, no API surface —
  no HEG step-6 planning-review trigger.

## Verification

- Manually created a fixture at `integrationTests/components/fixture-broken-widget/resources.js`
  containing an unparseable syntax error, plus a same-directory `fixture-broken-syntax.test.ts`
  to probe the glob-breadth concern:
  - `npm run lint` (full repo): fixture directory produced no findings; the colliding
    `.test.ts` file was still linted and flagged (`Unexpected token`) — confirms the `/**`
    anchor is directory-scoped, not a blanket prefix match.
  - `npm run format:check` (full repo): same result — fixture ignored, colliding file
    still checked (`SyntaxError: Type expected`).
  - Both runs otherwise reproduced the exact same 13 pre-existing, unrelated warnings
    present on `origin/main` (confirmed by running lint against the unmodified baseline).
  - Temp fixtures removed before commit; not part of this diff.
- `independent-review: codex+gemini (round 1), codex+gemini (round 2 delta) — LGTM, 1
  in-scope nit remains (documented above)`.

<sub>Review-Coverage: authored=claude; ran=gemini,codex; declined=cursor-grok,cursor-composer,domain; rounds=2 @ cc5c94ce6a18</sub>

<sub>Human-Review-Need: 3 @ cc5c94ce6a18</sub>
