### PR TITLE
Give a branched database its own blob store, cloned with hard links

### DIFF
--- a/dataLayer/blobBackup.ts
+++ b/dataLayer/blobBackup.ts
@@ -54,8 +54,12 @@ export function blobSnapshotDir(backupDir: string, backupId: number): string {
  * Hard-link `src` to `dest`, falling back to a copy when the two are on different filesystems (or
  * the filesystem does not support additional hard links). Never creates a symlink. Returns false
  * when the source vanishes so the caller can substitute a marker for it.
+ *
+ * A fallback copy is counted rather than merely tolerated: it turns a constant-time clone into an
+ * O(bytes) one that also doubles the disk, and a caller doing this on a latency budget (a branch
+ * materialized during application load) has to be able to say so.
  */
-async function linkOrCopy(src: string, dest: string): Promise<boolean> {
+async function linkOrCopy(src: string, dest: string, counts?: { copied: number }): Promise<boolean> {
 	await mkdir(dirname(dest), { recursive: true });
 	try {
 		await link(src, dest);
@@ -77,11 +81,12 @@ async function linkOrCopy(src: string, dest: string): Promise<boolean> {
 				if (copyError.code === 'ENOENT') return false;
 				throw copyError;
 			}
+			if (counts) counts.copied++;
 			return true;
 		}
 		if (error.code === 'EEXIST') {
 			await unlink(dest);
-			return linkOrCopy(src, dest);
+			return linkOrCopy(src, dest, counts);
 		}
 		throw error;
 	}
@@ -103,7 +108,8 @@ const BACKUP_MARKER_REASONS: CaptureMarkerReasons = {
 async function captureBlobFile(
 	srcPath: string,
 	destPath: string,
-	reasons: CaptureMarkerReasons = BACKUP_MARKER_REASONS
+	reasons: CaptureMarkerReasons = BACKUP_MARKER_REASONS,
+	counts?: { copied: number }
 ): Promise<BlobCaptureDisposition> {
 	let disposition: BlobCaptureDisposition;
 	try {
@@ -120,7 +126,7 @@ async function captureBlobFile(
 	}
 	if (disposition === 'skip') return disposition;
 	if (disposition === 'capture') {
-		if (await linkOrCopy(srcPath, destPath)) return disposition;
+		if (await linkOrCopy(srcPath, destPath, counts)) return disposition;
 		disposition = 'gone';
 	}
 	await mkdir(dirname(destPath), { recursive: true });
@@ -137,15 +143,18 @@ async function captureBlobFile(
  * only; restore must replace exactly what the snapshot holds.
  *
  * Also used by branch materialization (harper#644), which clones a base's blob roots into the
- * branch's own so the OS inode refcount does the reference counting.
+ * branch's own so the OS inode refcount does the reference counting. That caller passes `onProgress`
+ * because its walk runs inside a window other threads are waiting on, and `copied` because a walk
+ * that had to copy instead of link cost it time and disk it should report.
  */
 export async function copyTree(
 	srcRoot: string,
 	destRoot: string,
 	classify = false,
-	reasons?: CaptureMarkerReasons
-): Promise<{ substituted: number; captured: number }> {
-	const counts = { substituted: 0, captured: 0 };
+	reasons?: CaptureMarkerReasons,
+	onProgress?: () => void
+): Promise<{ substituted: number; captured: number; copied: number }> {
+	const counts = { substituted: 0, captured: 0, copied: 0 };
 	if (!existsSync(srcRoot)) return counts;
 	const stack: string[] = [srcRoot];
 	while (stack.length > 0) {
@@ -164,12 +173,13 @@ export async function copyTree(
 			} else if (entry.isFile()) {
 				const destPath = join(destRoot, relative(srcRoot, srcPath));
 				if (classify) {
-					const disposition = await captureBlobFile(srcPath, destPath, reasons);
+					const disposition = await captureBlobFile(srcPath, destPath, reasons, counts);
 					if (disposition === 'pending' || disposition === 'gone') counts.substituted++;
 					else if (disposition === 'capture') counts.captured++;
 				} else {
-					await linkOrCopy(srcPath, destPath);
+					await linkOrCopy(srcPath, destPath, counts);
 				}
+				onProgress?.();
 			}
 			// symlinks/other node types in a blob root are not expected and are intentionally skipped
 		}

--- a/dataLayer/blobBackup.ts
+++ b/dataLayer/blobBackup.ts
@@ -53,11 +53,8 @@ export function blobSnapshotDir(backupDir: string, backupId: number): string {
 /**
  * Hard-link `src` to `dest`, falling back to a copy when the two are on different filesystems (or
  * the filesystem does not support additional hard links). Never creates a symlink. Returns false
- * when the source vanishes so the caller can substitute a marker for it.
- *
- * A fallback copy is counted rather than merely tolerated: it turns a constant-time clone into an
- * O(bytes) one that also doubles the disk, and a caller doing this on a latency budget (a branch
- * materialized during application load) has to be able to say so.
+ * when the source vanishes so the caller can substitute a marker for it. `counts.copied` is what a
+ * caller on a latency budget needs: the fallback turns a constant-time clone into an O(bytes) one.
  */
 async function linkOrCopy(src: string, dest: string, counts?: { copied: number }): Promise<boolean> {
 	await mkdir(dirname(dest), { recursive: true });
@@ -143,9 +140,8 @@ async function captureBlobFile(
  * only; restore must replace exactly what the snapshot holds.
  *
  * Also used by branch materialization (harper#644), which clones a base's blob roots into the
- * branch's own so the OS inode refcount does the reference counting. That caller passes `onProgress`
- * because its walk runs inside a window other threads are waiting on, and `copied` because a walk
- * that had to copy instead of link cost it time and disk it should report.
+ * branch's own so the OS inode refcount does the reference counting. Its walk runs inside a window
+ * other threads wait on, which is what `onProgress` is for.
  */
 export async function copyTree(
 	srcRoot: string,

--- a/dataLayer/blobBackup.ts
+++ b/dataLayer/blobBackup.ts
@@ -88,10 +88,23 @@ async function linkOrCopy(src: string, dest: string): Promise<boolean> {
 	return true;
 }
 
-/**
- * Put one blob file into the snapshot, returning how the entry was captured.
- */
-async function captureBlobFile(srcPath: string, destPath: string): Promise<BlobCaptureDisposition> {
+/** What a substituted marker says happened, so a branch clone doesn't report itself as a backup. */
+export interface CaptureMarkerReasons {
+	gone: string;
+	pending: string;
+}
+
+const BACKUP_MARKER_REASONS: CaptureMarkerReasons = {
+	gone: 'blob was deleted while this backup was being taken',
+	pending: 'blob was not yet complete when this backup was taken',
+};
+
+/** Put one blob file into the destination, returning how the entry was captured. */
+async function captureBlobFile(
+	srcPath: string,
+	destPath: string,
+	reasons: CaptureMarkerReasons = BACKUP_MARKER_REASONS
+): Promise<BlobCaptureDisposition> {
 	let disposition: BlobCaptureDisposition;
 	try {
 		disposition = await classifyBlobFileForCapture(srcPath);
@@ -111,15 +124,7 @@ async function captureBlobFile(srcPath: string, destPath: string): Promise<BlobC
 		disposition = 'gone';
 	}
 	await mkdir(dirname(destPath), { recursive: true });
-	await writeFile(
-		destPath,
-		createCaptureMarker(
-			disposition,
-			disposition === 'gone'
-				? 'blob was deleted while this backup was being taken'
-				: 'blob was not yet complete when this backup was taken'
-		)
-	);
+	await writeFile(destPath, createCaptureMarker(disposition, disposition === 'gone' ? reasons.gone : reasons.pending));
 	return disposition;
 }
 
@@ -127,13 +132,18 @@ async function captureBlobFile(srcPath: string, destPath: string): Promise<BlobC
  * Recursively copy every file under `srcRoot` into `destRoot` (hard-link-else-copy), preserving the
  * relative directory structure. Missing `srcRoot` is a no-op (a database with no blobs yet).
  *
- * `classify` belongs to the snapshot direction only; restore must replace exactly what the snapshot
- * holds.
+ * `classify` substitutes a marker for a file that is mid-write or already gone, so the destination
+ * fails loudly on that blob rather than carrying a truncated one. It belongs to the capture direction
+ * only; restore must replace exactly what the snapshot holds.
+ *
+ * Also used by branch materialization (harper#644), which clones a base's blob roots into the
+ * branch's own so the OS inode refcount does the reference counting.
  */
-async function copyTree(
+export async function copyTree(
 	srcRoot: string,
 	destRoot: string,
-	classify = false
+	classify = false,
+	reasons?: CaptureMarkerReasons
 ): Promise<{ substituted: number; captured: number }> {
 	const counts = { substituted: 0, captured: 0 };
 	if (!existsSync(srcRoot)) return counts;
@@ -154,7 +164,7 @@ async function copyTree(
 			} else if (entry.isFile()) {
 				const destPath = join(destRoot, relative(srcRoot, srcPath));
 				if (classify) {
-					const disposition = await captureBlobFile(srcPath, destPath);
+					const disposition = await captureBlobFile(srcPath, destPath, reasons);
 					if (disposition === 'pending' || disposition === 'gone') counts.substituted++;
 					else if (disposition === 'capture') counts.captured++;
 				} else {

--- a/dataLayer/schema.ts
+++ b/dataLayer/schema.ts
@@ -79,16 +79,18 @@ export async function createSchemaStructure(schemaCreateObject: any) {
 		})
 	);
 	if (validation) throw new ClientError(validation.message);
-	// The same refusal schema authoring makes in `table()`: a branch resolves its blob root from its
-	// store identity, so a database under that name shares the root -- two allocators minting the same
-	// file paths, and `drop_database` deleting the branch's blobs (harper#644).
+
+	transformReq(schemaCreateObject);
+	// After the normalization, because that is what settles which of `database`/`schema` names the
+	// database being created. The same refusal schema authoring makes in `table()`: a branch resolves
+	// its blob root from its store identity, so a database under that name shares the root -- two
+	// allocators minting the same file paths, and `drop_database` deleting the branch's blobs
+	// (harper#644).
 	if (isBranchIdentity(schemaCreateObject.schema)) {
 		throw new ClientError(
 			`'${schemaCreateObject.schema}' is in use as a branch store identity and cannot be a database name`
 		);
 	}
-
-	transformReq(schemaCreateObject);
 
 	if (!(await schemaMetadataValidator.checkSchemaExists(schemaCreateObject.schema))) {
 		throw handleHDBError(

--- a/dataLayer/schema.ts
+++ b/dataLayer/schema.ts
@@ -14,7 +14,7 @@ import { handleHDBError, ClientError } from '../utility/errors/hdbError.ts';
 import { HDB_ERROR_MSGS, HTTP_STATUS_CODES } from '../utility/errors/commonErrors.ts';
 
 import { SchemaEventMsg } from '../server/threads/itc.js';
-import { getDatabases, dropTableMeta } from '../resources/databases.ts';
+import { getDatabases, dropTableMeta, isBranchIdentity } from '../resources/databases.ts';
 import { transformReq } from '../utility/common_utils.ts';
 import { server } from '../server/Server.ts';
 import { cleanupOrphans } from '../resources/blob.ts';
@@ -79,6 +79,14 @@ export async function createSchemaStructure(schemaCreateObject: any) {
 		})
 	);
 	if (validation) throw new ClientError(validation.message);
+	// The same refusal schema authoring makes in `table()`: a branch resolves its blob root from its
+	// store identity, so a database under that name shares the root -- two allocators minting the same
+	// file paths, and `drop_database` deleting the branch's blobs (harper#644).
+	if (isBranchIdentity(schemaCreateObject.schema)) {
+		throw new ClientError(
+			`'${schemaCreateObject.schema}' is in use as a branch store identity and cannot be a database name`
+		);
+	}
 
 	transformReq(schemaCreateObject);
 

--- a/resources/branchDatabase.ts
+++ b/resources/branchDatabase.ts
@@ -1,10 +1,12 @@
-import { existsSync } from 'node:fs';
-import { mkdir, rename, rm, rmdir } from 'node:fs/promises';
-import { dirname, relative } from 'node:path';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { mkdir, rename, rm, rmdir, writeFile } from 'node:fs/promises';
+import { basename, dirname, join, relative } from 'node:path';
 import logger from '../utility/logging/harper_logger.ts';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import { commonValidators } from '../validation/common_validators.ts';
 import * as env from '../utility/environment/environmentManager.ts';
+import { copyTree } from '../dataLayer/blobBackup.ts';
+import { getBlobPathsForDatabaseName } from './blob.ts';
 import type { RocksDatabase } from '@harperfast/rocksdb-js';
 import {
 	type BranchDatabase,
@@ -14,6 +16,8 @@ import {
 	hydrateBranchRelationships,
 	isReadOnlyMode,
 	openBranchDatabase,
+	releaseBranchIdentity,
+	reserveBranchIdentity,
 	resolveBranchPath,
 } from './databases.ts';
 import { replayLogs, replayTimeBudgetMs } from './replayLogs.ts';
@@ -70,15 +74,159 @@ function claimStateFor(baseName: string, branchPath: string): BigInt64Array {
  * Take the checkpoint into a temporary sibling and rename it into place, so a crash mid-copy leaves
  * debris rather than a half-populated directory that RocksDB would then refuse to open.
  */
-async function materializeBranch(baseName: string, branchPath: string): Promise<void> {
+/**
+ * Reproduce the base's blob roots as the branch's own, hard-linking each file so the OS inode
+ * refcount does the reference counting: the branch and base share the bytes, each holds its own
+ * directory entry, and the data is freed only when the last link to it goes. That is what lets the
+ * branch keep its own ID allocator -- `getNextFileId` seeds from the highest filename already in its
+ * directory, and the clone carries the base's filenames -- with no shared allocator, no high-water
+ * mark, and no gated deletion (harper#644).
+ *
+ * A blob that is mid-write or already reclaimed is substituted with a marker rather than linked. A
+ * partially-written blob would otherwise be linked as a whole one, and worse, the abort that follows
+ * stamps PENDING onto that inode IN PLACE -- through the branch's link as well, since it is the same
+ * inode. The marker makes that blob fail loudly in the branch instead.
+ */
+async function cloneBlobRoots(baseName: string, storeName: string): Promise<void> {
+	const baseRoots = getBlobPathsForDatabaseName(baseName);
+	const branchRoots = getBlobPathsForDatabaseName(storeName);
+	let substituted = 0;
+	for (let index = 0; index < baseRoots.length; index++) {
+		const staging = `${branchRoots[index]}.staging`;
+		await rm(staging, { recursive: true, force: true });
+		// Created up front rather than left to the walk: a base with no blobs at all copies nothing, and
+		// the branch still needs its own (empty) root to exist so its allocator starts where the base's
+		// would have.
+		await mkdir(staging, { recursive: true });
+		const counts = await copyTree(baseRoots[index], staging, true, {
+			gone: 'blob was already reclaimed from the base when this branch was created',
+			pending: 'blob was still being written to the base when this branch was created',
+		});
+		substituted += counts.substituted;
+		await rm(branchRoots[index], { recursive: true, force: true });
+		await mkdir(dirname(branchRoots[index]), { recursive: true });
+		await rename(staging, branchRoots[index]);
+	}
+	if (substituted > 0) {
+		logger.warn?.(
+			`Branch of '${baseName}' substituted ${substituted} blob file(s) with markers because they were ` +
+				`mid-write or already reclaimed when it was created; reads of those blobs in the branch will fail`
+		);
+	}
+}
+
+/** Remove a branch's blob roots and any staging siblings left by an interrupted clone. */
+async function removeBlobRootsFor(storeName: string): Promise<void> {
+	for (const root of getBlobPathsForDatabaseName(storeName)) {
+		for (const target of [root, `${root}.staging`]) {
+			await rm(target, { recursive: true, force: true }).catch((error) =>
+				logger.warn?.(`Could not remove branch blob root ${target}`, error)
+			);
+		}
+	}
+}
+
+const COMPLETION_MARKER = '.branch-complete';
+
+/**
+ * What materialization published, written inside the branch directory just before it is renamed into
+ * place. Because that rename is a single atomic publish, a branch directory carrying this marker is
+ * one whose checkpoint AND blob roots were both finished.
+ */
+interface BranchCompletion {
+	blobRoots: string[];
+}
+
+type BranchState =
+	| { state: 'absent' }
+	/** No branch was ever published here -- leftovers that are not a store, safe to clear and redo. */
+	| { state: 'debris' }
+	/** A real store with no usable marker: pre-dates the marker, or lost it. Data-bearing either way. */
+	| { state: 'unmarked'; why: string }
+	| { state: 'complete' }
+	/** Was published complete; part of what it recorded is gone or no longer matches the config. */
+	| { state: 'damaged'; problem: string };
+
+/**
+ * Does this directory hold database data? Not "does CURRENT exist" -- a store that lost CURRENT still
+ * has its MANIFEST and SSTs, and a single missing file cannot stand for "there is nothing here to
+ * lose". Anything that answers yes is never deleted, only refused.
+ */
+function holdsStoreData(branchPath: string): boolean {
+	let entries: string[];
+	try {
+		entries = readdirSync(branchPath);
+	} catch {
+		return false;
+	}
+	return entries.some(
+		(name) => name === 'CURRENT' || /^(MANIFEST|OPTIONS)-/.test(name) || name.endsWith('.sst') || name.endsWith('.log')
+	);
+}
+
+/**
+ * What a branch directory on disk actually is, and in particular whether it may be destroyed.
+ *
+ * A branch's blob roots live on the volumes named by `storage.blobPaths`, not inside the branch
+ * directory, so the two cannot be published by one atomic rename and nothing fsyncs either parent. A
+ * directory alone therefore proves nothing: trusting it would adopt a branch whose allocator restarts
+ * from an empty root and mints file ids its own checkpointed rows already reference. The marker,
+ * written inside staging before the single rename that publishes it, is what proves both halves
+ * landed -- and recording the roots keeps an operator adding a `blobPaths` entry from reading as
+ * damage, since the new root was never this branch's.
+ *
+ * Materialization cannot leave a marker-less branch directory, so anything marker-less that still
+ * looks like a store came from elsewhere -- a branch older than the marker, or one whose marker was
+ * lost -- and is carrying data. It is refused, never deleted.
+ */
+function readBranchState(branchPath: string, storeName: string): BranchState {
+	if (!existsSync(branchPath)) return { state: 'absent' };
+	const looksLikeAStore = holdsStoreData(branchPath);
+	let recorded: BranchCompletion;
+	try {
+		recorded = JSON.parse(readFileSync(join(branchPath, COMPLETION_MARKER), 'utf8'));
+	} catch {
+		return looksLikeAStore ? { state: 'unmarked', why: 'it has no readable completion marker' } : { state: 'debris' };
+	}
+	if (!Array.isArray(recorded.blobRoots) || recorded.blobRoots.some((root) => typeof root !== 'string')) {
+		return { state: 'unmarked', why: 'its completion marker is malformed' };
+	}
+	const configured = getBlobPathsForDatabaseName(storeName);
+	// By index, not by set: `storageIndex` on a row is a position in this list, so a reordered
+	// `storage.blobPaths` would silently resolve every row through the wrong root.
+	if (recorded.blobRoots.length !== configured.length || recorded.blobRoots.some((root, i) => root !== configured[i])) {
+		return {
+			state: 'damaged',
+			problem:
+				`its blob roots no longer match the configured storage.blobPaths ` +
+				`(recorded ${JSON.stringify(recorded.blobRoots)}, configured ${JSON.stringify(configured)})`,
+		};
+	}
+	const missing = recorded.blobRoots.filter((root) => !existsSync(root));
+	return missing.length
+		? { state: 'damaged', problem: `blob root(s) are missing: ${missing.join(', ')}` }
+		: { state: 'complete' };
+}
+
+async function materializeBranch(baseName: string, branchPath: string, storeName: string): Promise<void> {
 	const staging = `${branchPath}.staging`;
 	await rm(staging, { recursive: true, force: true });
 	await mkdir(dirname(branchPath), { recursive: true });
 	try {
 		await database({ database: baseName, table: undefined }).createCheckpoint(staging);
+		await cloneBlobRoots(baseName, storeName);
+		await writeFile(
+			join(staging, COMPLETION_MARKER),
+			JSON.stringify({ blobRoots: getBlobPathsForDatabaseName(storeName) } satisfies BranchCompletion)
+		);
 		await rename(staging, branchPath);
 	} catch (error) {
 		await rm(staging, { recursive: true, force: true }).catch(() => {});
+		// The blob roots too, staging siblings included: a clone that failed partway leaves the roots it
+		// already published and nothing owns them once this attempt is abandoned. Only safe because this
+		// branch never became complete -- one that did is never rebuilt, so this cannot remove the last
+		// copy of anything.
+		await removeBlobRootsFor(storeName);
 		throw error;
 	}
 }
@@ -144,57 +292,91 @@ function branchStoreName(appName: string, baseName: string): string {
 async function openOrCreate(baseName: string, appName: string, branchPath: string): Promise<OpenBranch> {
 	const claimState = claimStateFor(baseName, branchPath);
 	const storeName = branchStoreName(appName, baseName);
-	// The claim's CREATING window now covers the winner's replay as well as its checkpoint, so
-	// waiters must outlast the replay budget too, or a merely slow (but live) recovery would time
-	// out every other thread's application load minutes before the winner publishes READY.
-	const deadline = Date.now() + CLAIM_TIMEOUT_MS + replayTimeBudgetMs();
-	for (;;) {
-		// The deadline bounds the whole protocol, not just a single wait: an unexpected state word --
-		// a future state, a buffer another version wrote -- must fail this load, never spin forever.
-		if (Date.now() > deadline) throw new Error(`Timed out claiming the branch at ${branchPath}`);
-		const previous = Atomics.compareExchange(claimState, 0, UNCLAIMED, CREATING);
-		if (previous === READY) break;
-		if (previous === UNCLAIMED) {
-			let branch: BranchDatabase | undefined;
-			try {
-				// Adopt rather than recreate. The branch outlives the process that first made it, so on
-				// every restart after the first the directory is already here — and `materializeBranch`
-				// only ever publishes by renaming a finished checkpoint into place, so a directory that
-				// exists is always a complete one, never a half-copy to be distrusted.
-				if (!existsSync(branchPath)) await materializeBranch(baseName, branchPath);
-				branch = openBranchDatabase(branchPath, baseName, storeName);
-				// The branch's column families write with the WAL disabled, so writes since its last
-				// memtable flush exist only in its own transaction log — which a process that died
-				// without the exit-time flush (a crash, a Windows hard kill) always leaves behind.
-				// Replay must finish before READY, because READY is what releases the other threads to
-				// serve reads. A fresh checkpoint carries no transaction_logs (verified: the native
-				// checkpoint copies only RocksDB files), so replay after materialize is a no-op; the
-				// read-only skip mirrors the base's boot replay.
-				if (!isReadOnlyMode()) await replayLogs(branch.rootStore as RocksDatabase, branch.tables, true);
-				Atomics.store(claimState, 0, READY);
-			} catch (error) {
-				// Release rather than record the failure. A claim that stays un-releasable turns one
-				// transient error -- a full disk, a rename losing a race -- into a branch that can never
-				// be created again for the life of the process, because the buffer outlives every retry.
-				// The branch is closed first — it holds the path and store identity a retry needs — and
-				// a close failure must not leave the claim wedged in CREATING for the whole deadline.
+	// Reserved before the claim, and so before materialization: cloning the blob tree REMOVES and
+	// replaces the root this identity resolves to, while `openBranchDatabase`'s own copy of this check
+	// runs only after that has happened. A database created while the checkpoint is still copying
+	// cannot take the same name.
+	reserveBranchIdentity(storeName);
+	let handedOver = false;
+	try {
+		// The claim's CREATING window now covers the winner's replay as well as its checkpoint, so
+		// waiters must outlast the replay budget too, or a merely slow (but live) recovery would time
+		// out every other thread's application load minutes before the winner publishes READY.
+		const deadline = Date.now() + CLAIM_TIMEOUT_MS + replayTimeBudgetMs();
+		for (;;) {
+			// The deadline bounds the whole protocol, not just a single wait: an unexpected state word --
+			// a future state, a buffer another version wrote -- must fail this load, never spin forever.
+			if (Date.now() > deadline) throw new Error(`Timed out claiming the branch at ${branchPath}`);
+			const previous = Atomics.compareExchange(claimState, 0, UNCLAIMED, CREATING);
+			if (previous === READY) break;
+			if (previous === UNCLAIMED) {
+				let branch: BranchDatabase | undefined;
 				try {
-					branch?.close();
-				} catch (closeError) {
-					logger.warn(`Error closing branch at ${branchPath} after a failed open`, closeError);
+					// Adopt rather than recreate. The branch outlives the process that first made it, so on
+					// every restart after the first the directory is already here — and `materializeBranch`
+					// only ever publishes by renaming a finished checkpoint into place, so a directory that
+					// exists is always a complete one, never a half-copy to be distrusted.
+					const existing = readBranchState(branchPath, storeName);
+					if (existing.state === 'damaged' || existing.state === 'unmarked') {
+						const problem = existing.state === 'damaged' ? existing.problem : existing.why;
+						throw new Error(
+							`Branch database at ${branchPath} cannot be trusted: ${problem}. Refusing to serve or rebuild ` +
+								`it, because rebuilding re-forks from the base and would discard anything written to this ` +
+								`branch. If this branch's data is not needed, delete the directory (and its blob roots) to ` +
+								`have it recreated from the base on the next load.`
+						);
+					}
+					if (existing.state !== 'complete') {
+						// Absent, or leftovers that are not a store: nothing here can be lost.
+						await rm(branchPath, { recursive: true, force: true });
+						await materializeBranch(baseName, branchPath, storeName);
+					}
+					releaseBranchIdentity(storeName);
+					branch = openBranchDatabase(branchPath, baseName, storeName);
+					// The branch's column families write with the WAL disabled, so writes since its last
+					// memtable flush exist only in its own transaction log — which a process that died
+					// without the exit-time flush (a crash, a Windows hard kill) always leaves behind.
+					// Replay must finish before READY, because READY is what releases the other threads to
+					// serve reads. A fresh checkpoint carries no transaction_logs (verified: the native
+					// checkpoint copies only RocksDB files), so replay after materialize is a no-op; the
+					// read-only skip mirrors the base's boot replay.
+					if (!isReadOnlyMode()) await replayLogs(branch.rootStore as RocksDatabase, branch.tables, true);
+					Atomics.store(claimState, 0, READY);
+				} catch (error) {
+					// Release rather than record the failure. A claim that stays un-releasable turns one
+					// transient error -- a full disk, a rename losing a race -- into a branch that can never
+					// be created again for the life of the process, because the buffer outlives every retry.
+					// The branch is closed first — it holds the path and store identity a retry needs — and
+					// a close failure must not leave the claim wedged in CREATING for the whole deadline.
+					try {
+						branch?.close();
+					} catch (closeError) {
+						logger.warn(`Error closing branch at ${branchPath} after a failed open`, closeError);
+					}
+					Atomics.store(claimState, 0, UNCLAIMED);
+					throw error;
+				} finally {
+					wakeWaiters(claimState);
 				}
-				Atomics.store(claimState, 0, UNCLAIMED);
-				throw error;
-			} finally {
-				wakeWaiters(claimState);
+				handedOver = true;
+				return { branch, claimState };
 			}
-			return { branch, claimState };
+			// Someone else holds it. A wait that settles on UNCLAIMED means they failed and released, so
+			// take another turn at being the one who creates it.
+			if ((await awaitClaim(claimState, branchPath, deadline)) === READY) break;
 		}
-		// Someone else holds it. A wait that settles on UNCLAIMED means they failed and released, so
-		// take another turn at being the one who creates it.
-		if ((await awaitClaim(claimState, branchPath, deadline)) === READY) break;
+		// Released immediately before the open, with no `await` in between, so nothing can slip into the
+		// gap -- and so `openBranchDatabase`'s check stays strict rather than being taught to ignore a
+		// reservation, which would also make it ignore a DIFFERENT branch holding the same name.
+		releaseBranchIdentity(storeName);
+		const adopted = openBranchDatabase(branchPath, baseName, storeName);
+		handedOver = true;
+		return { branch: adopted, claimState };
+	} finally {
+		// `openBranchDatabase` takes the identity over for the life of the handle; anything short of
+		// that has to hand it back, or the application can never load again in this process.
+		if (!handedOver) releaseBranchIdentity(storeName);
 	}
-	return { branch: openBranchDatabase(branchPath, baseName, storeName), claimState };
 }
 
 /** Remove the now-empty `<app>` directory a removed branch leaves behind. */
@@ -244,7 +426,19 @@ async function removeBranchAt(branchPath: string): Promise<void> {
 	await rm(branchPath, { recursive: true, force: true }).catch((error) =>
 		logger.warn?.(`Could not remove branch directory ${branchPath}`, error)
 	);
+	// The clone gives a branch blob roots of its own, outside its directory, so removing only the
+	// directory strands them -- and because they are hard links, the bytes survive the base deleting
+	// its own copies. Only once the directory is actually gone: removing them while it survives (a
+	// held handle, permissions) would leave a branch that still looks adoptable but whose allocator
+	// restarts from an empty root and remints ids its own rows hold. Leaking them the other way round
+	// is recoverable; that is not. Derived from the path, so a branch that never opened is cleaned up.
+	if (!existsSync(branchPath)) await removeBlobRootsFor(branchStoreNameFor(branchPath));
 	await pruneEmptyParents(branchRootOf(branchPath), branchPath);
+}
+
+/** `<storage>/`branches`/<app>/<db>` — the same identity `branchStoreName` composed on the way in. */
+function branchStoreNameFor(branchPath: string): string {
+	return branchStoreName(basename(dirname(branchPath)), basename(branchPath));
 }
 
 /**

--- a/resources/branchDatabase.ts
+++ b/resources/branchDatabase.ts
@@ -291,6 +291,18 @@ function readBranchState(branchPath: string, storeName: string): BranchState {
 		: { state: 'complete', blobRoots: recorded.blobRoots };
 }
 
+function warnAboutUnusedBlobRoots(branchPath: string, storeName: string, blobRoots: string[]): void {
+	const configured = getBlobPathsForDatabaseName(storeName);
+	if (blobRoots.length < configured.length) {
+		logger.warn?.(
+			`Branch database at ${branchPath} keeps the ${blobRoots.length} blob root(s) it was published ` +
+				`with; the ${configured.length - blobRoots.length} storage.blobPaths entry(ies) added since are ` +
+				`not used by it. Its rows address roots by position, so only a branch rebuilt from the base ` +
+				`can take the added capacity.`
+		);
+	}
+}
+
 /**
  * Take the checkpoint into a temporary sibling and rename it into place, so a crash mid-copy leaves
  * debris rather than a half-populated directory that RocksDB would then refuse to open. Reports the
@@ -461,16 +473,7 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 					}
 					if (existing.state === 'complete') {
 						blobRoots = existing.blobRoots;
-						const configured = getBlobPathsForDatabaseName(storeName);
-						// Once per process per branch: only the thread that won the claim reaches this.
-						if (blobRoots.length < configured.length) {
-							logger.warn?.(
-								`Branch database at ${branchPath} keeps the ${blobRoots.length} blob root(s) it was published ` +
-									`with; the ${configured.length - blobRoots.length} storage.blobPaths entry(ies) added since are ` +
-									`not used by it. Its rows address roots by position, so only a branch rebuilt from the base ` +
-									`can take the added capacity.`
-							);
-						}
+						warnAboutUnusedBlobRoots(branchPath, storeName, blobRoots);
 					} else {
 						// Absent, or leftovers that are not a store: nothing here can be lost.
 						await rm(branchPath, { recursive: true, force: true });
@@ -523,6 +526,7 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 					`complete: ${published.state === 'damaged' ? published.problem : published.state === 'unmarked' ? published.why : published.state}`
 			);
 		}
+		warnAboutUnusedBlobRoots(branchPath, storeName, published.blobRoots);
 		// Released immediately before the open, with no `await` in between, so nothing can slip into the
 		// gap -- and so `openBranchDatabase`'s check stays strict rather than being taught to ignore a
 		// reservation, which would also make it ignore a DIFFERENT branch holding the same name.

--- a/resources/branchDatabase.ts
+++ b/resources/branchDatabase.ts
@@ -6,7 +6,7 @@ import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import { commonValidators } from '../validation/common_validators.ts';
 import * as env from '../utility/environment/environmentManager.ts';
 import { copyTree } from '../dataLayer/blobBackup.ts';
-import { getBlobPathsForDatabaseName } from './blob.ts';
+import { getBlobPathsForDatabaseName, getRootBlobPathsForDB } from './blob.ts';
 import type { RocksDatabase } from '@harperfast/rocksdb-js';
 import {
 	type BranchDatabase,
@@ -118,28 +118,36 @@ export function claimDeadlineFor(state: BigInt64Array, budget: number): () => nu
  * inode. The marker makes that blob fail loudly in the branch instead.
  */
 async function cloneBlobRoots(baseName: string, branchRoots: string[], progress: () => void): Promise<void> {
-	const baseRoots = getBlobPathsForDatabaseName(baseName);
+	// What the base's own rows resolve through, which is not the configured list if `storage.blobPaths`
+	// changed while its store was open -- reading the configured volumes would clone an empty tree.
+	const baseRoots = getRootBlobPathsForDB(database({ database: baseName, table: undefined }) as never);
 	let substituted = 0;
 	let copied = 0;
-	for (let index = 0; index < baseRoots.length; index++) {
+	// Over the BRANCH's roots, not the base's: a row's `storageIndex` is a position in the branch's own
+	// list, and its marker records every entry, so each one has to exist even where the base has no
+	// counterpart to clone from.
+	for (let index = 0; index < branchRoots.length; index++) {
 		const staging = `${branchRoots[index]}.staging`;
 		await rm(staging, { recursive: true, force: true });
 		// Created up front rather than left to the walk: a base with no blobs at all copies nothing, and
 		// the branch still needs its own (empty) root to exist so its allocator starts where the base's
 		// would have.
 		await mkdir(staging, { recursive: true });
-		const counts = await copyTree(
-			baseRoots[index],
-			staging,
-			true,
-			{
-				gone: 'blob was already reclaimed from the base when this branch was created',
-				pending: 'blob was still being written to the base when this branch was created',
-			},
-			progress
-		);
-		substituted += counts.substituted;
-		copied += counts.copied;
+		const source = baseRoots[index];
+		if (source) {
+			const counts = await copyTree(
+				source,
+				staging,
+				true,
+				{
+					gone: 'blob was already reclaimed from the base when this branch was created',
+					pending: 'blob was still being written to the base when this branch was created',
+				},
+				progress
+			);
+			substituted += counts.substituted;
+			copied += counts.copied;
+		}
 		await rm(branchRoots[index], { recursive: true, force: true });
 		await mkdir(dirname(branchRoots[index]), { recursive: true });
 		await rename(staging, branchRoots[index]);
@@ -349,7 +357,9 @@ async function awaitClaim(state: BigInt64Array, branchPath: string, deadline: ()
 	for (;;) {
 		const current = Atomics.load(state, CLAIM_STATE);
 		if (current !== CREATING) return current;
-		if (!announced && Date.now() > patience) {
+		// Both conditions: past the original budget, and still going only because the deadline moved. The
+		// clock alone would print this on the very turn a winner that reported nothing times out.
+		if (!announced && Date.now() > patience && deadline() > patience) {
 			announced = true;
 			logger.warn?.(
 				`Still waiting for another thread to create the branch at ${branchPath}; it is reporting ` +
@@ -423,10 +433,10 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 				let branch: BranchDatabase | undefined;
 				let blobRoots: string[] = [];
 				try {
-					// Adopt rather than recreate. The branch outlives the process that first made it, so on
-					// every restart after the first the directory is already here — and `materializeBranch`
-					// only ever publishes by renaming a finished checkpoint into place, so a directory that
-					// exists is always a complete one, never a half-copy to be distrusted.
+					// Adopt rather than recreate: the branch outlives the process that first made it, so on
+					// every restart after the first the directory is already here. What it is, though, is a
+					// question -- the blob roots are published separately from the directory, so existence
+					// alone proves nothing and the marker is what has to be read.
 					const existing = readBranchState(branchPath, storeName);
 					if (existing.state === 'damaged' || existing.state === 'unmarked') {
 						const problem = existing.state === 'damaged' ? existing.problem : existing.why;
@@ -600,8 +610,10 @@ async function removeBranchAt(branchPath: string): Promise<void> {
 			if (!(await removeBlobRoots(blobRoots))) {
 				blobRootsStranded = true;
 				logger.warn?.(
-					`Refusing '${storeName}' to new databases for the life of this process: the branch at ` +
-						`${branchPath} left blob files behind and a database under that name would resolve onto them`
+					`Refusing '${storeName}' to new databases on this worker for the life of the process: the ` +
+						`branch at ${branchPath} left blob files behind and a database under that name would ` +
+						`resolve onto them. Other workers no longer see the branch directory, so remove those ` +
+						`files by hand to make the name safe again`
 				);
 			}
 		}
@@ -620,11 +632,14 @@ async function removeBranchAt(branchPath: string): Promise<void> {
  */
 function recordedBlobRootsAt(branchPath: string, storeName: string): string[] {
 	const published = readBranchState(branchPath, storeName);
+	const configured = getBlobPathsForDatabaseName(storeName);
 	// A marker that reads as damaged still names what this branch published, and that is what may be
 	// deleted; only a branch with no usable marker at all leaves configuration as the best answer.
+	// Either way, nothing outside this node's configured volumes is deleted: a branch directory carried
+	// over from a host with different `storage.blobPaths` names paths this node never wrote.
 	return published.state === 'complete' || published.state === 'damaged'
-		? published.blobRoots
-		: getBlobPathsForDatabaseName(storeName);
+		? published.blobRoots.filter((root) => configured.includes(root))
+		: configured;
 }
 
 /** `<storage>/`branches`/<app>/<db>` — the same identity `branchStoreName` composed on the way in. */

--- a/resources/branchDatabase.ts
+++ b/resources/branchDatabase.ts
@@ -16,6 +16,7 @@ import {
 	hydrateBranchRelationships,
 	isReadOnlyMode,
 	openBranchDatabase,
+	quarantineBranchIdentity,
 	releaseBranchIdentity,
 	reserveBranchIdentity,
 	resolveBranchPath,
@@ -42,15 +43,16 @@ const UNCLAIMED = 0n;
 const CREATING = 1n;
 const READY = 2n;
 
-/** Slot holding the claim itself. */
 const CLAIM_STATE = 0;
-/** Slot the winner bumps as materialization advances; see `claimDeadlineFor`. */
 const CLAIM_PROGRESS = 1;
 
 const MAX_NAME_LENGTH = commonValidators.schema_length.maximum;
 
 /** How long a loser waits on a winner that reports NO progress before giving up on the branch; the
- *  winner's replay budget is added on top where the deadline is built (`openOrCreate`). */
+ *  winner's replay budget is added on top where the deadline is built (`openOrCreate`). Progress is
+ *  reported per checkpoint and per cloned file, so that is the granularity this bounds: a single
+ *  unit that takes longer than the budget still expires it, which needs a byte copy (no hard links)
+ *  of one blob tens of gigabytes large. */
 const CLAIM_TIMEOUT_MS = 10 * 60 * 1000;
 
 interface OpenBranch {
@@ -78,7 +80,6 @@ function claimStateFor(baseName: string, branchPath: string): BigInt64Array {
 	return new BigInt64Array(baseStore.getUserSharedBuffer(`branch-claim:${branchPath}`, seed.buffer));
 }
 
-/** One unit of materialization finished, which buys every waiting thread another full budget. */
 export function reportClaimProgress(state: BigInt64Array): void {
 	Atomics.add(state, CLAIM_PROGRESS, 1n);
 }
@@ -257,7 +258,9 @@ function readBranchState(branchPath: string, storeName: string): BranchState {
 		recorded.blobRoots.length === 0 ||
 		recorded.blobRoots.some((r) => typeof r !== 'string')
 	) {
-		return { state: 'unmarked', why: 'its completion marker is malformed' };
+		// Same split as an unreadable marker above: refuse anything carrying store data, but a directory
+		// holding nothing but a bad marker has nothing to lose and must stay clearable.
+		return looksLikeAStore ? { state: 'unmarked', why: 'its completion marker is malformed' } : { state: 'debris' };
 	}
 	const configured = getBlobPathsForDatabaseName(storeName);
 	// By index, not by set: `storageIndex` on a row is a position in this list, so a reordered
@@ -293,6 +296,14 @@ async function materializeBranch(
 ): Promise<string[]> {
 	const staging = `${branchPath}.staging`;
 	const blobRoots = getBlobPathsForDatabaseName(storeName);
+	// Publishing an empty root list would record a marker no later load can accept, bricking the branch
+	// on every subsequent boot instead of failing here, where the configuration is the visible problem.
+	if (blobRoots.length === 0) {
+		throw new Error(
+			`Cannot create the branch at ${branchPath}: storage.blobPaths is configured with no entries, so ` +
+				`the branch has nowhere of its own to keep blobs`
+		);
+	}
 	await rm(staging, { recursive: true, force: true });
 	await mkdir(dirname(branchPath), { recursive: true });
 	try {
@@ -331,9 +342,20 @@ function wakeWaiters(state: BigInt64Array): void {
 
 /** Wait until the claim leaves CREATING, and report the state it settled on. */
 async function awaitClaim(state: BigInt64Array, branchPath: string, deadline: () => number): Promise<bigint> {
+	// A progress-extended deadline has no ceiling, so a wait past the original budget must say why it is
+	// still waiting rather than looking like a hang with no thread to point at.
+	const patience = deadline();
+	let announced = false;
 	for (;;) {
 		const current = Atomics.load(state, CLAIM_STATE);
 		if (current !== CREATING) return current;
+		if (!announced && Date.now() > patience) {
+			announced = true;
+			logger.warn?.(
+				`Still waiting for another thread to create the branch at ${branchPath}; it is reporting ` +
+					`progress, so this wait is extended for as long as it keeps doing so`
+			);
+		}
 		const remaining = deadline() - Date.now();
 		if (remaining <= 0) throw new Error(`Timed out waiting for another thread to create the branch at ${branchPath}`);
 		const slice = Math.min(remaining, 1000);
@@ -381,8 +403,9 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 	// cannot take the same name.
 	reserveBranchIdentity(storeName);
 	let handedOver = false;
-	// An abandoned attempt whose roots could not be removed keeps the name: they still hold this
-	// identity's files, and a database created under it would resolve its own new ids onto them.
+	// An abandoned attempt whose roots could not be removed does not hand the name back to a DATABASE:
+	// those roots still hold this identity's files, and a database created under the name would resolve
+	// its own new ids onto them. The branch may still retake it, which is what repairs the condition.
 	let blobRootsStranded = false;
 	try {
 		// The claim's CREATING window now covers the winner's replay as well as its checkpoint, so
@@ -488,7 +511,10 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 	} finally {
 		// `openBranchDatabase` takes the identity over for the life of the handle; anything short of
 		// that has to hand it back, or the application can never load again in this process.
-		if (!handedOver && !blobRootsStranded) releaseBranchIdentity(storeName);
+		if (!handedOver) {
+			if (blobRootsStranded) quarantineBranchIdentity(storeName);
+			else releaseBranchIdentity(storeName);
+		}
 	}
 }
 
@@ -540,7 +566,8 @@ async function removeBranchAt(branchPath: string): Promise<void> {
 	// `isBranchIdentity` is what stops `table()` claiming this name, and once the directory is gone its
 	// on-disk half sees nothing either, so the reservation is the only thing left holding the name while
 	// the blob roots are still being removed.
-	let releaseAfterCleanup = true;
+	let holdsIdentity = true;
+	let blobRootsStranded = false;
 	if (opened) {
 		opened.branch.close();
 		// Same turn as the close that released it, so nothing can slip into the gap.
@@ -553,7 +580,7 @@ async function removeBranchAt(branchPath: string): Promise<void> {
 		try {
 			reserveBranchIdentity(storeName);
 		} catch (error) {
-			releaseAfterCleanup = false;
+			holdsIdentity = false;
 			logger.warn?.(`Leaving the blob roots of the branch at ${branchPath} in place: its identity is in use`, error);
 		}
 	}
@@ -567,20 +594,23 @@ async function removeBranchAt(branchPath: string): Promise<void> {
 		// held handle, permissions) would leave a branch that still looks adoptable but whose allocator
 		// restarts from an empty root and remints ids its own rows hold. Leaking them the other way round
 		// is recoverable; that is not.
-		if (releaseAfterCleanup && !existsSync(branchPath)) {
-			// A root that survived still holds this branch's blob files, so the identity is never handed
-			// back: a database taking the name would resolve its own new file ids onto them.
+		if (holdsIdentity && !existsSync(branchPath)) {
+			// A root that survived still holds this branch's blob files, so the name is not handed back to
+			// a database: one taking it would resolve its own new file ids onto them.
 			if (!(await removeBlobRoots(blobRoots))) {
-				releaseAfterCleanup = false;
+				blobRootsStranded = true;
 				logger.warn?.(
-					`Keeping '${storeName}' reserved for the life of this process: the branch at ${branchPath} ` +
-						`left blob files behind and a database under that name would resolve onto them`
+					`Refusing '${storeName}' to new databases for the life of this process: the branch at ` +
+						`${branchPath} left blob files behind and a database under that name would resolve onto them`
 				);
 			}
 		}
 		await pruneEmptyParents(branchRootOf(branchPath), branchPath);
 	} finally {
-		if (releaseAfterCleanup) releaseBranchIdentity(storeName);
+		if (holdsIdentity) {
+			if (blobRootsStranded) quarantineBranchIdentity(storeName);
+			else releaseBranchIdentity(storeName);
+		}
 	}
 }
 

--- a/resources/branchDatabase.ts
+++ b/resources/branchDatabase.ts
@@ -117,21 +117,14 @@ export function claimDeadlineFor(state: BigInt64Array, budget: number): () => nu
  * stamps PENDING onto that inode IN PLACE -- through the branch's link as well, since it is the same
  * inode. The marker makes that blob fail loudly in the branch instead.
  */
-async function cloneBlobRoots(baseName: string, branchRoots: string[], progress: () => void): Promise<void> {
-	// What the base's own rows resolve through, which is not the configured list if `storage.blobPaths`
-	// changed while its store was open -- reading the configured volumes would clone an empty tree.
-	const baseRoots = getRootBlobPathsForDB(database({ database: baseName, table: undefined }) as never);
+async function cloneBlobRoots(
+	baseName: string,
+	baseRoots: string[],
+	branchRoots: string[],
+	progress: () => void
+): Promise<void> {
 	let substituted = 0;
 	let copied = 0;
-	if (baseRoots.length > branchRoots.length) {
-		// Every root the branch will have is cloned below, but the base has more than that, and a
-		// checkpointed row whose `storageIndex` lands past the branch's list resolves through nothing.
-		logger.warn?.(
-			`Branch of '${baseName}' has ${branchRoots.length} blob root(s) where the base resolves through ` +
-				`${baseRoots.length}; rows referencing the base's higher-numbered volumes will not be readable ` +
-				`in it. storage.blobPaths shrank while the base was open`
-		);
-	}
 	// A row's `storageIndex` is a position in the branch's own list, and its marker records every entry.
 	for (let index = 0; index < branchRoots.length; index++) {
 		const staging = `${branchRoots[index]}.staging`;
@@ -319,12 +312,24 @@ async function materializeBranch(
 				`the branch has nowhere of its own to keep blobs`
 		);
 	}
+	const base = database({ database: baseName, table: undefined });
+	// What the base's own rows resolve through, which is not the configured list if `storage.blobPaths`
+	// changed while its store was open. Refuse before taking a checkpoint: the configuration already
+	// proves that publishing this clone would leave rows on an omitted volume unreadable.
+	const baseRoots = getRootBlobPathsForDB(base as never);
+	if (baseRoots.length > blobRoots.length) {
+		throw new Error(
+			`Cannot create a branch of '${baseName}': the open base resolves through ${baseRoots.length} blob ` +
+				`root(s), but storage.blobPaths now provides ${blobRoots.length}; publishing the branch would ` +
+				`make rows on the omitted volume(s) unreadable`
+		);
+	}
 	await rm(staging, { recursive: true, force: true });
 	await mkdir(dirname(branchPath), { recursive: true });
 	try {
-		await database({ database: baseName, table: undefined }).createCheckpoint(staging);
+		await base.createCheckpoint(staging);
 		report.progress();
-		await cloneBlobRoots(baseName, blobRoots, report.progress);
+		await cloneBlobRoots(baseName, baseRoots, blobRoots, report.progress);
 		await writeFile(join(staging, COMPLETION_MARKER), JSON.stringify({ blobRoots } satisfies BranchCompletion));
 		await rename(staging, branchPath);
 		return blobRoots;

--- a/resources/branchDatabase.ts
+++ b/resources/branchDatabase.ts
@@ -42,9 +42,14 @@ const UNCLAIMED = 0n;
 const CREATING = 1n;
 const READY = 2n;
 
+/** Slot holding the claim itself. */
+const CLAIM_STATE = 0;
+/** Slot the winner bumps as materialization advances; see `claimDeadlineFor`. */
+const CLAIM_PROGRESS = 1;
+
 const MAX_NAME_LENGTH = commonValidators.schema_length.maximum;
 
-/** How long a loser waits for the winner's checkpoint before giving up on the branch; the
+/** How long a loser waits on a winner that reports NO progress before giving up on the branch; the
  *  winner's replay budget is added on top where the deadline is built (`openOrCreate`). */
 const CLAIM_TIMEOUT_MS = 10 * 60 * 1000;
 
@@ -53,6 +58,8 @@ interface OpenBranch {
 	/** Reset on removal: the buffer outlives the directory, and a stale READY would make the next
 	 *  caller skip materialization and then fail to open a directory that is no longer there. */
 	claimState: BigInt64Array;
+	/** What the handle resolves blobs through, so teardown deletes exactly what this branch owns. */
+	blobRoots: string[];
 }
 
 // Keyed on the in-flight open, not the finished one: within a thread the losers of the claim wake on
@@ -67,14 +74,35 @@ const branchesByPath = new Map<string, Promise<OpenBranch>>();
  */
 function claimStateFor(baseName: string, branchPath: string): BigInt64Array {
 	const baseStore = database({ database: baseName, table: undefined });
-	const seed = new BigInt64Array([UNCLAIMED]);
+	const seed = new BigInt64Array([UNCLAIMED, 0n]);
 	return new BigInt64Array(baseStore.getUserSharedBuffer(`branch-claim:${branchPath}`, seed.buffer));
 }
 
+/** One unit of materialization finished, which buys every waiting thread another full budget. */
+export function reportClaimProgress(state: BigInt64Array): void {
+	Atomics.add(state, CLAIM_PROGRESS, 1n);
+}
+
 /**
- * Take the checkpoint into a temporary sibling and rename it into place, so a crash mid-copy leaves
- * debris rather than a half-populated directory that RocksDB would then refuse to open.
+ * A deadline that follows the winner's progress rather than the clock alone. The claim window covers a
+ * hard-link clone of the base's entire blob tree, so any fixed budget is wrong for a large enough base:
+ * every waiting thread's load fails while the winner is healthily copying, the winner then publishes,
+ * and the next deploy succeeds -- so a real outage reads as a flap. Restarting the budget on each unit
+ * of reported work bounds a winner that has STOPPED rather than one that is merely slow.
  */
+export function claimDeadlineFor(state: BigInt64Array, budget: number): () => number {
+	let seen = Atomics.load(state, CLAIM_PROGRESS);
+	let at = Date.now() + budget;
+	return () => {
+		const progress = Atomics.load(state, CLAIM_PROGRESS);
+		if (progress !== seen) {
+			seen = progress;
+			at = Date.now() + budget;
+		}
+		return at;
+	};
+}
+
 /**
  * Reproduce the base's blob roots as the branch's own, hard-linking each file so the OS inode
  * refcount does the reference counting: the branch and base share the bytes, each holds its own
@@ -88,9 +116,10 @@ function claimStateFor(baseName: string, branchPath: string): BigInt64Array {
  * stamps PENDING onto that inode IN PLACE -- through the branch's link as well, since it is the same
  * inode. The marker makes that blob fail loudly in the branch instead.
  */
-async function cloneBlobRoots(baseName: string, branchRoots: string[]): Promise<void> {
+async function cloneBlobRoots(baseName: string, branchRoots: string[], progress: () => void): Promise<void> {
 	const baseRoots = getBlobPathsForDatabaseName(baseName);
 	let substituted = 0;
+	let copied = 0;
 	for (let index = 0; index < baseRoots.length; index++) {
 		const staging = `${branchRoots[index]}.staging`;
 		await rm(staging, { recursive: true, force: true });
@@ -98,19 +127,36 @@ async function cloneBlobRoots(baseName: string, branchRoots: string[]): Promise<
 		// the branch still needs its own (empty) root to exist so its allocator starts where the base's
 		// would have.
 		await mkdir(staging, { recursive: true });
-		const counts = await copyTree(baseRoots[index], staging, true, {
-			gone: 'blob was already reclaimed from the base when this branch was created',
-			pending: 'blob was still being written to the base when this branch was created',
-		});
+		const counts = await copyTree(
+			baseRoots[index],
+			staging,
+			true,
+			{
+				gone: 'blob was already reclaimed from the base when this branch was created',
+				pending: 'blob was still being written to the base when this branch was created',
+			},
+			progress
+		);
 		substituted += counts.substituted;
+		copied += counts.copied;
 		await rm(branchRoots[index], { recursive: true, force: true });
 		await mkdir(dirname(branchRoots[index]), { recursive: true });
 		await rename(staging, branchRoots[index]);
+		progress();
 	}
 	if (substituted > 0) {
 		logger.warn?.(
 			`Branch of '${baseName}' substituted ${substituted} blob file(s) with markers because they were ` +
 				`mid-write or already reclaimed when it was created; reads of those blobs in the branch will fail`
+		);
+	}
+	if (copied > 0) {
+		// The hard link is the whole design: without it the branch is a second full copy of the base's
+		// blobs, taken while the application is loading, and nothing else in the log would say so.
+		logger.warn?.(
+			`Branch of '${baseName}' could not hard-link ${copied} blob file(s) and copied their bytes instead; ` +
+				`on a filesystem without hard links a branch costs a full copy of the base's blobs, in disk and ` +
+				`in the time every application load that creates one takes`
 		);
 	}
 }
@@ -157,8 +203,9 @@ type BranchState =
 	| { state: 'unmarked'; why: string }
 	/** `blobRoots` is what was published with it, and what the branch stays pinned to while it is open. */
 	| { state: 'complete'; blobRoots: string[] }
-	/** Was published complete; part of what it recorded is gone or no longer matches the config. */
-	| { state: 'damaged'; problem: string };
+	/** Was published complete; part of what it recorded is gone or no longer matches the config.
+	 *  `blobRoots` is still what it recorded, and so still the only list a removal may delete. */
+	| { state: 'damaged'; problem: string; blobRoots: string[] };
 
 /**
  * Does this directory hold database data? Not "does CURRENT exist" -- a store that lost CURRENT still
@@ -202,7 +249,14 @@ function readBranchState(branchPath: string, storeName: string): BranchState {
 		return looksLikeAStore ? { state: 'unmarked', why: 'it has no readable completion marker' } : { state: 'debris' };
 	}
 	// `JSON.parse('null')` succeeds and yields null, so this cannot go straight to a property access.
-	if (recorded == null || !Array.isArray(recorded.blobRoots) || recorded.blobRoots.some((r) => typeof r !== 'string')) {
+	// An empty list would pass the prefix check below and pin the branch to no roots at all, so the
+	// first blob write would fail on an undefined path instead of here, where it can say why.
+	if (
+		recorded == null ||
+		!Array.isArray(recorded.blobRoots) ||
+		recorded.blobRoots.length === 0 ||
+		recorded.blobRoots.some((r) => typeof r !== 'string')
+	) {
 		return { state: 'unmarked', why: 'its completion marker is malformed' };
 	}
 	const configured = getBlobPathsForDatabaseName(storeName);
@@ -217,23 +271,34 @@ function readBranchState(branchPath: string, storeName: string): BranchState {
 			problem:
 				`its blob roots no longer match the configured storage.blobPaths ` +
 				`(recorded ${JSON.stringify(recorded.blobRoots)}, configured ${JSON.stringify(configured)})`,
+			blobRoots: recorded.blobRoots,
 		};
 	}
 	const missing = recorded.blobRoots.filter((root) => !existsSync(root));
 	return missing.length
-		? { state: 'damaged', problem: `blob root(s) are missing: ${missing.join(', ')}` }
+		? { state: 'damaged', problem: `blob root(s) are missing: ${missing.join(', ')}`, blobRoots: recorded.blobRoots }
 		: { state: 'complete', blobRoots: recorded.blobRoots };
 }
 
-/** Publishes the branch and reports the blob roots its marker records, which is what it is pinned to. */
-async function materializeBranch(baseName: string, branchPath: string, storeName: string): Promise<string[]> {
+/**
+ * Take the checkpoint into a temporary sibling and rename it into place, so a crash mid-copy leaves
+ * debris rather than a half-populated directory that RocksDB would then refuse to open. Reports the
+ * blob roots the marker records, which is what the branch is then pinned to.
+ */
+async function materializeBranch(
+	baseName: string,
+	branchPath: string,
+	storeName: string,
+	report: { progress: () => void; strandedRoots: () => void }
+): Promise<string[]> {
 	const staging = `${branchPath}.staging`;
 	const blobRoots = getBlobPathsForDatabaseName(storeName);
 	await rm(staging, { recursive: true, force: true });
 	await mkdir(dirname(branchPath), { recursive: true });
 	try {
 		await database({ database: baseName, table: undefined }).createCheckpoint(staging);
-		await cloneBlobRoots(baseName, blobRoots);
+		report.progress();
+		await cloneBlobRoots(baseName, blobRoots, report.progress);
 		await writeFile(join(staging, COMPLETION_MARKER), JSON.stringify({ blobRoots } satisfies BranchCompletion));
 		await rename(staging, branchPath);
 		return blobRoots;
@@ -243,7 +308,8 @@ async function materializeBranch(baseName: string, branchPath: string, storeName
 		// already published and nothing owns them once this attempt is abandoned. Only safe because this
 		// branch never became complete -- one that did is never rebuilt, so this cannot remove the last
 		// copy of anything.
-		await removeBlobRoots(blobRoots);
+		// Surviving roots still hold this identity's files, so the caller must not release the name.
+		if (!(await removeBlobRoots(blobRoots))) report.strandedRoots();
 		throw error;
 	}
 }
@@ -260,19 +326,19 @@ function isShared(state: BigInt64Array): boolean {
 }
 
 function wakeWaiters(state: BigInt64Array): void {
-	if (isShared(state)) Atomics.notify(state, 0);
+	if (isShared(state)) Atomics.notify(state, CLAIM_STATE);
 }
 
 /** Wait until the claim leaves CREATING, and report the state it settled on. */
-async function awaitClaim(state: BigInt64Array, branchPath: string, deadline: number): Promise<bigint> {
+async function awaitClaim(state: BigInt64Array, branchPath: string, deadline: () => number): Promise<bigint> {
 	for (;;) {
-		const current = Atomics.load(state, 0);
+		const current = Atomics.load(state, CLAIM_STATE);
 		if (current !== CREATING) return current;
-		const remaining = deadline - Date.now();
+		const remaining = deadline() - Date.now();
 		if (remaining <= 0) throw new Error(`Timed out waiting for another thread to create the branch at ${branchPath}`);
 		const slice = Math.min(remaining, 1000);
 		if (isShared(state)) {
-			const wait = (Atomics as any).waitAsync(state, 0, CREATING, slice);
+			const wait = (Atomics as any).waitAsync(state, CLAIM_STATE, CREATING, slice);
 			if (wait.async) await wait.value;
 		} else {
 			await new Promise((resolve) => setTimeout(resolve, Math.min(slice, 5)));
@@ -315,19 +381,24 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 	// cannot take the same name.
 	reserveBranchIdentity(storeName);
 	let handedOver = false;
+	// An abandoned attempt whose roots could not be removed keeps the name: they still hold this
+	// identity's files, and a database created under it would resolve its own new ids onto them.
+	let blobRootsStranded = false;
 	try {
 		// The claim's CREATING window now covers the winner's replay as well as its checkpoint, so
 		// waiters must outlast the replay budget too, or a merely slow (but live) recovery would time
-		// out every other thread's application load minutes before the winner publishes READY.
-		const deadline = Date.now() + CLAIM_TIMEOUT_MS + replayTimeBudgetMs();
+		// out every other thread's application load minutes before the winner publishes READY. The
+		// clone in between is unbounded in the base's size, which is why the budget follows progress.
+		const deadline = claimDeadlineFor(claimState, CLAIM_TIMEOUT_MS + replayTimeBudgetMs());
 		for (;;) {
 			// The deadline bounds the whole protocol, not just a single wait: an unexpected state word --
 			// a future state, a buffer another version wrote -- must fail this load, never spin forever.
-			if (Date.now() > deadline) throw new Error(`Timed out claiming the branch at ${branchPath}`);
-			const previous = Atomics.compareExchange(claimState, 0, UNCLAIMED, CREATING);
+			if (Date.now() > deadline()) throw new Error(`Timed out claiming the branch at ${branchPath}`);
+			const previous = Atomics.compareExchange(claimState, CLAIM_STATE, UNCLAIMED, CREATING);
 			if (previous === READY) break;
 			if (previous === UNCLAIMED) {
 				let branch: BranchDatabase | undefined;
+				let blobRoots: string[] = [];
 				try {
 					// Adopt rather than recreate. The branch outlives the process that first made it, so on
 					// every restart after the first the directory is already here — and `materializeBranch`
@@ -343,7 +414,6 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 								`have it recreated from the base on the next load.`
 						);
 					}
-					let blobRoots: string[];
 					if (existing.state === 'complete') {
 						blobRoots = existing.blobRoots;
 						const configured = getBlobPathsForDatabaseName(storeName);
@@ -359,7 +429,10 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 					} else {
 						// Absent, or leftovers that are not a store: nothing here can be lost.
 						await rm(branchPath, { recursive: true, force: true });
-						blobRoots = await materializeBranch(baseName, branchPath, storeName);
+						blobRoots = await materializeBranch(baseName, branchPath, storeName, {
+							progress: () => reportClaimProgress(claimState),
+							strandedRoots: () => (blobRootsStranded = true),
+						});
 					}
 					releaseBranchIdentity(storeName);
 					branch = openBranchDatabase(branchPath, baseName, storeName, blobRoots);
@@ -371,7 +444,7 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 					// checkpoint copies only RocksDB files), so replay after materialize is a no-op; the
 					// read-only skip mirrors the base's boot replay.
 					if (!isReadOnlyMode()) await replayLogs(branch.rootStore as RocksDatabase, branch.tables, true);
-					Atomics.store(claimState, 0, READY);
+					Atomics.store(claimState, CLAIM_STATE, READY);
 				} catch (error) {
 					// Release rather than record the failure. A claim that stays un-releasable turns one
 					// transient error -- a full disk, a rename losing a race -- into a branch that can never
@@ -383,13 +456,13 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 					} catch (closeError) {
 						logger.warn(`Error closing branch at ${branchPath} after a failed open`, closeError);
 					}
-					Atomics.store(claimState, 0, UNCLAIMED);
+					Atomics.store(claimState, CLAIM_STATE, UNCLAIMED);
 					throw error;
 				} finally {
 					wakeWaiters(claimState);
 				}
 				handedOver = true;
-				return { branch, claimState };
+				return { branch, claimState, blobRoots };
 			}
 			// Someone else holds it. A wait that settles on UNCLAIMED means they failed and released, so
 			// take another turn at being the one who creates it.
@@ -411,11 +484,11 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 		releaseBranchIdentity(storeName);
 		const adopted = openBranchDatabase(branchPath, baseName, storeName, published.blobRoots);
 		handedOver = true;
-		return { branch: adopted, claimState };
+		return { branch: adopted, claimState, blobRoots: published.blobRoots };
 	} finally {
 		// `openBranchDatabase` takes the identity over for the life of the handle; anything short of
 		// that has to hand it back, or the application can never load again in this process.
-		if (!handedOver) releaseBranchIdentity(storeName);
+		if (!handedOver && !blobRootsStranded) releaseBranchIdentity(storeName);
 	}
 }
 
@@ -459,10 +532,10 @@ async function removeBranchAt(branchPath: string): Promise<void> {
 	branchesByPath.delete(branchPath);
 	const opened = await pending?.catch(() => null);
 	const storeName = branchStoreNameFor(branchPath);
-	// Read while the marker is still on disk: what this branch owns is what it published, which for a
-	// branch that predates an appended `storage.blobPaths` entry is a prefix of the configured list.
-	const published = readBranchState(branchPath, storeName);
-	const blobRoots = published.state === 'complete' ? published.blobRoots : getBlobPathsForDatabaseName(storeName);
+	// What this branch owns is what it published, not what is configured now: an entry appended to
+	// `storage.blobPaths` since may already hold a `<storeName>` directory this branch never wrote.
+	// The open handle is already pinned to them; otherwise the marker still on disk names them.
+	const blobRoots = opened?.blobRoots ?? recordedBlobRootsAt(branchPath, storeName);
 	// The identity has to be held for every deletion below, not just checked before them:
 	// `isBranchIdentity` is what stops `table()` claiming this name, and once the directory is gone its
 	// on-disk half sees nothing either, so the reservation is the only thing left holding the name while
@@ -472,7 +545,7 @@ async function removeBranchAt(branchPath: string): Promise<void> {
 		opened.branch.close();
 		// Same turn as the close that released it, so nothing can slip into the gap.
 		retakeBranchIdentity(storeName);
-		Atomics.store(opened.claimState, 0, UNCLAIMED);
+		Atomics.store(opened.claimState, CLAIM_STATE, UNCLAIMED);
 		wakeWaiters(opened.claimState);
 	} else {
 		// Never opened here, so the name has to be claimed outright. Failing means something else already
@@ -509,6 +582,19 @@ async function removeBranchAt(branchPath: string): Promise<void> {
 	} finally {
 		if (releaseAfterCleanup) releaseBranchIdentity(storeName);
 	}
+}
+
+/**
+ * The roots a branch on disk recorded, falling back to configuration only for one that never
+ * published a usable marker -- an abandoned materialization, whose roots ARE the configured ones.
+ */
+function recordedBlobRootsAt(branchPath: string, storeName: string): string[] {
+	const published = readBranchState(branchPath, storeName);
+	// A marker that reads as damaged still names what this branch published, and that is what may be
+	// deleted; only a branch with no usable marker at all leaves configuration as the best answer.
+	return published.state === 'complete' || published.state === 'damaged'
+		? published.blobRoots
+		: getBlobPathsForDatabaseName(storeName);
 }
 
 /** `<storage>/`branches`/<app>/<db>` — the same identity `branchStoreName` composed on the way in. */

--- a/resources/branchDatabase.ts
+++ b/resources/branchDatabase.ts
@@ -188,7 +188,8 @@ function readBranchState(branchPath: string, storeName: string): BranchState {
 	} catch {
 		return looksLikeAStore ? { state: 'unmarked', why: 'it has no readable completion marker' } : { state: 'debris' };
 	}
-	if (!Array.isArray(recorded.blobRoots) || recorded.blobRoots.some((root) => typeof root !== 'string')) {
+	// `JSON.parse('null')` succeeds and yields null, so this cannot go straight to a property access.
+	if (recorded == null || !Array.isArray(recorded.blobRoots) || recorded.blobRoots.some((r) => typeof r !== 'string')) {
 		return { state: 'unmarked', why: 'its completion marker is malformed' };
 	}
 	const configured = getBlobPathsForDatabaseName(storeName);

--- a/resources/branchDatabase.ts
+++ b/resources/branchDatabase.ts
@@ -19,6 +19,7 @@ import {
 	releaseBranchIdentity,
 	reserveBranchIdentity,
 	resolveBranchPath,
+	retakeBranchIdentity,
 } from './databases.ts';
 import { replayLogs, replayTimeBudgetMs } from './replayLogs.ts';
 
@@ -87,9 +88,8 @@ function claimStateFor(baseName: string, branchPath: string): BigInt64Array {
  * stamps PENDING onto that inode IN PLACE -- through the branch's link as well, since it is the same
  * inode. The marker makes that blob fail loudly in the branch instead.
  */
-async function cloneBlobRoots(baseName: string, storeName: string): Promise<void> {
+async function cloneBlobRoots(baseName: string, branchRoots: string[]): Promise<void> {
 	const baseRoots = getBlobPathsForDatabaseName(baseName);
-	const branchRoots = getBlobPathsForDatabaseName(storeName);
 	let substituted = 0;
 	for (let index = 0; index < baseRoots.length; index++) {
 		const staging = `${branchRoots[index]}.staging`;
@@ -115,15 +115,27 @@ async function cloneBlobRoots(baseName: string, storeName: string): Promise<void
 	}
 }
 
-/** Remove a branch's blob roots and any staging siblings left by an interrupted clone. */
-async function removeBlobRootsFor(storeName: string): Promise<void> {
-	for (const root of getBlobPathsForDatabaseName(storeName)) {
+/**
+ * Remove the given blob roots and any staging siblings left by an interrupted clone. The roots are
+ * passed in rather than re-derived, because a published branch owns exactly what its completion
+ * marker recorded: deriving them from current configuration would let a `storage.blobPaths` entry
+ * added since -- one that may already hold a `<storeName>` directory restored from elsewhere --
+ * be deleted by a branch that never wrote it.
+ *
+ * Reports whether every removal succeeded, because a root left behind still belongs to this
+ * identity and the caller must not hand the name back while it does.
+ */
+async function removeBlobRoots(roots: string[]): Promise<boolean> {
+	let removed = true;
+	for (const root of roots) {
 		for (const target of [root, `${root}.staging`]) {
-			await rm(target, { recursive: true, force: true }).catch((error) =>
-				logger.warn?.(`Could not remove branch blob root ${target}`, error)
-			);
+			await rm(target, { recursive: true, force: true }).catch((error) => {
+				removed = false;
+				logger.warn?.(`Could not remove branch blob root ${target}`, error);
+			});
 		}
 	}
+	return removed;
 }
 
 const COMPLETION_MARKER = '.branch-complete';
@@ -143,7 +155,8 @@ type BranchState =
 	| { state: 'debris' }
 	/** A real store with no usable marker: pre-dates the marker, or lost it. Data-bearing either way. */
 	| { state: 'unmarked'; why: string }
-	| { state: 'complete' }
+	/** `blobRoots` is what was published with it, and what the branch stays pinned to while it is open. */
+	| { state: 'complete'; blobRoots: string[] }
 	/** Was published complete; part of what it recorded is gone or no longer matches the config. */
 	| { state: 'damaged'; problem: string };
 
@@ -194,8 +207,11 @@ function readBranchState(branchPath: string, storeName: string): BranchState {
 	}
 	const configured = getBlobPathsForDatabaseName(storeName);
 	// By index, not by set: `storageIndex` on a row is a position in this list, so a reordered
-	// `storage.blobPaths` would silently resolve every row through the wrong root.
-	if (recorded.blobRoots.length !== configured.length || recorded.blobRoots.some((root, i) => root !== configured[i])) {
+	// `storage.blobPaths` would silently resolve every row through the wrong root. A configured list
+	// that only GREW leaves every recorded index exactly where it was, which is why an appended volume
+	// is compatible where a removed, reordered or replaced one is not -- the branch goes on resolving
+	// through what it recorded, so the appended root is simply never its.
+	if (recorded.blobRoots.length > configured.length || recorded.blobRoots.some((root, i) => root !== configured[i])) {
 		return {
 			state: 'damaged',
 			problem:
@@ -206,28 +222,28 @@ function readBranchState(branchPath: string, storeName: string): BranchState {
 	const missing = recorded.blobRoots.filter((root) => !existsSync(root));
 	return missing.length
 		? { state: 'damaged', problem: `blob root(s) are missing: ${missing.join(', ')}` }
-		: { state: 'complete' };
+		: { state: 'complete', blobRoots: recorded.blobRoots };
 }
 
-async function materializeBranch(baseName: string, branchPath: string, storeName: string): Promise<void> {
+/** Publishes the branch and reports the blob roots its marker records, which is what it is pinned to. */
+async function materializeBranch(baseName: string, branchPath: string, storeName: string): Promise<string[]> {
 	const staging = `${branchPath}.staging`;
+	const blobRoots = getBlobPathsForDatabaseName(storeName);
 	await rm(staging, { recursive: true, force: true });
 	await mkdir(dirname(branchPath), { recursive: true });
 	try {
 		await database({ database: baseName, table: undefined }).createCheckpoint(staging);
-		await cloneBlobRoots(baseName, storeName);
-		await writeFile(
-			join(staging, COMPLETION_MARKER),
-			JSON.stringify({ blobRoots: getBlobPathsForDatabaseName(storeName) } satisfies BranchCompletion)
-		);
+		await cloneBlobRoots(baseName, blobRoots);
+		await writeFile(join(staging, COMPLETION_MARKER), JSON.stringify({ blobRoots } satisfies BranchCompletion));
 		await rename(staging, branchPath);
+		return blobRoots;
 	} catch (error) {
 		await rm(staging, { recursive: true, force: true }).catch(() => {});
 		// The blob roots too, staging siblings included: a clone that failed partway leaves the roots it
 		// already published and nothing owns them once this attempt is abandoned. Only safe because this
 		// branch never became complete -- one that did is never rebuilt, so this cannot remove the last
 		// copy of anything.
-		await removeBlobRootsFor(storeName);
+		await removeBlobRoots(blobRoots);
 		throw error;
 	}
 }
@@ -327,13 +343,26 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 								`have it recreated from the base on the next load.`
 						);
 					}
-					if (existing.state !== 'complete') {
+					let blobRoots: string[];
+					if (existing.state === 'complete') {
+						blobRoots = existing.blobRoots;
+						const configured = getBlobPathsForDatabaseName(storeName);
+						// Once per process per branch: only the thread that won the claim reaches this.
+						if (blobRoots.length < configured.length) {
+							logger.warn?.(
+								`Branch database at ${branchPath} keeps the ${blobRoots.length} blob root(s) it was published ` +
+									`with; the ${configured.length - blobRoots.length} storage.blobPaths entry(ies) added since are ` +
+									`not used by it. Its rows address roots by position, so only a branch rebuilt from the base ` +
+									`can take the added capacity.`
+							);
+						}
+					} else {
 						// Absent, or leftovers that are not a store: nothing here can be lost.
 						await rm(branchPath, { recursive: true, force: true });
-						await materializeBranch(baseName, branchPath, storeName);
+						blobRoots = await materializeBranch(baseName, branchPath, storeName);
 					}
 					releaseBranchIdentity(storeName);
-					branch = openBranchDatabase(branchPath, baseName, storeName);
+					branch = openBranchDatabase(branchPath, baseName, storeName, blobRoots);
 					// The branch's column families write with the WAL disabled, so writes since its last
 					// memtable flush exist only in its own transaction log — which a process that died
 					// without the exit-time flush (a crash, a Windows hard kill) always leaves behind.
@@ -366,11 +395,21 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 			// take another turn at being the one who creates it.
 			if ((await awaitClaim(claimState, branchPath, deadline)) === READY) break;
 		}
+		// This thread never read the branch it is adopting, and a branch resolves blob ids through the
+		// roots its marker names, so the marker has to be read here too rather than pinned only on the
+		// thread that won the claim.
+		const published = readBranchState(branchPath, storeName);
+		if (published.state !== 'complete') {
+			throw new Error(
+				`Branch database at ${branchPath} was published by another thread but no longer reads as ` +
+					`complete: ${published.state === 'damaged' ? published.problem : published.state === 'unmarked' ? published.why : published.state}`
+			);
+		}
 		// Released immediately before the open, with no `await` in between, so nothing can slip into the
 		// gap -- and so `openBranchDatabase`'s check stays strict rather than being taught to ignore a
 		// reservation, which would also make it ignore a DIFFERENT branch holding the same name.
 		releaseBranchIdentity(storeName);
-		const adopted = openBranchDatabase(branchPath, baseName, storeName);
+		const adopted = openBranchDatabase(branchPath, baseName, storeName, published.blobRoots);
 		handedOver = true;
 		return { branch: adopted, claimState };
 	} finally {
@@ -419,22 +458,57 @@ async function removeBranchAt(branchPath: string): Promise<void> {
 	const pending = branchesByPath.get(branchPath);
 	branchesByPath.delete(branchPath);
 	const opened = await pending?.catch(() => null);
+	const storeName = branchStoreNameFor(branchPath);
+	// Read while the marker is still on disk: what this branch owns is what it published, which for a
+	// branch that predates an appended `storage.blobPaths` entry is a prefix of the configured list.
+	const published = readBranchState(branchPath, storeName);
+	const blobRoots = published.state === 'complete' ? published.blobRoots : getBlobPathsForDatabaseName(storeName);
+	// The identity has to be held for every deletion below, not just checked before them:
+	// `isBranchIdentity` is what stops `table()` claiming this name, and once the directory is gone its
+	// on-disk half sees nothing either, so the reservation is the only thing left holding the name while
+	// the blob roots are still being removed.
+	let releaseAfterCleanup = true;
 	if (opened) {
 		opened.branch.close();
+		// Same turn as the close that released it, so nothing can slip into the gap.
+		retakeBranchIdentity(storeName);
 		Atomics.store(opened.claimState, 0, UNCLAIMED);
 		wakeWaiters(opened.claimState);
+	} else {
+		// Never opened here, so the name has to be claimed outright. Failing means something else already
+		// answers to it, and then the blob root it resolves to is not ours to delete.
+		try {
+			reserveBranchIdentity(storeName);
+		} catch (error) {
+			releaseAfterCleanup = false;
+			logger.warn?.(`Leaving the blob roots of the branch at ${branchPath} in place: its identity is in use`, error);
+		}
 	}
-	await rm(branchPath, { recursive: true, force: true }).catch((error) =>
-		logger.warn?.(`Could not remove branch directory ${branchPath}`, error)
-	);
-	// The clone gives a branch blob roots of its own, outside its directory, so removing only the
-	// directory strands them -- and because they are hard links, the bytes survive the base deleting
-	// its own copies. Only once the directory is actually gone: removing them while it survives (a
-	// held handle, permissions) would leave a branch that still looks adoptable but whose allocator
-	// restarts from an empty root and remints ids its own rows hold. Leaking them the other way round
-	// is recoverable; that is not. Derived from the path, so a branch that never opened is cleaned up.
-	if (!existsSync(branchPath)) await removeBlobRootsFor(branchStoreNameFor(branchPath));
-	await pruneEmptyParents(branchRootOf(branchPath), branchPath);
+	try {
+		await rm(branchPath, { recursive: true, force: true }).catch((error) =>
+			logger.warn?.(`Could not remove branch directory ${branchPath}`, error)
+		);
+		// The clone gives a branch blob roots of its own, outside its directory, so removing only the
+		// directory strands them -- and because they are hard links, the bytes survive the base deleting
+		// its own copies. Only once the directory is actually gone: removing them while it survives (a
+		// held handle, permissions) would leave a branch that still looks adoptable but whose allocator
+		// restarts from an empty root and remints ids its own rows hold. Leaking them the other way round
+		// is recoverable; that is not.
+		if (releaseAfterCleanup && !existsSync(branchPath)) {
+			// A root that survived still holds this branch's blob files, so the identity is never handed
+			// back: a database taking the name would resolve its own new file ids onto them.
+			if (!(await removeBlobRoots(blobRoots))) {
+				releaseAfterCleanup = false;
+				logger.warn?.(
+					`Keeping '${storeName}' reserved for the life of this process: the branch at ${branchPath} ` +
+						`left blob files behind and a database under that name would resolve onto them`
+				);
+			}
+		}
+		await pruneEmptyParents(branchRootOf(branchPath), branchPath);
+	} finally {
+		if (releaseAfterCleanup) releaseBranchIdentity(storeName);
+	}
 }
 
 /** `<storage>/`branches`/<app>/<db>` — the same identity `branchStoreName` composed on the way in. */

--- a/resources/branchDatabase.ts
+++ b/resources/branchDatabase.ts
@@ -123,9 +123,16 @@ async function cloneBlobRoots(baseName: string, branchRoots: string[], progress:
 	const baseRoots = getRootBlobPathsForDB(database({ database: baseName, table: undefined }) as never);
 	let substituted = 0;
 	let copied = 0;
-	// Over the BRANCH's roots, not the base's: a row's `storageIndex` is a position in the branch's own
-	// list, and its marker records every entry, so each one has to exist even where the base has no
-	// counterpart to clone from.
+	if (baseRoots.length > branchRoots.length) {
+		// Every root the branch will have is cloned below, but the base has more than that, and a
+		// checkpointed row whose `storageIndex` lands past the branch's list resolves through nothing.
+		logger.warn?.(
+			`Branch of '${baseName}' has ${branchRoots.length} blob root(s) where the base resolves through ` +
+				`${baseRoots.length}; rows referencing the base's higher-numbered volumes will not be readable ` +
+				`in it. storage.blobPaths shrank while the base was open`
+		);
+	}
+	// A row's `storageIndex` is a position in the branch's own list, and its marker records every entry.
 	for (let index = 0; index < branchRoots.length; index++) {
 		const staging = `${branchRoots[index]}.staging`;
 		await rm(staging, { recursive: true, force: true });
@@ -351,14 +358,16 @@ function wakeWaiters(state: BigInt64Array): void {
 /** Wait until the claim leaves CREATING, and report the state it settled on. */
 async function awaitClaim(state: BigInt64Array, branchPath: string, deadline: () => number): Promise<bigint> {
 	// A progress-extended deadline has no ceiling, so a wait past the original budget must say why it is
-	// still waiting rather than looking like a hang with no thread to point at.
+	// still waiting rather than reading as a hang with no thread to point at.
 	const patience = deadline();
 	let announced = false;
 	for (;;) {
 		const current = Atomics.load(state, CLAIM_STATE);
 		if (current !== CREATING) return current;
-		// Both conditions: past the original budget, and still going only because the deadline moved. The
-		// clock alone would print this on the very turn a winner that reported nothing times out.
+		const remaining = deadline() - Date.now();
+		if (remaining <= 0) throw new Error(`Timed out waiting for another thread to create the branch at ${branchPath}`);
+		// After the timeout check, and only once the deadline itself has moved: on the clock alone this
+		// would claim the winner is alive on the very turn the wait gives up on it.
 		if (!announced && Date.now() > patience && deadline() > patience) {
 			announced = true;
 			logger.warn?.(
@@ -366,8 +375,6 @@ async function awaitClaim(state: BigInt64Array, branchPath: string, deadline: ()
 					`progress, so this wait is extended for as long as it keeps doing so`
 			);
 		}
-		const remaining = deadline() - Date.now();
-		if (remaining <= 0) throw new Error(`Timed out waiting for another thread to create the branch at ${branchPath}`);
 		const slice = Math.min(remaining, 1000);
 		if (isShared(state)) {
 			const wait = (Atomics as any).waitAsync(state, CLAIM_STATE, CREATING, slice);
@@ -633,10 +640,10 @@ async function removeBranchAt(branchPath: string): Promise<void> {
 function recordedBlobRootsAt(branchPath: string, storeName: string): string[] {
 	const published = readBranchState(branchPath, storeName);
 	const configured = getBlobPathsForDatabaseName(storeName);
-	// A marker that reads as damaged still names what this branch published, and that is what may be
-	// deleted; only a branch with no usable marker at all leaves configuration as the best answer.
-	// Either way, nothing outside this node's configured volumes is deleted: a branch directory carried
-	// over from a host with different `storage.blobPaths` names paths this node never wrote.
+	// A marker that reads as damaged still names what this branch published, and only a branch with no
+	// usable marker at all leaves configuration as the best answer. Nothing outside this node's
+	// configured volumes is deleted either way: a branch directory carried over from a host configured
+	// differently names paths this node never wrote.
 	return published.state === 'complete' || published.state === 'damaged'
 		? published.blobRoots.filter((root) => configured.includes(root))
 		: configured;

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1364,6 +1364,22 @@ function branchIdentityPair(storeName: string): string[] {
 }
 
 /**
+ * Identities whose blob roots outlived the branch that owned them, because a removal or an abandoned
+ * materialization could not delete them. A database created under such a name would resolve its own
+ * fresh file ids onto files it never wrote, so the name stays refused -- but only against DATABASES.
+ * The branch itself may take it back: materializing it replaces those roots wholesale, which is the
+ * only route that clears the condition without an operator.
+ */
+const quarantinedBranchIdentities = new Set<string>();
+
+export function quarantineBranchIdentity(storeName: string): void {
+	for (const name of branchIdentityPair(storeName)) {
+		quarantinedBranchIdentities.add(name);
+		openBranchIdentities.delete(name);
+	}
+}
+
+/**
  * True when `dbPath` is a directory an open branch owns. The database scan opens any directory that
  * holds CURRENT + MANIFEST-*, and harper#643 places a branch inside the directory it walks, so
  * without this a rescan would rebuild the branch's tables into the global map, overwrite the store
@@ -1445,7 +1461,10 @@ export function reserveBranchIdentity(storeName: string): void {
  * the database scan, which at that exact moment would find the branch directory unowned.
  */
 export function retakeBranchIdentity(storeName: string): void {
-	for (const name of branchIdentityPair(storeName)) openBranchIdentities.add(name);
+	for (const name of branchIdentityPair(storeName)) {
+		openBranchIdentities.add(name);
+		quarantinedBranchIdentities.delete(name);
+	}
 }
 
 export function releaseBranchIdentity(storeName: string): void {
@@ -1454,7 +1473,7 @@ export function releaseBranchIdentity(storeName: string): void {
 
 /** Is this name spoken for by a branch? Database creation has to refuse it -- they share a blob root. */
 export function isBranchIdentity(name: string): boolean {
-	if (openBranchIdentities.has(name)) return true;
+	if (openBranchIdentities.has(name) || quarantinedBranchIdentities.has(name)) return true;
 	// The in-memory set covers only branches open in THIS process, so after a restart -- or for an
 	// application that is simply not loaded -- a database could take the name of an on-disk branch and
 	// share its blob root. The staging sibling goes through the same route, because it names the path

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1352,6 +1352,18 @@ const openBranches = new Map<string, BranchDatabase | undefined>();
 const openBranchIdentities = new Set<string>();
 
 /**
+ * Materialization renames its clone in from `<blobRoot>.staging`, so a branch owns two database
+ * names rather than one: a database legally called `<storeName>.staging` resolves its own blob root
+ * to exactly the path the clone removes and renames over. Every check, reservation and release
+ * covers the pair, so the name cannot be claimed at any point where a branch operation may still
+ * delete what it resolves to.
+ */
+const BRANCH_STAGING_SUFFIX = '.staging';
+function branchIdentityPair(storeName: string): string[] {
+	return [storeName, storeName + BRANCH_STAGING_SUFFIX];
+}
+
+/**
  * True when `dbPath` is a directory an open branch owns. The database scan opens any directory that
  * holds CURRENT + MANIFEST-*, and harper#643 places a branch inside the directory it walks, so
  * without this a rescan would rebuild the branch's tables into the global map, overwrite the store
@@ -1430,7 +1442,7 @@ export function assertBranchIdentityAvailable(storeName: string): void {
 	// The on-disk scan, not just the in-memory maps: a database that exists on disk but has not been
 	// loaded is absent from both, and it owns the blob root this identity would destroy.
 	getDatabases();
-	for (const name of [storeName, `${storeName}.staging`]) {
+	for (const name of branchIdentityPair(storeName)) {
 		// The directory as well as the maps. `getDatabases` skips a database blocked by restore, so an
 		// in-memory check alone reports its name as free while its blob root is very much real -- and
 		// materialization would then remove and replace it.
@@ -1452,11 +1464,21 @@ export function assertBranchIdentityAvailable(storeName: string): void {
  */
 export function reserveBranchIdentity(storeName: string): void {
 	assertBranchIdentityAvailable(storeName);
-	openBranchIdentities.add(storeName);
+	retakeBranchIdentity(storeName);
+}
+
+/**
+ * Take the pair back for an operation that owned it a statement ago -- cleanup, which has to keep
+ * holding the names through the deletions its `close()` just released them for. Deliberately without
+ * the availability check: nothing can have taken a name the caller held until now, and the check runs
+ * the database scan, which at that exact moment would find the branch directory unowned.
+ */
+export function retakeBranchIdentity(storeName: string): void {
+	for (const name of branchIdentityPair(storeName)) openBranchIdentities.add(name);
 }
 
 export function releaseBranchIdentity(storeName: string): void {
-	openBranchIdentities.delete(storeName);
+	for (const name of branchIdentityPair(storeName)) openBranchIdentities.delete(name);
 }
 
 /** Is this name spoken for by a branch? Database creation has to refuse it -- they share a blob root. */
@@ -1464,18 +1486,20 @@ export function isBranchIdentity(name: string): boolean {
 	if (openBranchIdentities.has(name)) return true;
 	// The in-memory set covers only branches open in THIS process, so after a restart -- or for an
 	// application that is simply not loaded -- a database could take the name of an on-disk branch and
-	// share its blob root. The identity carries the application name's length precisely so it can be
-	// taken apart again without guessing where the name ends.
-	const prefix = /^(\d+)_/.exec(name);
+	// share its blob root. The staging sibling goes through the same route, because it names the path
+	// materialization renames over. The identity carries the application name's length precisely so it
+	// can be taken apart again without guessing where the name ends.
+	const storeName = name.endsWith(BRANCH_STAGING_SUFFIX) ? name.slice(0, -BRANCH_STAGING_SUFFIX.length) : name;
+	const prefix = /^(\d+)_/.exec(storeName);
 	if (!prefix) return false;
 	const appLength = Number(prefix[1]);
-	const appName = name.slice(prefix[0].length, prefix[0].length + appLength);
+	const appName = storeName.slice(prefix[0].length, prefix[0].length + appLength);
 	if (
 		appName.length !== appLength ||
-		name.slice(prefix[0].length + appLength, prefix[0].length + appLength + 2) !== '__'
+		storeName.slice(prefix[0].length + appLength, prefix[0].length + appLength + 2) !== '__'
 	)
 		return false;
-	const baseName = name.slice(prefix[0].length + appLength + 2);
+	const baseName = storeName.slice(prefix[0].length + appLength + 2);
 	if (!baseName) return false;
 	try {
 		return existsSync(resolveBranchPath(baseName, appName));
@@ -1485,7 +1509,12 @@ export function isBranchIdentity(name: string): boolean {
 	}
 }
 
-export function openBranchDatabase(path: string, databaseName: string, storeName: string): BranchDatabase {
+export function openBranchDatabase(
+	path: string,
+	databaseName: string,
+	storeName: string,
+	blobRoots?: string[]
+): BranchDatabase {
 	assertLegalBranchName(databaseName, 'logical database name');
 	assertLegalBranchName(storeName, 'store identity');
 	if (!existsSync(path)) throw new Error(`Cannot open branch database: no directory at ${path}`);
@@ -1516,12 +1545,18 @@ export function openBranchDatabase(path: string, databaseName: string, storeName
 	// `rocksdbDatabaseEnvs` partway through, so anything re-entering `database()` during initStores
 	// would otherwise find the branch's store on an unowned path
 	openBranches.set(path, undefined);
-	openBranchIdentities.add(storeName);
+	retakeBranchIdentity(storeName);
 	try {
 		rootStore = readRocksMetaDb(path, null, databaseName, { destination: tables, storeName, openedStores });
+		// Pin the handle to the roots the caller proved this branch was published with, before it is
+		// handed out. A row's `storageIndex` is a position in that list, so resolving through current
+		// configuration instead would let an appended volume take writes at an index the branch's own
+		// completion marker never recorded -- and a later change at that index would then silently
+		// re-address them. `closeBranchHandles` clears the entry with the rest of the handle.
+		if (blobRoots) databasePaths.set(rootStore as unknown as RootDatabase, blobRoots);
 	} catch (error) {
 		openBranches.delete(path);
-		openBranchIdentities.delete(storeName);
+		releaseBranchIdentity(storeName);
 		const stranded = rocksdbDatabaseEnvs.get(path);
 		rocksdbDatabaseEnvs.delete(path);
 		closeBranchHandles(path, stranded, openedStores);
@@ -1538,7 +1573,7 @@ export function openBranchDatabase(path: string, databaseName: string, storeName
 			if (closed) return;
 			closed = true;
 			openBranches.delete(path);
-			openBranchIdentities.delete(storeName);
+			releaseBranchIdentity(storeName);
 			rocksdbDatabaseEnvs.delete(path);
 			closeBranchHandles(path, rootStore, openedStores);
 		},

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1406,9 +1406,9 @@ function assertLegalBranchName(name: string, description: string): void {
  * live base Table class — which is why schema operations through a branch are refused
  * (branchGuard.ts).
  *
- * A branch's blob roots start empty, so a row whose blob was written before the checkpoint reads
- * back as a missing file until harper#644 links the base's blob tree into them. Non-blob rows are
- * unaffected, for reads and writes alike.
+ * A branch's blob roots are a hard-link clone of the base's, taken with the checkpoint, so a row
+ * whose blob predates the branch reads back normally and the branch allocates new file ids in its own
+ * directory (harper#644).
  *
  * A branch is the checkpoint's SST content plus its own transaction-log tail. This function opens
  * only the stores; replaying the tail is `openOrCreate`'s job (branchDatabase.ts), where the
@@ -1416,6 +1416,46 @@ function assertLegalBranchName(name: string, description: string): void {
  * branch — the same recovery contract a base database gets at boot, without which a process that
  * died unflushed silently rewinds the branch to its last memtable flush (harper#643).
  */
+/**
+ * Refuse a branch store identity that something else already answers to.
+ *
+ * `storeName` picks the branch's blob roots, and blob file ids restart from each store's own counter,
+ * so two holders of one identity write the same file paths and truncate each other. It must be
+ * checked BEFORE anything destructive runs: materialization removes and replaces the blob root that
+ * this name resolves to, and a real database may legally be called `5_myapp__data` -- `schemaRegex`
+ * permits digits, `_` and `.`. The `.staging` sibling materialization writes is covered too, since a
+ * database may legally carry that name as well.
+ */
+export function assertBranchIdentityAvailable(storeName: string): void {
+	// The on-disk scan, not just the in-memory maps: a database that exists on disk but has not been
+	// loaded is absent from both, and it owns the blob root this identity would destroy.
+	getDatabases();
+	for (const name of [storeName, `${storeName}.staging`]) {
+		if (databases[name] || definedDatabases?.has(name) || openBranchIdentities.has(name)) {
+			throw new Error(`Cannot use '${storeName}' as a branch store identity: '${name}' is already in use`);
+		}
+	}
+}
+
+/**
+ * Claim the identity as well as checking it, so the window between the check and the branch actually
+ * opening cannot be filled by a concurrent create or a second branch. `releaseBranchIdentity` hands
+ * it back if materialization never gets as far as opening.
+ */
+export function reserveBranchIdentity(storeName: string): void {
+	assertBranchIdentityAvailable(storeName);
+	openBranchIdentities.add(storeName);
+}
+
+export function releaseBranchIdentity(storeName: string): void {
+	openBranchIdentities.delete(storeName);
+}
+
+/** Is this name spoken for by a branch? Database creation has to refuse it -- they share a blob root. */
+export function isBranchIdentity(name: string): boolean {
+	return openBranchIdentities.has(name);
+}
+
 export function openBranchDatabase(path: string, databaseName: string, storeName: string): BranchDatabase {
 	assertLegalBranchName(databaseName, 'logical database name');
 	assertLegalBranchName(storeName, 'store identity');
@@ -1432,11 +1472,7 @@ export function openBranchDatabase(path: string, databaseName: string, storeName
 	// a loaded database's store is closed by `closeLoadedDatabases`, so adopting it would mean this
 	// handle's `close()` tears down a live database
 	if (rocksdbDatabaseEnvs.has(path)) throw new Error(`Cannot branch ${path}: it is already open as a database`);
-	// `storeName` picks the blob roots, and blob file ids restart from each store's own checkpointed
-	// counter, so two holders of one identity write the same file paths and truncate each other
-	if (databases[storeName] || definedDatabases?.has(storeName) || openBranchIdentities.has(storeName)) {
-		throw new Error(`Cannot use '${storeName}' as a branch store identity: it is already in use`);
-	}
+	assertBranchIdentityAvailable(storeName);
 
 	const tables: Tables = Object.create(null);
 	// initStores opens a table's column families well before `setTable` publishes it into `tables`,
@@ -2057,6 +2093,12 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 	// fix still loads (data stays accessible) and can be dropped to remediate.
 	if ((RESERVED_DATABASE_NAMES as readonly string[]).includes(databaseName)) {
 		throw new ClientError(`'${databaseName}' is a reserved name and cannot be used as a database name`);
+	}
+	// A branch resolves its blob root from its store identity, so a database created under that same
+	// name would share the root: two allocators minting the same file paths and truncating each other,
+	// and the branch's teardown removing the database's blobs.
+	if (isBranchIdentity(databaseName)) {
+		throw new ClientError(`'${databaseName}' is in use as a branch store identity and cannot be a database name`);
 	}
 	const rootStore = database({ database: databaseName, table: tableName });
 	const tables = databases[databaseName];

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1432,20 +1432,31 @@ export function assertBranchIdentityAvailable(storeName: string): void {
 	for (const name of branchIdentityPair(storeName)) {
 		// The directory as well as the maps. `getDatabases` skips a database blocked by restore, so an
 		// in-memory check alone reports its name as free while its blob root is very much real -- and
-		// materialization would then remove and replace it. The `.staging` half also asks whether a
-		// BRANCH owns it: `<storeName>.staging` is a legal identity for a branch of a database named
-		// `<base>.staging`, whose live blob root is the path this clone renames over. The primary half
-		// cannot ask, because the branch being opened owns that directory itself.
+		// materialization would then remove and replace it.
 		if (
 			databases[name] ||
 			definedDatabases?.has(name) ||
 			openBranchIdentities.has(name) ||
 			existsSync(resolveDatabasePath(name)) ||
-			(name !== storeName && branchDirectoryExistsFor(name))
+			anotherBranchOwns(name, storeName)
 		) {
 			throw new Error(`Cannot use '${storeName}' as a branch store identity: '${name}' is already in use`);
 		}
 	}
+}
+
+/**
+ * Does a branch OTHER than the one being opened already answer to this name on disk? `.staging` is
+ * what makes the question two-sided: `<identity>.staging` is both the path a clone renames over and
+ * a legal identity for a branch of a database literally named `<base>.staging`, so each of the pair
+ * can belong to somebody else. Only the primary name read as itself is excluded -- that directory is
+ * the very branch this call is opening.
+ */
+function anotherBranchOwns(name: string, storeName: string): boolean {
+	if (name !== storeName) return branchDirectoryExistsFor(name);
+	return name.endsWith(BRANCH_STAGING_SUFFIX)
+		? branchDirectoryExistsFor(name.slice(0, -BRANCH_STAGING_SUFFIX.length))
+		: false;
 }
 
 /**

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1432,12 +1432,16 @@ export function assertBranchIdentityAvailable(storeName: string): void {
 	for (const name of branchIdentityPair(storeName)) {
 		// The directory as well as the maps. `getDatabases` skips a database blocked by restore, so an
 		// in-memory check alone reports its name as free while its blob root is very much real -- and
-		// materialization would then remove and replace it.
+		// materialization would then remove and replace it. The `.staging` half also asks whether a
+		// BRANCH owns it: `<storeName>.staging` is a legal identity for a branch of a database named
+		// `<base>.staging`, whose live blob root is the path this clone renames over. The primary half
+		// cannot ask, because the branch being opened owns that directory itself.
 		if (
 			databases[name] ||
 			definedDatabases?.has(name) ||
 			openBranchIdentities.has(name) ||
-			existsSync(resolveDatabasePath(name))
+			existsSync(resolveDatabasePath(name)) ||
+			(name !== storeName && branchDirectoryExistsFor(name))
 		) {
 			throw new Error(`Cannot use '${storeName}' as a branch store identity: '${name}' is already in use`);
 		}

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1400,35 +1400,6 @@ function assertLegalBranchName(name: string, description: string): void {
 }
 
 /**
- * Open a RocksDB directory as a **scope-private** database: its Table classes are built into an
- * object the caller owns and nothing is registered in the global `databases` map, so no enumerator
- * of that map — analytics, `describe_all`, worker teardown, replication — can observe it.
- *
- * `databaseName` is the *logical* name the application knows (`data`), so its schema and code need
- * no changes. `storeName` is the branch's own identity and is what `getRootBlobPathsForDB` resolves
- * blob directories from, which is how a branch gets its own blob roots rather than writing into the
- * base's.
- *
- * The caller owns the returned handle; the only thing that closes it on the caller's behalf is
- * `closeBranchDatabases`, which `closeLoadedDatabases` runs at thread teardown so a branch left open
- * on an exiting worker does not leak its handles into the process-global RocksDB registry.
- *
- * NOT SAFE FOR SCHEMA MUTATION. A branch's Table classes carry the base's logical name, so a
- * `dropTable()` or equivalent through one resolves against the global schema and would delete the
- * live base Table class — which is why schema operations through a branch are refused
- * (branchGuard.ts).
- *
- * A branch's blob roots are a hard-link clone of the base's, taken with the checkpoint, so a row
- * whose blob predates the branch reads back normally and the branch allocates new file ids in its own
- * directory (harper#644).
- *
- * A branch is the checkpoint's SST content plus its own transaction-log tail. This function opens
- * only the stores; replaying the tail is `openOrCreate`'s job (branchDatabase.ts), where the
- * cross-thread claim elects exactly one replayer and awaits it before any thread may open the
- * branch — the same recovery contract a base database gets at boot, without which a process that
- * died unflushed silently rewinds the branch to its last memtable flush (harper#643).
- */
-/**
  * Refuse a branch store identity that something else already answers to.
  *
  * `storeName` picks the branch's blob roots, and blob file ids restart from each store's own counter,
@@ -1487,9 +1458,20 @@ export function isBranchIdentity(name: string): boolean {
 	// The in-memory set covers only branches open in THIS process, so after a restart -- or for an
 	// application that is simply not loaded -- a database could take the name of an on-disk branch and
 	// share its blob root. The staging sibling goes through the same route, because it names the path
-	// materialization renames over. The identity carries the application name's length precisely so it
-	// can be taken apart again without guessing where the name ends.
-	const storeName = name.endsWith(BRANCH_STAGING_SUFFIX) ? name.slice(0, -BRANCH_STAGING_SUFFIX.length) : name;
+	// materialization renames over -- but BOTH readings of a name ending in `.staging` have to be
+	// tried: `schemaRegex` permits `.`, so `4_myapp__data.staging` is either the sibling of a branch of
+	// `data` or a branch of a database actually called `data.staging`.
+	if (branchDirectoryExistsFor(name)) return true;
+	return name.endsWith(BRANCH_STAGING_SUFFIX)
+		? branchDirectoryExistsFor(name.slice(0, -BRANCH_STAGING_SUFFIX.length))
+		: false;
+}
+
+/**
+ * Is there a branch directory answering to this store identity? The identity carries the application
+ * name's length precisely so it can be taken apart again without guessing where the name ends.
+ */
+function branchDirectoryExistsFor(storeName: string): boolean {
 	const prefix = /^(\d+)_/.exec(storeName);
 	if (!prefix) return false;
 	const appLength = Number(prefix[1]);
@@ -1509,6 +1491,38 @@ export function isBranchIdentity(name: string): boolean {
 	}
 }
 
+/**
+ * Open a RocksDB directory as a **scope-private** database: its Table classes are built into an
+ * object the caller owns and nothing is registered in the global `databases` map, so no enumerator
+ * of that map — analytics, `describe_all`, worker teardown, replication — can observe it.
+ *
+ * `databaseName` is the *logical* name the application knows (`data`), so its schema and code need
+ * no changes. `storeName` is the branch's own identity and is what `getRootBlobPathsForDB` resolves
+ * blob directories from, which is how a branch gets its own blob roots rather than writing into the
+ * base's.
+ *
+ * The caller owns the returned handle; the only thing that closes it on the caller's behalf is
+ * `closeBranchDatabases`, which `closeLoadedDatabases` runs at thread teardown so a branch left open
+ * on an exiting worker does not leak its handles into the process-global RocksDB registry.
+ *
+ * NOT SAFE FOR SCHEMA MUTATION. A branch's Table classes carry the base's logical name, so a
+ * `dropTable()` or equivalent through one resolves against the global schema and would delete the
+ * live base Table class — which is why schema operations through a branch are refused
+ * (branchGuard.ts).
+ *
+ * A branch's blob roots are a hard-link clone of the base's, taken with the checkpoint, so a row
+ * whose blob predates the branch reads back normally and the branch allocates new file ids in its own
+ * directory (harper#644).
+ *
+ * A branch is the checkpoint's SST content plus its own transaction-log tail. This function opens
+ * only the stores; replaying the tail is `openOrCreate`'s job (branchDatabase.ts), where the
+ * cross-thread claim elects exactly one replayer and awaits it before any thread may open the
+ * branch — the same recovery contract a base database gets at boot, without which a process that
+ * died unflushed silently rewinds the branch to its last memtable flush (harper#643).
+ *
+ * Pass `blobRoots` to pin the handle to the roots the branch was published with; without it the
+ * store resolves them from current configuration, which is only right for a branch being created.
+ */
 export function openBranchDatabase(
 	path: string,
 	databaseName: string,

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1431,7 +1431,15 @@ export function assertBranchIdentityAvailable(storeName: string): void {
 	// loaded is absent from both, and it owns the blob root this identity would destroy.
 	getDatabases();
 	for (const name of [storeName, `${storeName}.staging`]) {
-		if (databases[name] || definedDatabases?.has(name) || openBranchIdentities.has(name)) {
+		// The directory as well as the maps. `getDatabases` skips a database blocked by restore, so an
+		// in-memory check alone reports its name as free while its blob root is very much real -- and
+		// materialization would then remove and replace it.
+		if (
+			databases[name] ||
+			definedDatabases?.has(name) ||
+			openBranchIdentities.has(name) ||
+			existsSync(resolveDatabasePath(name))
+		) {
 			throw new Error(`Cannot use '${storeName}' as a branch store identity: '${name}' is already in use`);
 		}
 	}
@@ -1453,7 +1461,28 @@ export function releaseBranchIdentity(storeName: string): void {
 
 /** Is this name spoken for by a branch? Database creation has to refuse it -- they share a blob root. */
 export function isBranchIdentity(name: string): boolean {
-	return openBranchIdentities.has(name);
+	if (openBranchIdentities.has(name)) return true;
+	// The in-memory set covers only branches open in THIS process, so after a restart -- or for an
+	// application that is simply not loaded -- a database could take the name of an on-disk branch and
+	// share its blob root. The identity carries the application name's length precisely so it can be
+	// taken apart again without guessing where the name ends.
+	const prefix = /^(\d+)_/.exec(name);
+	if (!prefix) return false;
+	const appLength = Number(prefix[1]);
+	const appName = name.slice(prefix[0].length, prefix[0].length + appLength);
+	if (
+		appName.length !== appLength ||
+		name.slice(prefix[0].length + appLength, prefix[0].length + appLength + 2) !== '__'
+	)
+		return false;
+	const baseName = name.slice(prefix[0].length + appLength + 2);
+	if (!baseName) return false;
+	try {
+		return existsSync(resolveBranchPath(baseName, appName));
+	} catch {
+		// Not a name a branch path could hold, so no branch owns it.
+		return false;
+	}
 }
 
 export function openBranchDatabase(path: string, databaseName: string, storeName: string): BranchDatabase {

--- a/unitTests/dataLayer/blobBackup.test.js
+++ b/unitTests/dataLayer/blobBackup.test.js
@@ -257,9 +257,8 @@ describe('blobBackup', function () {
 
 			const counts = await copyTree(rootA, join(tempDir, 'walked'), true, undefined, () => ticks++);
 
-			// Branch materialization holds a cross-thread claim for the whole walk, and every other
-			// thread's application load is waiting on it; without a tick per file a big enough base
-			// times all of them out while this is healthily copying.
+			// Branch materialization holds a cross-thread claim for the whole walk; without a tick per file
+			// a big enough base times every waiting thread out while this is healthily copying.
 			assert.strictEqual(ticks, 3, 'every file walked reports progress');
 			assert.strictEqual(counts.captured, 3);
 			assert.strictEqual(counts.copied, 0, 'a same-filesystem walk hard-links and copies nothing');

--- a/unitTests/dataLayer/blobBackup.test.js
+++ b/unitTests/dataLayer/blobBackup.test.js
@@ -8,6 +8,7 @@ const {
 	blobSnapshotDir,
 	blobsReadmeContent,
 	copyBlobRootsByIndex,
+	copyTree,
 	snapshotBlobs,
 	restoreBlobSnapshot,
 	deleteBlobSnapshot,
@@ -244,6 +245,24 @@ describe('blobBackup', function () {
 			await copyBlobRootsByIndex(destination, [rootA, rootB]);
 			assert.ok(!existsSync(join(destination, '0', '001/002/003')), 'a stale file from the previous copy is gone');
 			assert.strictEqual(blobBody(join(destination, '0', '001/002/009')), 'delta');
+		});
+	});
+
+	describe('copyTree', function () {
+		it('reports one unit of progress per file, so a caller inside a claim window can prove it is alive', async function () {
+			writeBlob(rootA, '001/002/003', 'alpha');
+			writeBlob(rootA, '001/002/004', 'beta');
+			writeBlob(rootA, '007/008/009', 'gamma');
+			let ticks = 0;
+
+			const counts = await copyTree(rootA, join(tempDir, 'walked'), true, undefined, () => ticks++);
+
+			// Branch materialization holds a cross-thread claim for the whole walk, and every other
+			// thread's application load is waiting on it; without a tick per file a big enough base
+			// times all of them out while this is healthily copying.
+			assert.strictEqual(ticks, 3, 'every file walked reports progress');
+			assert.strictEqual(counts.captured, 3);
+			assert.strictEqual(counts.copied, 0, 'a same-filesystem walk hard-links and copies nothing');
 		});
 	});
 

--- a/unitTests/resources/branchDatabase.test.js
+++ b/unitTests/resources/branchDatabase.test.js
@@ -25,12 +25,6 @@ function publishHandBuiltBranch(branchPath, appName, baseName) {
 	_writeFileSync(_join(branchPath, '.branch-complete'), JSON.stringify({ blobRoots }));
 }
 
-const { cpSync: _cpSync } = require('node:fs');
-/** Copy a directory tree, for on-disk states these tests have to construct by hand. */
-function cpSyncForTest(from, to) {
-	_cpSync(from, to, { recursive: true });
-}
-
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 const describeUnlessLmdb = isLMDB ? describe.skip : describe;
 const itUnlessLmdb = isLMDB ? it.skip : it;
@@ -916,5 +910,55 @@ describeUnlessLmdb('branch blob-root safety (harper#644)', () => {
 		// fallback to copyFile would double disk and make first load O(bytes) with nothing noticing.
 		assert.strictEqual(statSync(branchFile).ino, statSync(baseFile).ino, 'same inode');
 		assert.ok(statSync(branchFile).nlink >= 2, 'and more than one link to it');
+	});
+});
+
+describeUnlessLmdb('branch identity is unavailable across restarts and restores (harper#644)', () => {
+	const { mkdirSync, writeFileSync, rmSync } = require('node:fs');
+	const { join } = require('node:path');
+	const { isBranchIdentity, resolveDatabasePath } = require('#src/resources/databases');
+
+	before(function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		table({ table: 'Src', database: 'identbase', attributes: [{ name: 'id', isPrimaryKey: true }] });
+	});
+
+	afterEach(async function () {
+		await removeBranches();
+		rmSync(resolveBranchPath('identbase', 'identApp'), { recursive: true, force: true });
+	});
+
+	it('recognises a branch identity from the directory, not just from what this process has open', async function () {
+		this.timeout(30000);
+		const identity = `${'identApp'.length}_identApp__identbase`;
+		assert.strictEqual(isBranchIdentity(identity), false, 'sanity: nothing owns it yet');
+
+		await getOrCreateBranch('identbase', 'identApp');
+		await removeBranches(); // drops the in-memory set, as a restart would
+		mkdirSync(resolveBranchPath('identbase', 'identApp'), { recursive: true });
+
+		// The in-memory set only knows branches open in THIS process. After a restart -- or for an app
+		// that is simply not loaded -- a database could otherwise take this name and share the branch's
+		// blob root, which is silent corruption in both directions.
+		assert.strictEqual(isBranchIdentity(identity), true, 'the on-disk branch still owns its identity');
+	});
+
+	it('refuses an identity whose database exists on disk but is not loaded', async function () {
+		this.timeout(30000);
+		const { assertBranchIdentityAvailable } = require('#src/resources/databases');
+		const identity = `${'blockedApp'.length}_blockedApp__identbase`;
+
+		// `getDatabases()` skips a database blocked by restore, so it is absent from every in-memory
+		// map while its blob root is real -- and materialization would remove and replace that root.
+		// A directory standing in for exactly that: present on disk, absent from the maps.
+		const planted = resolveDatabasePath(identity);
+		mkdirSync(planted, { recursive: true });
+		writeFileSync(join(planted, 'CURRENT'), 'a database this process has not loaded\n');
+		try {
+			assert.throws(() => assertBranchIdentityAvailable(identity), /already in use/);
+		} finally {
+			rmSync(planted, { recursive: true, force: true });
+		}
 	});
 });

--- a/unitTests/resources/branchDatabase.test.js
+++ b/unitTests/resources/branchDatabase.test.js
@@ -1085,21 +1085,28 @@ describeUnlessLmdb('branch identity is unavailable across restarts and restores 
 		assert.strictEqual(isBranchIdentity(`${identity}.staging`), true, 'the sibling is spoken for as well');
 	});
 
-	it('refuses to materialize over the live blob root of a branch of a database named .staging', async function () {
+	it("refuses either branch whose staging path is the other branch's live blob root", async function () {
 		this.timeout(30000);
-		// `<identity>.staging` is the path the clone removes and renames over, and it is also the legal
-		// identity of a branch of a database called `identbase.staging`. That branch's root is live data.
+		// `<identity>.staging` is the path a clone removes and renames over, and it is also the legal
+		// identity of a branch of a database named `<base>.staging`. Whichever of the two is created
+		// second must be refused, or materializing it destroys the other's live blob root.
 		const { assertBranchIdentityAvailable } = require('#src/resources/databases');
-		const planted = resolveBranchPath('identbase.staging', 'identApp');
-		mkdirSync(planted, { recursive: true });
-		try {
-			assert.throws(
-				() => assertBranchIdentityAvailable(`${'identApp'.length}_identApp__identbase`),
-				/already in use/,
-				"the sibling path is another branch's blob root, not scratch space"
-			);
-		} finally {
-			rmSync(planted, { recursive: true, force: true });
+		const plain = `${'identApp'.length}_identApp__identbase`;
+		for (const [existing, refused] of [
+			['identbase.staging', plain],
+			['identbase', `${plain}.staging`],
+		]) {
+			const planted = resolveBranchPath(existing, 'identApp');
+			mkdirSync(planted, { recursive: true });
+			try {
+				assert.throws(
+					() => assertBranchIdentityAvailable(refused),
+					/already in use/,
+					`a branch of '${existing}' already answers to what '${refused}' would take`
+				);
+			} finally {
+				rmSync(planted, { recursive: true, force: true });
+			}
 		}
 	});
 

--- a/unitTests/resources/branchDatabase.test.js
+++ b/unitTests/resources/branchDatabase.test.js
@@ -1161,8 +1161,9 @@ describeUnlessLmdb('branch identity is unavailable across restarts and restores 
 	});
 });
 
-describeUnlessLmdb('appended blob volumes (harper#644)', () => {
-	const { mkdirSync, writeFileSync, rmSync, cpSync } = require('node:fs');
+describeUnlessLmdb('blob-volume configuration changes (harper#644)', () => {
+	const { mkdirSync, mkdtempSync, writeFileSync, rmSync, cpSync } = require('node:fs');
+	const { tmpdir } = require('node:os');
 	const { join } = require('node:path');
 	const { getBlobPathsForDatabaseName, createBlob, getFilePathForBlob } = require('#src/resources/blob');
 	const environment = require('#src/utility/environment/environmentManager');
@@ -1191,13 +1192,17 @@ describeUnlessLmdb('appended blob volumes (harper#644)', () => {
 	 * `removeBranches` is the only exported release and it deletes, so what is on disk is set aside
 	 * and put back around it.
 	 */
-	async function reloadFromDisk(branchPath, blobRoots) {
-		const aside = [branchPath, ...blobRoots].map((path) => [path, `${path}.savedforTest`]);
-		for (const [live, saved] of aside) cpSync(live, saved, { recursive: true });
-		await removeBranches();
-		for (const [live, saved] of aside) {
-			cpSync(saved, live, { recursive: true });
-			rmSync(saved, { recursive: true, force: true });
+	async function reloadFromDisk(branch, branchPath, blobRoots) {
+		const backupRoot = mkdtempSync(join(tmpdir(), 'harper.branch-reload-'));
+		const aside = [branchPath, ...blobRoots].map((path, index) => [path, join(backupRoot, String(index))]);
+		try {
+			await branch.rootStore.createCheckpoint(aside[0][1]);
+			cpSync(join(branchPath, '.branch-complete'), join(aside[0][1], '.branch-complete'));
+			for (const [live, saved] of aside.slice(1)) cpSync(live, saved, { recursive: true });
+			await removeBranches();
+			for (const [live, saved] of aside) cpSync(saved, live, { recursive: true });
+		} finally {
+			rmSync(backupRoot, { recursive: true, force: true });
 		}
 	}
 
@@ -1221,6 +1226,18 @@ describeUnlessLmdb('appended blob volumes (harper#644)', () => {
 			});
 		}
 		await databases.volbase.Vol.put({ id: 'seed', payload: await createBlob(PAYLOAD) });
+
+		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume, secondVolume]);
+		table({
+			table: 'Vol',
+			database: 'volbaseShrink',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'payload', type: 'Blob' },
+			],
+		});
+		await databases.volbaseShrink.Vol.put({ id: 'seed', payload: await createBlob(PAYLOAD) });
+		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume]);
 	});
 
 	beforeEach(function () {
@@ -1232,7 +1249,7 @@ describeUnlessLmdb('appended blob volumes (harper#644)', () => {
 		await removeBranches();
 		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume]);
 		for (const appName of ['volApp']) {
-			for (const baseName of ['volbase', 'volbase2']) {
+			for (const baseName of ['volbase', 'volbase2', 'volbaseShrink']) {
 				rmSync(resolveBranchPath(baseName, appName), { recursive: true, force: true });
 				for (const volume of [firstVolume, secondVolume]) {
 					rmSync(join(volume, `${appName.length}_${appName}__${baseName}`), { recursive: true, force: true });
@@ -1251,7 +1268,7 @@ describeUnlessLmdb('appended blob volumes (harper#644)', () => {
 		assert.ok(await created.tables.Vol.get('seed'), 'sanity: the branch carries the base row');
 		const branchPath = resolveBranchPath('volbase', 'volApp');
 		const recorded = getBlobPathsForDatabaseName(STORE);
-		await reloadFromDisk(branchPath, recorded);
+		await reloadFromDisk(created, branchPath, recorded);
 
 		// Every recorded root keeps its index, so every `storageIndex` a row already holds still means
 		// what it meant. Refusing the branch here would take an application offline for a configuration
@@ -1273,12 +1290,10 @@ describeUnlessLmdb('appended blob volumes (harper#644)', () => {
 
 	it('pins a branch adopted on the waiter path, not only one this thread published', async function () {
 		this.timeout(30000);
-		await getOrCreateBranch('volbase', 'volApp');
 		const recorded = getBlobPathsForDatabaseName(STORE);
 
-		// A failed application load releases its handles without resetting the claim word, which is the
-		// state every thread that did not win the claim sees: the branch is READY and this thread has
-		// never read it. Plant a complete-looking branch that is not a database to make the load fail.
+		// A failed application load closes every handle it opened but leaves a successfully-published
+		// branch's claim READY. The next call has no cached handle and must take the waiter/adopter path.
 		const failing = resolveBranchPath('volbase2', 'volApp');
 		mkdirSync(failing, { recursive: true });
 		writeFileSync(join(failing, 'CURRENT'), 'not a database');
@@ -1338,12 +1353,23 @@ describeUnlessLmdb('appended blob volumes (harper#644)', () => {
 		await assert.rejects(() => getOrCreateBranch('volbase', 'volApp'), /nowhere of its own to keep blobs/);
 	});
 
+	it('refuses to publish a branch after the open base loses a configured blob volume', async function () {
+		this.timeout(30000);
+		const branchPath = resolveBranchPath('volbaseShrink', 'volApp');
+
+		await assert.rejects(
+			() => getOrCreateBranch('volbaseShrink', 'volApp'),
+			/open base resolves through 2 blob root\(s\), but storage\.blobPaths now provides 1/
+		);
+		assert.strictEqual(existsSync(branchPath), false, 'an incomplete branch must not be published');
+	});
+
 	it('still refuses a branch whose recorded roots were dropped from the configuration', async function () {
 		this.timeout(30000);
 		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume, secondVolume]);
-		await getOrCreateBranch('volbase', 'volApp');
+		const created = await getOrCreateBranch('volbase', 'volApp');
 		const branchPath = resolveBranchPath('volbase', 'volApp');
-		await reloadFromDisk(branchPath, getBlobPathsForDatabaseName(STORE));
+		await reloadFromDisk(created, branchPath, getBlobPathsForDatabaseName(STORE));
 
 		// Growth is compatible because it moves no index; shrinking removes root 1 outright, and every
 		// row whose `storageIndex` is 1 would resolve through nothing.
@@ -1354,9 +1380,9 @@ describeUnlessLmdb('appended blob volumes (harper#644)', () => {
 	it('still refuses a branch whose recorded roots were reordered', async function () {
 		this.timeout(30000);
 		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume, secondVolume]);
-		await getOrCreateBranch('volbase', 'volApp');
+		const created = await getOrCreateBranch('volbase', 'volApp');
 		const branchPath = resolveBranchPath('volbase', 'volApp');
-		await reloadFromDisk(branchPath, getBlobPathsForDatabaseName(STORE));
+		await reloadFromDisk(created, branchPath, getBlobPathsForDatabaseName(STORE));
 
 		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [secondVolume, firstVolume]);
 		await assert.rejects(() => getOrCreateBranch('volbase', 'volApp'), /no longer match the configured/);

--- a/unitTests/resources/branchDatabase.test.js
+++ b/unitTests/resources/branchDatabase.test.js
@@ -10,6 +10,27 @@ const { getOrCreateBranch, removeBranches } = require('#src/resources/branchData
 const { replayLogs } = require('#src/resources/replayLogs');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 
+const { writeFileSync: _writeFileSync, mkdirSync: _mkdirSync } = require('node:fs');
+const { join: _join } = require('node:path');
+const { getBlobPathsForDatabaseName: _blobRoots } = require('#src/resources/blob');
+
+/**
+ * Finish a branch that a test built by hand so it reads as one materialization published: the
+ * completion marker naming the blob roots, and those roots present. Without it such a branch is
+ * (correctly) refused as a real store carrying no marker.
+ */
+function publishHandBuiltBranch(branchPath, appName, baseName) {
+	const blobRoots = _blobRoots(`${appName.length}_${appName}__${baseName}`);
+	for (const root of blobRoots) _mkdirSync(root, { recursive: true });
+	_writeFileSync(_join(branchPath, '.branch-complete'), JSON.stringify({ blobRoots }));
+}
+
+const { cpSync: _cpSync } = require('node:fs');
+/** Copy a directory tree, for on-disk states these tests have to construct by hand. */
+function cpSyncForTest(from, to) {
+	_cpSync(from, to, { recursive: true });
+}
+
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 const describeUnlessLmdb = isLMDB ? describe.skip : describe;
 const itUnlessLmdb = isLMDB ? it.skip : it;
@@ -174,6 +195,7 @@ describeUnlessLmdb('branch lifecycle (harper#643)', () => {
 		await mkdir(join(branchPath, '..'), { recursive: true });
 		await database({ database: 'lifebase', table: undefined }).createCheckpoint(staging);
 		await rename(staging, branchPath);
+		publishHandBuiltBranch(branchPath, 'appAdopt', 'lifebase');
 
 		// Hold the branch store's replay lock from a second handle on the same directory (handles on
 		// one path share the native store, and the lock table lives on it): the elected replay must
@@ -396,7 +418,7 @@ describe('scoped databases binding (harper#643)', () => {
 
 describeUnlessLmdb('branch rollback is scoped to the failing application (harper#643)', () => {
 	const { mkdirSync, writeFileSync, rmSync } = require('node:fs');
-	const { dirname } = require('node:path');
+	const { dirname, join } = require('node:path');
 	let prepareBranches;
 
 	// An occupied branch directory no longer injects a fault: a directory that is already there is a
@@ -413,8 +435,11 @@ describeUnlessLmdb('branch rollback is scoped to the failing application (harper
 	/** Fail while opening — the branch path itself is adopted, then turns out not to be a database. */
 	function failBranchOpen(baseName, appName) {
 		const path = resolveBranchPath(baseName, appName);
-		mkdirSync(dirname(path), { recursive: true });
-		writeFileSync(path, 'not a database');
+		mkdirSync(path, { recursive: true });
+		// Has to read as a COMPLETE branch, or adoption treats it as leftovers and rebuilds from the base
+		// instead of failing: a marker naming roots that exist, over something that is not a database.
+		writeFileSync(join(path, 'CURRENT'), 'not a database');
+		publishHandBuiltBranch(path, appName, baseName);
 		return path;
 	}
 
@@ -687,3 +712,209 @@ describeUnlessLmdb(
 		});
 	}
 );
+
+describeUnlessLmdb('blobs in a branch (harper#644)', () => {
+	const { createBlob, getFilePathForBlob, getBlobPathsForDatabaseName } = require('#src/resources/blob');
+	// Comfortably above any inline threshold, and compressible content would be fine too -- only the
+	// size decides whether this lands in the blob tree.
+	const PAYLOAD = Buffer.alloc(64 * 1024, 'base blob contents ');
+	const BRANCH_STORE = `${'blobApp'.length}_blobApp__blobbase`;
+	let BlobSource;
+
+	function assertFileBacked(blob, what) {
+		assert.ok(getFilePathForBlob(blob), `${what} must be a file-backed blob for this suite to test anything`);
+	}
+
+	before(async function () {
+		this.timeout(30000);
+		setupTestDBPath();
+		setMainIsWorker(true);
+		BlobSource = table({
+			table: 'BlobSource',
+			database: 'blobbase',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'payload', type: 'Blob' },
+			],
+		});
+		// Written to the base BEFORE any branch exists, so a branch's checkpointed record references a
+		// blob file the base already owns -- the case that is broken without the clone.
+		await BlobSource.put({ id: 'from-base', payload: await createBlob(PAYLOAD) });
+		assertFileBacked((await databases.blobbase.BlobSource.get('from-base')).payload, "the base's blob");
+	});
+
+	afterEach(async function () {
+		await removeBranches();
+	});
+
+	it('serves a blob the base wrote before the branch was taken', async function () {
+		this.timeout(30000);
+		const branch = await getOrCreateBranch('blobbase', 'blobApp');
+
+		const record = await branch.tables.BlobSource.get('from-base');
+		assert.ok(record, 'the branch has the row');
+		assertFileBacked(record.payload, "the branch's view of the blob");
+		// The branch resolves blob ids under its OWN root, so without the clone this file is not there.
+		assert.ok(existsSync(getFilePathForBlob(record.payload)), 'the branch has its own copy of the file');
+		assert.ok(PAYLOAD.equals(Buffer.from(await record.payload.bytes())), 'and it reads back byte-identical');
+	});
+
+	it("writes its own blobs into its own root, leaving the base's bytes alone", async function () {
+		this.timeout(30000);
+		const branch = await getOrCreateBranch('blobbase', 'blobApp');
+		const replacement = Buffer.alloc(64 * 1024, 'branch wrote this ');
+
+		await branch.tables.BlobSource.put({ id: 'from-base', payload: await createBlob(replacement) });
+		const throughBranch = await branch.tables.BlobSource.get('from-base');
+		assert.ok(replacement.equals(Buffer.from(await throughBranch.payload.bytes())));
+
+		const base = await databases.blobbase.BlobSource.get('from-base');
+		assert.ok(PAYLOAD.equals(Buffer.from(await base.payload.bytes())), "the base's blob is untouched");
+	});
+
+	it('removes its blob root when the branch is removed', async function () {
+		this.timeout(30000);
+		await getOrCreateBranch('blobbase', 'blobApp');
+		const [branchBlobRoot] = getBlobPathsForDatabaseName(BRANCH_STORE);
+		assert.ok(existsSync(branchBlobRoot), `expected a branch blob root at ${branchBlobRoot}`);
+
+		await removeBranches();
+
+		// The blob root lives outside the branch directory, so removing only the directory would strand
+		// it -- and being hard links, the bytes would survive the base deleting its own copies.
+		assert.strictEqual(existsSync(branchBlobRoot), false, 'the branch takes its blob root with it');
+		assert.ok(existsSync(getBlobPathsForDatabaseName('blobbase')[0]), "the base's blob root stays");
+	});
+});
+
+describeUnlessLmdb('branch blob-root safety (harper#644)', () => {
+	const { mkdirSync, writeFileSync, rmSync, statSync, cpSync } = require('node:fs');
+	const { join } = require('node:path');
+	const { getBlobPathsForDatabaseName, createBlob, getFilePathForBlob } = require('#src/resources/blob');
+	const STORE = `${'safeApp'.length}_safeApp__safebase`;
+
+	before(async function () {
+		this.timeout(30000);
+		setupTestDBPath();
+		setMainIsWorker(true);
+		table({
+			table: 'Safe',
+			database: 'safebase',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'payload', type: 'Blob' },
+			],
+		});
+		await databases.safebase.Safe.put({ id: 'seed', payload: await createBlob(Buffer.alloc(64 * 1024, 'x')) });
+	});
+
+	afterEach(async function () {
+		await removeBranches();
+		// A refused branch never entered the handle cache, so `removeBranches` cannot reach it; left in
+		// place it would fail every later test in this suite the same way.
+		rmSync(resolveBranchPath('safebase', 'safeApp'), { recursive: true, force: true });
+		for (const root of getBlobPathsForDatabaseName(STORE)) rmSync(root, { recursive: true, force: true });
+	});
+
+	it('refuses an identity a real database already answers to, before removing anything', async function () {
+		this.timeout(30000);
+		// A branch's blob root is `<blobs>/<identity>` and materialization REMOVES and replaces it, so a
+		// database legally named like the identity would have its blob root deleted. schemaRegex permits
+		// digits, `_` and `.`, so this name is reachable. Its own app name, because registering the
+		// database claims that identity for the rest of the process.
+		const clashStore = `${'clashApp'.length}_clashApp__safebase`;
+		table({ table: 'Victim', database: clashStore, attributes: [{ name: 'id', isPrimaryKey: true }] });
+		const victimRoot = getBlobPathsForDatabaseName(clashStore)[0];
+		mkdirSync(victimRoot, { recursive: true });
+		writeFileSync(join(victimRoot, 'precious'), 'the victim database owns this');
+
+		await assert.rejects(() => getOrCreateBranch('safebase', 'clashApp'), /already in use/);
+
+		assert.ok(existsSync(join(victimRoot, 'precious')), "the real database's blob root must survive");
+	});
+
+	it('refuses to serve or rebuild a branch that lost a blob root, rather than silently re-forking', async function () {
+		this.timeout(30000);
+		await getOrCreateBranch('safebase', 'safeApp');
+		const branchPath = resolveBranchPath('safebase', 'safeApp');
+
+		// Keep a real, complete branch aside, tear the live one down so nothing is cached, then put back
+		// the directory WITHOUT its blob roots. That is the state a power loss can leave, since the
+		// directory and the roots live on different volumes and neither rename is fsynced.
+		const saved = `${branchPath}.savedforTest`;
+		cpSync(branchPath, saved, { recursive: true });
+		await removeBranches();
+		cpSync(saved, branchPath, { recursive: true });
+		rmSync(saved, { recursive: true, force: true });
+		assert.ok(
+			getBlobPathsForDatabaseName(STORE).every((root) => !existsSync(root)),
+			'sanity: directory present, blob roots gone'
+		);
+
+		// Rebuilding here would re-fork from the base and silently discard everything written to the
+		// branch since it was created; a branch that was once complete may hold data that exists nowhere
+		// else. Refusing leaves it intact and puts the decision in front of an operator.
+		await assert.rejects(() => getOrCreateBranch('safebase', 'safeApp'), /cannot be trusted/);
+		assert.ok(existsSync(branchPath), 'and it does not delete what it refused to serve');
+
+		rmSync(branchPath, { recursive: true, force: true });
+	});
+
+	it('clears leftovers that are not a store and rebuilds, where there is nothing to lose', async function () {
+		this.timeout(30000);
+		const branchPath = resolveBranchPath('safebase', 'safeApp');
+		// No completion marker AND no CURRENT: not a database, so nothing was ever written here and
+		// clearing it is safe. This is the only shape that may be deleted.
+		mkdirSync(branchPath, { recursive: true });
+		writeFileSync(join(branchPath, 'stray'), 'leftovers that are not a store');
+
+		const branch = await getOrCreateBranch('safebase', 'safeApp');
+		assert.ok(await branch.tables.Safe.get('seed'), 'rebuilt from the base');
+		assert.ok(getBlobPathsForDatabaseName(STORE).every((root) => existsSync(root)));
+	});
+
+	it('refuses, never deletes, a real store that carries no completion marker', async function () {
+		this.timeout(30000);
+		// Exactly the shape every branch created before the marker existed has, and the shape a branch
+		// whose marker was lost to operator cleanup or an unsynced write has. Materialization cannot
+		// produce it -- it publishes by renaming a staging directory that already holds the marker -- so
+		// anything marker-less that IS a store came from elsewhere and is carrying data.
+		const branchPath = resolveBranchPath('safebase', 'safeApp');
+		mkdirSync(branchPath, { recursive: true });
+		writeFileSync(join(branchPath, 'CURRENT'), 'MANIFEST-000001\n');
+
+		await assert.rejects(() => getOrCreateBranch('safebase', 'safeApp'), /cannot be trusted/);
+		assert.ok(existsSync(join(branchPath, 'CURRENT')), 'the store must still be there, not re-forked away');
+	});
+
+	it('refuses a branch whose recorded blob roots no longer match the configuration', async function () {
+		this.timeout(30000);
+		await getOrCreateBranch('safebase', 'safeApp');
+		const branchPath = resolveBranchPath('safebase', 'safeApp');
+		const saved = `${branchPath}.savedforTest`;
+		cpSync(branchPath, saved, { recursive: true });
+		await removeBranches();
+		cpSync(saved, branchPath, { recursive: true });
+		rmSync(saved, { recursive: true, force: true });
+
+		// `storageIndex` on a row is a position in this list, so a reordered or resized blobPaths would
+		// resolve rows through the wrong root. The marker records what was published, which is exactly
+		// what makes that detectable.
+		writeFileSync(join(branchPath, '.branch-complete'), JSON.stringify({ blobRoots: ['/nowhere/at/all'] }));
+
+		await assert.rejects(() => getOrCreateBranch('safebase', 'safeApp'), /no longer match the configured/);
+	});
+
+	it('hard-links rather than copies, so the clone costs no extra bytes', async function () {
+		this.timeout(30000);
+		const branch = await getOrCreateBranch('safebase', 'safeApp');
+
+		const baseFile = getFilePathForBlob((await databases.safebase.Safe.get('seed')).payload);
+		const branchFile = getFilePathForBlob((await branch.tables.Safe.get('seed')).payload);
+		assert.notStrictEqual(baseFile, branchFile, 'the branch resolves its own path');
+		// The whole design rests on this: same inode, so the OS refcount IS the reference count. A silent
+		// fallback to copyFile would double disk and make first load O(bytes) with nothing noticing.
+		assert.strictEqual(statSync(branchFile).ino, statSync(baseFile).ino, 'same inode');
+		assert.ok(statSync(branchFile).nlink >= 2, 'and more than one link to it');
+	});
+});

--- a/unitTests/resources/branchDatabase.test.js
+++ b/unitTests/resources/branchDatabase.test.js
@@ -782,8 +782,8 @@ describeUnlessLmdb('blobs in a branch (harper#644)', () => {
 });
 
 describeUnlessLmdb('branch blob-root safety (harper#644)', () => {
-	const { mkdirSync, writeFileSync, readFileSync, rmSync, statSync, cpSync } = require('node:fs');
-	const { join } = require('node:path');
+	const { chmodSync, mkdirSync, writeFileSync, readFileSync, rmSync, statSync, cpSync } = require('node:fs');
+	const { dirname, join } = require('node:path');
 	const { getBlobPathsForDatabaseName, createBlob, getFilePathForBlob } = require('#src/resources/blob');
 	const STORE = `${'safeApp'.length}_safeApp__safebase`;
 
@@ -883,13 +883,10 @@ describeUnlessLmdb('branch blob-root safety (harper#644)', () => {
 
 	it("substitutes a marker, in the branch's own words, for a base blob that was mid-write", async function () {
 		this.timeout(30000);
-		// The hard link would otherwise carry a truncated blob into the branch -- and worse, the abort
-		// that follows stamps PENDING onto that inode IN PLACE, through the branch's link as well. This
-		// is what the clone passes its own `CaptureMarkerReasons` for: the branch must not describe
-		// itself as a backup when it explains the substitution.
+		// Linking it would carry a truncated blob in, and the abort that follows stamps PENDING onto that
+		// inode in place -- through the branch's link too, since it is the same inode.
 		const [baseRoot] = getBlobPathsForDatabaseName('safebase');
-		// An uncompressed header promising 100 bytes over a file holding 10: the shape of a write that
-		// has stamped its size but not landed its body.
+		// An uncompressed header promising 100 bytes over a file holding 10.
 		const header = Buffer.alloc(8);
 		header.writeUInt16BE(0, 0);
 		header.writeUIntBE(100, 2, 6);
@@ -906,11 +903,22 @@ describeUnlessLmdb('branch blob-root safety (harper#644)', () => {
 		}
 	});
 
+	it('clears a directory holding nothing but a malformed completion marker, and rebuilds', async function () {
+		this.timeout(30000);
+		// Refusing is only right where there is data to lose; a directory holding nothing but marker
+		// garbage has none, so it must stay clearable rather than needing an operator.
+		const branchPath = resolveBranchPath('safebase', 'safeApp');
+		mkdirSync(branchPath, { recursive: true });
+		writeFileSync(join(branchPath, '.branch-complete'), JSON.stringify({ blobRoots: [] }));
+
+		const branch = await getOrCreateBranch('safebase', 'safeApp');
+		assert.ok(await branch.tables.Safe.get('seed'), 'rebuilt from the base');
+	});
+
 	it('refuses a completion marker that records no blob roots at all', async function () {
 		this.timeout(30000);
 		// An empty list is an exact prefix of anything, so without its own guard it reads as complete and
-		// pins the branch to no roots — the first blob write would then fail on an undefined path rather
-		// than here, where the branch can say what is wrong with it.
+		// the first blob write fails on an undefined path instead of here.
 		const branchPath = resolveBranchPath('safebase', 'safeApp');
 		mkdirSync(branchPath, { recursive: true });
 		writeFileSync(join(branchPath, 'CURRENT'), 'MANIFEST-000001\n');
@@ -966,6 +974,34 @@ describeUnlessLmdb('branch blob-root safety (harper#644)', () => {
 				}),
 			/branch store identity/
 		);
+	});
+
+	it('refuses a stranded identity to databases, while letting the branch itself take it back', async function () {
+		this.timeout(30000);
+		// Removal needs write permission on the containing directory, so a read-only volume is a real
+		// filesystem refusal rather than a stubbed one.
+		if (process.platform === 'win32' || process.getuid?.() === 0) return this.skip();
+		await getOrCreateBranch('safebase', 'safeApp');
+		const [root] = getBlobPathsForDatabaseName(STORE);
+		const volume = dirname(root);
+
+		chmodSync(volume, 0o500);
+		try {
+			await removeBranches();
+			assert.ok(existsSync(root), 'sanity: the blob root outlived the branch directory');
+			assert.throws(
+				() => table({ table: 'Squatter', database: STORE, attributes: [{ name: 'id', isPrimaryKey: true }] }),
+				/branch store identity/,
+				'a database under that name would mint its own file ids onto the files left behind'
+			);
+		} finally {
+			chmodSync(volume, 0o700);
+		}
+
+		// Materializing replaces those roots wholesale, so the branch is the one holder that may take the
+		// name back; otherwise one transient EBUSY makes the application unloadable for the process life.
+		const rebuilt = await getOrCreateBranch('safebase', 'safeApp');
+		assert.ok(await rebuilt.tables.Safe.get('seed'), 'the application loads again');
 	});
 
 	it('keeps the identity reserved until the blob roots are gone, not just the directory', async function () {
@@ -1252,6 +1288,15 @@ describeUnlessLmdb('appended blob volumes (harper#644)', () => {
 		assert.ok(existsSync(join(stranger, 'precious')), 'the reordered configuration is not what it owns');
 	});
 
+	it('refuses to publish a branch when no blob volume is configured at all', async function () {
+		this.timeout(30000);
+		// The marker it would otherwise write records no roots, which no later load can accept: the branch
+		// would be bricked on every boot after this one.
+		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, []);
+
+		await assert.rejects(() => getOrCreateBranch('volbase', 'volApp'), /nowhere of its own to keep blobs/);
+	});
+
 	it('still refuses a branch whose recorded roots were dropped from the configuration', async function () {
 		this.timeout(30000);
 		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume, secondVolume]);
@@ -1278,10 +1323,8 @@ describeUnlessLmdb('appended blob volumes (harper#644)', () => {
 });
 
 describe('the claim budget follows the winner (harper#644)', () => {
-	// The winner holds the claim for a checkpoint AND a hard-link clone of the base's whole blob tree,
-	// so the budget every other thread waits on cannot be a constant: on a large enough base it expires
-	// while the winner is healthily copying. Driven directly because within one isolate `branchesByPath`
-	// dedupes callers, so nothing in-process ever takes the waiting side of this protocol.
+	// Driven directly: within one isolate `branchesByPath` dedupes callers, so nothing in-process ever
+	// takes the waiting side of this protocol.
 	const { claimDeadlineFor, reportClaimProgress } = require('#src/resources/branchDatabase');
 
 	it('restarts the budget when the winner reports progress, and runs it down when it does not', async function () {

--- a/unitTests/resources/branchDatabase.test.js
+++ b/unitTests/resources/branchDatabase.test.js
@@ -782,7 +782,7 @@ describeUnlessLmdb('blobs in a branch (harper#644)', () => {
 });
 
 describeUnlessLmdb('branch blob-root safety (harper#644)', () => {
-	const { mkdirSync, writeFileSync, rmSync, statSync, cpSync } = require('node:fs');
+	const { mkdirSync, writeFileSync, readFileSync, rmSync, statSync, cpSync } = require('node:fs');
 	const { join } = require('node:path');
 	const { getBlobPathsForDatabaseName, createBlob, getFilePathForBlob } = require('#src/resources/blob');
 	const STORE = `${'safeApp'.length}_safeApp__safebase`;
@@ -881,6 +881,44 @@ describeUnlessLmdb('branch blob-root safety (harper#644)', () => {
 		assert.ok(existsSync(join(branchPath, 'CURRENT')), 'the store must still be there, not re-forked away');
 	});
 
+	it("substitutes a marker, in the branch's own words, for a base blob that was mid-write", async function () {
+		this.timeout(30000);
+		// The hard link would otherwise carry a truncated blob into the branch -- and worse, the abort
+		// that follows stamps PENDING onto that inode IN PLACE, through the branch's link as well. This
+		// is what the clone passes its own `CaptureMarkerReasons` for: the branch must not describe
+		// itself as a backup when it explains the substitution.
+		const [baseRoot] = getBlobPathsForDatabaseName('safebase');
+		// An uncompressed header promising 100 bytes over a file holding 10: the shape of a write that
+		// has stamped its size but not landed its body.
+		const header = Buffer.alloc(8);
+		header.writeUInt16BE(0, 0);
+		header.writeUIntBE(100, 2, 6);
+		mkdirSync(join(baseRoot, '900/900'), { recursive: true });
+		writeFileSync(join(baseRoot, '900/900/900'), Buffer.concat([header, Buffer.alloc(10, 'z')]));
+
+		try {
+			await getOrCreateBranch('safebase', 'safeApp');
+			const substituted = readFileSync(join(getBlobPathsForDatabaseName(STORE)[0], '900/900/900'));
+			assert.strictEqual(substituted.readUInt16BE(0), 0xfe, 'the branch gets a PENDING marker, not the torn bytes');
+			assert.match(substituted.subarray(8).toString(), /still being written to the base when this branch was created/);
+		} finally {
+			rmSync(join(baseRoot, '900'), { recursive: true, force: true });
+		}
+	});
+
+	it('refuses a completion marker that records no blob roots at all', async function () {
+		this.timeout(30000);
+		// An empty list is an exact prefix of anything, so without its own guard it reads as complete and
+		// pins the branch to no roots — the first blob write would then fail on an undefined path rather
+		// than here, where the branch can say what is wrong with it.
+		const branchPath = resolveBranchPath('safebase', 'safeApp');
+		mkdirSync(branchPath, { recursive: true });
+		writeFileSync(join(branchPath, 'CURRENT'), 'MANIFEST-000001\n');
+		writeFileSync(join(branchPath, '.branch-complete'), JSON.stringify({ blobRoots: [] }));
+
+		await assert.rejects(() => getOrCreateBranch('safebase', 'safeApp'), /cannot be trusted/);
+	});
+
 	it('refuses a branch whose recorded blob roots no longer match the configuration', async function () {
 		this.timeout(30000);
 		await getOrCreateBranch('safebase', 'safeApp');
@@ -933,8 +971,10 @@ describeUnlessLmdb('branch blob-root safety (harper#644)', () => {
 	it('keeps the identity reserved until the blob roots are gone, not just the directory', async function () {
 		this.timeout(30000);
 		const branch = await getOrCreateBranch('safebase', 'safeApp');
-		// Real files to delete, so removal spans several turns of the event loop rather than none.
-		for (let i = 0; i < 8; i++) {
+		// Not a timing race: every step of a recursive `rm` is a separate libuv round trip, so the window
+		// between the directory going and the last root going spans dozens of event-loop turns, and
+		// `setImmediate` samples every one of them. The blobs are here to make it dozens rather than two.
+		for (let i = 0; i < 12; i++) {
 			await branch.tables.Safe.put({ id: `blob-${i}`, payload: await createBlob(Buffer.alloc(64 * 1024, `${i}`)) });
 		}
 		const branchPath = resolveBranchPath('safebase', 'safeApp');
@@ -1007,6 +1047,22 @@ describeUnlessLmdb('branch identity is unavailable across restarts and restores 
 		// A rebuild of this branch renames `<root>.staging` over `<root>`, so the sibling name has to be
 		// unavailable across a restart for the same reason the identity itself is.
 		assert.strictEqual(isBranchIdentity(`${identity}.staging`), true, 'the sibling is spoken for as well');
+	});
+
+	it('recognises a branch of a database whose own name ends in .staging', function () {
+		// `schemaRegex` permits `.`, so this name has two readings: the staging sibling of a branch of
+		// `stage`, and a branch of a database actually called `stage.staging`. Both own a blob path, so
+		// stripping the suffix before parsing must not lose the second one.
+		const identity = `${'identApp'.length}_identApp__stage.staging`;
+		assert.strictEqual(isBranchIdentity(identity), false, 'sanity: nothing owns it yet');
+
+		const planted = resolveBranchPath('stage.staging', 'identApp');
+		mkdirSync(planted, { recursive: true });
+		try {
+			assert.strictEqual(isBranchIdentity(identity), true, 'the branch of `stage.staging` owns its identity');
+		} finally {
+			rmSync(planted, { recursive: true, force: true });
+		}
 	});
 
 	it('refuses an identity whose database exists on disk but is not loaded', async function () {
@@ -1178,6 +1234,24 @@ describeUnlessLmdb('appended blob volumes (harper#644)', () => {
 		assert.ok(existsSync(join(stranger, 'precious')), 'the unrecorded one is left alone');
 	});
 
+	it('deletes what the open handle is pinned to, not what a reordered configuration now says', async function () {
+		this.timeout(30000);
+		await getOrCreateBranch('volbase', 'volApp');
+		const [recordedRoot] = getBlobPathsForDatabaseName(STORE);
+
+		// Reordering is refused at adoption, but a branch already open goes on serving through what it
+		// published — so its teardown has to delete that, not whatever the configuration now names.
+		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [secondVolume, firstVolume]);
+		const stranger = join(secondVolume, STORE);
+		mkdirSync(stranger, { recursive: true });
+		writeFileSync(join(stranger, 'precious'), 'this branch never wrote here');
+
+		await removeBranches();
+
+		assert.strictEqual(existsSync(recordedRoot), false, 'the recorded root goes with the branch');
+		assert.ok(existsSync(join(stranger, 'precious')), 'the reordered configuration is not what it owns');
+	});
+
 	it('still refuses a branch whose recorded roots were dropped from the configuration', async function () {
 		this.timeout(30000);
 		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume, secondVolume]);
@@ -1200,5 +1274,25 @@ describeUnlessLmdb('appended blob volumes (harper#644)', () => {
 
 		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [secondVolume, firstVolume]);
 		await assert.rejects(() => getOrCreateBranch('volbase', 'volApp'), /no longer match the configured/);
+	});
+});
+
+describe('the claim budget follows the winner (harper#644)', () => {
+	// The winner holds the claim for a checkpoint AND a hard-link clone of the base's whole blob tree,
+	// so the budget every other thread waits on cannot be a constant: on a large enough base it expires
+	// while the winner is healthily copying. Driven directly because within one isolate `branchesByPath`
+	// dedupes callers, so nothing in-process ever takes the waiting side of this protocol.
+	const { claimDeadlineFor, reportClaimProgress } = require('#src/resources/branchDatabase');
+
+	it('restarts the budget when the winner reports progress, and runs it down when it does not', async function () {
+		const claimState = new BigInt64Array(2);
+		const deadline = claimDeadlineFor(claimState, 1000);
+		const first = deadline();
+
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.strictEqual(deadline(), first, 'a winner that has reported nothing still expires on schedule');
+
+		reportClaimProgress(claimState);
+		assert.ok(deadline() > first, 'a unit of work finished buys the waiters another full budget');
 	});
 });

--- a/unitTests/resources/branchDatabase.test.js
+++ b/unitTests/resources/branchDatabase.test.js
@@ -911,6 +911,58 @@ describeUnlessLmdb('branch blob-root safety (harper#644)', () => {
 		assert.strictEqual(statSync(branchFile).ino, statSync(baseFile).ino, 'same inode');
 		assert.ok(statSync(branchFile).nlink >= 2, 'and more than one link to it');
 	});
+
+	it('refuses a database named after the identity the clone renames from', async function () {
+		this.timeout(30000);
+		await getOrCreateBranch('safebase', 'safeApp');
+
+		// `cloneBlobRoots` populates `<root>.staging` and renames it over `<root>`, and a blob root is
+		// `<blobs>/<database>`, so a database legally called `<identity>.staging` resolves its own root
+		// to the very path materialization removes and replaces.
+		assert.throws(
+			() =>
+				table({
+					table: 'Sneak',
+					database: `${STORE}.staging`,
+					attributes: [{ name: 'id', isPrimaryKey: true }],
+				}),
+			/branch store identity/
+		);
+	});
+
+	it('keeps the identity reserved until the blob roots are gone, not just the directory', async function () {
+		this.timeout(30000);
+		const branch = await getOrCreateBranch('safebase', 'safeApp');
+		// Real files to delete, so removal spans several turns of the event loop rather than none.
+		for (let i = 0; i < 8; i++) {
+			await branch.tables.Safe.put({ id: `blob-${i}`, payload: await createBlob(Buffer.alloc(64 * 1024, `${i}`)) });
+		}
+		const branchPath = resolveBranchPath('safebase', 'safeApp');
+		const [root] = getBlobPathsForDatabaseName(STORE);
+
+		let sawTheWindow = false;
+		const removal = removeBranches();
+		for (;;) {
+			const settled = await Promise.race([
+				removal.then(() => true),
+				new Promise((resolve) => setImmediate(() => resolve(false))),
+			]);
+			// Once the directory is gone the on-disk half of `isBranchIdentity` sees nothing either, so
+			// the held reservation is all that stops a database claiming the name — and having its own
+			// fresh blob files deleted by the removal still running.
+			if (!existsSync(branchPath) && existsSync(root)) {
+				sawTheWindow = true;
+				assert.throws(
+					() => table({ table: 'Racer', database: STORE, attributes: [{ name: 'id', isPrimaryKey: true }] }),
+					/branch store identity/,
+					'the identity must stay reserved for every turn of cleanup'
+				);
+			}
+			if (settled) break;
+		}
+		await removal;
+		assert.ok(sawTheWindow, 'sanity: the test must observe the window it guards');
+	});
 });
 
 describeUnlessLmdb('branch identity is unavailable across restarts and restores (harper#644)', () => {
@@ -944,6 +996,19 @@ describeUnlessLmdb('branch identity is unavailable across restarts and restores 
 		assert.strictEqual(isBranchIdentity(identity), true, 'the on-disk branch still owns its identity');
 	});
 
+	it('recognises the staging sibling of an on-disk branch identity too', async function () {
+		this.timeout(30000);
+		const identity = `${'identApp'.length}_identApp__identbase`;
+
+		await getOrCreateBranch('identbase', 'identApp');
+		await removeBranches(); // drops the in-memory set, as a restart would
+		mkdirSync(resolveBranchPath('identbase', 'identApp'), { recursive: true });
+
+		// A rebuild of this branch renames `<root>.staging` over `<root>`, so the sibling name has to be
+		// unavailable across a restart for the same reason the identity itself is.
+		assert.strictEqual(isBranchIdentity(`${identity}.staging`), true, 'the sibling is spoken for as well');
+	});
+
 	it('refuses an identity whose database exists on disk but is not loaded', async function () {
 		this.timeout(30000);
 		const { assertBranchIdentityAvailable } = require('#src/resources/databases');
@@ -960,5 +1025,180 @@ describeUnlessLmdb('branch identity is unavailable across restarts and restores 
 		} finally {
 			rmSync(planted, { recursive: true, force: true });
 		}
+	});
+});
+
+describeUnlessLmdb('appended blob volumes (harper#644)', () => {
+	const { mkdirSync, writeFileSync, rmSync, cpSync } = require('node:fs');
+	const { join } = require('node:path');
+	const { getBlobPathsForDatabaseName, createBlob, getFilePathForBlob } = require('#src/resources/blob');
+	const environment = require('#src/utility/environment/environmentManager');
+	const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+	const { prepareBranches } = require('#src/resources/branchDatabase');
+	const STORE = `${'volApp'.length}_volApp__volbase`;
+	const PAYLOAD = Buffer.alloc(64 * 1024, 'volume payload ');
+	let firstVolume, secondVolume, configuredBefore;
+
+	/** Where a run of new branch blobs actually landed. Blobs are spread across the configured roots by
+	 *  free space, so a pinned branch has to be proven over several writes rather than one. */
+	async function writeBlobs(branch, prefix) {
+		const paths = [];
+		for (let i = 0; i < 8; i++) {
+			const id = `${prefix}-${i}`;
+			await branch.tables.Vol.put({ id, payload: await createBlob(Buffer.alloc(64 * 1024, id)) });
+			const path = getFilePathForBlob((await branch.tables.Vol.get(id)).payload);
+			assert.ok(path, `sanity: ${id} must be file-backed`);
+			paths.push(path);
+		}
+		return paths;
+	}
+
+	/**
+	 * Give up this process's handle on a branch without touching its storage, the way a restart does.
+	 * `removeBranches` is the only exported release and it deletes, so what is on disk is set aside
+	 * and put back around it.
+	 */
+	async function reloadFromDisk(branchPath, blobRoots) {
+		const aside = [branchPath, ...blobRoots].map((path) => [path, `${path}.savedforTest`]);
+		for (const [live, saved] of aside) cpSync(live, saved, { recursive: true });
+		await removeBranches();
+		for (const [live, saved] of aside) {
+			cpSync(saved, live, { recursive: true });
+			rmSync(saved, { recursive: true, force: true });
+		}
+	}
+
+	before(async function () {
+		this.timeout(30000);
+		const dbPath = setupTestDBPath();
+		setMainIsWorker(true);
+		configuredBefore = environment.get(CONFIG_PARAMS.STORAGE_BLOBPATHS);
+		firstVolume = join(dbPath, 'blob-volume-1');
+		secondVolume = join(dbPath, 'blob-volume-2');
+		for (const volume of [firstVolume, secondVolume]) mkdirSync(volume, { recursive: true });
+		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume]);
+		for (const db of ['volbase', 'volbase2']) {
+			table({
+				table: 'Vol',
+				database: db,
+				attributes: [
+					{ name: 'id', isPrimaryKey: true },
+					{ name: 'payload', type: 'Blob' },
+				],
+			});
+		}
+		await databases.volbase.Vol.put({ id: 'seed', payload: await createBlob(PAYLOAD) });
+	});
+
+	beforeEach(function () {
+		// One volume to begin with, so appending the second is the operator action under test.
+		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume]);
+	});
+
+	afterEach(async function () {
+		await removeBranches();
+		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume]);
+		for (const appName of ['volApp']) {
+			for (const baseName of ['volbase', 'volbase2']) {
+				rmSync(resolveBranchPath(baseName, appName), { recursive: true, force: true });
+				for (const volume of [firstVolume, secondVolume]) {
+					rmSync(join(volume, `${appName.length}_${appName}__${baseName}`), { recursive: true, force: true });
+				}
+			}
+		}
+	});
+
+	after(function () {
+		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, configuredBefore);
+	});
+
+	it('stays loadable when a volume is appended, and keeps resolving through the roots it recorded', async function () {
+		this.timeout(30000);
+		const created = await getOrCreateBranch('volbase', 'volApp');
+		assert.ok(await created.tables.Vol.get('seed'), 'sanity: the branch carries the base row');
+		const branchPath = resolveBranchPath('volbase', 'volApp');
+		const recorded = getBlobPathsForDatabaseName(STORE);
+		await reloadFromDisk(branchPath, recorded);
+
+		// Every recorded root keeps its index, so every `storageIndex` a row already holds still means
+		// what it meant. Refusing the branch here would take an application offline for a configuration
+		// change that cannot have invalidated a single reference.
+		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume, secondVolume]);
+		const reopened = await getOrCreateBranch('volbase', 'volApp');
+		const seeded = await reopened.tables.Vol.get('seed');
+		assert.ok(PAYLOAD.equals(Buffer.from(await seeded.payload.bytes())), 'and it still reads its blobs');
+
+		// Pinned, not merely tolerated: a write into the appended volume would sit at an index the
+		// completion marker never recorded, so a later change at that index would silently re-address it.
+		// Several of them, because unpinned writes are spread over the volumes by free space, so one
+		// landing in the recorded root proves nothing.
+		for (const written of await writeBlobs(reopened, 'after')) {
+			assert.ok(written.startsWith(recorded[0]), `expected ${written} under the recorded root ${recorded[0]}`);
+		}
+		assert.strictEqual(existsSync(join(secondVolume, STORE)), false, 'the appended volume is not this branch’s');
+	});
+
+	it('pins a branch adopted on the waiter path, not only one this thread published', async function () {
+		this.timeout(30000);
+		await getOrCreateBranch('volbase', 'volApp');
+		const recorded = getBlobPathsForDatabaseName(STORE);
+
+		// A failed application load releases its handles without resetting the claim word, which is the
+		// state every thread that did not win the claim sees: the branch is READY and this thread has
+		// never read it. Plant a complete-looking branch that is not a database to make the load fail.
+		const failing = resolveBranchPath('volbase2', 'volApp');
+		mkdirSync(failing, { recursive: true });
+		writeFileSync(join(failing, 'CURRENT'), 'not a database');
+		publishHandBuiltBranch(failing, 'volApp', 'volbase2');
+		await assert.rejects(() => prepareBranches('volApp', ['volbase', 'volbase2'], undefined));
+		rmSync(failing, { recursive: true, force: true });
+
+		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume, secondVolume]);
+		const adopted = await getOrCreateBranch('volbase', 'volApp');
+		for (const written of await writeBlobs(adopted, 'waiter')) {
+			assert.ok(written.startsWith(recorded[0]), `expected ${written} under the recorded root ${recorded[0]}`);
+		}
+	});
+
+	it('removes only the roots it recorded, leaving a like-named directory on a volume it never used', async function () {
+		this.timeout(30000);
+		await getOrCreateBranch('volbase', 'volApp');
+		const [recordedRoot] = getBlobPathsForDatabaseName(STORE);
+
+		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume, secondVolume]);
+		// A directory that happens to carry this identity's name on the appended volume — restored from
+		// a backup, copied from another node — was never part of this branch and is not its to delete.
+		const stranger = join(secondVolume, STORE);
+		mkdirSync(stranger, { recursive: true });
+		writeFileSync(join(stranger, 'precious'), 'this branch never wrote here');
+
+		await removeBranches();
+
+		assert.strictEqual(existsSync(recordedRoot), false, 'the recorded root goes with the branch');
+		assert.ok(existsSync(join(stranger, 'precious')), 'the unrecorded one is left alone');
+	});
+
+	it('still refuses a branch whose recorded roots were dropped from the configuration', async function () {
+		this.timeout(30000);
+		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume, secondVolume]);
+		await getOrCreateBranch('volbase', 'volApp');
+		const branchPath = resolveBranchPath('volbase', 'volApp');
+		await reloadFromDisk(branchPath, getBlobPathsForDatabaseName(STORE));
+
+		// Growth is compatible because it moves no index; shrinking removes root 1 outright, and every
+		// row whose `storageIndex` is 1 would resolve through nothing.
+		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume]);
+		await assert.rejects(() => getOrCreateBranch('volbase', 'volApp'), /no longer match the configured/);
+	});
+
+	it('still refuses a branch whose recorded roots were reordered', async function () {
+		this.timeout(30000);
+		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [firstVolume, secondVolume]);
+		await getOrCreateBranch('volbase', 'volApp');
+		const branchPath = resolveBranchPath('volbase', 'volApp');
+		await reloadFromDisk(branchPath, getBlobPathsForDatabaseName(STORE));
+
+		environment.setProperty(CONFIG_PARAMS.STORAGE_BLOBPATHS, [secondVolume, firstVolume]);
+		await assert.rejects(() => getOrCreateBranch('volbase', 'volApp'), /no longer match the configured/);
 	});
 });

--- a/unitTests/resources/branchDatabase.test.js
+++ b/unitTests/resources/branchDatabase.test.js
@@ -1085,6 +1085,24 @@ describeUnlessLmdb('branch identity is unavailable across restarts and restores 
 		assert.strictEqual(isBranchIdentity(`${identity}.staging`), true, 'the sibling is spoken for as well');
 	});
 
+	it('refuses to materialize over the live blob root of a branch of a database named .staging', async function () {
+		this.timeout(30000);
+		// `<identity>.staging` is the path the clone removes and renames over, and it is also the legal
+		// identity of a branch of a database called `identbase.staging`. That branch's root is live data.
+		const { assertBranchIdentityAvailable } = require('#src/resources/databases');
+		const planted = resolveBranchPath('identbase.staging', 'identApp');
+		mkdirSync(planted, { recursive: true });
+		try {
+			assert.throws(
+				() => assertBranchIdentityAvailable(`${'identApp'.length}_identApp__identbase`),
+				/already in use/,
+				"the sibling path is another branch's blob root, not scratch space"
+			);
+		} finally {
+			rmSync(planted, { recursive: true, force: true });
+		}
+	});
+
 	it('recognises a branch of a database whose own name ends in .staging', function () {
 		// `schemaRegex` permits `.`, so this name has two readings: the staging sibling of a branch of
 		// `stage`, and a branch of a database actually called `stage.staging`. Both own a blob path, so
@@ -1099,6 +1117,22 @@ describeUnlessLmdb('branch identity is unavailable across restarts and restores 
 		} finally {
 			rmSync(planted, { recursive: true, force: true });
 		}
+	});
+
+	it('refuses create_database under a live branch identity, not only schema authoring', async function () {
+		this.timeout(30000);
+		// `create_database` reaches `database()` through its own bridge, so the guard on the `table()`
+		// authoring path never sees it: the database would share the branch's blob root, and dropping it
+		// deletes the branch's blobs.
+		const { createSchemaStructure } = require('#src/dataLayer/schema');
+		const identity = `${'identApp'.length}_identApp__identbase`;
+		await getOrCreateBranch('identbase', 'identApp');
+
+		await assert.rejects(
+			() => createSchemaStructure({ schema: identity }),
+			/in use as a branch store identity/,
+			'create_database must refuse the name for the same reason schema authoring does'
+		);
 	});
 
 	it('refuses an identity whose database exists on disk but is not loaded', async function () {


### PR DESCRIPTION
A branch is a RocksDB checkpoint, and a checkpoint clones the engine and nothing else. So a branch's records referenced blob ids that resolved under the branch's own — **empty** — blob root: any blob the base wrote before the branch was taken was unreadable, and once the branch wrote a blob of its own, `getNextFileId` seeded from that empty directory, started low, and could mint an id an existing record already referenced. That second one returns the wrong bytes rather than failing.

Closes the blob half of #642. Refs #644.

## The design: hard links, so the OS does the reference counting

Materialization reproduces each of the base's blob roots as the branch's own, hard-linking every file. The branch and base share the bytes, each holds its own directory entry, and the data is freed only when the last link goes.

That is what lets the branch keep **its own ID allocator**: `getNextFileId` seeds from the highest filename already in its directory, and the clone carries the base's filenames, so it naturally starts above every id that existed at checkpoint time. No shared allocator, no high-water mark, no gated deletion, no orphan-GC suspension — the filesystem already implements the refcounting those would have built by hand. #644 previously specified the shared-store design and has been rewritten to describe this one.

`copyTree` in `dataLayer/blobBackup.ts` already walked a blob tree hard-linking each file, with the cross-filesystem fallback; it is exported rather than reimplemented, with its marker wording parameterized so a branch does not describe itself as a backup. [It now also counts the fallback copies and ticks a progress callback per file](https://github.com/HarperFast/harper/pull/2426/changes?w=1#diff-ef6081f3b8edd93e7e5b3c8bb011fc94a74142673b26b7b93d2f31718d71fc98R151) — the first because a silent fallback turns a constant-time clone into an O(bytes) one and nothing else in the log would say so, the second because the walk runs inside a window other threads are blocked on.

The clone reads [the roots the base store actually resolves through](https://github.com/HarperFast/harper/pull/2426/changes?w=1#diff-cac868f688668988b75b365b484204e6a54f9fcbb121dab67b3358808b9dacf5R120), not the configured list — a `storage.blobPaths` edit against an already-open base would otherwise clone empty volumes — and iterates the *branch's* root list, so every entry its marker records exists even where the base has no counterpart.

## Why there is a completion marker

A branch's blob roots live on the `storage.blobPaths` volumes while its directory sits beside the base's storage root. The two cannot be published by one atomic rename, and neither parent is fsynced — so a power loss can replay the directory without its roots. Adopting on directory existence alone would then restart the allocator in an empty root and remint ids the branch's own checkpointed rows hold.

So materialization writes a marker inside staging, naming the roots it published, before the single rename that publishes the branch. The marker is what adoption trusts.

**The marker is also what the open branch resolves blobs through.** A row's `storageIndex` is a position in that list, so [the handle is pinned to the recorded roots](https://github.com/HarperFast/harper/pull/2426/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1604) rather than to current configuration — on the thread that published it and equally on [a thread that only adopted what a peer published](https://github.com/HarperFast/harper/pull/2426/changes?w=1#diff-cac868f688668988b75b365b484204e6a54f9fcbb121dab67b3358808b9dacf5R514). That is what makes an **appended** `storage.blobPaths` entry benign: [a recorded list that is an exact prefix of the configured one keeps every index where it was](https://github.com/HarperFast/harper/pull/2426/changes?w=1#diff-cac868f688668988b75b365b484204e6a54f9fcbb121dab67b3358808b9dacf5R286), so the branch loads and simply never uses the new volume, while a removed, reordered or replaced entry is still a hard refusal. Pinning is what keeps those detectable: an unpinned branch would write rows at an index its own marker never recorded.

**A directory that looks like a store but has no usable marker is refused, never deleted.** Materialization cannot produce that state, so anything in it came from somewhere else and is carrying data that exists nowhere else. Only leftovers that are not a store at all — including a directory holding nothing but a malformed marker — are cleared and rebuilt.

## The identity a branch answers to, and for how long

Cloning *removes and replaces* the blob root the branch's store identity resolves to, and `schemaRegex` permits digits, `_` and `.`, so a database may legally be named to collide with it. Two things follow.

**A branch owns a pair of names, not one.** The clone renames in from `<blobRoot>.staging`, and a database literally called `<storeName>.staging` resolves its own root to exactly that path. [Every check, reservation and release covers the pair](https://github.com/HarperFast/harper/pull/2426/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1362), and the on-disk question is [asked from both sides](https://github.com/HarperFast/harper/pull/2426/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1455) — `4_myapp__data.staging` is either the sibling of a branch of `data` or a branch of a database actually named `data.staging`, and whichever was created second must be refused.

**The reservation is held through every deletion, not merely checked before them.** `isBranchIdentity` is what stops another database taking the name, and once the branch directory is gone its on-disk half sees nothing either — so [cleanup retakes the pair on the same turn as the `close()` that released it](https://github.com/HarperFast/harper/pull/2426/changes?w=1#diff-cac868f688668988b75b365b484204e6a54f9fcbb121dab67b3358808b9dacf5R591) and holds it until the last blob root is removed. Removal deletes [only the roots the branch recorded](https://github.com/HarperFast/harper/pull/2426/changes?w=1#diff-cac868f688668988b75b365b484204e6a54f9fcbb121dab67b3358808b9dacf5R640), intersected with this node's configured volumes, so an appended volume that already holds a like-named directory restored from elsewhere is not collateral.

When a root **cannot** be removed, the name is not handed back: it goes into a [quarantine set](https://github.com/HarperFast/harper/pull/2426/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1373) that refuses it to databases — which would mint fresh ids onto the surviving files — while still letting the branch itself retake it, since materializing replaces those roots wholesale and is the only route that clears the condition without an operator.

Database creation refuses the name too. `create_database` reaches `database()` through its own bridge, so `table()`'s guard never saw it; [`createSchemaStructure` now makes the same refusal](https://github.com/HarperFast/harper/pull/2426/changes?w=1#diff-07a296e386acc3155215669015450d25a7ee06830408a635c73991d1ce3619b2R89), after `transformReq` — because that is what settles whether `database` or `schema` names the database being created.

## What bounds the wait while a branch materializes

The claim's CREATING window now covers a hard-link clone of the base's entire blob tree, so any fixed budget is wrong for a large enough base: every waiting thread's application load fails while the winner is healthily copying, the winner then publishes, and the next deploy succeeds — a real outage reading as a flap. The winner reports each unit of work on a second slot of the shared claim word and [a waiter's budget restarts whenever it does](https://github.com/HarperFast/harper/pull/2426/changes?w=1#diff-cac868f688668988b75b365b484204e6a54f9fcbb121dab67b3358808b9dacf5R94), so what is bounded is a winner that has *stopped* rather than one that is merely slow. Because that has no ceiling by construction, a wait outliving its original budget says once that the winner is still reporting progress, rather than reading as a hang with no thread to point at.

## For the human reviewer

1. **This redefines an on-disk contract that another PR's tests depend on.** #2414's replay tests build branch directories by hand; a published branch now includes a marker, so those fixtures publish one too (via a shared helper rather than special-casing). Worth a look — it's the kind of cross-PR coupling that is easy to get subtly wrong.
2. **Marker substitution is a deliberate trade, and it is permanent for that blob.** Backup uses it because a snapshot is restored once; a branch is long-lived and scope-private, so a blob that was mid-write at clone time is unreadable in that branch forever. The alternative — failing branch creation whenever the base has an in-flight blob — makes branching unreliable on a busy base. Owner-settled, but it is the judgement most worth disagreeing with.
3. **Pinning is the owner-chosen answer to appended volumes**, over extending the marker so an existing branch takes the new capacity. The marker stays immutable proof of what was published atomically with the branch and no new crash window is added; the cost is that a long-lived branch cannot use capacity added after it, and filling its original volumes needs a rebuild. Choosing the other way is a storage migration, not a tweak.
4. **The `create_database` guard sits at the operation's validation layer, not inside `database()`/`ensureDB` where the directory is actually allocated.** Two awaits separate the check from `createSchema`, so a branch materializing under exactly the colliding name inside that window is still possible, and every other route into `database()` — restore, replication, component config — stays unguarded. `table()`'s copy has no such gap because its `database()` call is synchronous. Moving the guard down is contained but touches the load and drop paths the reserved-name comment deliberately excludes.
5. **A `storage.blobPaths` list that shrank is refused before checkpoint work.** If an open base still resolves through more roots than current configuration provides, materialization fails rather than publishing a branch whose higher `storageIndex` rows are unreadable.
6. **A published branch that later reads damaged or unmarked stays offline until an operator acts**, rather than being re-forked from the base. That is deliberate — it is carrying data that exists nowhere else — but on an unattended node it means the application never loads again.
7. **The checkpoint phase reports one progress tick, at the end.** The progress-extended budget therefore covers the clone but not the checkpoint, so a base whose checkpoint degrades to a byte copy (branch directory on a different volume from the base's storage root) and exceeds `CLAIM_TIMEOUT_MS + replayTimeBudgetMs` still flaps every waiter. Finer granularity needs a native callback or a timer.
8. **The quarantine set is per worker thread.** Other workers no longer see the branch directory, so the residual is unreclaimed disk on them rather than an id collision — but it is an operator action, and the log says so.
9. **Reservations and quarantine are worker-local while blob paths are filesystem-global.** The branch-side checks close the in-worker collision paths, but a direct allocator on another worker can still race materialization before anything on disk holds the name. Closing that gap requires moving reservation into the common database-allocation path or introducing a process-shared lease, which is a broader storage-lifecycle change than this review fix.

## Known and deliberate

- **The branch's allocator seeds from a directory scan of its own clone**, so any way that clone can come up short of the base's high-water mark lets it re-mint an id a checkpointed row still holds. Two exist: a blob root that exists but was emptied still reads as `complete` (a base with no blobs legitimately clones an empty root, so emptiness is not a signal), and the base can unlink its highest-id blob in the window between `createCheckpoint` and the clone's `readdir`, so the clone never sees it and no substitute marker is written for it. Detecting either properly needs the marker to record an allocator floor, which was judged more mechanism than the residual risk justifies. This is the one remaining path where a read returns wrong bytes rather than failing.
- **The marker is not fsynced**, and neither is the staging directory or either parent before the publishing rename, so a power loss can leave a store directory visible with a zero-length `.branch-complete` — read as `unmarked` and refused until an operator removes it.
- **`.branch-complete` lives inside the RocksDB directory** so one rename publishes both halves. That couples branch metadata to a directory RocksDB owns; relocating it later needs a migration for every published branch.
- **Branch removal on undeploy is not in this PR.** It follows in a second PR built on an explicit sequence (drop → restart → prove no references remain → remove), rather than being iterated onto this one.

## Verification

`test:unit:resources` **1905 passing, 0 failing**; `test:unit:dataLayer` 261; `test:unit:backup` 88. `tsc --project tsconfig.build.json`, `lint:required`, prettier clean.

The regression tests added for this round each name the behaviour they pin: the staging identity refused from both orderings, `create_database` refused through all three request spellings, the identity held until the blob roots are gone rather than until the directory is, removal touching only recorded roots, a branch that stays loadable when a volume is appended and keeps resolving through what it recorded, continued refusal when recorded roots are dropped or reordered, an empty `storage.blobPaths` refused at publish rather than bricking the next boot, an open base with more roots than current configuration refused before checkpoint work, a directory holding nothing but a malformed marker cleared and rebuilt, a stranded identity refused to databases while the branch retakes it, and the claim budget restarting on progress but running down without it.

Every new behaviour is mutation-checked — removing the clone, and treating markerless stores as disposable, each fail the suite. The inode assertion (`statSync().ino`, `nlink >= 2`) is there so a silent fallback from `link` to `copyFile` fails rather than passing quietly, which would double disk and make first load O(bytes).

One trap worth recording: an early version of these tests used an 18-byte blob, which is stored **inline in the record** and never becomes a file — so every assertion passed with the clone entirely removed. The tests now use a 64KB payload and assert `getFilePathForBlob()` is non-null, so they cannot silently stop testing anything if the externalization threshold moves.

Complexity: medium

<sub>Review-Coverage: authored=codex; ran=claude; blocked=gemini(auth); declined=cursor-grok,cursor-composer,domain; rounds=3 @ 156a25ce6456</sub>

<sub>Human-Review-Need: 4 @ 156a25ce6456</sub>
