### PR TITLE
Deflake `Caching > Can load cached data` by driving cache expiry from the source instead of a 10ms TTL

### DIFF
--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -96,9 +96,10 @@ describe('Caching', () => {
 		};
 
 		CachingTable.sourcedFrom({
-			get(id) {
+			get(id, context) {
 				return new Promise((resolve) => {
 					sourceRequests++;
+					if (sourceExpiresAt !== undefined) context.expiresAt = sourceExpiresAt;
 					setTimeout(() => {
 						sourceResponses++;
 						resolve(
@@ -200,35 +201,63 @@ describe('Caching', () => {
 		sourceRequests = 0;
 		events = [];
 		const start = new Date();
-		CachingTable.setTTLExpiration(0.01);
-		await CachingTable.invalidate(23);
-		let result = await CachingTable.get(23);
-		assert.equal(result.id, 23);
-		assert.equal(result.name, 'name ' + 23);
-		assert(result.createdAt >= start);
-		assert(result.updatedAt >= start);
-		assert.equal(sourceRequests, 1);
-		await delay(5);
-		let target23 = new RequestTarget();
-		target23.id = 23;
-		result = await CachingTable.get(target23);
-		assert.equal(target23.loadedFromSource, false);
-		assert.equal(result.id, 23);
-		assert.equal(sourceRequests, 1);
-		// let it expire
-		await delay(10);
-		result = await CachingTable.get(target23);
-		assert.equal(result.id, 23);
-		assert.equal(result.name, 'name ' + 23);
-		assert.equal(sourceRequests, 2);
-		if (events.length > 0) console.log(events);
-		//assert.equal(events.length, 0);
-		await CachingTable.put(23, { name: 'expires in past' }, { expiresAt: 0 });
-		result = await CachingTable.get(target23);
-		assert(result.createdAt >= start);
-		assert(result.updatedAt >= start);
-		assert.equal(sourceRequests, 3);
-		assert.equal(target23.loadedFromSource, true);
+		// expiry here is driven by the expiration the source reports, not by sleeping against the TTL
+		CachingTable.setTTLExpiration(30);
+		// the fill lock is only released once the fill has settled; a past expiration may also have been
+		// evicted by the cleanup scan by the time it is observed
+		const entryCommitted = (expiresAt) => {
+			if (CachingTable.primaryStore.hasLock(23)) return false;
+			const entry = CachingTable.primaryStore.getEntry(23);
+			return entry ? entry.expiresAt === expiresAt : expiresAt < Date.now();
+		};
+		try {
+			const liveExpiresAt = (sourceExpiresAt = Date.now() + 60000);
+			await CachingTable.invalidate(23);
+			let result = await CachingTable.get(23);
+			assert.equal(result.id, 23);
+			assert.equal(result.name, 'name ' + 23);
+			assert(result.createdAt >= start);
+			assert(result.updatedAt >= start);
+			assert.equal(sourceRequests, 1);
+			await waitFor(() => entryCommitted(liveExpiresAt), { message: 'the source fill should commit' });
+			let target23 = new RequestTarget();
+			target23.id = 23;
+			result = await CachingTable.get(target23);
+			assert.equal(target23.loadedFromSource, false);
+			assert.equal(result.id, 23);
+			assert.equal(sourceRequests, 1);
+			const expiredAt = (sourceExpiresAt = Date.now() - 1);
+			await CachingTable.invalidate(23);
+			await CachingTable.get(23);
+			assert.equal(sourceRequests, 2);
+			await waitFor(() => entryCommitted(expiredAt), { message: 'the expired source fill should commit' });
+			// reloading restores a live entry, so the `expiresAt: 0` write below is the only reason the
+			// last get can miss
+			const reloadedExpiresAt = (sourceExpiresAt = Date.now() + 60000);
+			result = await CachingTable.get(target23);
+			assert.equal(result.id, 23);
+			assert.equal(result.name, 'name ' + 23);
+			assert.equal(target23.loadedFromSource, true);
+			assert.equal(sourceRequests, 3);
+			await waitFor(() => entryCommitted(reloadedExpiresAt), { message: 'the reload should commit a live entry' });
+			if (events.length > 0) console.log(events);
+			//assert.equal(events.length, 0);
+			const finalExpiresAt = (sourceExpiresAt = Date.now() - 1);
+			await CachingTable.put(23, { name: 'expires in past' }, { expiresAt: 0 });
+			await waitFor(() => entryCommitted(0), { message: 'the put should commit its past expiration' });
+			const expiredTarget23 = new RequestTarget();
+			expiredTarget23.id = 23;
+			result = await CachingTable.get(expiredTarget23);
+			assert.equal(result.name, 'name ' + 23);
+			assert(result.createdAt >= start);
+			assert(result.updatedAt >= start);
+			assert.equal(sourceRequests, 4);
+			assert.equal(expiredTarget23.loadedFromSource, true);
+			// the tests below expect their own first get(23) to reach the source
+			await waitFor(() => entryCommitted(finalExpiresAt), { message: 'the last fill should commit expired' });
+		} finally {
+			sourceExpiresAt = undefined;
+		}
 	});
 
 	it('loadedFromSource is observable on the target with loadAsInstance = false (#1576)', async function () {


### PR DESCRIPTION
`Caching > Can load cached data` asserted a cache hit five milliseconds after a fill whose entry expires ten milliseconds after it is stamped. An event-loop stall past the ~3ms of margin that left expired the entry, the second get correctly reloaded from source, and the test failed with `true == false` at its `loadedFromSource` assertion — twice on `main`'s Node 22 job on 2026-08-31, both times on that job only. Test-only change; no product code is touched.

## Which clock expired the entry

The table TTL from `setTTLExpiration(0.01)`, not the suite's `Source` class and its `Date.now() + 2` stamp. `CachingTable` is sourced from an object literal that never sets `context.expiresAt`, so `getFromSource` supplies it from the table TTL (`resources/Table.ts:6191`, `if (expirationMs && sourceContext.expiresAt == undefined) sourceContext.expiresAt = Date.now() + expirationMs`); the `Source` class with the 2ms stamp is `IndexedCachingTable`'s. Measured with throwaway instrumentation that sampled the stored entry immediately after the first get returned:

| table | its source | stored `expiresAt`, relative to that get returning |
| --- | --- | --- |
| `CachingTable` | object literal, no `expiresAt` | **+8 ms** — a `Date.now() + 10 ms` stamp taken ~2 ms before the get resolved |
| `IndexedCachingTable` | `Source` class, `Date.now() + 2` | −3 ms — already expired |

So `await delay(5)` was racing an ~8ms window while `delay(5)` itself commonly sleeps 5–6ms. Widening that sleep would only move the odds, so the test now drives the expiry instead of waiting for it.

## What changed

The `CachingTable` test source reports an expiration when the suite's [`sourceExpiresAt` override](https://github.com/HarperFast/harper/pull/2428/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR102) is set — the same mechanism [#2184](https://github.com/HarperFast/harper/pull/2184) gave the `Source` class for the sibling `Can load cached indexed data` — and falls back to the table TTL when it is not, so no other test changes behavior. The test then plants the state it wants instead of waiting for it: [a minute-long expiration](https://github.com/HarperFast/harper/pull/2428/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR214) for the entry the cache-hit assertion reads, and [an expiration already in the past](https://github.com/HarperFast/harper/pull/2428/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR229) for the entry the expiry-miss assertion reads, which is expired the moment it commits.

Both `delay()` calls are gone. Every wait is now [one `entryCommitted(expiresAt)` barrier](https://github.com/HarperFast/harper/pull/2428/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR208): the source-fill lock is released only once the fill has settled (`resources/Table.ts:6486-6498`), and the entry then carries the exact expiration the source reported — or is already gone, which is a legitimate outcome for a past expiration because the cleanup scan evicts it.

Two assertions had to be re-armed rather than merely preserved. The [reload after the expiry](https://github.com/HarperFast/harper/pull/2428/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR236) now restores a live entry, so the closing `put(..., { expiresAt: 0 })` is again the only reason the last get can miss; and that last get uses [its own `RequestTarget`](https://github.com/HarperFast/harper/pull/2428/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR248) and asserts the reloaded name, so neither `loadedFromSource` nor the returned record can pass on state left by the earlier miss. Source-request counts shift 2→3 and 3→4 because of the one added re-fill.

## For the human reviewer

1. **The TTL path is no longer exercised by this test.** Expiry is now proven through the source's reported `expiresAt`; the table TTL only has to be long enough not to interfere. The only remaining coverage of a table-TTL-stamped expiry in this file is the sleep-based `Handles distinct eviction time`. If you want this test to stay the TTL regression guard, that means re-introducing a timing dependence here — say so and I will add a separate deterministic TTL case instead.
2. **The commit barrier tolerates an evicted entry.** `entryCommitted` accepts a missing entry as committed when the expected expiration is in the past, because with `evictionMs` 0 the cleanup scan legitimately evicts such an entry within its scan interval; the stricter present-and-equal form used at `unitTests/resources/caching.test.js:955` would reintroduce a (small) race. The gate that actually proves the fill landed is the lock release; the equality is the added check. Reversible in one line if you would rather disable eviction for the test and keep the strict form.
3. **The cross-test handoff is kept, and now deliberate.** `Cache stampede is handled` has no precondition of its own: its `setTTLExpiration(0.01)` → sleep → `setTTLExpiration(40)` dance cannot retroactively expire an already-stored entry, so it depends on this test leaving id 23 expired. This PR keeps that contract explicitly ([the final barrier](https://github.com/HarperFast/harper/pull/2428/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR257)) rather than breaking it, because breaking it means editing a second test. Proven, not assumed: making this test's last fill land live fails `Cache stampede is handled` at its `waitFor(() => sourceRequests > 0)`, not this test. A one-line `await CachingTable.invalidate(23)` in the stampede test would remove the coupling — happy to fold it in if you would rather not carry it.

## Verification

Not observable end-to-end: this is a unit test with no product-code change, so the route is the unit suite plus a fault-injection reproduction.

- **Proved it fails first.** With a `--require` harness blocking the event loop for 20ms every 3ms (a stand-in for a loaded runner), the pre-change test failed **25/25** on Node 22, every time as `AssertionError: true == false` at `caching.test.js:215` — the exact CI signature. The reworked test passed **25/25** under the same injection.
- **Repeat runs.** Whole file, Node 22 (the job that flakes): **25/25** passing. Node 24: 10/10. Node 26: 10/10.
- **Assertions still discriminate**, checked by mutation: dropping `{ expiresAt: 0 }` from the closing `put` fails the test (`'expires in past' == 'name 23'`, then `3 == 4`); leaving the final fill live fails `Cache stampede is handled`.
- **Gates.** `npm run test:unit:resources` — 1875 passing, 23 pending. `npm run test:unit:main` — one failure, `configValidator > getDomainSocketPathLengthWarning`, which is an artifact of this worktree's long path (the suite excludes `unitTests/resources/` entirely, so it cannot see this change). `npm run lint:required` and `prettier --check` clean.

Refs #1138

Complexity: easy

<sub>Review-Coverage: authored=claude; ran=gemini,codex; adjudicated=domain; declined=cursor-grok,cursor-composer; rounds=5 @ 904bdfe9c249</sub>

<sub>Human-Review-Need: 3 (decisions: source-driven-vs-ttl-driven-expiry, tolerant-vs-strict-commit-barrier, shared-mutable-source-override, cross-test-precondition-kept-explicit) @ 904bdfe9c249</sub>
