### PR TITLE
Native HNSW index: file-primary mmap graph as a backend on the shared derived-index runtime

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -133,3 +133,47 @@ jobs:
       - name: Run unit tests
         timeout-minutes: 30
         run: npm run test:unit:windows
+
+  # The vectorIndexPlane suite self-skips when the optional native package is absent, so the
+  # load probe below is what keeps that skip from reading as a green run. The crate's own
+  # tests belong to HarperFast/hnsw's CI, not here: this job runs the published prebuild, so
+  # testing the crate source would grade something other than the binary under test.
+  hnsw-plane:
+    name: HNSW native plane (Node.js v24)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      # strict here, unlike the other jobs: the plane suite runs against dist/, so a tolerated
+      # build failure would grade a stale dist and still report green
+      - name: Build
+        run: npm run build
+
+      - name: Verify the published native binding loads
+        run: node -e "if (typeof require('@harperfast/hnsw').Plane?.open !== 'function') throw new Error('@harperfast/hnsw loaded without a Plane constructor');"
+
+      - name: Setup Harper
+        env:
+          DEFAULTS_MODE: 'dev'
+          HDB_ADMIN_USERNAME: 'admin'
+          HDB_ADMIN_PASSWORD: 'password'
+          ROOTPATH: '/tmp/hdb'
+          NODE_HOSTNAME: 'localhost'
+          LOGGING_LEVEL: 'info'
+        run: node --enable-source-maps ./dist/bin/harper.js install
+
+      - name: File-primary native plane tests
+        env:
+          HNSW_NATIVE_REBUILD_BENCHMARK: '1'
+        run: npx mocha unitTests/resources/vectorIndexPlane.test.js

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2210,3 +2210,122 @@ flowchart TD
     K -->|yes, after backoff| Y
     K -->|no| U[publish unavailable, release lock]
 ```
+
+## Native HNSW plane: a file-primary mmap graph on the derived-index runtime (`resources/indexes/HierarchicalNavigableSmallWorld.ts`, `resources/indexes/hnswDerivedIndex.ts`, `resources/indexes/hnswPlaneBinding.ts`)
+
+`@indexed(type: "HNSW", nativePlane: true)` replaces the RocksDB graph with a memory-mapped
+fixed-slot file owned by the native package `@harperfast/hnsw` (Rust, napi-rs, exact-pinned optional
+dependency; crate at HarperFast/hnsw). The file **is the index**: graph nodes, adjacency, the entry
+point, the id allocator and the freelist exist only there. RocksDB keeps the primary records, the
+`pk ↔ nodeId` mappings and the one durable replay cursor. Ordinary HNSW indexes are untouched.
+
+Why the whole search loop is native and not just the distance kernel: at 5M nodes / ef 512, ~85% of
+a warm JS visit is object bookkeeping (candidate heap, visited `Set`, property access, GC), the int8
+cosine is 10%, and a warm RocksDB `Get` per visit (~1–2 µs) is 20–40× the SIMD distance it feeds. A
+native loop over direct-addressed slots (`base + id × slot_size`, ~100–200 ns) with one NAPI crossing
+per query is the only shape that reaches the ceiling; measured 7.2 ms → 0.75 ms p50 at 1M × 768-d,
+recall@10 0.997 → 0.999.
+
+### File format
+
+One file per index, `<index store path>/<store name>.hnsw`, created sparse at `nativePlaneMaxNodes`
+slots (16M default; a structural, create-time header field — exhausting it makes the index
+unavailable until the value is raised and the index rebuilt). Header page: magic + format version
+(mismatch → rebuild, by contract), dims, quantization mode, `slot_size`/`layer0_cap`/`upper_cap`
+(derived from M/optimizeRouting at creation), entry point, atomic `id_high_water`, tag-guarded
+freelist head, a transaction watermark advanced only after an `msync` barrier, and a clean-shutdown
+flag. Layer-0 slot: seqlock word, flags + level, `scale`/`invMag`, degree, int8 vector padded to a
+4-byte boundary, `u32` neighbour ids — 1,344 B at 768-d with cap 128. Upper layers (~6% of nodes)
+live in a fixed-entry region in the same file (format v2), per-entry seqlocked. Per-edge cached
+distances are dropped: recomputing costs ~50 ns natively, storing costs 8 B and ~40% of a node.
+
+Degree cap is **128** for int8 (Kris, 2026-08-31, after measurement): cap 64 saved only 23.5% of
+the slot (the 768 B vector dominates) and lost 2.2 pts recall at 1M. It is a header field, so
+revising it is a rebuild, not a format change; a binary-code v2 slot reopens the question.
+
+### Concurrency
+
+Per-slot lock word: bit 31 locked, low bits the owner's pid; unlocked values are generations that
+readers validate seqlock-style. A lock unchanged for 20 ms whose owner pid is dead is taken over and
+the slot sanitized (marked invalid — a dead writer's payload is half-written; invisible until
+rewritten, never spliced-but-valid). Elapsed time alone never robs a live writer. There is no
+cross-slot atomicity: an insert writes its slot plus ~M neighbours' back-edges independently, and a
+traversal may see a half-linked state — a missing edge or a just-deleted neighbour is skipped. That
+relaxed adherence is safe _here_ because the read path loads the record and rescores exactly, which
+rejects a wrong candidate; it is not a general storage pattern. Fields a reader acts on are read
+through aligned `read_volatile`; the stored vector is an ordinary load so the int8 kernel keeps
+autovectorizing, and a torn vector only perturbs a distance the generation check discards.
+
+### Durability
+
+`msync` on a cadence, not per commit; the header watermark advances after a completed barrier. The
+graph therefore has bounded-lag durability with deterministic catch-up, while the source of truth
+(records, mappings, cursor) stays transactional. Backup treats the file as node-local derived state:
+include it after a barrier, or rebuild on restore. A file whose format or checksum does not validate
+is rebuilt from records. macOS `msync` is a weaker barrier than Linux (an `F_FULLFSYNC` pass is a
+known follow-up); Windows is supported through the prebuild; performance is a Linux target.
+
+### Search
+
+One crossing per query: `plane.search(query, k, ef, filter?)` runs on the module's thread pool with
+an epoch-stamped visited array and a fixed-capacity heap, asymmetric int8 distance with SIMD
+(AVX2/VNNI, NEON) and a scalar fallback. Filtering has two paths: a bitset over node ids for
+allow-lists and companion-condition candidate sets (zero callbacks), and a pipelined
+`ThreadsafeFunction` batch path for arbitrary JS predicates that keeps expanding in distance order
+while verdicts are in flight, bounded by the same `filterExpansion` visit budget as the JS path.
+Traversal never blocks on the event loop. A plane-backed `customIndex.search()` returns a
+promise-backed, async-only iterable (`resources/search.ts` wraps it); a synchronous consumer throws.
+Auto-ef reads the node count from `id_high_water` minus the freelist, which fixes the lifetime
+high-water inflation of the RocksDB graph (harper#2182). Every vector reaching the plane — a
+committed projection or a query target — passes one invariant (`assertPlaneVector`): array-like of
+positive length, every component a finite f32, a magnitude representable in f32, and the plane's
+`dims` once known. What fails it is the client's 400, never a plane failure; a query the plane
+cannot accept must not be read as corruption and cost a rebuild.
+
+### Delivery: a backend on the shared runtime
+
+Maintenance is off the record transaction. The commit path (`prepareCommitted`) only validates a
+changed projection; the derived-index runtime (§ above) reads the committed log and delivers batches
+to `HnswDerivedIndexBackend`:
+
+- `deliver()` enqueues and returns `accepted` (or `deferred` at 64 MiB queued); an applier drains
+  in 5 ms `setImmediate` slices. Each `records` entry (last-write-wins per key) becomes one
+  `applyDerivedValue(pk, vector | undefined, version)`: the stored mapping's signature short-circuits
+  an unchanged vector, an older observation is discarded, otherwise the old node is removed and the
+  new vector inserted with the mapping written **pending**, hidden from search.
+- `flush()` runs when the queue is empty: `plane.flushAsync()`, then pending mappings are published,
+  then the batch's `through` vector is written as the cursor under `Symbol.for('derived-index-cursor')`.
+  Application pauses while a barrier is in flight so the barrier publishes exactly the mappings it
+  covers. That order is the crash contract: a crash before the barrier leaves pending mappings that
+  replay re-derives; after it, a cursor that replays idempotently; never a published mapping to a
+  node the file did not durably get, and never a cursor over uncovered state.
+- `reset(epoch)` removes the cursor first, then the file (invalidated in-band and via a `.stale`
+  sidecar so no peer adopts a stale inode or an undeletable Windows file), then the mappings.
+- A vector the plane cannot hold at apply time (a dimensionality mismatch only the plane-holding
+  worker can see) is skipped and counted, never a rebuild.
+
+Readiness is the runtime's shared record on every worker, not `indexStore.isIndexing`: a search on
+a non-`ready` index is a 503 (`unavailable` after the rebuild budget); a `ready` index with no file
+and no surviving node mapping answers no results; one whose file is gone while mappings survive
+asks its owner for a rebuild. A search failure detaches this process from the plane and requests a
+rebuild — only the owner's `reset` destroys state, so a failure observed after a peer has already
+replaced the file cannot take out the replacement. Writer backpressure is the runtime's lag policy
+(`maxLagMilliseconds`, 30 s default on a `nativePlane` attribute), required because accepting
+unique-key load above native insert throughput and then rebuilding at that same throughput cannot
+converge.
+
+### What `nativePlane: true` requires, and what it does not promise
+
+| requirement                                                                                                                                                                                     | enforcement                                                                                                                                           |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Explicit `audit: true` on the table — the transaction log is the recovery source, and a vector-index option must not silently widen the audit-readable surface by inheriting the global setting | `ClientError` from `table()` and `attachDerivedIndexes()`; enabling logs once that the audit API retains full record history for the retention window |
+| RocksDB; `M=16`, `efConstruction=200`, `mL=1/ln(16)`, `optimizeRouting=0.5`, int8 cosine (the package's standalone `insert` fixes this geometry)                                                | `ClientError` at index construction — never a silent rebuild under native defaults                                                                    |
+| `@harperfast/hnsw` loads on the platform                                                                                                                                                        | absence is 503, not degraded: there is no JS graph to fall back to                                                                                    |
+| The log retains entries back to the cursor                                                                                                                                                      | a cursor the log cannot resolve rebuilds from records; 503 for the rebuild's duration                                                                 |
+
+Not promised: a single total order across concurrent CRDT/source-resolution arrivals (both delivery
+and replay re-read the authoritative record, so the index converges on what the primary store
+resolved; divergence is bounded by candidate selection, which the exact rescore filters), byte-identical
+graphs across nodes or rebuilds, or in-place format upgrades. Rebuild rate falls with graph size
+(≈4,700 inserts/s at 100k, 1,242/s at 1M measured), so a 16M rebuild is hours of 503; a native batch
+insert is the phase-3 follow-up.

--- a/dependencies.md
+++ b/dependencies.md
@@ -243,3 +243,15 @@ This is the inverse of the entries below — a dependency we take deliberate ste
 - Security: Microsoft-maintained TypeScript compiler, same publisher/package as the 5.x devDependency.
 - Overlap: Complements, does not replace, the `typescript` devDependency — TypeScript 7.0 ships no compiler API yet (planned for 7.1), so `@typescript-eslint/parser` still needs `typescript` 5.x. The 5.x and 7.x versions never coexist in `node_modules` at once: 5.x is the installed devDependency, 7.x is fetched on-demand by `npx` purely for `typecheck:fast`.
 - Eventual removal: Once TypeScript 7 stabilizes as the primary `typescript` devDependency (post-7.1's compiler API), this becomes redundant and `typecheck:fast` can be dropped.
+
+## @harperfast/hnsw (optional dependency)
+
+- Need for usage: Supplies the file-primary memory-mapped HNSW index used only by indexes that opt in with `nativePlane: true`. Harper keeps primary-key mappings and the replay cursor vector in RocksDB; graph nodes and adjacency exist only in the native file.
+- Size/memory cost: The JS/package metadata is about 250 KB unpacked plus one platform-specific native binary. Runtime mapped-file size is approximately 1,344 bytes per 768-dimensional int8 node at layer-0 cap 128; mappings are shared by the OS page cache across workers.
+- Security: First-party Apache-2.0 Harper package. It runs native code in-process, so Harper exact-pins the package and its own manifest exact-pins every platform prebuild to the same version. The dedicated CI job loads the registry prebuild and tests Harper against it.
+- Environment interaction: Lazily loaded only when an eligible index enables `nativePlane`; it creates a memory-mapped `.hnsw` derived-index file next to the index store and may create a `.stale` invalidation sidecar. It does not modify globals or install polyfills.
+- Overlap: None for an opted-in index. Ordinary HNSW indexes continue to use the JS/RocksDB graph; `nativePlane` indexes use native insert, mutation, and search through the shared post-commit derived-index runtime.
+- Transitive dependencies: Only exact-version, platform-specific optional prebuild packages; no JS runtime dependency tree.
+- Binary compilation: Supported Linux glibc x64/arm64, macOS arm64, and Windows x64 targets use prebuilds. Other targets attempt a Rust source build. Because the root package is optional Harper still installs if that build fails, but opted-in indexes remain unavailable until the module is present.
+- Can be deferred: Yes for ordinary HNSW indexes. The adapter loads lazily; an opted-in index returns 503 and retries rebuild when the native module is unavailable.
+- Eventual removal: Disable `nativePlane`, allow the schema reindex to rebuild the ordinary JS/CF graph, then remove the optional dependency and adapter integration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,6 +141,7 @@
 				"node": "^22.18.0 || >=24.0.0"
 			},
 			"optionalDependencies": {
+				"@harperfast/hnsw": "0.2.1",
 				"bufferutil": "4.1.0",
 				"segfault-handler": "1.3.0",
 				"utf-8-validate": "5.0.10"
@@ -2454,6 +2455,87 @@
 			"version": "1.0.3",
 			"license": "Apache-2.0"
 		},
+		"node_modules/@harperfast/hnsw": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/hnsw/-/hnsw-0.2.1.tgz",
+			"integrity": "sha512-ryUJYE9p7secerYYelVCfhc4kChBv6TZDvDFQUU7NQ99TC2dcPIXQjpOVxne2P6mQPQfh/WP5YmOYNjLn0UNbQ==",
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@harperfast/hnsw-darwin-arm64": "0.2.1",
+				"@harperfast/hnsw-linux-arm64-glibc": "0.2.1",
+				"@harperfast/hnsw-linux-x64-glibc": "0.2.1",
+				"@harperfast/hnsw-win32-x64": "0.2.1"
+			}
+		},
+		"node_modules/@harperfast/hnsw-darwin-arm64": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/hnsw-darwin-arm64/-/hnsw-darwin-arm64-0.2.1.tgz",
+			"integrity": "sha512-dCSrj+eTWyD0qvaN6zHGqo1cpwTOxyfXxP6Kl+EqpuiEcModb9gl1lG+dI6jzCBMJakjmWTgI8WiWrLSWm9p5w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@harperfast/hnsw-linux-arm64-glibc": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/hnsw-linux-arm64-glibc/-/hnsw-linux-arm64-glibc-0.2.1.tgz",
+			"integrity": "sha512-scLouN0oKR7s4Gv6h1RMzCfS7E0Lca/Tw4MeaLFD5rjQQh2YWvAfhwzPDh/HkPAiaUxEIgCXbc5KlRIzV8jZBQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@harperfast/hnsw-linux-x64-glibc": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/hnsw-linux-x64-glibc/-/hnsw-linux-x64-glibc-0.2.1.tgz",
+			"integrity": "sha512-yAReLrNpdRrs0HpPnG/nykSjz4ycMgJOAjMPMVyjkDCg9q2nO+4utn8mSBu59rNXAGdfqUHOYzXvIHrPc2E0Rg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@harperfast/hnsw-win32-x64": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/hnsw-win32-x64/-/hnsw-win32-x64-0.2.1.tgz",
+			"integrity": "sha512-TXbJhvg/7wIYrPFwGnjsOsvKcnevMXEctbDifZEiWLTUgSsepIHYKREaQXIIt+d7l08E3KGdfUl3vNaSZjGqjg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@harperfast/integration-testing": {
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/@harperfast/integration-testing/-/integration-testing-0.7.1.tgz",
@@ -2560,9 +2642,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2578,9 +2657,6 @@
 			"integrity": "sha512-MBM4Vv4ERdRgbmXZXQrGPhgmTmb0EX22dwDEFrq57mpn5IEuuXU4S/RXGAcsoEmYqYb86lvtukD5AnvxcefoSA==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -2598,9 +2674,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2616,9 +2689,6 @@
 			"integrity": "sha512-D/MfsqycP7ijIAAptUcITsMMzn7cnawdL3H1XUqe+h9fgNP7+y0gXk/9KxVA5D6cKPw1TkEDaeLuuBsiI2vFUA==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -3574,9 +3644,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3594,9 +3661,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3614,9 +3678,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3634,9 +3695,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3654,9 +3712,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3674,9 +3729,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3694,9 +3746,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3714,9 +3763,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/package.json
+++ b/package.json
@@ -262,6 +262,7 @@
 		}
 	},
 	"optionalDependencies": {
+		"@harperfast/hnsw": "0.2.1",
 		"bufferutil": "4.1.0",
 		"segfault-handler": "1.3.0",
 		"utf-8-validate": "5.0.10"

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -805,6 +805,7 @@ export function makeTable(options) {
 		static tableName = tableName;
 		static tableId = tableId;
 		static indices = indices;
+		static derivedIndexRuntime: { close(): Promise<void> } | undefined;
 		static audit = audit;
 		static databasePath = databasePath;
 		static databaseName = databaseName;
@@ -1646,6 +1647,12 @@ export function makeTable(options) {
 
 		static async dropTable() {
 			TableResource.assertSchemaMutable('drop a table');
+			// Release post-commit derived-index delivery before any destructive work: the runner's
+			// backend must have quiesced before its stores and native file are destroyed, and a
+			// same-name recreate must not race an owner still applying to the old generation.
+			const derivedIndexRuntime = TableResource.derivedIndexRuntime;
+			TableResource.derivedIndexRuntime = undefined;
+			await derivedIndexRuntime?.close();
 			const rootStore = primaryStore.rootStore;
 			if (databaseName === databasePath) {
 				// Persist a drop tombstone on the primary catalog entry BEFORE any
@@ -1782,6 +1789,7 @@ export function makeTable(options) {
 							const index = indices[attribute.name];
 							if (index)
 								try {
+									index.customIndex?.resetDerivedStorage?.();
 									index.dropSync();
 								} catch (error) {
 									ignoreAlreadyDropped(error);
@@ -1802,7 +1810,10 @@ export function makeTable(options) {
 					const drops = [];
 					for (const attribute of attributes) {
 						const index = indices[attribute.name];
-						if (index) drops.push(index.drop().catch(ignoreAlreadyDropped));
+						if (index) {
+							index.customIndex?.resetDerivedStorage?.();
+							drops.push(index.drop().catch(ignoreAlreadyDropped));
+						}
 					}
 					drops.push(primaryStore.drop().catch(ignoreAlreadyDropped));
 					await Promise.all(drops);
@@ -6223,6 +6234,7 @@ export function makeTable(options) {
 			const promises = [primaryStore.clear()];
 			for (const key in indices) {
 				const index = indices[key];
+				index.customIndex?.resetDerivedStorage?.();
 				promises.push(index.clearAsync ? index.clearAsync() : index.clear());
 			}
 			return Promise.all(promises);
@@ -6230,6 +6242,7 @@ export function makeTable(options) {
 		/** Release everything makeTable() registered process-wide; the class must not be used afterwards. */
 		static cleanup() {
 			disposed = true;
+			void TableResource.derivedIndexRuntime?.close();
 			clearTimeout(cleanupTimer);
 			settlePendingCleanup();
 			clearInterval(recordExpirationInterval);

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -4,7 +4,16 @@ import { initSync, getHdbBasePath, get as envGet } from '../utility/environment/
 import { INTERNAL_DBIS_NAME } from '../utility/lmdb/terms.ts';
 import { open, compareKeys, type Database, type RootDatabase } from 'lmdb';
 import { join, extname, basename } from 'path';
-import { existsSync, mkdirSync, readFileSync, readdirSync, realpathSync } from 'node:fs';
+import {
+	closeSync,
+	existsSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	readdirSync,
+	realpathSync,
+	unlinkSync,
+} from 'node:fs';
 import { unlink } from 'node:fs/promises';
 import {
 	getBaseSchemaPath,
@@ -35,10 +44,12 @@ import { databasePaths, deleteRootBlobPathsForDB } from './blob.ts';
 import { removeStorageReclamation } from '../server/storageReclamation.ts';
 import { commonValidators, schemaRegex } from '../validation/common_validators.ts';
 import { CUSTOM_INDEXES } from './indexes/customIndexes.ts';
+import { planeFilePathFor, planeStalePathFor } from './indexes/hnswPlaneBinding.ts';
 import { OpenDBIObject } from '../utility/lmdb/OpenDBIObject.ts';
 import { RocksDatabase, supportedCompression, type RocksDatabaseOptions } from '@harperfast/rocksdb-js';
 import { PrimaryRocksDatabase } from './PrimaryRocksDatabase.ts';
 import { replayLogs } from './replayLogs.ts';
+import { attachDerivedIndexes } from './indexes/hnswDerivedIndex.ts';
 import { totalmem } from 'node:os';
 import { RocksIndexStore } from './RocksIndexStore.ts';
 import { resolveRocksMemoryConfig } from '../utility/rocksMemoryConfig.ts';
@@ -1323,6 +1334,8 @@ function initStores(
 			table.schemaVersion = 1;
 			if (!destination) databaseEventsEmitter.emit('updateTable', table);
 		}
+		void table.derivedIndexRuntime?.close();
+		table.derivedIndexRuntime = attachDerivedIndexes(table);
 		if (Array.isArray(primaryAttribute.relationships)) {
 			relationshipsToHydrate.push({ table, databaseName, tableName, definitions: primaryAttribute.relationships });
 		} else if (primaryAttribute.relationships !== undefined) {
@@ -2262,6 +2275,9 @@ function openIndex(dbiKey: string, rootStore: RootDatabaseKind, attribute: any) 
 		const CustomIndex = CUSTOM_INDEXES[attribute.indexed.type];
 		if (CustomIndex) {
 			indexStore.customIndex = new CustomIndex(indexStore, attribute.indexed);
+			// derived state whose maintaining option is now off must not linger to be adopted
+			// stale on a later re-enable
+			indexStore.customIndex.cleanupDisabledPlane?.();
 		} else {
 			logger.error(`The indexing type '${attribute.indexed.type}' is unknown`);
 		}
@@ -2433,6 +2449,18 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 	// flag must be left as-is. Only an explicit value can re-assert on the existing-Table branch.
 	const schemaDefinedExplicit = tableDefinition.schemaDefined !== undefined;
 	if (schemaDefined == undefined) schemaDefined = true;
+	if (
+		attributes.some((attribute) => attribute.indexed?.type === 'HNSW' && attribute.indexed.nativePlane) &&
+		audit !== true &&
+		// An explicit false must fail here even for an already-audited Table. Nothing clears the
+		// static, so the runtime would stay attached while the descriptor persists audit: false,
+		// and the next process start would fail catalog load on the derived-index attach.
+		(audit === false || Table?.audit !== true)
+	) {
+		throw new ClientError(
+			`Table '${databaseName}.${tableName}' must explicitly enable audit logging before using nativePlane because its transaction log is the derived-index recovery source`
+		);
+	}
 	const relationshipDefinitions = schemaRelationshipsDefined ? normalizeRelationships(attributes) : undefined;
 	const internalDbiInit = createOpenDBIObject(false);
 
@@ -3052,6 +3080,8 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 		signalling.signalSchemaChange(
 			new SchemaEventMsg(process.pid, 'schema-change', Table.databaseName, Table.tableName, undefined, branchPath)
 		);
+	void Table.derivedIndexRuntime?.close();
+	Table.derivedIndexRuntime = attachDerivedIndexes(Table);
 
 	Table.origin = origin;
 	// scope-private: replication and other global subscribers must not learn of a branch class
@@ -3321,6 +3351,7 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 				};
 			});
 		for (const index of indicesToRemove) {
+			index.customIndex?.resetDerivedStorage?.();
 			track(index.drop(), (error) => onIndexPutRejected(index.name, error));
 		}
 		let interrupted;
@@ -3331,6 +3362,8 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			const start = resumeStartKey(attributes);
 			if (start === undefined) {
 				for (const attribute of attributes) {
+					// if we are starting from the beginning, clear out any previous index entries since we are rewriting
+					attribute.dbi.customIndex?.resetDerivedStorage?.();
 					if (attribute.dbi.clearAsync) {
 						// LMDB enqueues this ahead of the index writes, so the scan need not wait for it — but the
 						// barriers must, or a rejected clear certifies a checkpoint over stale entries.
@@ -3568,6 +3601,24 @@ function completeInterruptedDrop(rootStore, attributesDbi, databaseName: string,
 					ignoreAlreadyDropped(error);
 				} finally {
 					columnStore.close();
+				}
+				// derived HNSW plane files live next to the store; the normal drop path removes
+				// them through the custom index, but this recovery path drops raw column stores,
+				// and a same-name recreate must never open a stale plane over a fresh CF
+				try {
+					unlinkSync(planeFilePathFor(rootStore.path, columnName));
+				} catch (error: any) {
+					// a stale plane left behind (e.g. Windows EBUSY while still mapped) would be
+					// opened over a fresh same-name CF, resolving another graph's node ids
+					// against it — tombstone it so no attach ever adopts it
+					if (error?.code !== 'ENOENT') {
+						logger.warn(`could not delete the HNSW plane file for ${columnName}; tombstoning it as stale`, error);
+						try {
+							closeSync(openSync(planeStalePathFor(planeFilePathFor(rootStore.path, columnName)), 'w'));
+						} catch (tombstoneError) {
+							logger.warn(`could not tombstone the stale HNSW plane file for ${columnName}`, tombstoneError);
+						}
+					}
 				}
 			}
 		}

--- a/resources/indexes/HierarchicalNavigableSmallWorld.ts
+++ b/resources/indexes/HierarchicalNavigableSmallWorld.ts
@@ -1,11 +1,31 @@
+import { closeSync, existsSync, openSync, rmSync, statSync, unlinkSync } from 'node:fs';
 import { cosineDistance, euclideanDistance, dotProductDistance } from './vector.ts';
 import { FLOAT32_OPTIONS } from 'msgpackr';
 import { loggerWithTag } from '../../utility/logging/logger.ts';
-import { ClientError } from '../../utility/errors/hdbError.ts';
+import { ClientError, ServerError } from '../../utility/errors/hdbError.ts';
 import type { Id } from '../../resources/ResourceInterface.ts';
+import type { DerivedIndexReadiness } from '../derivedIndexRuntime.ts';
 import { SKIP } from '@harperfast/extended-iterable';
+import { RocksDatabase } from '@harperfast/rocksdb-js';
+import { createHash } from 'node:crypto';
+import {
+	getPlaneBinding,
+	invalidatePlaneFile as invalidateHnswPlaneFile,
+	planeFilePathFor,
+	planeStalePathFor,
+	PLANE_NO_ID,
+	type HnswPlane,
+} from './hnswPlaneBinding.ts';
 
 const logger = loggerWithTag('HNSW');
+
+/** Element-wise equality of the array-like projections a derived index stores; anything else that failed `===` counts as changed. */
+export function derivedValuesEqual(a: any, b: any): boolean {
+	if (a === b) return true;
+	if (a == null || b == null || typeof a.length !== 'number' || a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+	return true;
+}
 
 // int8 scalar quantization of stored graph nodes is ON by default. Each node holds the
 // vector as a compact int8 `bin` plus a per-vector `scale`, roughly a 5x size reduction
@@ -104,6 +124,22 @@ function autoScaleEfConstruction(nodeCount: number): number {
 // ef moves with the square root of the count and is capped, so a slightly stale size is immaterial;
 // this only has to be short enough that a table growing from empty picks up a larger ef promptly.
 const NODE_COUNT_TTL = 10_000;
+
+// Native traversal-plane geometry (DESIGN.md § Native HNSW plane). The layer-0 cap is derived from
+// M/optimizeRouting at creation to cover the JS graph's effective cap (grace overshoot above it
+// truncates by distance); a configuration deriving past this ceiling is refused as ineligible
+// rather than silently truncated. maxNodes is a fixed sparse reservation — pages materialize on
+// write — and ids at or past it are rejected by the crate, which disables the plane.
+const PLANE_LAYER0_CAP_MAX = 1024;
+const PLANE_MAX_NODES = 1 << 24;
+// An existing plane file that cannot be opened is normally another worker mid-create (retry);
+// past this age it is a crashed create and is deleted so the audit-backed runtime can rebuild it.
+const PLANE_STALE_CREATE_MS = 60_000;
+// Retry cadence while another worker holds the create; its header lands shortly after exclusive open.
+const PLANE_ATTACH_RETRY_MS = 250;
+// Marks an error thrown by an app-supplied filter during a plane search: the caller re-raises
+// it as an ordinary query failure instead of disabling the (healthy) plane.
+const NOT_A_PLANE_FAILURE = Symbol('notAPlaneFailure');
 
 class MinHeap {
 	private data: Candidate[] = [];
@@ -235,6 +271,23 @@ export class HierarchicalNavigableSmallWorld {
 	private convertedNodes = new WeakMap<object, any>();
 	private nodeCount = 0;
 	private nodeCountAt = 0;
+	// Native file-primary index. The RocksDB index store holds identity mappings and replay cursors;
+	// graph nodes and adjacency exist only in this file.
+	// undefined = not yet attached (may retry), null = unavailable or disabled for this process.
+	private plane: HnswPlane | null | undefined;
+	private planeEligible = false;
+	private planeRetryAt = 0;
+	private planeDisabledLogged = false;
+	private filePrimary = false;
+	private nativePlaneMaxNodes = PLANE_MAX_NODES;
+	// Installed by attachDerivedIndexes on every worker: shared readiness of the index and the way
+	// to ask its owner for a rebuild. Only the owning worker's runtime ever destroys native state.
+	private derivedHost?: { readiness: () => DerivedIndexReadiness; requestRebuild: () => boolean };
+	private pendingDerivedMappings = new Map<
+		Id,
+		{ id?: number; signature?: string; version?: number; pending?: boolean }
+	>();
+	postCommit?: true;
 	constructor(indexStore: any, options: any) {
 		this.indexStore = indexStore;
 		if (indexStore) {
@@ -265,8 +318,459 @@ export class HierarchicalNavigableSmallWorld {
 			if (options.optimizeRouting !== undefined) this.optimizeRouting = options.optimizeRouting;
 			if (options.filterExpansion !== undefined) this.filterExpansion = options.filterExpansion;
 		}
+		if (options?.nativePlane) {
+			if (!(indexStore?.rootStore instanceof RocksDatabase)) {
+				throw new ClientError('nativePlane requires the RocksDB storage engine');
+			}
+			const nativeML = 1 / Math.log(16);
+			if (
+				(options.M !== undefined && options.M !== 16) ||
+				(options.efConstruction !== undefined && options.efConstruction !== 200) ||
+				(options.mL !== undefined && options.mL !== nativeML) ||
+				(options.optimizeRouting !== undefined && options.optimizeRouting !== 0.5)
+			) {
+				throw new ClientError('nativePlane requires M=16, efConstruction=200, mL=1/ln(16), and optimizeRouting=0.5');
+			}
+			this.efConstruction = options.efConstruction ?? 200;
+			this.nativePlaneMaxNodes = options.nativePlaneMaxNodes ?? PLANE_MAX_NODES;
+			if (
+				!Number.isSafeInteger(this.nativePlaneMaxNodes) ||
+				this.nativePlaneMaxNodes < 1 ||
+				this.nativePlaneMaxNodes >= PLANE_NO_ID
+			) {
+				throw new ClientError('nativePlaneMaxNodes must be a positive integer below 2^32-1');
+			}
+			// The plane stores int8 bins and computes asymmetric cosine only, so the flag is a
+			// no-op for float (quantization: "none") and non-cosine indexes; a graph whose derived
+			// layer-0 cap exceeds the plane maximum is refused rather than silently truncated.
+			this.planeEligible =
+				this.int8 && this.distance === cosineDistance && this.planeLayer0Cap() <= PLANE_LAYER0_CAP_MAX;
+			if (!this.planeEligible) {
+				throw new ClientError('nativePlane requires an int8-quantized cosine HNSW index');
+			}
+			this.filePrimary = true;
+			this.postCommit = true;
+		}
 	}
+
+	/** Remove derived native state after the option is disabled. */
+	cleanupDisabledPlane(): void {
+		if (this.planeEligible) return;
+		const filePath = this.planeFilePath();
+		if (!filePath) return;
+		try {
+			if (existsSync(filePath)) this.invalidatePlaneFile(filePath, this.plane);
+			unlinkSync(filePath);
+			logger.info?.('deleted the HNSW plane file of an index no longer using nativePlane');
+		} catch (error: any) {
+			if (error?.code !== 'ENOENT') {
+				// A later re-enable must not adopt a file that missed mutations while disabled.
+				logger.warn?.('could not delete the HNSW plane file; marking it stale', error);
+				this.invalidatePlaneFile(filePath);
+			}
+		}
+	}
+
+	/** Absolute path of this index's plane file, or undefined when the store exposes no path. */
+	planeFilePath(): string | undefined {
+		const storePath = this.indexStore?.path;
+		const storeName = this.indexStore?.name;
+		if (typeof storePath !== 'string' || typeof storeName !== 'string') return undefined;
+		return planeFilePathFor(storePath, storeName);
+	}
+
+	/**
+	 * Open or lazily create the native file. An exclusive create resolves multi-worker races; the
+	 * derived-index runtime owns population, replay, and publication.
+	 */
+	private getPlane(dims?: number, dimsFromVector = false): HnswPlane | null {
+		if (this.plane !== undefined) return this.plane;
+		if (!this.planeEligible) return (this.plane = null);
+		const now = Date.now();
+		if (now < this.planeRetryAt) return null;
+		const Plane = getPlaneBinding();
+		if (!Plane) return (this.plane = null); // the loader warned once already
+		const filePath = this.planeFilePath();
+		if (!filePath) {
+			this.disablePlane(new Error('the index store exposes no path to place the plane file next to'));
+			return null;
+		}
+		try {
+			// a tombstone marks a plane a previous unlink could not remove (Windows EBUSY while
+			// mapped): the file is stale and must never be opened over a fresh graph
+			const stalePath = planeStalePathFor(filePath);
+			if (existsSync(stalePath)) {
+				try {
+					// force: either artifact may already be gone (the documented rollback deletes the
+					// plane file by hand), and an ENOENT here disables the plane on every later attach
+					rmSync(filePath, { force: true });
+					rmSync(stalePath, { force: true });
+				} catch {
+					this.planeRetryAt = now + NODE_COUNT_TTL;
+					return null;
+				}
+			}
+			if (existsSync(filePath)) {
+				try {
+					// Crash recovery is per-slot inside the crate. The clean flag is advisory;
+					// another worker may still be constructing this shared file.
+					return (this.plane = Plane.open(filePath));
+				} catch (openError) {
+					if (now - statSync(filePath).mtimeMs <= PLANE_STALE_CREATE_MS) {
+						// another worker is between its exclusive create and the header write
+						this.planeRetryAt = now + PLANE_ATTACH_RETRY_MS;
+						return null;
+					}
+					logger.warn?.('deleting an unopenable HNSW plane file left by an interrupted create', openError);
+					unlinkSync(filePath);
+					if (this.filePrimary) {
+						// The surviving mappings still name node ids from the file just removed.
+						// Creating a fresh plane here would resolve them against an empty graph;
+						// only reconstruction, which clears the mappings first, is safe.
+						this.planeRetryAt = now + PLANE_ATTACH_RETRY_MS;
+						return null;
+					}
+				}
+			}
+			if (!dims) return null; // open-only call and no file: nothing to attach yet
+			// A search target must not pin an empty index's dimensionality: creation is deferred to
+			// the first committed vector or to the rebuild scan. Return before the exclusive create
+			// rather than creating and unlinking — a concurrent insert that saw the empty file would
+			// read it as another worker's in-progress create and 503 for PLANE_STALE_CREATE_MS.
+			if (!dimsFromVector) return null;
+			let fd: number;
+			try {
+				fd = openSync(filePath, 'wx');
+			} catch {
+				// another worker won the create race; its header lands within moments
+				this.planeRetryAt = now + PLANE_ATTACH_RETRY_MS;
+				return null;
+			}
+			closeSync(fd);
+			try {
+				return (this.plane = Plane.create(filePath, dims, this.planeLayer0Cap(), this.nativePlaneMaxNodes));
+			} catch (createError) {
+				// Never leave a partial file that a later process could trust as current.
+				try {
+					unlinkSync(filePath);
+				} catch {
+					// the disable below already forces the JS path for this process
+				}
+				this.disablePlane(createError);
+				return null;
+			}
+		} catch (error) {
+			this.planeRetryAt = now + NODE_COUNT_TTL;
+			logger.warn?.('could not attach the HNSW plane file; will retry', error);
+			return null;
+		}
+	}
+
+	/** True only while the owning runtime publishes the index as ready, on whichever worker owns it. */
+	private planeSearchReady(plane: HnswPlane): boolean {
+		if (plane.invalidated()) {
+			this.plane = undefined;
+			return false;
+		}
+		return this.derivedReadiness() === 'ready';
+	}
+
+	private derivedReadiness(): DerivedIndexReadiness['state'] {
+		return this.derivedHost?.readiness().state ?? 'unknown';
+	}
+
+	/** The JS graph's effective layer-0 cap for this configuration; sizes the plane's slots. */
+	private planeLayer0Cap(): number {
+		return this.optimizeRouting ? this.M << 3 : this.M << 1;
+	}
+
+	/**
+	 * Detach this process from the plane after a failure and ask the index's owner for a rebuild.
+	 * Only the owner destroys native state (`resetDerivedStorage` under its epoch), so a failure
+	 * observed here after a peer has already replaced the file cannot take out the replacement.
+	 */
+	private disablePlane(error: unknown): void {
+		this.plane = undefined;
+		this.planeRetryAt = Date.now() + PLANE_ATTACH_RETRY_MS;
+		if (!this.planeDisabledLogged) {
+			this.planeDisabledLogged = true;
+			logger.error?.('the HNSW native index failed; requesting a rebuild from its owner', error);
+		}
+		this.derivedHost?.requestRebuild();
+	}
+
+	/**
+	 * Delete the derived plane state before an audit-backed reconstruction. Path invalidation
+	 * makes peers stop using an old mapping even when unlink leaves their mmap inode alive.
+	 */
+	resetDerivedStorage(): void {
+		this.pendingDerivedMappings.clear();
+		const attached = this.plane;
+		this.plane = undefined;
+		this.planeRetryAt = 0;
+		const filePath = this.planeFilePath();
+		if (!filePath) return;
+		if (this.filePrimary && existsSync(filePath)) this.invalidatePlaneFile(filePath, attached);
+		try {
+			unlinkSync(filePath);
+		} catch (error: any) {
+			if (error?.code !== 'ENOENT') {
+				// a stale file that cannot be deleted (e.g. Windows EBUSY while mapped) must not
+				// be reopened as if current — mark it so no process ever adopts it
+				this.plane = null;
+				logger.warn?.('could not delete the HNSW plane file; marking it stale', error);
+				this.invalidatePlaneFile(filePath, attached);
+			}
+		}
+	}
+
+	/** True while any node-id mapping survives, which is the only proof this index holds nodes. */
+	private hasNodeMappings(): boolean {
+		// Node ids are the store's numeric keys, so bounding the probe to that key space keeps this
+		// off a full scan of the primary-key mappings beside them.
+		for (const { key } of this.indexStore.getRange({ start: 0, end: Number.MAX_SAFE_INTEGER })) {
+			if (typeof key === 'number') return true;
+		}
+		return false;
+	}
+
+	/** Make an undeletable plane unadoptable before this process releases it. */
+	private invalidatePlaneFile(filePath: string, attached?: HnswPlane | null): void {
+		try {
+			invalidateHnswPlaneFile(filePath, attached);
+		} catch (error) {
+			logger.warn?.('could not invalidate the stale HNSW plane file', error);
+		}
+	}
+
+	/**
+	 * Native search over the plane: one NAPI crossing, traversal on the libuv pool, promise
+	 * resolution maps node ids back to primary keys through the existing pk resolution. The
+	 * predicate adapter runs on this thread's event loop (batched over a ThreadsafeFunction), so
+	 * this promise must never be awaited by code the predicate itself blocks on; the normal
+	 * request path awaits it safely.
+	 */
+	private searchPlane(
+		plane: HnswPlane,
+		target: number[],
+		ef: number,
+		filter: ((primaryKey: Id) => boolean) | undefined,
+		filterState: FilterState | undefined,
+		options: any
+	): Promise<any[]> {
+		const query = Float32Array.from(target);
+		let resultPromise: Promise<{ id: number; distance: number }[]>;
+		let predicateError: unknown;
+		if (filter && filterState) {
+			const predicate = (ids: number[]): Uint8Array => {
+				const verdicts = new Uint8Array(ids.length);
+				if (predicateError !== undefined) return verdicts; // already failed — deny remaining batches cheaply
+				try {
+					for (let i = 0; i < ids.length; i++) {
+						const primaryKey = this.safeGetSync(ids[i], options)?.primaryKey;
+						if (primaryKey !== undefined && this.admit(filter, filterState, primaryKey)) verdicts[i] = 1;
+					}
+				} catch (error) {
+					// an app-supplied filter threw: deny the batch and surface the error once the
+					// traversal resolves — the same query failure the JS path raises — instead of
+					// letting it escape into the fatal-strategy ThreadsafeFunction callback
+					predicateError ??= error;
+				}
+				return verdicts;
+			};
+			// pass the already-resolved JS visit budget verbatim so both paths stop at the same count
+			resultPromise = plane.searchWithPredicate(query, ef, ef, predicate, undefined, filterState.maxVisits);
+		} else {
+			resultPromise = plane.search(query, ef, ef);
+		}
+		return resultPromise.then((hits) => {
+			if (predicateError !== undefined) {
+				// the plane itself is healthy; mark the failure as the application's so the caller
+				// re-raises it rather than disabling the plane and retrying
+				try {
+					(predicateError as any)[NOT_A_PLANE_FAILURE] = true;
+				} catch {
+					// a frozen/primitive throw still propagates, it just also disables the plane
+				}
+				throw predicateError;
+			}
+			const entries: any[] = [];
+			try {
+				for (const hit of hits) {
+					const mapping = this.safeGetSync(hit.id, options);
+					if (mapping?.pending) continue;
+					const primaryKey = mapping?.primaryKey;
+					if (primaryKey === undefined) continue; // deleted/reused id raced the search
+					entries.push({ key: primaryKey, distance: hit.distance });
+				}
+			} catch (error) {
+				// The traversal already succeeded; this is a RocksDB read of the id mappings, which
+				// can fail transiently or because the store closed under an in-flight search. Tagging
+				// it keeps the caller from reading it as a plane failure and unlinking a healthy file,
+				// which costs a full reconstruction.
+				try {
+					(error as any)[NOT_A_PLANE_FAILURE] = true;
+				} catch {
+					// a frozen/primitive throw still propagates, it just also disables the plane
+				}
+				throw error;
+			}
+			// nodesVisited stays 0 here: layer-0 visits happen inside the native traversal
+			// (filterEvaluations is still counted by the predicate adapter)
+			return withStats(entries, filterState);
+		});
+	}
+
+	attachDerivedHost(host: { readiness: () => DerivedIndexReadiness; requestRebuild: () => boolean }): void {
+		this.derivedHost = host;
+	}
+
+	/**
+	 * The commit path only validates: a malformed vector is the client's 400 here rather than an
+	 * unindexable record later. The shared derived-index runtime reads the committed log; nothing
+	 * is staged on the transaction.
+	 */
+	prepareCommitted(primaryKey: Id, vector: number[], existingVector: number[]): void {
+		// O(dims) on every write to the table, so skip it when the projection did not change — an
+		// unchanged vector was validated when it was first written.
+		if (derivedValuesEqual(vector, existingVector)) return;
+		this.validateVector(primaryKey, vector);
+	}
+
+	/** The runtime's projection guard: what fails here is delivered as unindexable, not applied. */
+	assertDerivedValue(vector: unknown, label: string): void {
+		this.assertPlaneVector(vector as number[], label);
+	}
+
+	private validateVector(primaryKey: Id, vector?: number[]): void {
+		if (!vector) return;
+		this.assertPlaneVector(vector, `Vector for attribute "${String(primaryKey)}"`);
+	}
+
+	/**
+	 * Everything reaching the plane — a committed record's projection or a query target — has to
+	 * convert to the f32 it stores, and to a representable magnitude. What fails here would instead
+	 * throw out of `Float32Array.from` or out of the crate, as an error neither the search path nor
+	 * reconstruction can attribute to the record: a query would unlink a healthy file, and a record
+	 * would abort every rebuild attempt at the same entry.
+	 */
+	private assertPlaneVector(vector: number[], label: string): void {
+		// A positive integer length, not merely a numeric one: a negative or fractional length skips
+		// the component loop and the emptiness check, and reaches Plane.create with it.
+		const length = (vector as any)?.length;
+		if (!Number.isInteger(length) || length < 1) {
+			throw new ClientError(`${label} must be an array of at least one number.`);
+		}
+		let sumOfSquares = 0;
+		for (let i = 0; i < vector.length; i++) {
+			const component = vector[i];
+			// The type check precedes Math.fround, which throws a TypeError on the BigInt a msgpackr
+			// or cbor-x decode produces for a large int64.
+			if (typeof component !== 'number' || !Number.isFinite(Math.fround(component))) {
+				throw new ClientError(
+					`${label} has a component at index ${i} that is not a finite 32-bit float: ${String(component)}.`
+				);
+			}
+			const asFloat32 = Math.fround(component);
+			sumOfSquares += asFloat32 * asFloat32;
+		}
+		// Components can each be f32-finite while their squares are not, which stores invMag 0 and
+		// makes every distance involving that node NaN.
+		if (!Number.isFinite(Math.fround(sumOfSquares))) {
+			throw new ClientError(`${label} has a magnitude too large to represent in 32-bit floats.`);
+		}
+		// The plane's dimensionality is fixed at create time by the first committed vector.
+		const dims = this.plane?.dims;
+		if (dims !== undefined && vector.length !== dims) {
+			throw new ClientError(`${label} has ${vector.length} components, but this index stores ${dims}.`);
+		}
+	}
+
+	applyDerivedValue(primaryKey: Id, vector: number[], version?: number): void {
+		this.validateVector(primaryKey, vector);
+		const safeKey = typeof primaryKey === 'number' ? [KEY_PREFIX, primaryKey] : primaryKey;
+		const pendingMapping = this.pendingDerivedMappings.get(primaryKey);
+		const storedMapping = pendingMapping ?? this.indexStore.getSync(safeKey);
+		const oldNodeId = typeof storedMapping === 'number' ? storedMapping : storedMapping?.id;
+		if (storedMapping?.version != null && version != null && storedMapping.version > version) return;
+		const nativeVector = vector ? Float32Array.from(vector) : undefined;
+		const signature = nativeVector
+			? createHash('sha256')
+					.update(Buffer.from(nativeVector.buffer, nativeVector.byteOffset, nativeVector.byteLength))
+					.digest('base64url')
+			: undefined;
+		if (
+			oldNodeId != null &&
+			signature &&
+			storedMapping.signature === signature &&
+			!pendingMapping &&
+			!storedMapping.pending
+		) {
+			this.indexStore.putSync(safeKey, { id: oldNodeId, signature, version });
+			this.indexStore.putSync(oldNodeId, { primaryKey, version });
+			return;
+		}
+		let plane = vector ? this.getPlane(vector.length, true) : this.getPlane();
+		if (plane?.invalidated()) {
+			this.plane = undefined;
+			plane = vector ? this.getPlane(vector.length, true) : this.getPlane();
+		}
+		// The pre-commit check above ran before this worker had a plane to compare against, so it
+		// cannot have caught a mismatch. Reject before the removal below, or the record loses its
+		// old node on the way to failing.
+		if (vector && plane && vector.length !== plane.dims) {
+			throw new ClientError(
+				`Vector for attribute "${String(primaryKey)}" has ${vector.length} components, but this index stores ${plane.dims}.`
+			);
+		}
+		if (oldNodeId != null) {
+			plane?.remove(oldNodeId);
+			this.indexStore.removeSync(oldNodeId);
+		}
+		if (!vector) {
+			this.indexStore.removeSync(safeKey);
+			this.pendingDerivedMappings.set(primaryKey, { version });
+			return;
+		}
+		if (!plane) throw new ServerError('The native HNSW module is unavailable for a file-primary index', 503);
+		const nodeId = plane.insert(nativeVector!);
+		this.indexStore.putSync(safeKey, { id: nodeId, signature, version, pending: true });
+		this.indexStore.putSync(nodeId, { primaryKey, version, pending: true });
+		this.pendingDerivedMappings.set(primaryKey, { id: nodeId, signature, version, pending: true });
+	}
+
+	async flushDerived(watermark?: number): Promise<void> {
+		const plane = this.getPlane();
+		if (!plane) {
+			if (!getPlaneBinding()) throw new ServerError('The native HNSW module is unavailable', 503);
+			return this.publishDerivedMappings();
+		}
+		await plane.flushAsync(watermark);
+		this.publishDerivedMappings();
+	}
+
+	private publishDerivedMappings(): void {
+		for (const [primaryKey, mapping] of this.pendingDerivedMappings) {
+			const safeKey = typeof primaryKey === 'number' ? [KEY_PREFIX, primaryKey] : primaryKey;
+			if (mapping.id === undefined) {
+				this.indexStore.removeSync(safeKey);
+			} else {
+				const published = { id: mapping.id, signature: mapping.signature, version: mapping.version };
+				this.indexStore.putSync(safeKey, published);
+				this.indexStore.putSync(mapping.id, { primaryKey, version: mapping.version });
+			}
+		}
+		this.pendingDerivedMappings.clear();
+	}
+
 	index(primaryKey: Id, vector: number[], existingVector?: number[], options: any = {}) {
+		if (this.filePrimary) {
+			if (options.transaction) return this.prepareCommitted(primaryKey, vector, existingVector);
+			// runIndexing invokes custom indexes without a transaction. The shared runtime owns the
+			// primary-record rebuild and the log replay; populating here would duplicate native
+			// construction and race the owner's generation reset.
+			return;
+		}
 		// Reject non-finite components before touching the graph. NaN in particular poisons
 		// bisectInsert (arr[mid].distance <= NaN is always false → returns 0, pinning the
 		// candidate to rank 1 of every future search). Infinity causes analogous ordering
@@ -508,18 +1012,15 @@ export class HierarchicalNavigableSmallWorld {
 			}
 
 			// Store the new element
-			this.indexStore.put(
-				nodeId,
-				{
-					vector: storedVector,
-					scale: storedScale,
-					invMag,
-					level,
-					primaryKey,
-					...connections,
-				},
-				options
-			);
+			const storedNode = {
+				vector: storedVector,
+				scale: storedScale,
+				invMag,
+				level,
+				primaryKey,
+				...connections,
+			};
+			this.indexStore.put(nodeId, storedNode, options);
 		} else {
 			// removal of this node, but first make sure we have a valid entry point
 			if (entryPointId === nodeId) {
@@ -1163,6 +1664,56 @@ export class HierarchicalNavigableSmallWorld {
 					filterEvaluations: 0,
 				}
 			: undefined;
+		if (this.filePrimary && distanceFunction !== this.distance) {
+			throw new ClientError('A nativePlane index only supports its configured cosine distance');
+		}
+		// The plane traverses the index's own metric (cosine — the eligibility requirement), so a
+		// query overriding `distance` has to take the JS path: rescoreResults only corrects the
+		// reported distances of whatever candidates came back, not which candidates the beam kept.
+		if (this.planeEligible && distanceFunction === this.distance) {
+			const plane = this.getPlane(target.length, false);
+			// A file-primary index has no JS path to fall through to, so a target the plane cannot
+			// accept has to fail as the client error it is. Otherwise it throws out of
+			// Float32Array.from or the traversal, is read as plane corruption, and unlinks a healthy
+			// file — one malformed query costing a full reconstruction.
+			if (this.filePrimary && plane) this.assertPlaneVector(target, 'Search target');
+			// a non-file-primary query whose dimensionality differs from the graph's takes the JS
+			// path, which tolerates the mismatch, rather than disabling the healthy plane
+			if (plane && plane.dims === target.length && this.planeSearchReady(plane)) {
+				try {
+					return this.searchPlane(plane, target, effectiveEf, filter, filterState, options).catch((error) => {
+						// the query failed for a reason outside the traversal: re-raise instead of disabling the file
+						if (error?.[NOT_A_PLANE_FAILURE]) throw error;
+						// There is no JS graph behind a file-primary index: it stays unavailable until
+						// its audit-backed rebuild succeeds.
+						this.disablePlane(error);
+						throw new ServerError('The native HNSW index is rebuilding', 503);
+					});
+				} catch (error) {
+					// Handle a throw raised before the asynchronous native search returns its promise.
+					this.disablePlane(error);
+					throw new ServerError('The native HNSW index is rebuilding', 503);
+				}
+			}
+		}
+		if (this.filePrimary) {
+			const state = this.derivedReadiness();
+			if (state === 'unavailable') throw new ServerError('The native HNSW index is unavailable', 503);
+			const planePath = this.planeFilePath();
+			if (state !== 'ready' || (planePath && existsSync(planePath))) {
+				throw new ServerError('The native HNSW index is rebuilding', 503);
+			}
+			// The absence of a file is not proof of an empty index — it is also the state just after
+			// any process removes an unopenable one. Only the surviving node mappings prove it.
+			if (this.hasNodeMappings()) {
+				// A table taking no further writes never drains, so a query is the only thing left
+				// that can notice the graph is gone and ask for it back.
+				logger.error?.(`${this.indexStore.name} lost its native file while its node mappings survive`);
+				this.derivedHost?.requestRebuild();
+				throw new ServerError('The native HNSW index is rebuilding', 503);
+			}
+			return withStats([], filterState);
+		}
 		let entryPoint = this.getEntryPoint(options);
 		if (!entryPoint) return withStats([], filterState);
 		let entryPointId = entryPoint.id;

--- a/resources/indexes/hnswDerivedIndex.ts
+++ b/resources/indexes/hnswDerivedIndex.ts
@@ -1,0 +1,332 @@
+import { ClientError } from '../../utility/errors/hdbError.ts';
+import { loggerWithTag } from '../../utility/logging/logger.ts';
+import type { Id } from '../ResourceInterface.ts';
+import type { RocksTransactionLogStore } from '../RocksTransactionLogStore.ts';
+import {
+	DERIVED_INDEX_ACCEPTED,
+	DERIVED_INDEX_DEFERRED,
+	DerivedIndexRuntime,
+	readDerivedIndexReadiness,
+	type DerivedIndexBackend,
+	type DerivedIndexBackendHost,
+	type DerivedIndexBackendStateChange,
+	type DerivedIndexBatch,
+	type DerivedIndexCursor,
+	type DerivedIndexDeliveryResult,
+	type DerivedIndexFlushReason,
+	type DerivedIndexMutation,
+	type DerivedIndexReadiness,
+} from '../derivedIndexRuntime.ts';
+
+const logger = loggerWithTag('HNSW');
+
+/** The one durable cursor vector of a file-primary HNSW index, stored beside its node mappings. */
+export const DERIVED_INDEX_CURSOR_KEY = Symbol.for('derived-index-cursor');
+
+// Bounds on the queue between the runtime's delivery and the native applier. The runtime already
+// chunks a delivery by records and estimated bytes; this caps how many chunks may wait.
+const QUEUE_CAPACITY_BYTES = 64 * 1024 * 1024;
+const APPLY_SLICE_MILLIS = 5;
+// Writes to an index this far behind fail with a retryable 503 (see the runtime's lag policy).
+const DEFAULT_MAX_LAG_MILLISECONDS = 30_000;
+
+/**
+ * The native index methods the backend drives. `applyDerivedValue` inserts, replaces or removes
+ * one primary key's vector and stages its mapping as pending; `flushDerived` is the durability
+ * barrier that publishes the pending mappings; `resetDerivedStorage` destroys the native file.
+ */
+export interface DerivedNativeIndex {
+	readonly indexStore: any;
+	applyDerivedValue(primaryKey: Id, vector: number[] | undefined, version?: number): void;
+	flushDerived(): Promise<void>;
+	resetDerivedStorage(): void;
+	assertDerivedValue(vector: unknown, label: string): void;
+	attachDerivedHost(host: { readiness: () => DerivedIndexReadiness; requestRebuild: () => boolean }): void;
+}
+
+/**
+ * `DerivedIndexBackend` over a file-primary HNSW index. `deliver()` only enqueues; an applier drains
+ * the queue in bounded time slices so a 4096-record chunk at ~0.35 ms per native insert does not
+ * hold the event loop for a second and a half. The barrier is the plane's `msync`, after which the
+ * pending mappings and then the cursor vector are published — in that order, so a crash between
+ * any two steps leaves a cursor that replays (idempotently) over a mapping that was never published,
+ * never a published cursor over native state the barrier did not cover.
+ */
+export class HnswDerivedIndexBackend implements DerivedIndexBackend {
+	readonly id: string;
+	#index: DerivedNativeIndex;
+	#host?: DerivedIndexBackendHost;
+	#wake?: (change?: DerivedIndexBackendStateChange) => void;
+	#queue: DerivedIndexBatch[] = [];
+	#queuedBytes = 0;
+	#position = 0;
+	#scheduled = false;
+	#appliedCursor?: DerivedIndexCursor;
+	#appliedEpoch?: bigint;
+	#flushRequested = false;
+	#flushing?: Promise<void>;
+	#resetting?: Promise<void>;
+	#unindexable = 0;
+
+	constructor(id: string, index: DerivedNativeIndex) {
+		this.id = id;
+		this.#index = index;
+	}
+
+	attach(host: DerivedIndexBackendHost): void {
+		this.#host = host;
+	}
+
+	onStateChange(wake: (change?: DerivedIndexBackendStateChange) => void): () => void {
+		this.#wake = wake;
+		return () => {
+			if (this.#wake === wake) this.#wake = undefined;
+		};
+	}
+
+	getDurableCursor(): DerivedIndexCursor | undefined {
+		const cursor = this.#index.indexStore.getSync(DERIVED_INDEX_CURSOR_KEY);
+		return cursor === undefined ? undefined : (cursor as DerivedIndexCursor);
+	}
+
+	deliver(batch: DerivedIndexBatch): DerivedIndexDeliveryResult {
+		if (this.#queuedBytes >= QUEUE_CAPACITY_BYTES) return DERIVED_INDEX_DEFERRED;
+		this.#queue.push(batch);
+		this.#queuedBytes += batch.bytes;
+		this.#schedule();
+		return DERIVED_INDEX_ACCEPTED;
+	}
+
+	flush(_reason: DerivedIndexFlushReason): void {
+		this.#flushRequested = true;
+		if (this.#queue.length === 0 && !this.#scheduled) this.#runFlush();
+	}
+
+	/**
+	 * Drop what is queued and resolve once no barrier is in flight. The runtime quiesces an epoch
+	 * before it mints the next, so nothing of a newer epoch can be queued here yet.
+	 */
+	async shutdown(_epoch: bigint): Promise<void> {
+		this.#dropQueue();
+		await this.#flushing;
+		await this.#resetting;
+	}
+
+	/**
+	 * The cursor goes first: a crash anywhere after this line reopens cursorless and rebuilds, never
+	 * on a format-valid cursor over a destroyed graph.
+	 */
+	reset(_epoch: bigint): Promise<void> {
+		this.#dropQueue();
+		this.#appliedCursor = undefined;
+		this.#resetting = (async () => {
+			await this.#flushing;
+			this.#index.indexStore.removeSync(DERIVED_INDEX_CURSOR_KEY);
+			this.#index.resetDerivedStorage();
+			await this.#index.indexStore.clear();
+		})();
+		return this.#resetting.finally(() => (this.#resetting = undefined));
+	}
+
+	#dropQueue() {
+		this.#queue.length = 0;
+		this.#queuedBytes = 0;
+		this.#position = 0;
+	}
+
+	#schedule() {
+		if (this.#scheduled) return;
+		this.#scheduled = true;
+		setImmediate(() => {
+			this.#scheduled = false;
+			this.#applySlice();
+		});
+	}
+
+	#applySlice() {
+		// Application pauses while a barrier is in flight so the barrier publishes exactly the
+		// mappings it covers; the flush reschedules application when it settles.
+		if (this.#flushing) return;
+		const host = this.#host!;
+		const until = performance.now() + APPLY_SLICE_MILLIS;
+		const wasFull = this.#queuedBytes >= QUEUE_CAPACITY_BYTES;
+		while (this.#queue.length > 0 && performance.now() < until) {
+			const batch = this.#queue[0];
+			if (!host.isOwnerEpoch(batch.ownerEpoch)) {
+				this.#queue.shift();
+				this.#queuedBytes -= batch.bytes;
+				this.#position = 0;
+				continue;
+			}
+			const records = batch.records;
+			while (this.#position < records.length && performance.now() < until) {
+				try {
+					this.#apply(records[this.#position++]);
+				} catch (error) {
+					this.#queue.length = 0;
+					this.#queuedBytes = 0;
+					this.#position = 0;
+					logger.error(`Derived index '${this.id}' could not apply a record; requesting a rebuild`, error);
+					this.#wake?.('failed');
+					return;
+				}
+			}
+			if (this.#position < records.length) break;
+			this.#queue.shift();
+			this.#queuedBytes -= batch.bytes;
+			this.#position = 0;
+			this.#appliedEpoch = batch.ownerEpoch;
+			if (batch.through) this.#appliedCursor = batch.through;
+		}
+		if (this.#queue.length > 0) {
+			this.#schedule();
+			if (wasFull && this.#queuedBytes < QUEUE_CAPACITY_BYTES) this.#wake?.('changed');
+			return;
+		}
+		if (wasFull) this.#wake?.('changed');
+		if (this.#flushRequested) this.#runFlush();
+	}
+
+	#apply(mutation: DerivedIndexMutation) {
+		const { recordId, logVersion, state } = mutation;
+		if (state.kind !== 'record' || state.projection == null) {
+			this.#index.applyDerivedValue(recordId, undefined, logVersion);
+			return;
+		}
+		try {
+			this.#index.applyDerivedValue(recordId, state.projection as number[], state.version);
+		} catch (error) {
+			// The projection validated the vector, but the plane's dimensionality is only known to the
+			// worker holding it: a mismatch is this record's fault, not the index's. Same rule as the
+			// runtime's own 4xx handling — remove any entry and count it, never rebuild.
+			if (!(error instanceof ClientError)) throw error;
+			if (this.#unindexable++ === 0)
+				logger.warn?.(`Derived index '${this.id}' skipped a record its plane cannot hold: ${error.message}`);
+			this.#index.applyDerivedValue(recordId, undefined, state.version);
+		}
+	}
+
+	#runFlush() {
+		if (this.#flushing) return;
+		this.#flushRequested = false;
+		const cursor = this.#appliedCursor;
+		const epoch = this.#appliedEpoch;
+		const host = this.#host!;
+		this.#flushing = (async () => {
+			await this.#index.flushDerived();
+			if (epoch !== undefined && !host.isOwnerEpoch(epoch)) return;
+			if (cursor) this.#index.indexStore.putSync(DERIVED_INDEX_CURSOR_KEY, cursor);
+		})();
+		this.#flushing.then(
+			() => {
+				this.#flushing = undefined;
+				this.#wake?.('changed');
+				if (this.#queue.length > 0) this.#schedule();
+				else if (this.#flushRequested) this.#runFlush();
+			},
+			(error) => {
+				this.#flushing = undefined;
+				logger.error(`Derived index '${this.id}' durability barrier failed`, error);
+				this.#wake?.('failed');
+			}
+		);
+	}
+}
+
+type Registered = { runtime: DerivedIndexRuntime; tables: Map<number, { Table: any }> };
+const runtimes = new WeakMap<object, Registered>();
+
+function runtimeFor(auditStore: RocksTransactionLogStore): Registered {
+	let registered = runtimes.get(auditStore);
+	if (registered) return registered;
+	const tables = new Map<number, { Table: any }>();
+	const runtime = new DerivedIndexRuntime(
+		auditStore,
+		(tableId, recordId) => {
+			const entry = tables.get(tableId)?.Table.primaryStore.getEntry(recordId);
+			return entry?.value == null ? undefined : { version: entry.version, value: entry.value };
+		},
+		{
+			scanRecords: (tableId) =>
+				tables
+					.get(tableId)!
+					.Table.primaryStore.getRange({ versions: true, snapshot: false })
+					.map(({ key, value, version }) => ({ recordId: key, version, value })),
+		}
+	);
+	registered = { runtime, tables };
+	runtimes.set(auditStore, registered);
+	return registered;
+}
+
+const warnedAuditIndexes = new Set<string>();
+
+/**
+ * Register every post-commit custom index of a table with the shared derived-index runtime of its
+ * database. Returns the release for the table's registrations, or undefined when it has none. Runs
+ * on every worker; the runtime elects one owner per index.
+ */
+export function attachDerivedIndexes(Table: any): { close(): Promise<void> } | undefined {
+	const attributes = Table.attributes.filter(
+		(attribute: any) => Table.indices[attribute.name]?.customIndex?.postCommit
+	);
+	if (attributes.length === 0) return;
+	if (Table.audit !== true) {
+		throw new ClientError(
+			`Table '${Table.databaseName}.${Table.tableName}' must enable audit logging before using a post-commit derived index`
+		);
+	}
+	const auditStore = Table.auditStore as RocksTransactionLogStore;
+	const registered = runtimeFor(auditStore);
+	// A redefinition registers the same class again before the previous registration's release has
+	// settled, so the release must only remove what it installed, not whatever is current.
+	const installed = { Table };
+	registered.tables.set(Table.tableId, installed);
+	const releases: Array<() => Promise<void>> = [];
+	for (const attribute of attributes) {
+		const indexStore = Table.indices[attribute.name];
+		const index = indexStore.customIndex as DerivedNativeIndex & { postCommit: true };
+		const id = `hnsw:${indexStore.name}`;
+		const warningKey = `${Table.databaseName}.${Table.tableName}.${indexStore.name}`;
+		if (!warnedAuditIndexes.has(warningKey)) {
+			warnedAuditIndexes.add(warningKey);
+			logger.warn?.(
+				`Derived index ${indexStore.name} requires auditing; the audit API retains full record history for the configured retention window`
+			);
+		}
+		const resolver = Table.propertyResolvers?.[attribute.name];
+		const label = `Vector for attribute "${attribute.name}"`;
+		index.attachDerivedHost({
+			readiness: () => registered.runtime.getReadiness(id),
+			requestRebuild: () => registered.runtime.requestRebuild(id),
+		});
+		releases.push(
+			registered.runtime.register({
+				backend: new HnswDerivedIndexBackend(id, index),
+				projections: new Map([
+					[
+						Table.tableId,
+						(record: any) => {
+							const vector = resolver ? resolver(record) : record[attribute.name];
+							if (vector == null) return undefined;
+							index.assertDerivedValue(vector, label);
+							return vector;
+						},
+					],
+				]),
+				options: { maxLagMilliseconds: attribute.indexed?.maxLagMilliseconds ?? DEFAULT_MAX_LAG_MILLISECONDS },
+			})
+		);
+	}
+	return {
+		async close() {
+			await Promise.all(releases.map((release) => release()));
+			if (registered.tables.get(Table.tableId) === installed) registered.tables.delete(Table.tableId);
+		},
+	};
+}
+
+/** Shared readiness of an index on any worker, registered or not. */
+export function derivedIndexReadiness(auditStore: RocksTransactionLogStore, indexStoreName: string) {
+	return readDerivedIndexReadiness(auditStore, `hnsw:${indexStoreName}`);
+}

--- a/resources/indexes/hnswPlaneBinding.ts
+++ b/resources/indexes/hnswPlaneBinding.ts
@@ -1,0 +1,156 @@
+import { closeSync, fsyncSync, openSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { loggerWithTag } from '../../utility/logging/logger.ts';
+
+const logger = loggerWithTag('HNSW');
+
+export interface PlaneSearchHit {
+	id: number;
+	distance: number;
+}
+
+/** NAPI surface of the native file-primary HNSW index (`@harperfast/hnsw`). */
+export interface HnswPlane {
+	readonly dims: number;
+	readonly layer0Cap: number;
+	insert(vector: Float32Array): number;
+	remove(id: number): void;
+	writeNodeRaw(
+		id: number,
+		level: number,
+		vector: Buffer,
+		scale: number,
+		invMag: number,
+		neighbors: Uint32Array,
+		upper: Uint32Array[] | null
+	): void;
+	clearNode(id: number): void;
+	setEntryPoint(id: number, level: number): void;
+	getEntryPoint(): number[];
+	search(
+		vector: Float32Array,
+		k: number,
+		ef: number,
+		filter?: Uint8Array | null,
+		filterExpansion?: number | null
+	): Promise<PlaneSearchHit[]>;
+	searchWithPredicate(
+		vector: Float32Array,
+		k: number,
+		ef: number,
+		predicate: (ids: number[]) => Uint8Array,
+		filterExpansion?: number | null,
+		visitBudget?: number | null
+	): Promise<PlaneSearchHit[]>;
+	searchSync(vector: Float32Array, k: number, ef: number): PlaneSearchHit[];
+	writeNodeRawIfAbsent(
+		id: number,
+		level: number,
+		vector: Buffer,
+		scale: number,
+		invMag: number,
+		neighbors: Uint32Array,
+		upper: Uint32Array[] | null
+	): boolean;
+	openedClean(): boolean;
+	idHighWater(): number;
+	getWatermark(): number;
+	setWatermark(txn: number): void;
+	flush(watermark?: number): void;
+	flushAsync(watermark?: number): Promise<void>;
+	invalidateFile(): PlaneInvalidationOutcome;
+	invalidated(): boolean;
+}
+
+export interface HnswPlaneConstructor {
+	create(path: string, dims: number, layer0Cap: number, maxNodes: number): HnswPlane;
+	open(path: string): HnswPlane;
+}
+
+export interface PlaneInvalidationOutcome {
+	inBand: boolean;
+	sidecar: boolean;
+	inBandError?: string;
+	sidecarError?: string;
+}
+
+interface HnswPlanePackage {
+	Plane: HnswPlaneConstructor;
+	invalidatePlane(path: string): PlaneInvalidationOutcome;
+	stalePathFor(path: string): string;
+}
+
+/** Entry-point id meaning "none" (u32::MAX in the plane header). */
+export const PLANE_NO_ID = 0xffffffff;
+
+/**
+ * Where an index's plane file lives: next to its store, named by the dbiKey
+ * (`table/attribute`, flattened to a single file name). Exposed separately from the index
+ * instance so crash-recovery drop paths can remove the file without opening the index.
+ */
+export function planeFilePathFor(storePath: string, storeName: string): string {
+	// encodeURIComponent is injective and never emits a path separator: table `a` attribute
+	// `b.c` and table `a.b` attribute `c` must not share a plane file (dot-flattening let two
+	// indexes serve each other's node ids as their own primary keys)
+	return join(storePath, `${encodeURIComponent(storeName)}.hnsw`);
+}
+
+/**
+ * Tombstone marking a plane file that could not be deleted (e.g. Windows EBUSY while still
+ * mapped). Its presence means the plane file is STALE: never open it — delete both when
+ * possible and rebuild.
+ */
+export function planeStalePathFor(planePath: string): string {
+	// the package owns the convention; the literal covers the calls that precede its load
+	return binding?.stalePathFor(planePath) ?? `${planePath}.stale`;
+}
+
+let binding: HnswPlanePackage | null | undefined;
+
+function getHnswPackage(): HnswPlanePackage | null {
+	if (binding !== undefined) return binding;
+	try {
+		binding = require('@harperfast/hnsw') as HnswPlanePackage;
+	} catch (error) {
+		binding = null;
+		logger.warn?.(
+			`The @harperfast/hnsw native module is not available (${(error as Error).message}); ` +
+				'indexes with nativePlane enabled will remain unavailable until the module can load'
+		);
+	}
+	return binding;
+}
+
+/** The native plane constructor, or null when the compiled artifact is unavailable (warns once). */
+export function getPlaneBinding(): HnswPlaneConstructor | null {
+	return getHnswPackage()?.Plane ?? null;
+}
+
+/** Make a derived plane unadoptable before it is replaced or removed. */
+export function invalidatePlaneFile(filePath: string, attached?: HnswPlane | null): PlaneInvalidationOutcome {
+	if (attached) return attached.invalidateFile();
+	const hnswPackage = getHnswPackage();
+	if (hnswPackage) return hnswPackage.invalidatePlane(filePath);
+	// A plane can outlive the package that made it (uninstall, or a prebuild that stopped
+	// loading), and a reinstall would then adopt it. Only the sidecar is reachable without the
+	// package, and it has to survive a power loss to be worth writing, so fsync it and the
+	// directory entry that names it — the same durability the package's own sidecar has.
+	const fd = openSync(planeStalePathFor(filePath), 'w');
+	try {
+		fsyncSync(fd);
+	} finally {
+		closeSync(fd);
+	}
+	try {
+		const dirFd = openSync(dirname(filePath), 'r');
+		try {
+			fsyncSync(dirFd);
+		} finally {
+			closeSync(dirFd);
+		}
+	} catch {
+		// Windows cannot open a directory as a file; it also does not need this — the metadata
+		// journal already orders the create ahead of anything that could read the sidecar
+	}
+	return { inBand: false, sidecar: true };
+}

--- a/resources/search.ts
+++ b/resources/search.ts
@@ -550,26 +550,64 @@ export function searchByIndex(
 			// exploring until it has enough MATCHING results, rather than post-filtering an under-filled
 			// candidate set. Only indexes that opt in (filteredSearch) receive it; others post-filter as before.
 			const recordFilter = index.customIndex.filteredSearch ? searchCondition.recordFilter : undefined;
-			const loaded = index.customIndex.search(searchCondition, context, recordFilter, minResults).map((entry) => {
-				// if the custom index returns an entry with metadata, merge it with the loaded entry
-				if (typeof entry === 'object' && entry) {
-					const { key, ...otherProps } = entry;
-					if (key == null) return SKIP; // primaryKey missing from HNSW node — skip rather than crash
-					const loadedEntry = Table.primaryStore.getEntry(key, {
-						transaction: context && Table._readTxnForContext(context),
-					});
-					if (!loadedEntry) return SKIP; // record was deleted/expired or not yet visible
-					freezeRecord(loadedEntry?.value);
-					recordRead(loadedEntry);
-					return { ...otherProps, ...loadedEntry };
+			const searched = index.customIndex.search(searchCondition, context, recordFilter, minResults);
+			const processEntries = (entries: any[]) => {
+				const loaded = entries
+					.map((entry) => {
+						// if the custom index returns an entry with metadata, merge it with the loaded entry
+						if (typeof entry === 'object' && entry) {
+							const { key, ...otherProps } = entry;
+							if (key == null) return SKIP; // primaryKey missing from HNSW node — skip rather than crash
+							const loadedEntry = Table.primaryStore.getEntry(key, {
+								transaction: context && Table._readTxnForContext(context),
+							});
+							if (!loadedEntry) return SKIP; // record was deleted/expired or not yet visible
+							freezeRecord(loadedEntry?.value);
+							recordRead(loadedEntry);
+							return { ...otherProps, ...loadedEntry };
+						}
+						return entry;
+					})
+					.filter((entry) => entry !== SKIP);
+				if (index.customIndex.rescoreResults) {
+					const rescored = index.customIndex.rescoreResults(loaded, searchCondition, comparator, attribute_name);
+					if (rescored != null) return rescored as any;
 				}
-				return entry;
-			});
-			if (index.customIndex.rescoreResults) {
-				const rescored = index.customIndex.rescoreResults(loaded, searchCondition, comparator, attribute_name);
-				if (rescored != null) return rescored as any;
+				return loaded;
+			};
+			if (typeof (searched as any)?.then === 'function') {
+				const pending = (searched as Promise<any[]>).then(processEntries);
+				// A consumer may abandon this lazy iterable without calling next().
+				pending.catch(() => {});
+				const results: any = new ExtendedIterable();
+				results.iterate = (options?: { async?: boolean }) => {
+					if (!options?.async) {
+						throw new Error(
+							'This index resolves search results asynchronously; the results must be consumed with async iteration'
+						);
+					}
+					// Overlapping next() calls share one cursor and cannot duplicate its first entry.
+					const iteratorPromise = pending.then((entries) => entries[Symbol.iterator]());
+					iteratorPromise.catch(() => {});
+					let closed = false;
+					return {
+						next() {
+							if (closed) return Promise.resolve({ done: true, value: undefined });
+							return iteratorPromise.then((inner) => (closed ? { done: true, value: undefined } : inner.next()));
+						},
+						return(value?: any) {
+							closed = true;
+							iteratorPromise.then(
+								(inner) => (inner as any).return?.(value),
+								() => {}
+							);
+							return Promise.resolve({ done: true, value });
+						},
+					};
+				};
+				return results;
 			}
-			return loaded;
+			return processEntries(searched);
 		}
 		const scanned = index.getRange(rangeOptions).map(
 			filter

--- a/unitTests/resources/hnswDerivedIngest.bench.js
+++ b/unitTests/resources/hnswDerivedIngest.bench.js
@@ -1,0 +1,242 @@
+// Integrated ingest benchmark for the file-primary HNSW derived index. Excluded from
+// `test:unit:resources` by its `.bench.js` name; run it directly:
+//
+//   HOME=<isolated> npx mocha unitTests/resources/hnswDerivedIngest.bench.js
+//
+// The meter wraps whole backend methods: `applyDerivedValue` includes the vector hash and the
+// RocksDB mapping writes as well as the native insert, and `flushDerived` includes publishing
+// those mappings as well as the msync. It therefore bounds the backend's share, and does not
+// separate native from JS inside it — the isolated package numbers do that.
+//
+// The serialized case awaits full drain between writes, so it measures the cost of one isolated
+// write, not what a flush cadence could amortize. The repeated-key case counts distinct keys
+// across the whole run, not within one delivery window.
+require('../testUtils');
+const assert = require('node:assert');
+const { monitorEventLoopDelay } = require('node:perf_hooks');
+const { setupTestDBPath } = require('../testUtils');
+const { waitFor } = require('../waitFor');
+const { table } = require('#src/resources/databases');
+const { getPlaneBinding } = require('#src/resources/indexes/hnswPlaneBinding');
+const { DERIVED_INDEX_CURSOR_KEY } = require('#src/resources/indexes/hnswDerivedIndex');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+const DIMS = Number(process.env.BENCH_DIMS ?? 384);
+const SEED = Number(process.env.BENCH_SEED ?? 1000);
+const BURST = Number(process.env.BENCH_BURST ?? 2000);
+const TRICKLE = Number(process.env.BENCH_TRICKLE ?? 40);
+const HOT_KEYS = Number(process.env.BENCH_HOT_KEYS ?? 50);
+const HOT_ROUNDS = Number(process.env.BENCH_HOT_ROUNDS ?? 20);
+const DB = 'vector-ingest-bench';
+
+let seedState = 42;
+function rand() {
+	seedState = (seedState * 1103515245 + 12345) % 2147483648;
+	return seedState / 2147483648;
+}
+function makeVector() {
+	const vector = new Array(DIMS);
+	for (let i = 0; i < DIMS; i++) vector[i] = rand() * 2 - 1;
+	return vector;
+}
+
+function percentile(samples, fraction) {
+	if (samples.length === 0) return 0;
+	const sorted = [...samples].sort((a, b) => a - b);
+	return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * fraction))];
+}
+
+describe('HNSW file-primary ingest cost', function () {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+	if (!getPlaneBinding()) {
+		it.skip('skipped: @harperfast/hnsw native module is unavailable', () => {});
+		return;
+	}
+	this.timeout(20 * 60_000);
+	let Bench;
+	const meter = { applyCount: 0, applyMs: 0, flushCount: 0, flushMs: 0 };
+
+	function customIndex() {
+		return Bench.indices.vector.customIndex;
+	}
+
+	function instrument() {
+		const index = customIndex();
+		const apply = index.applyDerivedValue.bind(index);
+		const flush = index.flushDerived.bind(index);
+		index.applyDerivedValue = (key, vector, version) => {
+			const started = process.hrtime.bigint();
+			try {
+				return apply(key, vector, version);
+			} finally {
+				meter.applyMs += Number(process.hrtime.bigint() - started) / 1e6;
+				meter.applyCount++;
+			}
+		};
+		// flushDerived awaits the native barrier, so this spans an await and charges anything the
+		// loop ran meanwhile to the backend. It is an upper bound on barrier cost, and the reason
+		// the reported backend share is printed as a range with applyMs — which is synchronous and
+		// exact — as its floor.
+		index.flushDerived = async (watermark) => {
+			const started = process.hrtime.bigint();
+			try {
+				return await flush(watermark);
+			} finally {
+				meter.flushMs += Number(process.hrtime.bigint() - started) / 1e6;
+				meter.flushCount++;
+			}
+		};
+	}
+
+	function resetMeter() {
+		meter.applyCount = 0;
+		meter.applyMs = 0;
+		meter.flushCount = 0;
+		meter.flushMs = 0;
+	}
+
+	// Scanning the audit log to find the tail costs more than the drain being measured, so callers
+	// read the tail before starting a clock and pass it to drained(), which only polls cursors.
+	function auditTails() {
+		const tails = [];
+		for (const logName of Bench.auditStore.rootStore.listLogs()) {
+			let latest;
+			for (const entry of Bench.auditStore.getRange({ start: 0, log: logName }))
+				if (entry.endTxn) latest = entry.txnLogKey;
+			if (latest !== undefined) tails.push([logName, latest]);
+		}
+		return tails;
+	}
+
+	const POLL_MS = 1;
+
+	async function drained(tails = auditTails()) {
+		return waitFor(
+			() =>
+				tails.every(
+					([logName, latest]) => Bench.indices.vector.getSync(DERIVED_INDEX_CURSOR_KEY)?.logs?.[logName] === latest
+				),
+			{ timeout: 15 * 60_000, interval: POLL_MS, message: 'derived index did not drain' }
+		);
+	}
+
+	before(async () => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		Bench = table({
+			table: 'IngestBench',
+			database: DB,
+			audit: true,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{
+					name: 'vector',
+					indexed: { type: 'HNSW', nativePlane: true, efConstruction: 200 },
+					type: 'Array',
+				},
+			],
+		});
+		await Bench.indexingOperation;
+		await Bench.put(0, { vector: makeVector() });
+		await drained();
+		instrument();
+		// Seed a graph large enough that insert cost reflects a populated index rather than
+		// the near-empty one a fresh table would measure.
+		for (let id = 1; id <= SEED; id++) await Bench.put(id, { vector: makeVector() });
+		await drained();
+	});
+
+	it('burst ingest: foreground cost, drain cost, and event-loop occupancy', async () => {
+		resetMeter();
+		const loop = monitorEventLoopDelay({ resolution: 1 });
+		const putSamples = [];
+		loop.enable();
+		const startedWrites = process.hrtime.bigint();
+		for (let id = SEED + 1; id <= SEED + BURST; id++) {
+			const started = process.hrtime.bigint();
+			await Bench.put(id, { vector: makeVector() });
+			putSamples.push(Number(process.hrtime.bigint() - started) / 1e6);
+		}
+		const writeMs = Number(process.hrtime.bigint() - startedWrites) / 1e6;
+		loop.disable();
+		const writeLoopMax = loop.max / 1e6;
+		const writeLoopP99 = loop.percentile(99) / 1e6;
+		// Read the tail before the drain clock starts: scanning the retained log costs more than
+		// the drain, and inside the window it would be charged to the runtime.
+		const tails = auditTails();
+		loop.reset();
+		loop.enable();
+		const startedDrain = process.hrtime.bigint();
+		await drained(tails);
+		const drainMs = Number(process.hrtime.bigint() - startedDrain) / 1e6;
+		const totalMs = writeMs + drainMs;
+		loop.disable();
+
+		console.log(`\n== burst ${BURST} puts, dims=${DIMS}, graph≈${SEED + BURST} ==`);
+		console.log(
+			`  foreground put:      ${(writeMs / BURST).toFixed(3)} ms/put  (${Math.round(BURST / (writeMs / 1000))}/s)`
+		);
+		console.log(
+			`  put p50/p99:         ${percentile(putSamples, 0.5).toFixed(3)} / ${percentile(putSamples, 0.99).toFixed(3)} ms`
+		);
+		console.log(`  write+drain wall:    ${totalMs.toFixed(0)} ms  (${Math.round(BURST / (totalMs / 1000))} indexed/s)`);
+		console.log(
+			`  applyDerivedValue:   ${meter.applyCount} calls, ${meter.applyMs.toFixed(0)} ms total, ${(meter.applyMs / Math.max(1, meter.applyCount)).toFixed(3)} ms/call`
+		);
+		console.log(
+			`  flushDerived:        ${meter.flushCount} calls, ${meter.flushMs.toFixed(0)} ms total, ${(meter.flushMs / Math.max(1, meter.flushCount)).toFixed(3)} ms/call`
+		);
+		console.log(
+			`  flush share of drain:${((meter.flushMs / Math.max(1, meter.applyMs + meter.flushMs)) * 100).toFixed(1)} %`
+		);
+		console.log(
+			`  backend share of wall:${((meter.applyMs / Math.max(1, totalMs)) * 100).toFixed(1)}–${(((meter.applyMs + meter.flushMs) / Math.max(1, totalMs)) * 100).toFixed(1)} % of ${totalMs.toFixed(0)} ms (floor = synchronous apply ${meter.applyMs.toFixed(0)} ms; ceiling adds the barrier's ${meter.flushMs.toFixed(0)} ms, timed across an await)`
+		);
+		console.log(`  loop max/p99 writing:${writeLoopMax.toFixed(1)} / ${writeLoopP99.toFixed(1)} ms`);
+		console.log(
+			`  loop max/p99 draining:${(loop.max / 1e6).toFixed(1)} / ${(loop.percentile(99) / 1e6).toFixed(1)} ms`
+		);
+		assert.ok(meter.applyCount >= BURST);
+	});
+
+	it('serialized writes: freshness cost of one isolated write', async () => {
+		resetMeter();
+		const base = SEED + BURST + 1;
+		for (let n = 0; n < TRICKLE; n++) {
+			await Bench.put(base + n, { vector: makeVector() });
+			await drained();
+		}
+
+		// The wall clock here would carry a retained-log scan and a poll interval per record, both
+		// larger than the work; the meter is what this case is for.
+		console.log(`\n== serialized ${TRICKLE} puts, full drain between each ==`);
+		console.log(`  indexing work per record: ${((meter.applyMs + meter.flushMs) / TRICKLE).toFixed(2)} ms`);
+		console.log(
+			`  applyDerivedValue:     ${meter.applyCount} calls, ${(meter.applyMs / Math.max(1, meter.applyCount)).toFixed(3)} ms/call`
+		);
+		console.log(
+			`  flushDerived:          ${meter.flushCount} calls, ${(meter.flushMs / Math.max(1, meter.flushCount)).toFixed(3)} ms/call`
+		);
+		console.log(
+			`  flush share:           ${((meter.flushMs / Math.max(1, meter.applyMs + meter.flushMs)) * 100).toFixed(1)} %`
+		);
+		console.log(`  flushes per record:    ${(meter.flushCount / TRICKLE).toFixed(2)}`);
+	});
+
+	it('repeated keys: upper bound on what per-key coalescing could remove', async () => {
+		resetMeter();
+		const first = SEED + BURST + TRICKLE + 10;
+		for (let round = 0; round < HOT_ROUNDS; round++) {
+			for (let k = 0; k < HOT_KEYS; k++) await Bench.put(first + k, { vector: makeVector() });
+		}
+		await drained();
+		const writes = HOT_KEYS * HOT_ROUNDS;
+		console.log(`\n== ${HOT_KEYS} keys × ${HOT_ROUNDS} rounds = ${writes} commits ==`);
+		console.log(`  applyDerivedValue:   ${meter.applyCount} calls (${HOT_KEYS} distinct keys)`);
+		console.log(`  time in apply:       ${meter.applyMs.toFixed(0)} ms`);
+		console.log(
+			`  repeated keys:       ${(((meter.applyCount - HOT_KEYS) / Math.max(1, meter.applyCount)) * 100).toFixed(1)} % of apply calls`
+		);
+		console.log(`  flushDerived:        ${meter.flushCount} calls, ${meter.flushMs.toFixed(0)} ms total`);
+	});
+});

--- a/unitTests/resources/vectorIndexPlane-thread.js
+++ b/unitTests/resources/vectorIndexPlane-thread.js
@@ -1,0 +1,54 @@
+require('../testUtils');
+const { parentPort } = require('node:worker_threads');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { derivedIndexReadiness } = require('#src/resources/indexes/hnswDerivedIndex');
+
+if (parentPort) {
+	setupTestDBPath();
+	setMainIsWorker(true);
+	const PlaneTest = table({
+		table: 'PlaneTest',
+		database: 'vector-plane',
+		audit: true,
+		attributes: [
+			{ name: 'id', isPrimaryKey: true },
+			{ name: 'name', indexed: true },
+			{
+				name: 'vector',
+				indexed: { type: 'HNSW', nativePlane: true, efConstruction: 200 },
+				type: 'Array',
+			},
+		],
+	});
+
+	async function waitUntilReady() {
+		await PlaneTest.indexingOperation;
+		while (derivedIndexReadiness(PlaneTest.auditStore, PlaneTest.indices.vector.name).state !== 'ready')
+			await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+
+	void waitUntilReady().then(() =>
+		parentPort.postMessage({
+			type: 'ready',
+			retainedMarker: PlaneTest.indices.vector.getSync('__native-plane-reopen-marker__'),
+		})
+	);
+	parentPort.on('message', async (message) => {
+		if (message.type === 'shutdown') process.exit(0);
+		try {
+			if (message.type === 'commitAndBlock') {
+				await PlaneTest.put(message.record.id, message.record);
+				parentPort.postMessage({ type: 'committed' });
+				Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 60_000);
+				return;
+			}
+			if (message.type !== 'put') return;
+			for (const record of message.records) await PlaneTest.put(record.id, record);
+			parentPort.postMessage({ type: 'done' });
+		} catch (error) {
+			parentPort.postMessage({ type: 'error', message: error.message, stack: error.stack });
+		}
+	});
+}

--- a/unitTests/resources/vectorIndexPlane.test.js
+++ b/unitTests/resources/vectorIndexPlane.test.js
@@ -1,0 +1,677 @@
+require('../testUtils');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const { Worker } = require('node:worker_threads');
+const { setupTestDBPath } = require('../testUtils');
+const { waitFor } = require('../waitFor');
+const { table, resetDatabases } = require('#src/resources/databases');
+const { DatabaseTransaction } = require('#src/resources/DatabaseTransaction');
+const { getPlaneBinding } = require('#src/resources/indexes/hnswPlaneBinding');
+const { DERIVED_INDEX_CURSOR_KEY, derivedIndexReadiness } = require('#src/resources/indexes/hnswDerivedIndex');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+/** Shared readiness the owning worker publishes for a table's vector index, readable on any worker. */
+function indexReady(Table) {
+	return derivedIndexReadiness(Table.auditStore, Table.indices.vector.name).state === 'ready';
+}
+
+async function fromAsync(iterable) {
+	const out = [];
+	for await (const value of iterable) out.push(value);
+	return out;
+}
+
+const DIMS = 24;
+const N = 500;
+const EF = 200;
+const DB = 'vector-plane';
+const RETAINED_MARKER = '__native-plane-reopen-marker__';
+let seedState = 42;
+function rand() {
+	seedState = (seedState * 1103515245 + 12345) % 2147483648;
+	return seedState / 2147483648;
+}
+const centers = Array.from({ length: 20 }, () => Array.from({ length: DIMS }, () => rand() * 2 - 1));
+function makeVector(i) {
+	const center = centers[i % centers.length];
+	return center.map((value) => value + (rand() - 0.5) * 0.2);
+}
+function cosineDistance(a, b) {
+	let dot = 0;
+	let aa = 0;
+	let bb = 0;
+	for (let i = 0; i < a.length; i++) {
+		dot += a[i] * b[i];
+		aa += a[i] * a[i];
+		bb += b[i] * b[i];
+	}
+	return 1 - dot / Math.sqrt(aa * bb);
+}
+
+describe('HNSW native plane file-primary delivery', function () {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+	if (!getPlaneBinding()) {
+		it.skip('skipped: @harperfast/hnsw native module is unavailable', () => {});
+		return;
+	}
+	this.timeout(30_000);
+	let PlaneTest;
+	const vectors = new Map();
+
+	function defineTable() {
+		return table({
+			table: 'PlaneTest',
+			database: DB,
+			audit: true,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'name', indexed: true },
+				{
+					name: 'vector',
+					indexed: { type: 'HNSW', nativePlane: true, efConstruction: 200 },
+					type: 'Array',
+				},
+			],
+		});
+	}
+	function customIndex() {
+		return PlaneTest.indices.vector.customIndex;
+	}
+	async function nativeSearch(target, filter) {
+		return await customIndex().search(
+			{ target, comparator: 'sort', distance: 'cosine', ef: EF },
+			{ transaction: undefined },
+			filter
+		);
+	}
+	async function readySearch(target, filter) {
+		return waitFor(
+			async () => {
+				if (!indexReady(PlaneTest)) return false;
+				try {
+					return await nativeSearch(target, filter);
+				} catch (error) {
+					if (/rebuilding/.test(error.message)) return false;
+					throw error;
+				}
+			},
+			{ timeout: 15_000, message: 'native plane did not become searchable' }
+		);
+	}
+	async function waitForKey(id, target) {
+		return waitFor(
+			async () => {
+				const results = await readySearch(target);
+				return results.some((entry) => entry.key === id);
+			},
+			{ timeout: 15_000, message: `native plane did not index record ${id}` }
+		);
+	}
+	async function waitForCursors() {
+		return waitFor(
+			() => {
+				const cursor = PlaneTest.indices.vector.getSync(DERIVED_INDEX_CURSOR_KEY);
+				for (const logName of PlaneTest.auditStore.rootStore.listLogs()) {
+					let latest;
+					for (const entry of PlaneTest.auditStore.getRange({ start: 0, log: logName })) {
+						if (entry.endTxn) latest = entry.txnLogKey;
+					}
+					if (latest !== undefined && cursor?.logs?.[logName] !== latest) return false;
+				}
+				return true;
+			},
+			{ timeout: 15_000, message: 'the durable cursor did not reach the committed tail of every log' }
+		);
+	}
+
+	before(async () => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		PlaneTest = defineTable();
+		await PlaneTest.indexingOperation;
+		const firstVector = makeVector(0);
+		vectors.set(0, firstVector);
+		await PlaneTest.put(0, { name: 'rec0', vector: firstVector });
+		await waitForKey(0, firstVector);
+		await waitForCursors();
+		for (let i = 1; i < N; i++) {
+			const vector = makeVector(i);
+			vectors.set(i, vector);
+			await PlaneTest.put(i, { name: `rec${i}`, vector });
+		}
+		await waitForKey(3, vectors.get(3));
+		await waitFor(
+			() => {
+				let mappings = 0;
+				for (const { key } of PlaneTest.indices.vector.getRange()) if (typeof key === 'number') mappings++;
+				return mappings >= N;
+			},
+			{ timeout: 15_000, message: 'post-commit native delivery did not drain' }
+		);
+		await waitForCursors();
+	});
+
+	it('stores only primary-key mappings and cursors in RocksDB', () => {
+		assert.ok(fs.existsSync(customIndex().planeFilePath()));
+		let mappings = 0;
+		for (const { key, value } of PlaneTest.indices.vector.getRange()) {
+			if (typeof key !== 'number') continue;
+			mappings++;
+			assert.equal(value.level, undefined, 'the CF must not retain HNSW graph nodes');
+			assert.equal(value.vector, undefined, 'the CF must not retain graph vectors');
+			assert.equal(value.pending, undefined, 'published mappings must follow the native durability barrier');
+			assert.notEqual(value.primaryKey, undefined, 'numeric entries are native-id to primary-key mappings');
+		}
+		assert.ok(mappings >= N);
+	});
+
+	it('builds searchable native state with deterministic recall', async () => {
+		for (const probe of [3, 77, 300]) {
+			const entries = await nativeSearch(vectors.get(probe));
+			assert.equal(entries[0].key, probe);
+			const expected = [...vectors]
+				.sort((a, b) => cosineDistance(vectors.get(probe), a[1]) - cosineDistance(vectors.get(probe), b[1]))
+				.slice(0, 10)
+				.map(([id]) => id);
+			const returned = new Set(entries.slice(0, 20).map((entry) => entry.key));
+			assert.ok(
+				expected.filter((id) => returned.has(id)).length >= 9,
+				'recall@10 in the first 20 must be at least 0.9'
+			);
+		}
+	});
+
+	it('does not publish an aborted transaction to the plane', async () => {
+		const vector = makeVector(50_000);
+		const plane = customIndex().getPlane();
+		const highWater = plane.idHighWater();
+		const context = { transaction: new DatabaseTransaction() };
+		await PlaneTest.put(50_000, { name: 'aborted', vector }, context);
+		context.transaction.abort();
+		assert.equal(await PlaneTest.get(50_000), undefined);
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(plane.idHighWater(), highWater, 'an aborted write must allocate no native node');
+	});
+
+	it('keeps repeated same-key replay mappings pending until the native flush', async () => {
+		const id = 50_001;
+		const vector = makeVector(id);
+		const index = customIndex();
+		index.applyDerivedValue(id, vector, 1);
+		index.applyDerivedValue(id, vector, 2);
+		assert.ok(!(await nativeSearch(vector)).some((entry) => entry.key === id));
+		await index.flushDerived();
+		assert.ok((await nativeSearch(vector)).some((entry) => entry.key === id));
+		index.applyDerivedValue(id, undefined, 3);
+		await index.flushDerived();
+	});
+
+	it('ignores unrelated field changes and applies committed update/delete', async () => {
+		const plane = customIndex().getPlane();
+		const highWater = plane.idHighWater();
+		await PlaneTest.put(3, { name: 'renamed', vector: vectors.get(3) });
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(plane.idHighWater(), highWater, 'an unchanged vector must schedule no native insert');
+
+		const updated = makeVector(60_003);
+		vectors.set(3, updated);
+		await PlaneTest.put(3, { name: 'renamed', vector: updated });
+		await waitForKey(3, updated);
+		await PlaneTest.delete(77);
+		vectors.delete(77);
+		await waitFor(async () => !(await readySearch(updated)).some((entry) => entry.key === 77), {
+			timeout: 10_000,
+			message: 'deleted native id remained searchable',
+		});
+	});
+
+	it('applies predicates and full-stack exact rescoring', async () => {
+		const filtered = await readySearch(vectors.get(21), (id) => id % 3 === 0);
+		assert.ok(filtered.length > 0);
+		for (const entry of filtered) assert.equal(entry.key % 3, 0);
+		const target = vectors.get(42);
+		const results = await fromAsync(
+			PlaneTest.search({
+				sort: { attribute: 'vector', target, distance: 'cosine' },
+				select: ['id', '$distance'],
+				limit: 10,
+			})
+		);
+		assert.equal(results[0].id, 42);
+		for (let i = 1; i < results.length; i++) assert.ok(results[i].$distance >= results[i - 1].$distance);
+		const withCondition = await fromAsync(
+			PlaneTest.search({
+				sort: { attribute: 'vector', target, distance: 'cosine' },
+				conditions: [{ attribute: 'name', comparator: 'gt', value: 'rec9' }],
+				select: ['id', 'name'],
+				limit: 20,
+			})
+		);
+		assert.ok(withCondition.length > 0);
+		for (const record of withCondition) assert.ok(record.name > 'rec9');
+		const within = await fromAsync(
+			PlaneTest.search({
+				conditions: [{ attribute: 'vector', comparator: 'le', value: 0.05, target }],
+				select: ['id', '$distance'],
+			})
+		);
+		assert.ok(within.length > 0, 'le threshold query should return nearby records');
+		for (const record of within) assert.ok(record.$distance <= 0.05, `distance ${record.$distance} exceeds threshold`);
+	});
+
+	it('surfaces a throwing app filter without disabling the native plane', async () => {
+		const target = vectors.get(3);
+		await assert.rejects(
+			nativeSearch(target, () => {
+				throw new Error('filter boom');
+			}),
+			/filter boom/
+		);
+		assert.ok((await readySearch(target)).length > 0);
+	});
+
+	it('rejects a wrong-dimension write and query as client errors, not index failures', async () => {
+		const wrong = makeVector(0).concat(1);
+		await assert.rejects(
+			async () => PlaneTest.put(90_001, { name: 'wrong-dims', vector: wrong }),
+			(error) => {
+				assert.match(error.message, /components, but this index stores/);
+				assert.equal(error.statusCode, 400, 'a wrong-length vector is the caller mistake, not a 503');
+				return true;
+			}
+		);
+		// The native insert would throw an unclassifiable error instead, which reconstruction
+		// rethrows — one such record would abort every rebuild and strand the index at 503.
+		assert.equal(await PlaneTest.get(90_001), undefined, 'the rejected write must not commit');
+		await assert.rejects(
+			async () => nativeSearch(wrong),
+			(error) => {
+				assert.match(error.message, /Search target has/);
+				assert.equal(error.statusCode, 400);
+				return true;
+			}
+		);
+		// A BigInt component would throw out of Float32Array.from, which the caller reads as plane
+		// corruption and answers by unlinking a healthy file.
+		const bigintTarget = vectors.get(3).slice();
+		bigintTarget[0] = 1n;
+		await assert.rejects(async () => nativeSearch(bigintTarget), /not a finite 32-bit float/);
+		assert.ok(fs.existsSync(customIndex().planeFilePath()), 'a malformed query must not unlink the plane');
+		assert.ok((await readySearch(vectors.get(3))).length > 0, 'the index stays healthy');
+	});
+
+	it('rejects a component outside the f32 range instead of stranding reconstruction', async () => {
+		const overflowing = makeVector(0).slice();
+		overflowing[0] = 1e39; // finite as a double, Infinity as the f32 the plane stores
+		await assert.rejects(
+			async () => PlaneTest.put(90_002, { name: 'f32-overflow', vector: overflowing }),
+			(error) => {
+				assert.match(error.message, /not a finite 32-bit float/);
+				assert.equal(error.statusCode, 400);
+				return true;
+			}
+		);
+		assert.equal(await PlaneTest.get(90_002), undefined, 'the rejected write must not commit');
+
+		// f32-finite components whose squares are not: invMag would store 0 and every distance
+		// involving the node would be NaN.
+		const huge = makeVector(0).map(() => 1e20);
+		await assert.rejects(
+			async () => PlaneTest.put(90_003, { name: 'f32-magnitude', vector: huge }),
+			/magnitude too large/
+		);
+
+		// Math.fround throws a TypeError on a BigInt, which is not a ClientError and would strand
+		// reconstruction exactly as the native throw did.
+		const bigint = makeVector(0).slice();
+		bigint[0] = 1n;
+		await assert.rejects(
+			async () => PlaneTest.put(90_004, { name: 'f32-bigint', vector: bigint }),
+			/not a finite 32-bit float/
+		);
+
+		assert.ok((await readySearch(vectors.get(3))).length > 0, 'the index stays healthy');
+	});
+
+	it('rejects synchronous iteration of asynchronous plane-backed results', () => {
+		const results = PlaneTest.search({
+			sort: { attribute: 'vector', target: vectors.get(42), distance: 'cosine' },
+			select: ['id'],
+			limit: 5,
+		});
+		assert.throws(() => [...results], /async/i, 'sync iteration must throw instead of spinning');
+	});
+
+	it('serializes overlapping next calls on one plane-backed result cursor', async () => {
+		const query = () => ({
+			sort: { attribute: 'vector', target: vectors.get(42), distance: 'cosine' },
+			select: ['id'],
+			limit: 5,
+		});
+		const sequential = (await fromAsync(PlaneTest.search(query()))).map((record) => record.id);
+		assert.ok(sequential.length > 2, 'need several results to detect a duplicate or skip');
+		const iterator = PlaneTest.search(query()).iterate({ async: true });
+		const [first, second] = await Promise.all([iterator.next(), iterator.next()]);
+		const seen = [first.value.id, second.value.id];
+		for (let next = await iterator.next(); !next.done; next = await iterator.next()) seen.push(next.value.id);
+		assert.deepEqual(seen, sequential, 'overlapping next calls must yield the sequential order exactly once');
+	});
+
+	it('does not raise an unhandled rejection when a plane-backed iterable is abandoned', async () => {
+		const index = customIndex();
+		const unhandled = [];
+		const onUnhandled = (reason) => unhandled.push(reason);
+		process.on('unhandledRejection', onUnhandled);
+		try {
+			index.rescoreResults = () => {
+				throw new Error('rescore boom');
+			};
+			const results = PlaneTest.search({
+				sort: { attribute: 'vector', target: vectors.get(42), distance: 'cosine' },
+				select: ['id'],
+				limit: 5,
+			});
+			await results.iterate({ async: true }).return();
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		} finally {
+			delete index.rescoreResults;
+			process.off('unhandledRejection', onUnhandled);
+		}
+		assert.deepEqual(
+			unhandled.map((reason) => String(reason?.message ?? reason)),
+			[],
+			'an unobserved rejection here exits the process under Node default policy'
+		);
+	});
+
+	it('serializes post-commit delivery from two workers into one native file', async () => {
+		PlaneTest.indices.vector.putSync(RETAINED_MARKER, true);
+		const worker = new Worker(require.resolve('./vectorIndexPlane-thread.js'), {
+			workerData: { workerIndex: 1, workerCount: 2 },
+		});
+		const nextMessage = () =>
+			new Promise((resolve, reject) => {
+				worker.once('message', resolve);
+				worker.once('error', reject);
+			});
+		try {
+			const ready = await nextMessage();
+			assert.equal(ready.type, 'ready');
+			assert.equal(ready.retainedMarker, true, 'a peer worker should reopen a current plane without rebuilding it');
+			const workerRecords = [];
+			for (let i = 0; i < 20; i++) {
+				const id = 2_000 + i;
+				const vector = makeVector(id);
+				vectors.set(id, vector);
+				workerRecords.push({ id, name: `worker${i}`, vector });
+			}
+			const workerDone = nextMessage();
+			worker.postMessage({ type: 'put', records: workerRecords });
+			for (let i = 0; i < 20; i++) {
+				const id = 3_000 + i;
+				const vector = makeVector(id);
+				vectors.set(id, vector);
+				await PlaneTest.put(id, { name: `main${i}`, vector });
+			}
+			const result = await workerDone;
+			assert.equal(result.type, 'done', result.stack ?? result.message);
+			await waitForKey(2_003, vectors.get(2_003));
+			await waitForKey(3_003, vectors.get(3_003));
+		} finally {
+			await worker.terminate();
+		}
+		const replacement = new Worker(require.resolve('./vectorIndexPlane-thread.js'), {
+			workerData: { workerIndex: 1, workerCount: 2 },
+		});
+		try {
+			const ready = await new Promise((resolve, reject) => {
+				replacement.once('message', resolve);
+				replacement.once('error', reject);
+			});
+			assert.equal(ready.type, 'ready');
+			assert.equal(ready.retainedMarker, true, 'a replacement worker should reopen rather than rebuild the plane');
+			await waitForCursors();
+		} finally {
+			await replacement.terminate();
+		}
+	});
+
+	it('replays a committed write after its worker terminates before delivery', async () => {
+		const id = 4_000;
+		const vector = makeVector(id);
+		vectors.set(id, vector);
+		const worker = new Worker(require.resolve('./vectorIndexPlane-thread.js'), {
+			workerData: { workerIndex: 1, workerCount: 2 },
+		});
+		try {
+			const ready = await new Promise((resolve, reject) => {
+				worker.once('message', resolve);
+				worker.once('error', reject);
+			});
+			assert.equal(ready.type, 'ready');
+			const committed = new Promise((resolve, reject) => {
+				worker.once('message', resolve);
+				worker.once('error', reject);
+			});
+			worker.postMessage({ type: 'commitAndBlock', record: { id, name: 'crash-window', vector } });
+			assert.equal((await committed).type, 'committed');
+		} finally {
+			await worker.terminate();
+		}
+
+		const replacement = new Worker(require.resolve('./vectorIndexPlane-thread.js'), {
+			workerData: { workerIndex: 1, workerCount: 2 },
+		});
+		try {
+			const ready = await new Promise((resolve, reject) => {
+				replacement.once('message', resolve);
+				replacement.once('error', reject);
+			});
+			assert.equal(ready.type, 'ready');
+			await waitForKey(id, vector);
+		} finally {
+			await replacement.terminate();
+		}
+	});
+
+	it('rebuilds after a whole-table snapshot reload marker', async () => {
+		PlaneTest.indices.vector.putSync(999_998, { primaryKey: 'stale-snapshot-mapping' });
+		await PlaneTest.writeReloadMarker();
+		await waitFor(() => indexReady(PlaneTest) && PlaneTest.indices.vector.getSync(999_998) === undefined, {
+			timeout: 15_000,
+			message: 'whole-table reload marker did not replace derived mappings',
+		});
+		await waitForKey(42, vectors.get(42));
+	});
+
+	it('rebuilds when a replacement worker replays a snapshot reload marker', async () => {
+		PlaneTest.indices.vector.putSync(999_997, { primaryKey: 'stale-offline-snapshot-mapping' });
+		await PlaneTest.derivedIndexRuntime.close();
+		await PlaneTest.writeReloadMarker();
+		resetDatabases();
+		PlaneTest = defineTable();
+		await waitFor(() => indexReady(PlaneTest) && PlaneTest.indices.vector.getSync(999_997) === undefined, {
+			timeout: 15_000,
+			message: 'replayed reload marker did not replace derived mappings',
+		});
+		await waitForKey(42, vectors.get(42));
+	});
+
+	it('recovers searchable native state across a database reset', async () => {
+		const planePath = customIndex().planeFilePath();
+		resetDatabases();
+		PlaneTest = defineTable();
+		await waitForKey(42, vectors.get(42));
+		assert.ok(fs.existsSync(planePath));
+	});
+
+	it('rebuilds from primary records when its durable cursor is outside audit retention', async () => {
+		const index = customIndex();
+		const planePath = index.planeFilePath();
+		// A live owner's shutdown barrier republishes the cursor it applied, so the stale cursor has to
+		// be installed after the runtime has released — the shape of a restart onto a purged log.
+		await PlaneTest.derivedIndexRuntime.close();
+		PlaneTest.indices.vector.putSync(999_999, { primaryKey: 'stale-derived-mapping' });
+		PlaneTest.indices.vector.putSync(DERIVED_INDEX_CURSOR_KEY, { format: 1, logs: { local: 1 } });
+
+		resetDatabases();
+		PlaneTest = defineTable();
+		// The successor publishes ready on acquisition and meets the unresolvable cursor on its first
+		// drain turn, so the rebuild is proven by the stale mapping's disappearance, not by a search.
+		await waitFor(() => indexReady(PlaneTest) && PlaneTest.indices.vector.getSync(999_999) === undefined, {
+			timeout: 15_000,
+			message: 'the retention gap must replace stale derived mappings from primary records',
+		});
+		await waitForKey(42, vectors.get(42));
+		assert.ok(fs.existsSync(planePath));
+	});
+
+	it('answers an empty index with no results instead of a rebuilding 503', async () => {
+		const EmptyTable = table({
+			table: 'PlaneEmpty',
+			database: DB,
+			audit: true,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'vector', indexed: { type: 'HNSW', nativePlane: true, efConstruction: 200 }, type: 'Array' },
+			],
+		});
+		const index = EmptyTable.indices.vector.customIndex;
+		await waitFor(() => indexReady(EmptyTable), {
+			timeout: 15_000,
+			message: 'the empty derived runtime never became ready',
+		});
+		const results = await index.search(
+			{ target: makeVector(0), comparator: 'sort', distance: 'cosine', ef: EF },
+			{ transaction: undefined }
+		);
+		assert.deepEqual([...results], []);
+		// The search target must not publish a placeholder file: a concurrent first insert would
+		// read it as another worker's in-progress create and reject the write for a full minute.
+		assert.ok(!fs.existsSync(index.planeFilePath()));
+		await EmptyTable.dropTable();
+	});
+
+	it('reports 503 rather than no results when a populated index has lost its file', async () => {
+		const LostFile = table({
+			table: 'PlaneLostFile',
+			database: DB,
+			audit: true,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'vector', indexed: { type: 'HNSW', nativePlane: true, efConstruction: 200 }, type: 'Array' },
+			],
+		});
+		await LostFile.indexingOperation;
+		const index = LostFile.indices.vector.customIndex;
+		const probe = makeVector(5);
+		await LostFile.put(1, { vector: probe });
+		await waitFor(
+			async () => {
+				if (!indexReady(LostFile)) return false;
+				const hits = await index.search(
+					{ target: probe, comparator: 'sort', distance: 'cosine', ef: EF },
+					{
+						transaction: undefined,
+					}
+				);
+				return [...hits].some((entry) => entry.key === 1);
+			},
+			{ timeout: 15_000, message: 'the populated index never became searchable' }
+		);
+		index.plane = undefined;
+		fs.rmSync(index.planeFilePath(), { force: true });
+		// The node mappings survive the file, so emptiness is not proven: answering [] here would
+		// hide every indexed vector behind a query that looks successful.
+		assert.throws(
+			() => index.search({ target: probe, comparator: 'sort', distance: 'cosine', ef: EF }, { transaction: undefined }),
+			/rebuilding/
+		);
+		await LostFile.dropTable();
+	});
+
+	it('requires audit logging and native construction geometry', () => {
+		assert.throws(
+			() =>
+				table({
+					table: 'PlaneNoAudit',
+					database: DB,
+					audit: false,
+					attributes: [
+						{ name: 'id', isPrimaryKey: true },
+						{ name: 'vector', indexed: { type: 'HNSW', nativePlane: true }, type: 'Array' },
+					],
+				}),
+			/audit logging/
+		);
+		assert.throws(
+			() =>
+				table({
+					table: 'PlaneBadGeometry',
+					database: DB,
+					audit: true,
+					attributes: [
+						{ name: 'id', isPrimaryKey: true },
+						{ name: 'vector', indexed: { type: 'HNSW', nativePlane: true, M: 8 }, type: 'Array' },
+					],
+				}),
+			/requires M=16/
+		);
+		for (const bad of [[], { length: -1 }, { length: 1.5 }, {}]) {
+			assert.throws(
+				() => customIndex().prepareCommitted('bad-vector', bad, undefined, { transaction: {} }),
+				/must be an array of at least one number/,
+				`${JSON.stringify(bad)} must not reach the plane`
+			);
+		}
+		// An already-audited table must not be able to turn auditing off underneath a nativePlane
+		// index: nothing clears Table.audit, so the descriptor would persist audit: false and the
+		// next process start would fail catalog load on the derived-index attach.
+		assert.throws(
+			() =>
+				table({
+					table: 'PlaneTest',
+					database: DB,
+					audit: false,
+					attributes: [
+						{ name: 'id', isPrimaryKey: true },
+						{ name: 'name', indexed: true },
+						{
+							name: 'vector',
+							indexed: { type: 'HNSW', nativePlane: true, efConstruction: 200 },
+							type: 'Array',
+						},
+					],
+				}),
+			/audit logging/
+		);
+	});
+
+	(process.env.HNSW_NATIVE_REBUILD_BENCHMARK ? it : it.skip)(
+		'sustains the native rebuild insertion floor for 100k records',
+		async function () {
+			this.timeout(180_000);
+			const total = 100_000;
+			const index = customIndex();
+			const startedAt = Date.now();
+			for (let id = 100_000; id < 100_000 + total; id++) {
+				index.applyDerivedValue(id, makeVector(id), id);
+				if (id % 10_000 === 9_999) {
+					await index.flushDerived(id);
+					const indexed = id - 100_000 + 1;
+					const rate = Math.round(indexed / Math.max((Date.now() - startedAt) / 1_000, 0.001));
+					const eta = Math.ceil((total - indexed) / Math.max(rate, 1));
+					console.log(`Native rebuild benchmark: ${indexed}/${total} records, ${rate}/s, ETA ${eta}s`);
+				}
+			}
+			const rate = total / Math.max((Date.now() - startedAt) / 1_000, 0.001);
+			assert.ok(rate >= 1_000, `native rebuild rate ${Math.round(rate)}/s is below the 1,000/s floor`);
+		}
+	);
+
+	it('removes the native file when the table is dropped', async () => {
+		const planePath = customIndex().planeFilePath();
+		await PlaneTest.dropTable();
+		assert.ok(!fs.existsSync(planePath));
+	});
+});


### PR DESCRIPTION
A **file-primary** native HNSW vector index, as a backend on the shared derived-index runtime from #2567. The memory-mapped `.hnsw` file (`@harperfast/hnsw` 0.2.1, exact-pinned optional dependency) is the only home of graph nodes, adjacency, the entry point and the id allocator; RocksDB keeps the primary records, the `pk ↔ nodeId` mappings and one durable cursor vector. This PR is stacked on #2567 and shows only the HNSW part; it is that runtime's first consumer.

The durable design — file format, concurrency, durability, search path, how the index sits on the runtime, what `nativePlane: true` requires and does not promise — is the **§ Native HNSW plane** section of the root `DESIGN.md`. This description holds the transient part: decisions, measurements, verification.

## Why

Measured at 5M nodes / ef 512, ~85% of a JS search visit is object bookkeeping and a RocksDB `Get` per visit (~1–2 µs warm) dwarfs the ~50 ns SIMD distance it feeds:

| 1M × 768-d int8, ef 512 | JS (main) | native |
|---|---|---|
| search p50 | 7.2 ms | **0.75 ms** |
| per-visit cost | 4.34 µs | 0.33 µs |
| recall@10 (set) | 0.997 | 0.999 |

## What changed in this revision

The branch's own delivery runtime (`resources/DerivedIndexBackend.ts`, 486 lines) is deleted. In its place:

- [`resources/indexes/hnswDerivedIndex.ts`](https://github.com/HarperFast/harper/blob/kris/hnsw-native-plane/resources/indexes/hnswDerivedIndex.ts) — `HnswDerivedIndexBackend`: `deliver()` queues and returns accepted, an applier drains in 5 ms `setImmediate` slices, `plane.flushAsync()` is the barrier, then the pending mappings are published, then the batch's `through` vector is written as the one durable cursor (`Symbol.for('derived-index-cursor')`). Application pauses while a barrier is in flight so the barrier publishes exactly what it covers. `reset(epoch)` removes the cursor before the file and the mappings. `attachDerivedIndexes(Table)` registers a table's post-commit indexes with one runtime per database, on every worker.
- `HierarchicalNavigableSmallWorld.ts` — the commit path only validates (a malformed vector is still the client's 400); nothing is staged on the transaction. Search readiness is the runtime's shared record on every worker (`planeSearchReady`), not `isIndexing`; a failed search detaches and asks the owner for a rebuild instead of unlinking a file a peer may already have replaced. A vector the plane cannot hold at apply time is skipped and counted, never a rebuild.
- Writer backpressure is the runtime's lag policy: `maxLagMilliseconds` (30 s default on a `nativePlane` attribute, settable) → retryable 503 `DERIVED_INDEX_LAGGING` on local user writes to the table; canonical-source applies, replay and replication notifications are never shed.
- `RocksTransactionLogStore.aftercommit` no longer carries staged targets.

Six open items from the earlier design record are closed by the shared runtime: shared cross-worker readiness, a new origin's first write forcing a rebuild, per-key coalescing (the ingest bench's repeated-key shape now measures 265 native applies for 1,000 commits over 50 keys; it was 1,000), undecodable audit headers, and the whole-retention-window replay after a rebuild. An interior corrupt frame inside the committed prefix still fails the attempt closed — a log that cannot be read to its tail cannot be replayed from any anchor.

## What `nativePlane: true` requires

Unchanged: explicit `audit: true` on the table (the transaction log is the recovery source; inheriting the global setting is rejected), RocksDB, `M=16` / `efConstruction=200` / int8 cosine, `@harperfast/hnsw` loadable (absence = 503, not degraded). Not promised: a single total order across concurrent CRDT/source-resolution arrivals, byte-identical graphs across nodes or rebuilds, in-place format upgrades.

## Decisions

- **File-primary, not dual-write.** The phase-1 prototype mirrored the RocksDB graph into the file and cut search over; it never shipped, so there is no deployed population to protect, and keeping a second graph would pay its write and storage cost forever. Rejected alternatives: keep the CF graph as authority (duplicate writes, the cost this exists to remove); ship post-commit delivery first and cut over later (another temporary format, a migration, no compatibility evidence to gain); synchronous native mutation inside the record transaction (an aborted transaction can still publish an mmap write; recovery needs the log protocol anyway).
- **Transaction-log delivery, not an outbox** — raised by planning review as a better alternative and overruled by the repo owner in favour of #2489's single protocol; the reasoning is in #2567.
- **One runtime.** This branch's own `DerivedIndexBackend.ts` implemented the same protocol; the measured backend share of the write-and-index wall (95–97%) put the per-transaction bookkeeping the two runtimes differed on inside the remaining 3–5%, so it could not justify keeping both.
- **Committed-tail rebuild anchor.** The first convergence plan proposed a tighter anchor from staged/uncommitted positions and planning review disqualified it (an uncommitted anchor skips its own transaction; an aborted one may never exist as a boundary). Reading rocksdb-js retired the line of work: `commitFinished()` advances `lastCommittedPosition` to the earliest still-uncommitted write, so the committed tail is already a contiguous-prefix boundary and needs no storage-layer change.
- **Degree cap 128, sparse reservation at create, Apache-2.0 standalone package** (Kris, 2026-08-31), recorded in `DESIGN.md`.
- **Admission control is a lag budget, not a queue depth.** The old runtime rejected vector-changing writes at 65,536 pending keys / 262,144 tickets; the shared runtime's `maxLagMilliseconds` sheds the same writes on time behind, which is the quantity retention actually bounds.

## Measurements

Per-visit cost at 5M nodes / ef 512, 768-d int8: 4.34 µs per warm JS visit, of which the int8 cosine is 0.43 µs and a cold msgpackr node decode 5.57 µs; native per-visit 0.33 µs. 1M × 768-d: search p50 7.2 → 0.75 ms, recall@10 0.997 → 0.999. Package in isolation (N = 10,000): insert 208 µs (128-d) / 315 µs (384-d) / 835 µs (1536-d). Ingest bench on this branch (384-d, graph ≈3,000): foreground put 0.090 ms (11,078/s), `applyDerivedValue` 0.365 ms/call, `flushDerived` 8.96 ms/call, event loop max 11.8 ms while draining; repeated-key shape 265 applies for 1,000 commits over 50 keys. Rebuild insertion floor: 4,684/s at 100k against a 1,000/s CI gate; 1,242/s at 1M from the crate anchor.

## Verification

- `unitTests/resources/vectorIndexPlane.test.js` — **22 passing** against the real native package: mappings-only CF; deterministic recall; aborted transaction publishes nothing; unrelated field change schedules no insert; predicates and full-stack rescoring; wrong-dimension write/query are 400s; f32-range rejection; async result contract; **two workers into one native file; a committed write replayed after its worker dies before delivery; whole-table reload marker rebuilds (live and on a replacement worker); recovery across `resetDatabases`; a cursor outside retention rebuilds from primary records; an empty index answers no results; a populated index that lost its file answers 503; drop removes the file.**
- Full `test:unit:resources` on this branch: 2480 passing, 32 pending, 0 failing.
- `hnswDerivedIngest.bench.js` runs; the `hnsw-plane` CI job still requires the native binding to load rather than accepting a skip.
- `npm run build`, `tsc --noEmit`, `lint:required`, prettier: clean.

Restacking exposed one runtime defect, fixed in #2567: a log that has never written a file reports `oldestSequenceNumber: 0`, which the runtime read as a retention gap on every brand-new database.

Refs #2489, #693, #711, #895, #2182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
