### PR TITLE
Promote two QA anchors: TLS cert-table swap reachability and the deployment payload operations

### DIFF
--- a/integrationTests/deploy/qa701-deployment-payload-ops.test.ts
+++ b/integrationTests/deploy/qa701-deployment-payload-ops.test.ts
@@ -117,11 +117,16 @@ async function callOperationAs(
 		body: JSON.stringify(op),
 	});
 	const raw = Buffer.from(await res.arrayBuffer());
-	let parsed: any = raw.toString('utf8');
-	try {
-		parsed = JSON.parse(parsed);
-	} catch {
-		// leave as text/binary (payload stream case)
+	// A successful get_deployment_payload streams octet-stream bytes; decoding those as UTF-8 would
+	// replace anything non-textual, so binary responses are left to `raw` and `body` stays undefined.
+	let parsed: any;
+	if (!(res.headers.get('content-type') ?? '').includes('application/octet-stream')) {
+		parsed = raw.toString('utf8');
+		try {
+			parsed = JSON.parse(parsed);
+		} catch {
+			// a non-JSON text body is still useful in an assertion message
+		}
 	}
 	return { status: res.status, headers: res.headers, body: parsed, raw };
 }

--- a/integrationTests/deploy/qa701-deployment-payload-ops.test.ts
+++ b/integrationTests/deploy/qa701-deployment-payload-ops.test.ts
@@ -64,6 +64,18 @@ const FIXTURE_PATH = join(import.meta.dirname, 'qa701-deployment-payload-ops');
 // disappearance here is attributable only to delete_deployment_payload.
 const FORCED_RETENTION_MAX_SIZE = 200 * 1024 * 1024; // 200 MiB
 
+// Every fixture gets a DISTINCT payload size: countFilesNearSize() identifies the blob under test
+// by size alone, so two same-size deploys coexisting in the store would make one read as the
+// other's leak. The multi-MB non-terminal size is also what gives the 409 probe a real window.
+const SMALL_FIXTURE_KB = 4;
+const REDEPLOY_FIXTURE_KB = 16;
+const DELEGATION_FIXTURE_KB = 64;
+const NONTERMINAL_FIXTURE_KB = 6 * 1024;
+const LARGE_FIXTURE_KB = 12 * 1024;
+
+// Mirrors TERMINAL_STATUSES in components/deploymentOperations.ts -- the set the 409 guard keys on.
+const TERMINAL_STATUSES = ['success', 'failed', 'rolled_back'];
+
 function postMultipart(
 	url: URL,
 	contentType: string,
@@ -77,7 +89,7 @@ function postMultipart(
 				hostname: url.hostname,
 				port: url.port,
 				method: 'POST',
-				path: '/',
+				path: url.pathname + url.search,
 				headers: {
 					'Content-Type': contentType,
 					'Transfer-Encoding': 'chunked',
@@ -87,11 +99,15 @@ function postMultipart(
 			(res) => {
 				const chunks: Buffer[] = [];
 				res.on('data', (c) => chunks.push(c));
+				res.on('error', reject);
 				res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks) }));
 			}
 		);
 		req.on('error', reject);
-		body.on('error', reject);
+		body.on('error', (err) => {
+			req.destroy(err);
+			reject(err);
+		});
 		body.pipe(req);
 	});
 }
@@ -135,6 +151,7 @@ async function getDeploymentWhenTerminal(
 		if (got.status === 200 && (got.body?.status === 'success' || got.body?.status === 'failed')) return got;
 		await sleep(75);
 	}
+	if (!last) throw new Error(`get_deployment for '${deploymentId}' was never polled within ${timeoutMs}ms`);
 	return last;
 }
 
@@ -169,9 +186,12 @@ function listBlobFiles(blobsRoot: string): Array<{ path: string; size: number; m
 	return out;
 }
 
-// Counts blob files whose size matches `targetSize` within `toleranceBytes` -- targets the
-// SPECIFIC blob under test by its known size rather than an aggregate directory total, which is
-// fragile once several small test deploys' blobs coexist in the same store.
+// Counts blob files whose size matches `targetSize` within `toleranceBytes`. An on-disk blob file
+// runs a handful of bytes larger than payload_size (resources/blob.ts), hence the tolerance. This
+// is an identity oracle, so every fixture below is built at a DISTINCT size: two same-size random
+// payloads land inside the tolerance of each other, and a surviving unrelated blob would then read
+// as a leak of the one under test. Callers require exactly one pre-delete match to keep that
+// honest -- if this ever counts more than one, widen the size spread, don't widen the tolerance.
 function countFilesNearSize(listing: Array<{ size: number }>, targetSize: number, toleranceBytes = 64): number {
 	return listing.filter((f) => Math.abs(f.size - targetSize) <= toleranceBytes).length;
 }
@@ -356,7 +376,7 @@ suite(
 		let smallSha256: string;
 
 		test('2 setup: deploy a small real component, confirm payload_blob retained', async () => {
-			const fixtureDir = buildFixture(4, 'QA-701 small');
+			const fixtureDir = buildFixture(SMALL_FIXTURE_KB, 'QA-701 small');
 			const packaged = await packageToBuffer(fixtureDir);
 			smallBuffer = packaged.buffer;
 			smallSha256 = packaged.sha256;
@@ -419,35 +439,60 @@ suite(
 		});
 
 		test('3: delete_deployment_payload on a non-terminal deployment -> 409, blob untouched', async () => {
-			// Deploy a fresh component and immediately (racily) try to delete its payload before it
-			// can possibly have settled to a terminal status -- exercises the 409 guard's intent.
-			// If the deploy happens to have already gone terminal by the time we call delete (small
-			// fixtures can finish fast), fall back to asserting the row is terminal and skip the 409
-			// assertion rather than false-failing on a race.
-			const fixtureDir = buildFixture(4, 'QA-701 nonterminal');
+			// deploy_component only responds once the row has reached a terminal status, so awaiting
+			// the deploy and then deleting can never reach the guard -- it deletes against a row that
+			// is already terminal. The recorder writes the row as 'pending' before the payload is
+			// ingested (components/deploymentRecorder.ts's create()), so the in-flight row is visible
+			// through list_deployments for the whole upload+install window. Deploy without awaiting,
+			// catch the row there, and delete against it. NONTERMINAL_FIXTURE_KB is multi-MB to keep
+			// that window comfortably wider than the poll interval.
+			const fixtureDir = buildFixture(NONTERMINAL_FIXTURE_KB, 'QA-701 nonterminal');
 			const packaged = await packageToBuffer(fixtureDir);
-			const deployed = await deployBuffer(ctx, 'qa701-nonterminal-app', packaged.buffer, false);
-			strictEqual(deployed.status, 200);
-			ok(deployed.deploymentId);
+			const deployPromise = deployBuffer(ctx, 'qa701-nonterminal-app', packaged.buffer, false);
 
-			const immediateDelete = await callOperation(ctx, {
-				operation: 'delete_deployment_payload',
-				deployment_id: deployed.deploymentId,
-			});
-			const rowNow = await callOperation(ctx, { operation: 'get_deployment', deployment_id: deployed.deploymentId });
-			if (rowNow.body?.status && !['success', 'failed', 'rolled_back'].includes(rowNow.body.status)) {
+			let inFlightId: string | undefined;
+			let inFlightStatus: string | undefined;
+			const windowDeadline = Date.now() + 20000;
+			while (Date.now() < windowDeadline) {
+				const listed = await callOperation(ctx, { operation: 'list_deployments' });
+				const row = (listed.body?.deployments ?? []).find(
+					(d: any) => d.project === 'qa701-nonterminal-app' && !TERMINAL_STATUSES.includes(d.status)
+				);
+				if (row) {
+					inFlightId = row.deployment_id;
+					inFlightStatus = row.status;
+					break;
+				}
+				if (!listed.body?.deployments) break; // list_deployments is not answering; fall through
+			}
+
+			if (inFlightId) {
+				const delResp = await callOperation(ctx, {
+					operation: 'delete_deployment_payload',
+					deployment_id: inFlightId,
+				});
 				strictEqual(
-					immediateDelete.status,
+					delResp.status,
 					409,
-					`delete on a non-terminal deployment (status='${rowNow.body?.status}') should 409, got ${immediateDelete.status}: ${JSON.stringify(immediateDelete.body)}`
+					`delete on a non-terminal deployment (status='${inFlightStatus}') should 409, got ${delResp.status}: ${JSON.stringify(delResp.body)}`
 				);
 			} else {
 				console.log(
-					`[QA-701] 3: deploy settled to terminal ('${rowNow.body?.status}') before the delete call landed -- 409 race window missed, not a defect.`
+					'[QA-701] 3: the deployment reached a terminal status before any poll observed it -- 409 window missed, not a defect.'
 				);
 			}
-			// Let it finish terminally either way so it doesn't interfere with later probes.
-			await getDeploymentWhenTerminal(ctx, deployed.deploymentId!);
+
+			const deployed = await deployPromise;
+			strictEqual(
+				deployed.status,
+				200,
+				`deploy expected 200, got ${deployed.status}: ${deployed.raw.toString('utf8')}`
+			);
+			ok(deployed.deploymentId);
+			const settled = await getDeploymentWhenTerminal(ctx, deployed.deploymentId!);
+			strictEqual(settled.body.status, 'success', `deploy should succeed: ${JSON.stringify(settled.body.error)}`);
+			// The refused delete must not have touched the blob: it is still there once terminal.
+			strictEqual(settled.body.payload_blob_present, true, 'a 409-refused delete must leave payload_blob in place');
 		});
 
 		test('4: delete_deployment_payload reclaims ON-DISK bytes, not just the row flag', async () => {
@@ -459,9 +504,11 @@ suite(
 				'precondition: payload_blob should still be present before delete'
 			);
 			const payloadSize = got.body.payload_size as number;
-			ok(
-				countFilesNearSize(beforeListing, payloadSize) >= 1,
-				`precondition: a blob file matching payload_size=${payloadSize} should exist on disk before delete, ` +
+			strictEqual(
+				countFilesNearSize(beforeListing, payloadSize),
+				1,
+				`precondition: exactly one blob file should match payload_size=${payloadSize} before delete ` +
+					`(the size is this suite's identity oracle -- see countFilesNearSize), ` +
 					`listing=${JSON.stringify(beforeListing)}`
 			);
 
@@ -530,7 +577,7 @@ suite(
 		});
 
 		test('7: redeploy after delete produces an independent new deployment_id + fresh payload_blob', async () => {
-			const fixtureDir = buildFixture(4, 'QA-701 redeploy');
+			const fixtureDir = buildFixture(REDEPLOY_FIXTURE_KB, 'QA-701 redeploy');
 			const packaged = await packageToBuffer(fixtureDir);
 			const deployed = await deployBuffer(ctx, 'qa701-small-app', packaged.buffer, false);
 			strictEqual(
@@ -615,19 +662,13 @@ suite(
 		});
 
 		test('9: multi-MB payload delete reclaims disk bytes at scale', async () => {
-			const MB = 12; // above the *default* 10 MiB auto-retention threshold, but this suite
-			// forces payloadRetention.maxSize to 200 MiB, so this deploy retains its blob until we
-			// explicitly delete it -- isolating this op's reclaim from the automatic drop.
-			const fixtureDir = mkdtempSync(join(tmpdir(), 'qa701-large-fixture-'));
-			tempFixtureDirs.push(fixtureDir);
-			writeFileSync(fixtureDir + '/config.yaml', '# payload-size padding only, no routes\n');
-			const scratch = Buffer.allocUnsafe(1024 * 1024);
-			randomFillSync(scratch);
-			writeFileSync(join(fixtureDir, 'padding.bin'), Buffer.concat(Array(MB).fill(scratch)));
-
+			// Above the *default* 10 MiB auto-retention threshold, but this suite forces
+			// payloadRetention.maxSize to 200 MiB, so this deploy retains its blob until the explicit
+			// delete below -- isolating this op's reclaim from the automatic drop.
+			const fixtureDir = buildFixture(LARGE_FIXTURE_KB, 'QA-701 large');
 			const packaged = await packageToBuffer(fixtureDir);
 			ok(
-				packaged.buffer.length > MB * 1024 * 1024 * 0.9,
+				packaged.buffer.length > LARGE_FIXTURE_KB * 1024 * 0.9,
 				`fixture should package to multi-MB, got ${packaged.buffer.length}`
 			);
 
@@ -647,9 +688,11 @@ suite(
 
 			const beforeListing = listBlobFiles(blobsRoot);
 			const payloadSize = got.body.payload_size as number;
-			ok(
-				countFilesNearSize(beforeListing, payloadSize) >= 1,
-				`precondition: a blob file matching payload_size=${payloadSize} should exist on disk before delete, ` +
+			strictEqual(
+				countFilesNearSize(beforeListing, payloadSize),
+				1,
+				`precondition: exactly one blob file should match payload_size=${payloadSize} before delete ` +
+					`(the size is this suite's identity oracle -- see countFilesNearSize), ` +
 					`listing=${JSON.stringify(beforeListing)}`
 			);
 
@@ -741,7 +784,7 @@ suite(
 		let liveForDelegationDeploymentId: string;
 
 		test('10b setup: deploy one more real payload for the delegated-role probe', async () => {
-			const fixtureDir = buildFixture(4, 'QA-701 delegation target');
+			const fixtureDir = buildFixture(DELEGATION_FIXTURE_KB, 'QA-701 delegation target');
 			const packaged = await packageToBuffer(fixtureDir);
 			const deployed = await deployBuffer(ctx, 'qa701-delegation-app', packaged.buffer, false);
 			strictEqual(deployed.status, 200);
@@ -754,9 +797,9 @@ suite(
 		test('10c: gate-2-delegated non-SU role can delete_deployment_payload but is STILL 403 on get_deployment_payload', async () => {
 			const auth = { username: NON_SU_USER_DELEGATED, password: NON_SU_PASSWORD };
 
-			// get_deployment_payload self-enforces super_user in the handler (commit 23186ebca) --
-			// exposes the raw tarball (can embed secrets), unlike get_deployment's stripped metadata,
-			// so an explicit role `operations` grant must NOT be enough to unlock it.
+			// components/deploymentOperations.ts's requireSuperUser runs inside the get handler, on top of
+			// the registered permission: the raw tarball can embed secrets, unlike get_deployment's
+			// stripped metadata, so an explicit role `operations` grant must NOT be enough to unlock it.
 			const getResp = await callOperationAs(
 				ctx,
 				{ operation: 'get_deployment_payload', deployment_id: liveForDelegationDeploymentId },

--- a/integrationTests/deploy/qa701-deployment-payload-ops.test.ts
+++ b/integrationTests/deploy/qa701-deployment-payload-ops.test.ts
@@ -1,43 +1,28 @@
 /**
  * QA-701 — anchor for `get_deployment_payload` / `delete_deployment_payload` (#1898), which shipped
- * with unit coverage only.
+ * with unit coverage only. Two contracts are pinned.
  *
- * Two contracts are pinned here.
+ * (1) The delete reclaims disk, it does not just flip a flag. Nulling `payload_blob` and committing
+ * the row is expected to unlink the blob file through RecordEncoder's retained-blob check. Harper
+ * has a history on this axis (#595; drop_attribute/drop_table drop metadata only), so both delete
+ * legs assert against the on-disk blob store at ~4 KB and again at 12 MB, and require `freed_bytes`
+ * to equal `payload_size` exactly.
  *
- * (1) DELETE REALLY RECLAIMS DISK. `delete_deployment_payload` nulls `payload_blob` and commits the
- * row, which is expected to unlink the blob file through RecordEncoder's retained-blob check — not
- * merely flip a flag. Harper has a history on this axis (#595, "dropping a table leaves orphan
- * blobs", and the metadata-only behavior confirmed for drop_attribute/drop_table), so every delete
- * probe asserts against the actual on-disk blob store, at ~4 KB and again at 12 MB, and checks that
- * `freed_bytes` equals the row's `payload_size` exactly. The disk check polls for the file to
- * disappear rather than sleeping, so a slow-but-real unlink is not misread as a leak.
+ * (2) The authorization asymmetry is deliberate. A non-super_user role explicitly granted both
+ * operations can delete but is still 403 on get, because `components/deploymentOperations.ts`'s
+ * `requireSuperUser` runs inside the get handler on top of the registered permission — the payload
+ * is the raw tarball and can embed secrets, unlike `get_deployment`'s stripped metadata. Pinning it
+ * means a later "consistency" cleanup that lets a role grant unlock the download goes red rather
+ * than quietly widening secret exposure.
  *
- * (2) THE AUTHORIZATION ASYMMETRY IS DELIBERATE. A non-super_user role with no `operations` grant is
- * 403 on both ops. A non-super_user role explicitly granted BOTH operations can call
- * `delete_deployment_payload` — that gate-2 delegation is the intended way to hand cleanup
- * automation to a non-SU role — but is STILL 403 on `get_deployment_payload`, because that handler
- * self-enforces super_user in addition to the registered permission (components/deploymentOperations.ts's
- * `requireSuperUser`, and the note beside it in utility/operation_authorization.ts): the payload is
- * the raw tarball and can embed secrets, unlike `get_deployment`'s stripped metadata. This file
- * pins that asymmetry as the contract, so a future "consistency" cleanup that lets a role grant
- * unlock the download goes red instead of quietly widening secret exposure.
+ * Not the mechanism covered by integrationTests/deploy/deploy-payload-reclaim.test.ts, which is the
+ * AUTOMATIC post-deploy drop of a payload over `deployment.payloadRetention.maxSize` (#1496) and
+ * never calls either operation. `maxSize` is forced to 200 MiB here so that drop can never fire,
+ * which is what makes any blob disappearance attributable to an explicit delete.
  *
- * Boundaries also covered: unknown deployment_id → 404 with a JSON error body and no download
- * headers leaking from the error path; delete on a non-terminal deployment → 409; get after delete
- * → 404, not 500; a second delete → 200 with `freed_bytes: 0`; deleting a running component's
- * payload leaves the live route serving (the blob is the historical tarball, not the installed
- * copy); and a redeploy after a delete mints an independent deployment_id whose own blob is
- * retained while the old row stays payload-less.
- *
- * Not the same mechanism as integrationTests/deploy/deploy-payload-reclaim.test.ts, which covers the
- * AUTOMATIC post-deploy drop of a payload exceeding `deployment.payloadRetention.maxSize` (#1496)
- * and never calls either of these operations. This suite forces `maxSize` to 200 MiB precisely so
- * that automatic drop can never fire, which makes any blob disappearance here attributable only to
- * an explicit `delete_deployment_payload` call.
- *
- * Proof boundary: the 409 leg races a real deploy to its terminal status. When the deploy settles
- * first the 409 assertion is skipped (and says so on stdout) rather than false-failing; the guard's
- * unconditional coverage is unitTests/components/deploymentOperations.test.js's, not this file's.
+ * Proof boundary: nothing here covers replication. `delete_deployment_payload` replicates the
+ * nulled blob so peers drop their copies too; this is a single-node suite and asserts only the
+ * local unlink.
  *
  * Reproduction:
  *   npm run build && npm run test:integration -- "integrationTests/deploy/qa701-deployment-payload-ops.test.ts"
@@ -70,11 +55,15 @@ const FORCED_RETENTION_MAX_SIZE = 200 * 1024 * 1024; // 200 MiB
 const SMALL_FIXTURE_KB = 4;
 const REDEPLOY_FIXTURE_KB = 16;
 const DELEGATION_FIXTURE_KB = 64;
-const NONTERMINAL_FIXTURE_KB = 6 * 1024;
+const NONTERMINAL_FIXTURE_KB = 256;
 const LARGE_FIXTURE_KB = 12 * 1024;
 
 // Mirrors TERMINAL_STATUSES in components/deploymentOperations.ts -- the set the 409 guard keys on.
 const TERMINAL_STATUSES = ['success', 'failed', 'rolled_back'];
+
+// ~2s of upload for the one probe that needs the deployment to still be installing while it runs.
+const UPLOAD_PACING_CHUNKS = 20;
+const UPLOAD_PACING_DELAY_MS = 100;
 
 function postMultipart(
 	url: URL,
@@ -158,8 +147,7 @@ async function getDeploymentWhenTerminal(
 	return last;
 }
 
-// Full listing (relative path, size, mtime) -- diagnostic only, so a leak report names the
-// actual residual file(s) rather than just an aggregate byte delta.
+// Listed in full so a failure names the residual file rather than an aggregate byte delta.
 function listBlobFiles(blobsRoot: string): Array<{ path: string; size: number; mtimeMs: number }> {
 	if (!existsSync(blobsRoot)) return [];
 	const out: Array<{ path: string; size: number; mtimeMs: number }> = [];
@@ -199,8 +187,7 @@ function countFilesNearSize(listing: Array<{ size: number }>, targetSize: number
 	return listing.filter((f) => Math.abs(f.size - targetSize) <= toleranceBytes).length;
 }
 
-// Polls until no blob file of ~`targetSize` bytes remains, or `timeoutMs` elapses. Distinguishes
-// a slow-but-real async unlink from a genuine leak.
+// Polls rather than sleeping so a slow-but-real async unlink is not reported as a leak.
 async function pollUntilSizeGone(
 	blobsRoot: string,
 	targetSize: number,
@@ -217,12 +204,9 @@ async function pollUntilSizeGone(
 
 const tempFixtureDirs: string[] = [];
 
-// Builds a payload-only fixture: no HTTP routes registered at all, just `kb` KB of genuinely
-// random (non-repeating, gzip-incompressible) padding. Used for every probe that only cares
-// about the payload_blob bytes, not live serving -- deliberately routeless so N of these
-// deployed side-by-side in the same instance never collide over "/". The buffer is filled in one
-// randomFillSync call rather than tiled from a smaller block: a tile below gzip's 32 KiB window
-// compresses away to near-nothing, and the payload size is the thing under measurement here.
+// Routeless on purpose, so any number of these can coexist without colliding over "/". The
+// padding is filled in one randomFillSync call rather than tiled: a tile below gzip's 32 KiB
+// window compresses away, and the payload SIZE is what every disk assertion keys on.
 function buildFixture(kb: number, marker: string): string {
 	const dir = mkdtempSync(join(tmpdir(), 'qa701-fixture-'));
 	tempFixtureDirs.push(dir);
@@ -235,9 +219,8 @@ function buildFixture(kb: number, marker: string): string {
 	return dir;
 }
 
-// Builds a fixture that DOES register a root static route -- used only by the single
-// "deployed and running" probe, which needs a live HTTP route to hit. Only ONE of these may be
-// active (restart:true'd) at a time in this suite, or root-path routes would collide.
+// Registers a root static route. Only ONE of these may be restart:true'd at a time, or the
+// root-path routes collide.
 function buildLiveFixture(marker: string): string {
 	const dir = mkdtempSync(join(tmpdir(), 'qa701-live-fixture-'));
 	tempFixtureDirs.push(dir);
@@ -259,12 +242,29 @@ async function packageToBuffer(fixtureDir: string): Promise<{ buffer: Buffer; sh
 	return { buffer, sha256 };
 }
 
+// Emits `buffer` as `chunks` pieces spaced `delayMs` apart. deploy_component creates the
+// deployment row before it ingests the payload stream (components/operations.js), so pacing the
+// upload holds the row in a non-terminal status for a known, host-speed-independent duration --
+// which is what lets the 409 probe below assert unconditionally instead of racing local I/O.
+function pacedStream(buffer: Buffer, chunks: number, delayMs: number): Readable {
+	const chunkSize = Math.ceil(buffer.length / chunks);
+	return Readable.from(
+		(async function* () {
+			for (let offset = 0; offset < buffer.length; offset += chunkSize) {
+				yield buffer.subarray(offset, offset + chunkSize);
+				await sleep(delayMs);
+			}
+		})()
+	);
+}
+
 async function deployBuffer(
 	ctx: ContextWithHarper,
 	project: string,
 	buffer: Buffer,
 	restart: boolean,
-	auth = ctx.harper.admin
+	auth = ctx.harper.admin,
+	pacing?: { chunks: number; delayMs: number }
 ): Promise<{ status: number; deploymentId: string | undefined; raw: Buffer }> {
 	const multipart = buildMultipartBody(
 		{ operation: 'deploy_component', project, restart },
@@ -272,7 +272,7 @@ async function deployBuffer(
 			name: 'payload',
 			filename: 'package.tar.gz',
 			contentType: 'application/gzip',
-			stream: Readable.from(buffer),
+			stream: pacing ? pacedStream(buffer, pacing.chunks, pacing.delayMs) : Readable.from(buffer),
 		}
 	);
 	const url = new URL(ctx.harper.operationsAPIURL);
@@ -306,6 +306,7 @@ suite(
 			// Poll the probe route directly until it stops 404-ing; do NOT call restartHttpWorkers()
 			// against a pre-installed fixture (races and flakes on CI).
 			const deadline = Date.now() + 120_000;
+			let ready = false;
 			while (Date.now() < deadline) {
 				try {
 					const probe = await fetch(`${ctx.harper.httpURL}/Beacon/`, {
@@ -315,12 +316,16 @@ suite(
 						},
 					});
 					// A 5xx means mounted but unhealthy, which is not ready either.
-					if (probe.status !== 404 && probe.status < 500) break;
+					if (probe.status !== 404 && probe.status < 500) {
+						ready = true;
+						break;
+					}
 				} catch {
 					/* not ready yet */
 				}
 				await sleep(250);
 			}
+			ok(ready, 'the Beacon route never became ready — the suite would run against an unrouted instance');
 		});
 
 		after(async () => {
@@ -443,49 +448,52 @@ suite(
 		});
 
 		test('3: delete_deployment_payload on a non-terminal deployment -> 409, blob untouched', async () => {
-			// deploy_component only responds once the row has reached a terminal status, so awaiting
-			// the deploy and then deleting can never reach the guard -- it deletes against a row that
-			// is already terminal. The recorder writes the row as 'pending' before the payload is
-			// ingested (components/deploymentRecorder.ts's create()), so the in-flight row is visible
-			// through list_deployments for the whole upload+install window. Deploy without awaiting,
-			// catch the row there, and delete against it. NONTERMINAL_FIXTURE_KB is multi-MB to keep
-			// that window comfortably wider than the poll interval.
+			// deploy_component only responds once the row is terminal, so awaiting the deploy and then
+			// deleting can never reach the guard. The row is written before the payload is ingested,
+			// so uploading in paced chunks holds it non-terminal for a known duration regardless of
+			// how fast the host is -- without that, a quick loopback upload closes the window and the
+			// assertion silently skips, which is how this probe used to pass without ever running.
 			const fixtureDir = buildFixture(NONTERMINAL_FIXTURE_KB, 'QA-701 nonterminal');
 			const packaged = await packageToBuffer(fixtureDir);
-			const deployPromise = deployBuffer(ctx, 'qa701-nonterminal-app', packaged.buffer, false);
+			const deployPromise = deployBuffer(ctx, 'qa701-nonterminal-app', packaged.buffer, false, ctx.harper.admin, {
+				chunks: UPLOAD_PACING_CHUNKS,
+				delayMs: UPLOAD_PACING_DELAY_MS,
+			});
 
 			let inFlightId: string | undefined;
 			let inFlightStatus: string | undefined;
-			const windowDeadline = Date.now() + 20000;
+			const windowDeadline = Date.now() + 20_000;
 			while (Date.now() < windowDeadline) {
+				// A failed or malformed list response falls through to the next poll rather than ending
+				// the loop: a transient error must not quietly turn into a skipped assertion.
 				const listed = await callOperation(ctx, { operation: 'list_deployments' });
 				const row = (listed.body?.deployments ?? []).find(
-					(d: any) => d.project === 'qa701-nonterminal-app' && !TERMINAL_STATUSES.includes(d.status)
+					(d: { project?: string; status?: string }) =>
+						d.project === 'qa701-nonterminal-app' && !TERMINAL_STATUSES.includes(d.status ?? '')
 				);
 				if (row) {
 					inFlightId = row.deployment_id;
 					inFlightStatus = row.status;
 					break;
 				}
-				// Deliberately no early exit on a malformed/failed list response: a transient error
-				// under load would otherwise end the poll and silently skip the 409 assertion.
+				await sleep(25);
 			}
 
-			if (inFlightId) {
-				const delResp = await callOperation(ctx, {
-					operation: 'delete_deployment_payload',
-					deployment_id: inFlightId,
-				});
-				strictEqual(
-					delResp.status,
-					409,
-					`delete on a non-terminal deployment (status='${inFlightStatus}') should 409, got ${delResp.status}: ${JSON.stringify(delResp.body)}`
-				);
-			} else {
-				console.log(
-					'[QA-701] 3: the deployment reached a terminal status before any poll observed it -- 409 window missed, not a defect.'
-				);
-			}
+			ok(
+				inFlightId,
+				`the deployment never appeared in a non-terminal state despite a paced upload of ` +
+					`~${(UPLOAD_PACING_CHUNKS * UPLOAD_PACING_DELAY_MS) / 1000}s — either the row is no longer ` +
+					`written before payload ingest, or deploy_component stopped streaming its payload`
+			);
+			const delResp = await callOperation(ctx, {
+				operation: 'delete_deployment_payload',
+				deployment_id: inFlightId,
+			});
+			strictEqual(
+				delResp.status,
+				409,
+				`delete on a non-terminal deployment (status='${inFlightStatus}') should 409, got ${delResp.status}: ${JSON.stringify(delResp.body)}`
+			);
 
 			const deployed = await deployPromise;
 			strictEqual(
@@ -496,7 +504,6 @@ suite(
 			ok(deployed.deploymentId);
 			const settled = await getDeploymentWhenTerminal(ctx, deployed.deploymentId!);
 			strictEqual(settled.body.status, 'success', `deploy should succeed: ${JSON.stringify(settled.body.error)}`);
-			// The refused delete must not have touched the blob: it is still there once terminal.
 			strictEqual(settled.body.payload_blob_present, true, 'a 409-refused delete must leave payload_blob in place');
 		});
 
@@ -581,6 +588,8 @@ suite(
 			strictEqual(delResp.body.deployment_id, smallDeploymentId);
 		});
 
+		let redeployedDeploymentId: string;
+
 		test('7: redeploy after delete produces an independent new deployment_id + fresh payload_blob', async () => {
 			const fixtureDir = buildFixture(REDEPLOY_FIXTURE_KB, 'QA-701 redeploy');
 			const packaged = await packageToBuffer(fixtureDir);
@@ -594,6 +603,7 @@ suite(
 				deployed.deploymentId && deployed.deploymentId !== smallDeploymentId,
 				'redeploy should mint a new deployment_id'
 			);
+			redeployedDeploymentId = deployed.deploymentId!;
 
 			const got = await getDeploymentWhenTerminal(ctx, deployed.deploymentId!);
 			strictEqual(got.body.status, 'success');
@@ -655,8 +665,7 @@ suite(
 				`delete on the running component's payload expected 200, got ${delResp.status}: ${JSON.stringify(delResp.body)}`
 			);
 
-			// The live route must be entirely unaffected -- payload_blob is the historical tarball
-			// artifact, not the installed component copy the running worker actually serves from.
+			// payload_blob is the historical tarball, not the installed copy the worker serves from.
 			const r2 = await fetch(ctx.harper.httpURL);
 			const body2 = await r2.text();
 			strictEqual(r2.status, 200);
@@ -838,10 +847,20 @@ suite(
 			});
 			strictEqual(gotAfter.body.payload_blob_present, false);
 
-			// SU caller can still get a byte-identical download for a DIFFERENT, still-present blob
-			// (sanity: the SU gate itself isn't broken by the presence of a delegated role).
-			const suCheck = await callOperation(ctx, { operation: 'get_deployment', deployment_id: smallDeploymentId });
-			ok(suCheck.status === 200, 'SU caller should still be able to read deployment metadata normally');
+			// The SU download path must still work with a delegated role in place. This has to target a
+			// deployment whose payload is still present -- the redeploy from probe 7 -- because every
+			// other row in this suite has had its payload deleted by now.
+			const suDownload = await callOperationAs(
+				ctx,
+				{ operation: 'get_deployment_payload', deployment_id: redeployedDeploymentId },
+				ctx.harper.admin
+			);
+			strictEqual(
+				suDownload.status,
+				200,
+				`a super_user download must still succeed alongside a delegated role, got ${suDownload.status}: ${suDownload.raw.toString('utf8').slice(0, 200)}`
+			);
+			ok(suDownload.raw.length > 0, 'the super_user download should return the payload bytes');
 		});
 	}
 );

--- a/integrationTests/deploy/qa701-deployment-payload-ops.test.ts
+++ b/integrationTests/deploy/qa701-deployment-payload-ops.test.ts
@@ -1,0 +1,799 @@
+/**
+ * QA-701 — anchor for `get_deployment_payload` / `delete_deployment_payload` (#1898), which shipped
+ * with unit coverage only.
+ *
+ * Two contracts are pinned here.
+ *
+ * (1) DELETE REALLY RECLAIMS DISK. `delete_deployment_payload` nulls `payload_blob` and commits the
+ * row, which is expected to unlink the blob file through RecordEncoder's retained-blob check — not
+ * merely flip a flag. Harper has a history on this axis (#595, "dropping a table leaves orphan
+ * blobs", and the metadata-only behavior confirmed for drop_attribute/drop_table), so every delete
+ * probe asserts against the actual on-disk blob store, at ~4 KB and again at 12 MB, and checks that
+ * `freed_bytes` equals the row's `payload_size` exactly. The disk check polls for the file to
+ * disappear rather than sleeping, so a slow-but-real unlink is not misread as a leak.
+ *
+ * (2) THE AUTHORIZATION ASYMMETRY IS DELIBERATE. A non-super_user role with no `operations` grant is
+ * 403 on both ops. A non-super_user role explicitly granted BOTH operations can call
+ * `delete_deployment_payload` — that gate-2 delegation is the intended way to hand cleanup
+ * automation to a non-SU role — but is STILL 403 on `get_deployment_payload`, because that handler
+ * self-enforces super_user in addition to the registered permission (components/deploymentOperations.ts's
+ * `requireSuperUser`, and the note beside it in utility/operation_authorization.ts): the payload is
+ * the raw tarball and can embed secrets, unlike `get_deployment`'s stripped metadata. This file
+ * pins that asymmetry as the contract, so a future "consistency" cleanup that lets a role grant
+ * unlock the download goes red instead of quietly widening secret exposure.
+ *
+ * Boundaries also covered: unknown deployment_id → 404 with a JSON error body and no download
+ * headers leaking from the error path; delete on a non-terminal deployment → 409; get after delete
+ * → 404, not 500; a second delete → 200 with `freed_bytes: 0`; deleting a running component's
+ * payload leaves the live route serving (the blob is the historical tarball, not the installed
+ * copy); and a redeploy after a delete mints an independent deployment_id whose own blob is
+ * retained while the old row stays payload-less.
+ *
+ * Not the same mechanism as integrationTests/deploy/deploy-payload-reclaim.test.ts, which covers the
+ * AUTOMATIC post-deploy drop of a payload exceeding `deployment.payloadRetention.maxSize` (#1496)
+ * and never calls either of these operations. This suite forces `maxSize` to 200 MiB precisely so
+ * that automatic drop can never fire, which makes any blob disappearance here attributable only to
+ * an explicit `delete_deployment_payload` call.
+ *
+ * Proof boundary: the 409 leg races a real deploy to its terminal status. When the deploy settles
+ * first the 409 assertion is skipped (and says so on stdout) rather than false-failing; the guard's
+ * unconditional coverage is unitTests/components/deploymentOperations.test.js's, not this file's.
+ *
+ * Reproduction:
+ *   npm run build && npm run test:integration -- "integrationTests/deploy/qa701-deployment-payload-ops.test.ts"
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { join } from 'node:path';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readdirSync, statSync, type Dirent } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { request as httpRequest } from 'node:http';
+import { Readable } from 'node:stream';
+import { createHash, randomFillSync } from 'node:crypto';
+
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+
+// Reach into built dist directly, same pattern as the sibling deploy-*.test.ts files.
+import { streamPackagedDirectory } from '../../dist/components/packageComponent.js';
+import { buildMultipartBody } from '../../dist/bin/multipartBuilder.js';
+
+const FIXTURE_PATH = join(import.meta.dirname, 'qa701-deployment-payload-ops');
+// Forced high so every deploy in this suite retains its payload_blob regardless of size —
+// isolates the two explicit ops from the automatic post-deploy retention drop, so any blob
+// disappearance here is attributable only to delete_deployment_payload.
+const FORCED_RETENTION_MAX_SIZE = 200 * 1024 * 1024; // 200 MiB
+
+function postMultipart(
+	url: URL,
+	contentType: string,
+	body: Readable,
+	auth: { username: string; password: string }
+): Promise<{ status: number; body: Buffer }> {
+	return new Promise((resolve, reject) => {
+		const req = httpRequest(
+			{
+				protocol: url.protocol,
+				hostname: url.hostname,
+				port: url.port,
+				method: 'POST',
+				path: '/',
+				headers: {
+					'Content-Type': contentType,
+					'Transfer-Encoding': 'chunked',
+					'Authorization': 'Basic ' + Buffer.from(`${auth.username}:${auth.password}`).toString('base64'),
+				},
+			},
+			(res) => {
+				const chunks: Buffer[] = [];
+				res.on('data', (c) => chunks.push(c));
+				res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks) }));
+			}
+		);
+		req.on('error', reject);
+		body.on('error', reject);
+		body.pipe(req);
+	});
+}
+
+async function callOperationAs(
+	ctx: ContextWithHarper,
+	op: Record<string, unknown>,
+	auth: { username: string; password: string }
+): Promise<{ status: number; headers: Headers; body: any; raw: Buffer }> {
+	const url = new URL(ctx.harper.operationsAPIURL);
+	const authHeader = 'Basic ' + Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
+	const res = await fetch(url, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', 'Authorization': authHeader },
+		body: JSON.stringify(op),
+	});
+	const raw = Buffer.from(await res.arrayBuffer());
+	let parsed: any = raw.toString('utf8');
+	try {
+		parsed = JSON.parse(parsed);
+	} catch {
+		// leave as text/binary (payload stream case)
+	}
+	return { status: res.status, headers: res.headers, body: parsed, raw };
+}
+
+async function callOperation(ctx: ContextWithHarper, op: Record<string, unknown>) {
+	return callOperationAs(ctx, op, ctx.harper.admin);
+}
+
+async function getDeploymentWhenTerminal(
+	ctx: ContextWithHarper,
+	deploymentId: string,
+	timeoutMs = 20000
+): Promise<any> {
+	const deadline = Date.now() + timeoutMs;
+	let last: any;
+	while (Date.now() < deadline) {
+		const got = await callOperation(ctx, { operation: 'get_deployment', deployment_id: deploymentId });
+		last = got;
+		if (got.status === 200 && (got.body?.status === 'success' || got.body?.status === 'failed')) return got;
+		await sleep(75);
+	}
+	return last;
+}
+
+// Full listing (relative path, size, mtime) -- diagnostic only, so a leak report names the
+// actual residual file(s) rather than just an aggregate byte delta.
+function listBlobFiles(blobsRoot: string): Array<{ path: string; size: number; mtimeMs: number }> {
+	if (!existsSync(blobsRoot)) return [];
+	const out: Array<{ path: string; size: number; mtimeMs: number }> = [];
+	const stack = [blobsRoot];
+	while (stack.length) {
+		const dir = stack.pop()!;
+		let entries: Dirent[];
+		try {
+			entries = readdirSync(dir, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+		for (const entry of entries) {
+			const full = join(dir, entry.name);
+			if (entry.isDirectory()) {
+				stack.push(full);
+			} else {
+				try {
+					const st = statSync(full);
+					out.push({ path: full.slice(blobsRoot.length), size: st.size, mtimeMs: st.mtimeMs });
+				} catch {
+					// vanished mid-list; ignore
+				}
+			}
+		}
+	}
+	return out;
+}
+
+// Counts blob files whose size matches `targetSize` within `toleranceBytes` -- targets the
+// SPECIFIC blob under test by its known size rather than an aggregate directory total, which is
+// fragile once several small test deploys' blobs coexist in the same store.
+function countFilesNearSize(listing: Array<{ size: number }>, targetSize: number, toleranceBytes = 64): number {
+	return listing.filter((f) => Math.abs(f.size - targetSize) <= toleranceBytes).length;
+}
+
+// Polls until no blob file of ~`targetSize` bytes remains, or `timeoutMs` elapses. Distinguishes
+// a slow-but-real async unlink from a genuine leak.
+async function pollUntilSizeGone(
+	blobsRoot: string,
+	targetSize: number,
+	timeoutMs = 8000
+): Promise<Array<{ path: string; size: number; mtimeMs: number }>> {
+	const deadline = Date.now() + timeoutMs;
+	let listing = listBlobFiles(blobsRoot);
+	while (countFilesNearSize(listing, targetSize) > 0 && Date.now() < deadline) {
+		await sleep(200);
+		listing = listBlobFiles(blobsRoot);
+	}
+	return listing;
+}
+
+const tempFixtureDirs: string[] = [];
+
+// Builds a payload-only fixture: no HTTP routes registered at all, just `kb` KB of genuinely
+// random (non-repeating, gzip-incompressible) padding. Used for every probe that only cares
+// about the payload_blob bytes, not live serving -- deliberately routeless so N of these
+// deployed side-by-side in the same instance never collide over "/". The buffer is filled in one
+// randomFillSync call rather than tiled from a smaller block: a tile below gzip's 32 KiB window
+// compresses away to near-nothing, and the payload size is the thing under measurement here.
+function buildFixture(kb: number, marker: string): string {
+	const dir = mkdtempSync(join(tmpdir(), 'qa701-fixture-'));
+	tempFixtureDirs.push(dir);
+	writeFileSync(join(dir, 'config.yaml'), `# ${marker} -- payload-size padding only, no routes registered\n`);
+	if (kb > 0) {
+		const scratch = Buffer.allocUnsafe(1024 * kb);
+		randomFillSync(scratch);
+		writeFileSync(join(dir, 'padding.bin'), scratch);
+	}
+	return dir;
+}
+
+// Builds a fixture that DOES register a root static route -- used only by the single
+// "deployed and running" probe, which needs a live HTTP route to hit. Only ONE of these may be
+// active (restart:true'd) at a time in this suite, or root-path routes would collide.
+function buildLiveFixture(marker: string): string {
+	const dir = mkdtempSync(join(tmpdir(), 'qa701-live-fixture-'));
+	tempFixtureDirs.push(dir);
+	writeFileSync(join(dir, 'config.yaml'), 'static:\n  files: web\nrest: true\n');
+	mkdirSync(join(dir, 'web'), { recursive: true });
+	writeFileSync(join(dir, 'web', 'index.html'), `<h1>${marker}</h1>`);
+	return dir;
+}
+
+// Packages fixtureDir into an in-memory tarball buffer (so we know the EXACT uploaded bytes to
+// compare against what get_deployment_payload streams back), and returns it alongside its sha256.
+async function packageToBuffer(fixtureDir: string): Promise<{ buffer: Buffer; sha256: string }> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of streamPackagedDirectory(fixtureDir, { skip_node_modules: true })) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	const buffer = Buffer.concat(chunks);
+	const sha256 = createHash('sha256').update(buffer).digest('hex');
+	return { buffer, sha256 };
+}
+
+async function deployBuffer(
+	ctx: ContextWithHarper,
+	project: string,
+	buffer: Buffer,
+	restart: boolean,
+	auth = ctx.harper.admin
+): Promise<{ status: number; deploymentId: string | undefined; raw: Buffer }> {
+	const multipart = buildMultipartBody(
+		{ operation: 'deploy_component', project, restart },
+		{
+			name: 'payload',
+			filename: 'package.tar.gz',
+			contentType: 'application/gzip',
+			stream: Readable.from(buffer),
+		}
+	);
+	const url = new URL(ctx.harper.operationsAPIURL);
+	const response = await postMultipart(url, multipart.contentType, multipart.stream, auth);
+	let parsed: any;
+	try {
+		parsed = JSON.parse(response.body.toString('utf8'));
+	} catch {
+		parsed = response.body.toString('utf8');
+	}
+	return { status: response.status, deploymentId: parsed?.deployment_id, raw: response.body };
+}
+
+suite(
+	'QA-701 deployment payload operations: boundaries, on-disk reclaim, and the authorization asymmetry (#1898)',
+	(ctx: ContextWithHarper) => {
+		let blobsRoot: string;
+		const NON_SU_ROLE_PLAIN = 'qa701_non_su_plain';
+		const NON_SU_USER_PLAIN = 'qa701_non_su_plain_user';
+		const NON_SU_ROLE_DELEGATED = 'qa701_non_su_delegated';
+		const NON_SU_USER_DELEGATED = 'qa701_non_su_delegated_user';
+		const NON_SU_PASSWORD = 'Qa701!nonSuPassw0rd';
+
+		before(async () => {
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+				config: { deployment: { payloadRetention: { maxSize: String(FORCED_RETENTION_MAX_SIZE) } } },
+				env: {},
+			});
+			blobsRoot = join(ctx.harper.dataRootDir, 'blobs');
+
+			// Poll the probe route directly until it stops 404-ing; do NOT call restartHttpWorkers()
+			// against a pre-installed fixture (races and flakes on CI).
+			const deadline = Date.now() + 120_000;
+			while (Date.now() < deadline) {
+				try {
+					const probe = await fetch(`${ctx.harper.httpURL}/Beacon/`, {
+						headers: {
+							Authorization:
+								'Basic ' + Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64'),
+						},
+					});
+					if (probe.status !== 404) break;
+				} catch {
+					/* not ready yet */
+				}
+				await sleep(250);
+			}
+		});
+
+		after(async () => {
+			for (const dir of tempFixtureDirs) {
+				try {
+					rmSync(dir, { recursive: true, force: true });
+				} catch {
+					// best-effort
+				}
+			}
+			await teardownHarper(ctx);
+		});
+
+		test('verify Harper', async () => {
+			const response = await fetch(`${ctx.harper.operationsAPIURL}/health`);
+			strictEqual(response.status, 200);
+		});
+
+		test('1: get/delete on a deployment_id that was never deployed -> clean 404, JSON body', async () => {
+			const getResp = await callOperation(ctx, {
+				operation: 'get_deployment_payload',
+				deployment_id: 'qa701-never-existed',
+			});
+			strictEqual(
+				getResp.status,
+				404,
+				`get_deployment_payload on unknown id: expected 404, got ${getResp.status}: ${JSON.stringify(getResp.body)}`
+			);
+			ok(
+				typeof getResp.body?.error === 'string' && getResp.body.error.includes('qa701-never-existed'),
+				`expected error naming the id, got ${JSON.stringify(getResp.body)}`
+			);
+			// The success path sets content-disposition/octet-stream headers; the error path must
+			// not leak them (would indicate the stream branch started before the 404 check landed).
+			ok(
+				!getResp.headers.get('content-disposition'),
+				`error response should not carry a download content-disposition header, got ${getResp.headers.get('content-disposition')}`
+			);
+
+			const delResp = await callOperation(ctx, {
+				operation: 'delete_deployment_payload',
+				deployment_id: 'qa701-never-existed',
+			});
+			strictEqual(
+				delResp.status,
+				404,
+				`delete_deployment_payload on unknown id: expected 404, got ${delResp.status}: ${JSON.stringify(delResp.body)}`
+			);
+			ok(
+				typeof delResp.body?.error === 'string' && delResp.body.error.includes('qa701-never-existed'),
+				`expected error naming the id, got ${JSON.stringify(delResp.body)}`
+			);
+		});
+
+		let smallDeploymentId: string;
+		let smallBuffer: Buffer;
+		let smallSha256: string;
+
+		test('2 setup: deploy a small real component, confirm payload_blob retained', async () => {
+			const fixtureDir = buildFixture(4, 'QA-701 small');
+			const packaged = await packageToBuffer(fixtureDir);
+			smallBuffer = packaged.buffer;
+			smallSha256 = packaged.sha256;
+
+			const deployed = await deployBuffer(ctx, 'qa701-small-app', smallBuffer, false);
+			strictEqual(
+				deployed.status,
+				200,
+				`deploy expected 200, got ${deployed.status}: ${deployed.raw.toString('utf8')}`
+			);
+			ok(deployed.deploymentId, 'deploy should return a deployment_id');
+			smallDeploymentId = deployed.deploymentId!;
+
+			const got = await getDeploymentWhenTerminal(ctx, smallDeploymentId);
+			strictEqual(got.status, 200);
+			strictEqual(got.body.status, 'success', `deploy should succeed: ${JSON.stringify(got.body.error)}`);
+			strictEqual(
+				got.body.payload_blob_present,
+				true,
+				'payload_blob should be retained under the forced high retention threshold'
+			);
+			strictEqual(
+				got.body.payload_hash,
+				smallSha256,
+				'row payload_hash should match the sha256 of the exact uploaded bytes'
+			);
+			strictEqual(
+				got.body.payload_size,
+				smallBuffer.length,
+				'row payload_size should match the exact uploaded byte count'
+			);
+		});
+
+		test('2: get_deployment_payload streams byte-identical bytes (sha256 round-trip)', async () => {
+			const url = new URL(ctx.harper.operationsAPIURL);
+			const auth =
+				'Basic ' + Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64');
+			const res = await fetch(url, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', 'Authorization': auth },
+				body: JSON.stringify({ operation: 'get_deployment_payload', deployment_id: smallDeploymentId }),
+			});
+			const downloaded = Buffer.from(await res.arrayBuffer());
+			strictEqual(res.status, 200, `expected 200, got ${res.status}: ${downloaded.toString('utf8').slice(0, 300)}`);
+			ok(
+				(res.headers.get('content-disposition') ?? '').includes(smallDeploymentId),
+				`expected content-disposition to name the deployment, got ${res.headers.get('content-disposition')}`
+			);
+			strictEqual(
+				downloaded.length,
+				smallBuffer.length,
+				'downloaded byte length should exactly match uploaded byte length'
+			);
+			const downloadedSha256 = createHash('sha256').update(downloaded).digest('hex');
+			strictEqual(
+				downloadedSha256,
+				smallSha256,
+				'downloaded bytes must be byte-identical (sha256 match) to the uploaded tarball'
+			);
+		});
+
+		test('3: delete_deployment_payload on a non-terminal deployment -> 409, blob untouched', async () => {
+			// Deploy a fresh component and immediately (racily) try to delete its payload before it
+			// can possibly have settled to a terminal status -- exercises the 409 guard's intent.
+			// If the deploy happens to have already gone terminal by the time we call delete (small
+			// fixtures can finish fast), fall back to asserting the row is terminal and skip the 409
+			// assertion rather than false-failing on a race.
+			const fixtureDir = buildFixture(4, 'QA-701 nonterminal');
+			const packaged = await packageToBuffer(fixtureDir);
+			const deployed = await deployBuffer(ctx, 'qa701-nonterminal-app', packaged.buffer, false);
+			strictEqual(deployed.status, 200);
+			ok(deployed.deploymentId);
+
+			const immediateDelete = await callOperation(ctx, {
+				operation: 'delete_deployment_payload',
+				deployment_id: deployed.deploymentId,
+			});
+			const rowNow = await callOperation(ctx, { operation: 'get_deployment', deployment_id: deployed.deploymentId });
+			if (rowNow.body?.status && !['success', 'failed', 'rolled_back'].includes(rowNow.body.status)) {
+				strictEqual(
+					immediateDelete.status,
+					409,
+					`delete on a non-terminal deployment (status='${rowNow.body?.status}') should 409, got ${immediateDelete.status}: ${JSON.stringify(immediateDelete.body)}`
+				);
+			} else {
+				console.log(
+					`[QA-701] 3: deploy settled to terminal ('${rowNow.body?.status}') before the delete call landed -- 409 race window missed, not a defect.`
+				);
+			}
+			// Let it finish terminally either way so it doesn't interfere with later probes.
+			await getDeploymentWhenTerminal(ctx, deployed.deploymentId!);
+		});
+
+		test('4: delete_deployment_payload reclaims ON-DISK bytes, not just the row flag', async () => {
+			const beforeListing = listBlobFiles(blobsRoot);
+			const got = await callOperation(ctx, { operation: 'get_deployment', deployment_id: smallDeploymentId });
+			strictEqual(
+				got.body.payload_blob_present,
+				true,
+				'precondition: payload_blob should still be present before delete'
+			);
+			const payloadSize = got.body.payload_size as number;
+			ok(
+				countFilesNearSize(beforeListing, payloadSize) >= 1,
+				`precondition: a blob file matching payload_size=${payloadSize} should exist on disk before delete, ` +
+					`listing=${JSON.stringify(beforeListing)}`
+			);
+
+			const delResp = await callOperation(ctx, {
+				operation: 'delete_deployment_payload',
+				deployment_id: smallDeploymentId,
+			});
+			strictEqual(delResp.status, 200, `expected 200, got ${delResp.status}: ${JSON.stringify(delResp.body)}`);
+			strictEqual(delResp.body.deployment_id, smallDeploymentId);
+			strictEqual(delResp.body.freed_bytes, smallBuffer.length, 'freed_bytes should match the original payload_size');
+			strictEqual(delResp.body.freed_bytes, payloadSize);
+
+			const gotAfter = await callOperation(ctx, { operation: 'get_deployment', deployment_id: smallDeploymentId });
+			strictEqual(gotAfter.status, 200);
+			strictEqual(gotAfter.body.payload_blob_present, false, 'payload_blob_present should flip to false after delete');
+			strictEqual(gotAfter.body.status, 'success', 'row metadata/status should be retained (audit trail), not wiped');
+			ok(
+				Array.isArray(gotAfter.body.event_log) &&
+					gotAfter.body.event_log.some((e: any) => e.event === 'payload_dropped'),
+				`expected an audit event_log entry for payload_dropped, got ${JSON.stringify(gotAfter.body.event_log)}`
+			);
+
+			// Poll (not a fixed sleep) for the SPECIFIC blob file matching this payload's exact size
+			// to vanish on disk -- targets the actual bytes under test rather than an aggregate
+			// directory total, which is fragile once multiple small test deploys' blobs coexist.
+			const afterListing = await pollUntilSizeGone(blobsRoot, payloadSize, 8000);
+			console.log(
+				`[QA-701] 4 disk listing: payloadSize=${payloadSize} before=${JSON.stringify(beforeListing)} after=${JSON.stringify(afterListing)}`
+			);
+			strictEqual(
+				countFilesNearSize(afterListing, payloadSize),
+				0,
+				`DEFECT-LEAK: a blob file matching payload_size=${payloadSize} is still on disk after delete_deployment_payload ` +
+					`(listing=${JSON.stringify(afterListing)})`
+			);
+		});
+
+		test('5: get_deployment_payload after delete -> 404, not 500', async () => {
+			const getResp = await callOperation(ctx, {
+				operation: 'get_deployment_payload',
+				deployment_id: smallDeploymentId,
+			});
+			strictEqual(
+				getResp.status,
+				404,
+				`expected 404 after delete, got ${getResp.status}: ${JSON.stringify(getResp.body)}`
+			);
+			ok(
+				typeof getResp.body?.error === 'string' && /reclaim|delete/i.test(getResp.body.error),
+				`expected error to explain the payload was reclaimed/deleted, got ${JSON.stringify(getResp.body)}`
+			);
+		});
+
+		test('6: delete_deployment_payload is idempotent on an already-gone payload', async () => {
+			const delResp = await callOperation(ctx, {
+				operation: 'delete_deployment_payload',
+				deployment_id: smallDeploymentId,
+			});
+			strictEqual(
+				delResp.status,
+				200,
+				`second delete should not error, got ${delResp.status}: ${JSON.stringify(delResp.body)}`
+			);
+			strictEqual(delResp.body.freed_bytes, 0, 'second delete should report freed_bytes: 0 (nothing left to free)');
+			strictEqual(delResp.body.deployment_id, smallDeploymentId);
+		});
+
+		test('7: redeploy after delete produces an independent new deployment_id + fresh payload_blob', async () => {
+			const fixtureDir = buildFixture(4, 'QA-701 redeploy');
+			const packaged = await packageToBuffer(fixtureDir);
+			const deployed = await deployBuffer(ctx, 'qa701-small-app', packaged.buffer, false);
+			strictEqual(
+				deployed.status,
+				200,
+				`redeploy expected 200, got ${deployed.status}: ${deployed.raw.toString('utf8')}`
+			);
+			ok(
+				deployed.deploymentId && deployed.deploymentId !== smallDeploymentId,
+				'redeploy should mint a new deployment_id'
+			);
+
+			const got = await getDeploymentWhenTerminal(ctx, deployed.deploymentId!);
+			strictEqual(got.body.status, 'success');
+			strictEqual(got.body.payload_blob_present, true, 'the NEW deployment should have its own fresh payload_blob');
+
+			// Old row must remain independently gone -- confirms delete scoped to the old
+			// deployment_id, not the project.
+			const oldRow = await callOperation(ctx, { operation: 'get_deployment', deployment_id: smallDeploymentId });
+			strictEqual(
+				oldRow.body.payload_blob_present,
+				false,
+				'the OLD deployment row must remain payload-less after redeploy'
+			);
+		});
+
+		test('8: deleting the payload of a DEPLOYED-AND-RUNNING component does not disturb the live route', async () => {
+			// The ONLY component in this suite deployed with a static route + restart:true (see
+			// buildLiveFixture's header note on root-path route collisions) -- fetch the root URL
+			// directly, not a project subpath.
+			const fixtureDir = buildLiveFixture('QA-701 LIVE MARKER');
+			const packaged = await packageToBuffer(fixtureDir);
+			const deployed = await deployBuffer(ctx, 'qa701-live-app', packaged.buffer, true);
+			strictEqual(
+				deployed.status,
+				200,
+				`deploy(restart:true) expected 200, got ${deployed.status}: ${deployed.raw.toString('utf8')}`
+			);
+			const got = await getDeploymentWhenTerminal(ctx, deployed.deploymentId!, 30000);
+			strictEqual(got.body.status, 'success', `deploy should succeed: ${JSON.stringify(got.body.error)}`);
+
+			// Wait for the restart to settle and the component to actually serve.
+			let serving = false;
+			let lastBody = '';
+			const readyDeadline = Date.now() + 30000;
+			while (Date.now() < readyDeadline) {
+				try {
+					const r = await fetch(ctx.harper.httpURL);
+					if (r.status === 200) {
+						lastBody = await r.text();
+						if (lastBody.includes('QA-701 LIVE MARKER')) {
+							serving = true;
+							break;
+						}
+					}
+				} catch {
+					/* not ready */
+				}
+				await sleep(500);
+			}
+			ok(serving, `precondition: qa701-live-app should be serving before the payload delete (last body: ${lastBody})`);
+
+			const delResp = await callOperation(ctx, {
+				operation: 'delete_deployment_payload',
+				deployment_id: deployed.deploymentId,
+			});
+			strictEqual(
+				delResp.status,
+				200,
+				`delete on the running component's payload expected 200, got ${delResp.status}: ${JSON.stringify(delResp.body)}`
+			);
+
+			// The live route must be entirely unaffected -- payload_blob is the historical tarball
+			// artifact, not the installed component copy the running worker actually serves from.
+			const r2 = await fetch(ctx.harper.httpURL);
+			const body2 = await r2.text();
+			strictEqual(r2.status, 200);
+			ok(
+				body2.includes('QA-701 LIVE MARKER'),
+				`running component should still serve after its deployment payload was deleted, got: ${body2}`
+			);
+		});
+
+		test('9: multi-MB payload delete reclaims disk bytes at scale', async () => {
+			const MB = 12; // above the *default* 10 MiB auto-retention threshold, but this suite
+			// forces payloadRetention.maxSize to 200 MiB, so this deploy retains its blob until we
+			// explicitly delete it -- isolating this op's reclaim from the automatic drop.
+			const fixtureDir = mkdtempSync(join(tmpdir(), 'qa701-large-fixture-'));
+			tempFixtureDirs.push(fixtureDir);
+			writeFileSync(fixtureDir + '/config.yaml', '# payload-size padding only, no routes\n');
+			const scratch = Buffer.allocUnsafe(1024 * 1024);
+			randomFillSync(scratch);
+			writeFileSync(join(fixtureDir, 'padding.bin'), Buffer.concat(Array(MB).fill(scratch)));
+
+			const packaged = await packageToBuffer(fixtureDir);
+			ok(
+				packaged.buffer.length > MB * 1024 * 1024 * 0.9,
+				`fixture should package to multi-MB, got ${packaged.buffer.length}`
+			);
+
+			const deployed = await deployBuffer(ctx, 'qa701-large-app', packaged.buffer, false);
+			strictEqual(
+				deployed.status,
+				200,
+				`large deploy expected 200, got ${deployed.status}: ${deployed.raw.toString('utf8')}`
+			);
+			const got = await getDeploymentWhenTerminal(ctx, deployed.deploymentId!, 30000);
+			strictEqual(got.body.status, 'success', `large deploy should succeed: ${JSON.stringify(got.body.error)}`);
+			strictEqual(
+				got.body.payload_blob_present,
+				true,
+				'large payload should be retained under the forced high threshold'
+			);
+
+			const beforeListing = listBlobFiles(blobsRoot);
+			const payloadSize = got.body.payload_size as number;
+			ok(
+				countFilesNearSize(beforeListing, payloadSize) >= 1,
+				`precondition: a blob file matching payload_size=${payloadSize} should exist on disk before delete, ` +
+					`listing=${JSON.stringify(beforeListing)}`
+			);
+
+			const delResp = await callOperation(ctx, {
+				operation: 'delete_deployment_payload',
+				deployment_id: deployed.deploymentId,
+			});
+			strictEqual(delResp.status, 200, `expected 200, got ${delResp.status}: ${JSON.stringify(delResp.body)}`);
+			strictEqual(delResp.body.freed_bytes, payloadSize);
+
+			// Poll (not a fixed sleep) so a slow-but-real async unlink at multi-MB scale isn't
+			// mistaken for a leak; 8s ceiling before treating it as a genuine defect.
+			const afterListing = await pollUntilSizeGone(blobsRoot, payloadSize, 8000);
+			console.log(
+				`[QA-701] 9 disk listing (multi-MB): payloadSize=${payloadSize} before=${JSON.stringify(beforeListing)} after=${JSON.stringify(afterListing)}`
+			);
+			strictEqual(
+				countFilesNearSize(afterListing, payloadSize),
+				0,
+				`DEFECT-LEAK: a blob file matching payload_size=${payloadSize} is still on disk after delete_deployment_payload ` +
+					`(listing=${JSON.stringify(afterListing)})`
+			);
+		});
+
+		test('10 setup: non-super_user roles (plain-forbidden and gate-2-delegated)', async () => {
+			const plainRole = await callOperation(ctx, {
+				operation: 'add_role',
+				role: NON_SU_ROLE_PLAIN,
+				permission: { super_user: false },
+			});
+			strictEqual(
+				plainRole.status,
+				200,
+				`add_role(plain) expected 200, got ${plainRole.status}: ${JSON.stringify(plainRole.body)}`
+			);
+			const plainUser = await callOperation(ctx, {
+				operation: 'add_user',
+				role: NON_SU_ROLE_PLAIN,
+				username: NON_SU_USER_PLAIN,
+				password: NON_SU_PASSWORD,
+				active: true,
+			});
+			strictEqual(
+				plainUser.status,
+				200,
+				`add_user(plain) expected 200, got ${plainUser.status}: ${JSON.stringify(plainUser.body)}`
+			);
+
+			const delegatedRole = await callOperation(ctx, {
+				operation: 'add_role',
+				role: NON_SU_ROLE_DELEGATED,
+				permission: { super_user: false, operations: ['get_deployment_payload', 'delete_deployment_payload'] },
+			});
+			strictEqual(
+				delegatedRole.status,
+				200,
+				`add_role(delegated) expected 200, got ${delegatedRole.status}: ${JSON.stringify(delegatedRole.body)}`
+			);
+			const delegatedUser = await callOperation(ctx, {
+				operation: 'add_user',
+				role: NON_SU_ROLE_DELEGATED,
+				username: NON_SU_USER_DELEGATED,
+				password: NON_SU_PASSWORD,
+				active: true,
+			});
+			strictEqual(
+				delegatedUser.status,
+				200,
+				`add_user(delegated) expected 200, got ${delegatedUser.status}: ${JSON.stringify(delegatedUser.body)}`
+			);
+		});
+
+		test('10a: default non-SU role (no operations grant) gets 403 on both ops', async () => {
+			const auth = { username: NON_SU_USER_PLAIN, password: NON_SU_PASSWORD };
+			const getResp = await callOperationAs(
+				ctx,
+				{ operation: 'get_deployment_payload', deployment_id: 'qa701-anything' },
+				auth
+			);
+			strictEqual(getResp.status, 403, `expected 403, got ${getResp.status}: ${JSON.stringify(getResp.body)}`);
+			const delResp = await callOperationAs(
+				ctx,
+				{ operation: 'delete_deployment_payload', deployment_id: 'qa701-anything' },
+				auth
+			);
+			strictEqual(delResp.status, 403, `expected 403, got ${delResp.status}: ${JSON.stringify(delResp.body)}`);
+		});
+
+		let liveForDelegationDeploymentId: string;
+
+		test('10b setup: deploy one more real payload for the delegated-role probe', async () => {
+			const fixtureDir = buildFixture(4, 'QA-701 delegation target');
+			const packaged = await packageToBuffer(fixtureDir);
+			const deployed = await deployBuffer(ctx, 'qa701-delegation-app', packaged.buffer, false);
+			strictEqual(deployed.status, 200);
+			const got = await getDeploymentWhenTerminal(ctx, deployed.deploymentId!);
+			strictEqual(got.body.status, 'success');
+			strictEqual(got.body.payload_blob_present, true);
+			liveForDelegationDeploymentId = deployed.deploymentId!;
+		});
+
+		test('10c: gate-2-delegated non-SU role can delete_deployment_payload but is STILL 403 on get_deployment_payload', async () => {
+			const auth = { username: NON_SU_USER_DELEGATED, password: NON_SU_PASSWORD };
+
+			// get_deployment_payload self-enforces super_user in the handler (commit 23186ebca) --
+			// exposes the raw tarball (can embed secrets), unlike get_deployment's stripped metadata,
+			// so an explicit role `operations` grant must NOT be enough to unlock it.
+			const getResp = await callOperationAs(
+				ctx,
+				{ operation: 'get_deployment_payload', deployment_id: liveForDelegationDeploymentId },
+				auth
+			);
+			strictEqual(
+				getResp.status,
+				403,
+				`get_deployment_payload should stay 403 even with an explicit operations grant (self-enforced SU), got ${getResp.status}: ${JSON.stringify(getResp.body)}`
+			);
+
+			// delete_deployment_payload has no such self-enforcement -- the explicit operations grant
+			// (gate-2) is the intended, documented way to delegate cleanup automation (#1893's stated
+			// use case) to a non-SU role.
+			const delResp = await callOperationAs(
+				ctx,
+				{ operation: 'delete_deployment_payload', deployment_id: liveForDelegationDeploymentId },
+				auth
+			);
+			strictEqual(
+				delResp.status,
+				200,
+				`delete_deployment_payload should succeed for a role explicitly granted the operation, got ${delResp.status}: ${JSON.stringify(delResp.body)}`
+			);
+
+			// Confirm the delegated delete actually did something real (as everywhere else here:
+			// row metadata retained, blob gone).
+			const gotAfter = await callOperation(ctx, {
+				operation: 'get_deployment',
+				deployment_id: liveForDelegationDeploymentId,
+			});
+			strictEqual(gotAfter.body.payload_blob_present, false);
+
+			// SU caller can still get a byte-identical download for a DIFFERENT, still-present blob
+			// (sanity: the SU gate itself isn't broken by the presence of a delegated role).
+			const suCheck = await callOperation(ctx, { operation: 'get_deployment', deployment_id: smallDeploymentId });
+			ok(suCheck.status === 200, 'SU caller should still be able to read deployment metadata normally');
+		});
+	}
+);

--- a/integrationTests/deploy/qa701-deployment-payload-ops.test.ts
+++ b/integrationTests/deploy/qa701-deployment-payload-ops.test.ts
@@ -103,7 +103,10 @@ function postMultipart(
 				res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks) }));
 			}
 		);
-		req.on('error', reject);
+		req.on('error', (err) => {
+			body.destroy(err);
+			reject(err);
+		});
 		body.on('error', (err) => {
 			req.destroy(err);
 			reject(err);
@@ -311,7 +314,8 @@ suite(
 								'Basic ' + Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64'),
 						},
 					});
-					if (probe.status !== 404) break;
+					// A 5xx means mounted but unhealthy, which is not ready either.
+					if (probe.status !== 404 && probe.status < 500) break;
 				} catch {
 					/* not ready yet */
 				}
@@ -463,7 +467,8 @@ suite(
 					inFlightStatus = row.status;
 					break;
 				}
-				if (!listed.body?.deployments) break; // list_deployments is not answering; fall through
+				// Deliberately no early exit on a malformed/failed list response: a transient error
+				// under load would otherwise end the poll and silently skip the 409 assertion.
 			}
 
 			if (inFlightId) {

--- a/integrationTests/deploy/qa701-deployment-payload-ops/config.yaml
+++ b/integrationTests/deploy/qa701-deployment-payload-ops/config.yaml
@@ -1,0 +1,6 @@
+# QA-701 base fixture, pre-installed via setupHarperWithFixture. It exists only as a readiness
+# beacon — a real REST route to poll until routing is live. The payload tarballs actually under
+# test are deployed at runtime via deploy_component against throwaway fixtures.
+graphqlSchema:
+  files: '*.graphql'
+rest: true

--- a/integrationTests/deploy/qa701-deployment-payload-ops/schema.graphql
+++ b/integrationTests/deploy/qa701-deployment-payload-ops/schema.graphql
@@ -1,0 +1,5 @@
+# Trivial table, only so the readiness poll has a real REST route to hit.
+type Beacon @table(audit: false) @export {
+	id: ID @primaryKey
+	value: Int
+}

--- a/integrationTests/security/qa877-tls-cert-swap.test.ts
+++ b/integrationTests/security/qa877-tls-cert-swap.test.ts
@@ -169,20 +169,49 @@ function tally(serials: number[]): string {
 	return [...counts.entries()].map(([serial, n]) => `${serial}=${n}`).join(', ');
 }
 
-/** Poll until a fresh connection serves `expectedSerial`, or the deadline passes. Returns ms taken, or -1. */
-async function waitForSerial(hostname: string, expectedSerial: number, deadlineMs: number): Promise<number> {
+/**
+ * Poll whole fan-outs until EVERY fresh handshake serves `expectedSerial`, or the deadline passes;
+ * `tookMs` is -1 if it never converged. Waiting on the all-worker condition rather than on the
+ * first worker to flip is what makes this safe under load: each worker debounces its own
+ * updateTLS() rebuild independently, so a one-connection probe can succeed while another worker is
+ * still on the old context, and an immediate all-workers assertion would then fail a rotation that
+ * was merely mid-flight.
+ */
+async function waitForAllWorkers(
+	hostname: string,
+	expectedSerial: number,
+	attempts: number,
+	deadlineMs: number
+): Promise<{ tookMs: number; serials: number[]; errors: number }> {
 	const start = Date.now();
 	const deadline = start + deadlineMs;
-	while (Date.now() < deadline) {
-		try {
-			const cert = await servedCert(hostname);
-			if (cert.serial === expectedSerial) return Date.now() - start;
-		} catch {
-			// transient — keep polling
+	let last = await fanOut(hostname, attempts);
+	while (true) {
+		if (last.errors === 0 && last.serials.length === attempts && last.serials.every((s) => s === expectedSerial)) {
+			return { tookMs: Date.now() - start, ...last };
 		}
+		if (Date.now() >= deadline) return { tookMs: -1, ...last };
 		await sleep(400);
+		last = await fanOut(hostname, attempts);
 	}
-	return -1;
+}
+
+/** Observed live worker count via the operations API (best-effort, 0 on failure) — same guard as cert-reload.test.ts. */
+async function observedWorkerCount(ctx: ContextWithHarper): Promise<number> {
+	try {
+		const res = await fetch(ctx.harper.operationsAPIURL, {
+			method: 'POST',
+			headers: {
+				'Authorization': `Basic ${Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64')}`,
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ operation: 'system_information', attributes: ['threads'] }),
+		});
+		const body = (await res.json()) as { threads?: unknown };
+		return Array.isArray(body.threads) ? body.threads.length : 0;
+	} catch {
+		return 0;
+	}
 }
 
 for (const WORKERS of [1, 4]) {
@@ -240,6 +269,16 @@ for (const WORKERS of [1, 4]) {
 			const SERIAL_ROTATE_AFTER_SCHEMA_CHANGE = 87703; // rotation after an ordinary schema change
 
 			test(`threads=${WORKERS}: baseline cert is served (peer cert inspected, not just "connected")`, async () => {
+				// The harness hardcodes --THREADS_COUNT=1 and this suite overrides it via config. If
+				// the override were ignored, or workers died during startup, every handshake below
+				// would land on one survivor and the whole per-worker-divergence premise would be
+				// silently vacuous.
+				const workerCount = await observedWorkerCount(ctx);
+				ok(
+					workerCount >= WORKERS,
+					`expected at least ${WORKERS} worker threads for this arm, observed ${workerCount} — the arm would be vacuous`
+				);
+
 				const { serials, errors } = await fanOut(ctx.harper.hostname, 10);
 				equal(errors, 0, `unexpected handshake failures: ${errors}/10`);
 				ok(
@@ -250,27 +289,42 @@ for (const WORKERS of [1, 4]) {
 
 			test(`threads=${WORKERS}: rotation with no schema change propagates normally (control, mirrors #586)`, async () => {
 				await writeFile(certPath, await makeServerCertPem(keyPair, SERIAL_ROTATE_NO_SWAP));
-				const took = await waitForSerial(ctx.harper.hostname, SERIAL_ROTATE_NO_SWAP, PROPAGATION_WAIT_MS);
-				ok(took >= 0, `rotation never propagated within ${PROPAGATION_WAIT_MS}ms`);
-				console.log(`[QA-877 threads=${WORKERS}] rotation (no schema change) propagated in ${took}ms`);
-
-				const { serials, errors } = await fanOut(ctx.harper.hostname, FANOUT_ATTEMPTS);
+				const { tookMs, serials, errors } = await waitForAllWorkers(
+					ctx.harper.hostname,
+					SERIAL_ROTATE_NO_SWAP,
+					FANOUT_ATTEMPTS,
+					PROPAGATION_WAIT_MS
+				);
+				console.log(`[QA-877 threads=${WORKERS}] rotation (no schema change) reached every worker in ${tookMs}ms`);
 				equal(errors, 0, `unexpected handshake failures: ${errors}/${FANOUT_ATTEMPTS}`);
 				ok(
-					serials.every((s) => s === SERIAL_ROTATE_NO_SWAP),
-					`expected every worker to serve ${SERIAL_ROTATE_NO_SWAP} after settling, got: ${tally(serials)}`
+					tookMs >= 0,
+					`rotation did not reach every worker within ${PROPAGATION_WAIT_MS}ms, last tally: ${tally(serials)}`
 				);
 			});
 
 			test(`threads=${WORKERS}: an ordinary schema change (create_attribute) triggers resetDatabases() but does not disturb the currently-served cert`, async () => {
-				const result = await sendOperation(ctx.harper, {
+				const attribute = `qa877SchemaChange_${WORKERS}`;
+				await sendOperation(ctx.harper, {
 					operation: 'create_attribute',
 					schema: 'data',
 					table: 'Widget',
-					attribute: `qa877SchemaChange_${WORKERS}`,
+					attribute,
 				});
-				ok(result, 'create_attribute did not succeed');
-				await sleep(1500); // let the ITC schema broadcast reach every worker's resetDatabases()
+				// sendOperation already fails a non-200, but a 200 that did not actually alter the
+				// schema would make the rest of this arm vacuous — so read the attribute back.
+				const described = await sendOperation(ctx.harper, {
+					operation: 'describe_table',
+					database: 'data',
+					table: 'Widget',
+				});
+				ok(
+					(described?.attributes ?? []).some((a: { attribute?: string }) => a.attribute === attribute),
+					`create_attribute reported success but '${attribute}' is not on the table: ${JSON.stringify(described?.attributes)}`
+				);
+				// A fixed wait is right here: the assertion below is that something did NOT happen
+				// (the served cert did not change), so there is no condition to poll for.
+				await sleep(1500);
 
 				const { serials, errors } = await fanOut(ctx.harper.hostname, FANOUT_ATTEMPTS);
 				equal(errors, 0, `unexpected handshake failures right after the schema change: ${errors}/${FANOUT_ATTEMPTS}`);
@@ -282,28 +336,26 @@ for (const WORKERS of [1, 4]) {
 
 			test(`threads=${WORKERS}: rotation AFTER that schema change ALSO propagates normally (#2004 does not reproduce via this trigger)`, async () => {
 				await writeFile(certPath, await makeServerCertPem(keyPair, SERIAL_ROTATE_AFTER_SCHEMA_CHANGE));
-				const took = await waitForSerial(ctx.harper.hostname, SERIAL_ROTATE_AFTER_SCHEMA_CHANGE, PROPAGATION_WAIT_MS);
-
-				const { serials, errors } = await fanOut(ctx.harper.hostname, FANOUT_ATTEMPTS);
+				const { tookMs, serials, errors } = await waitForAllWorkers(
+					ctx.harper.hostname,
+					SERIAL_ROTATE_AFTER_SCHEMA_CHANGE,
+					FANOUT_ATTEMPTS,
+					PROPAGATION_WAIT_MS
+				);
 				const staleCount = serials.filter((s) => s === SERIAL_ROTATE_NO_SWAP).length;
-				const freshCount = serials.filter((s) => s === SERIAL_ROTATE_AFTER_SCHEMA_CHANGE).length;
 				console.log(
-					`[QA-877 threads=${WORKERS}] rotation after schema change: took=${took}ms errors=${errors} ` +
-						`stale(${SERIAL_ROTATE_NO_SWAP})=${staleCount} fresh(${SERIAL_ROTATE_AFTER_SCHEMA_CHANGE})=${freshCount} ` +
-						`tally=${tally(serials)}`
+					`[QA-877 threads=${WORKERS}] rotation after schema change: tookMs=${tookMs} errors=${errors} ` +
+						`stale(${SERIAL_ROTATE_NO_SWAP})=${staleCount} tally=${tally(serials)}`
 				);
 
-				// This is the headline empirical result: per the file header, an ordinary schema change
-				// does NOT swap the cert-table object (resources/databases.ts reuses the Table wrapper
-				// in place unless the storage engine itself changed), so the rotation reaches every
-				// worker just like the no-schema-change control above. If this ever starts failing, it
-				// means create_attribute's resetDatabases() call started forcing a real table-object
-				// swap — which would mean #2004 is reachable via a MUCH more common trigger than
-				// currently understood, and this finding should be revisited/promoted urgently.
-				ok(took >= 0, `rotation after an ordinary schema change never propagated within ${PROPAGATION_WAIT_MS}ms`);
+				// A red assertion here means create_attribute's resetDatabases() call started forcing a
+				// real table-object swap, which makes #2004 reachable from a far more common trigger
+				// than currently understood. Escalate rather than adjust.
+				equal(errors, 0, `unexpected handshake failures: ${errors}/${FANOUT_ATTEMPTS}`);
 				ok(
-					serials.every((s) => s === SERIAL_ROTATE_AFTER_SCHEMA_CHANGE),
-					`expected every worker to serve ${SERIAL_ROTATE_AFTER_SCHEMA_CHANGE}, got: ${tally(serials)}`
+					tookMs >= 0,
+					`rotation after an ordinary schema change did not reach every worker within ` +
+						`${PROPAGATION_WAIT_MS}ms, last tally: ${tally(serials)}`
 				);
 			});
 
@@ -318,10 +370,15 @@ for (const WORKERS of [1, 4]) {
 				});
 				await waitForReady();
 
-				const { serials, errors } = await fanOut(ctx.harper.hostname, 10);
+				const { tookMs, serials, errors } = await waitForAllWorkers(
+					ctx.harper.hostname,
+					SERIAL_ROTATE_AFTER_SCHEMA_CHANGE,
+					10,
+					PROPAGATION_WAIT_MS
+				);
 				equal(errors, 0, `unexpected handshake failures after restart: ${errors}/10`);
 				ok(
-					serials.every((s) => s === SERIAL_ROTATE_AFTER_SCHEMA_CHANGE),
+					tookMs >= 0,
 					`expected the restart to serve the on-disk cert (${SERIAL_ROTATE_AFTER_SCHEMA_CHANGE}), got: ${tally(serials)}`
 				);
 			});

--- a/integrationTests/security/qa877-tls-cert-swap.test.ts
+++ b/integrationTests/security/qa877-tls-cert-swap.test.ts
@@ -1,64 +1,41 @@
 /**
- * QA-877 — anchor for the cert-table object-swap gap described in #2004, and the narrowing of
- * which triggers can actually reach it.
+ * QA-877 — anchor for the cert-table object-swap gap in #2004, and for how narrow its triggers are.
  *
- * #2004: `createTLSSelector`'s `updateTLS()` (security/keys.ts) binds its `hdb_certificate`
- * subscription to a specific table OBJECT. Paths that replace `databases.system.hdb_certificate`
- * with a NEW object — `resetDatabases()` (copy_db, ITC restart handling) and the LMDB→RocksDB
- * engine migration — orphan that subscription. #1999 made `updateTLS()` detect the swap
- * (`subscribedTable !== databases.system.hdb_certificate`) and re-subscribe, but that comparison
- * only runs when something re-enters `updateTLS()`. After a swap the only re-entry triggers are the
- * now-orphaned subscription (dead — bound to the OLD object), the zero-certs retry timer (armed
- * only when the last pass resolved empty, the #1998 path), and a private-key hot reload. So a swap
- * while `secureContexts` is NON-EMPTY would leave no pending trigger and the selector would keep
- * serving stale contexts.
+ * `createTLSSelector`'s `updateTLS()` (security/keys.ts) binds its `hdb_certificate` subscription to
+ * a specific table OBJECT, so a path that replaces `databases.system.hdb_certificate` with a new
+ * object orphans it. #1999 made `updateTLS()` detect the swap and re-subscribe, but that check only
+ * runs when something re-enters `updateTLS()` — and after a swap the only re-entry triggers are the
+ * orphaned subscription itself, the zero-certs retry timer (#1998), and a private-key hot reload. A
+ * swap while `secureContexts` is non-empty would therefore leave no pending trigger at all.
  *
- * WHAT THIS FILE PINS
+ * #2004 names `resetDatabases()` among the swapping paths. What this file pins is that an ordinary,
+ * ops-API-reachable schema change does not get there: `create_attribute` on an unrelated table fans
+ * the schema broadcast to every worker, yet a rotation immediately afterwards still reaches every
+ * worker with zero stale certificates across 30 fresh handshakes. The reason is in
+ * resources/databases.ts — the reconciliation loop `resetDatabases()` re-runs mutates the existing
+ * Table wrapper in place unless the storage ENGINE changed for that database, which an attribute
+ * add never does. A rotation with no schema change runs as the control, since the schema-change leg
+ * means nothing if plain rotation is broken, and both run at threads 1 and 4 because the #586-class
+ * failure signature is per-worker divergence.
  *
- * The invariant asserted here is that an ordinary, ops-API-reachable schema change does NOT reach
- * that precondition: `create_attribute` on an unrelated table fans a schema broadcast out to every
- * worker and each runs `resetDatabases()`, yet a cert rotation performed immediately afterwards
- * still propagates to every worker, with zero stale certificates across 30 fresh handshakes per
- * thread count. The reason is in resources/databases.ts: the reconciliation loop `resetDatabases()`
- * re-runs (`getDatabases()` → `initStores()`) mutates the EXISTING Table wrapper in place unless
- * the storage ENGINE changed for that database, and an attribute add never flips that. This
- * narrows #2004's own phrasing for this ITC path — the schema broadcast alone is not sufficient;
- * something must additionally force a table recreate.
+ * A red run on the schema-change leg means an ordinary schema change started forcing a real
+ * table-object swap, making #2004 reachable from a far more common trigger. Escalate, do not adjust.
  *
- * If this file ever goes red on the "rotation after a schema change" leg, an ordinary schema change
- * has started forcing a real table-object swap, which makes #2004 reachable from a far more common
- * trigger than currently understood. That is an escalation, not a flake.
+ * Proof boundary: the vulnerable precondition — a swap while `secureContexts` is non-empty — is NOT
+ * reproduced here, and no safe in-process route to it was found. The LMDB→RocksDB migration runs in
+ * `migrateOnStart()` before the HTTP listeners exist, so the first `updateTLS()` pass necessarily
+ * populates from the post-migration table rather than being swapped out from under a populated one;
+ * `harper copydb system <path>` would mean a second process opening the same live store files; and
+ * forcing the swap from a jsResource is blocked by the component loader confining module resolution
+ * to the component's own directory. The broadcast itself is not asserted from here either —
+ * `create_attribute` is read back through `describe_table`, and that the broadcast drives
+ * `resetDatabases()` on every worker is established by resources/databases.ts and
+ * unitTests/security/keys.test.js.
  *
- * The broadcast itself is not asserted from here — `create_attribute`'s own success is the
- * confirmation the schema change landed, and that the broadcast is what drives `resetDatabases()`
- * on every worker is established by resources/databases.ts and unitTests/security/keys.test.js.
- *
- * A rotation with no schema change in between is included as an in-suite control (it must keep
- * working for the schema-change leg to mean anything), and both legs run at `threads: 1` and
- * `threads: 4` because the #586-class failure signature is per-worker divergence, invisible to a
- * single-worker run.
- *
- * PROOF BOUNDARY
- *
- * This file does NOT reproduce the "swap while secureContexts is non-empty" precondition, and no
- * safe in-process route to it was found. The other paths #2004 names are boot-time or out of band:
- * the LMDB→RocksDB migration runs in `migrateOnStart()` before the HTTP listeners exist, so in any
- * one process's lifetime the first `updateTLS()` pass necessarily populates FROM the post-migration
- * table rather than being swapped out from under an already-populated one (and a worker-only
- * restart hands the new thread a fresh `createTLSSelector()` closure with empty contexts too); the
- * CLI `harper copydb system <path>` would mean a second process opening the same live store files,
- * which is not something a test should do to a running instance. Forcing the swap in-process from a
- * jsResource is also not available: the component loader confines a component's module resolution
- * to its own installed directory, and that boundary is a deliberate security control.
- *
- * Prior art, not restated here:
- *   - integrationTests/security/cert-reload.test.ts (#586) — plain on-disk renewal, no swap, must
- *     reach every worker.
- *   - integrationTests/security/cert-key-reload.test.ts — cert+key race, orthogonal to this bug.
- *   - unitTests/security/keys.test.js ("createTLSSelector when the hdb_certificate table object is
- *     swapped out") — whitebox proof that the #1999 fix works once SOMETHING re-enters
- *     `updateTLS()`; it manufactures that re-entry through the OLD table, which is precisely the
- *     gap #2004 flags as uncovered.
+ * Prior art: integrationTests/security/cert-reload.test.ts (#586, plain renewal reaching every
+ * worker), cert-key-reload.test.ts (cert+key race), and unitTests/security/keys.test.js, whose
+ * swap suite proves the #1999 fix works once something re-enters `updateTLS()` — manufacturing that
+ * re-entry through the OLD table, which is the gap #2004 flags as uncovered.
  *
  * Reproduction:
  *   npm run build && npm run test:integration -- "integrationTests/security/qa877-tls-cert-swap.test.ts"
@@ -118,8 +95,8 @@ async function makeServerCertPem(keyPair: Ed25519KeyPair, serialNumber: number):
 }
 
 interface ServedCert {
-	/** Decimal serial (Node reports serialNumber as hex; normalized once here via parseInt(.., 16)
-	 * so every comparison downstream is a plain decimal `===`, avoiding hex-case footguns). */
+	/** Normalized from Node's hex `serialNumber` once here, so comparisons downstream are plain
+	 * decimal `===` and cannot trip over hex casing. */
 	serial: number;
 	fingerprint256: string;
 	subjectCN?: string;
@@ -158,7 +135,7 @@ function servedCert(hostname: string): Promise<ServedCert> {
 	});
 }
 
-/** Fan out N fresh handshakes (SO_REUSEPORT spreads them across workers) and tabulate served serials. */
+/** N fresh handshakes at once; SO_REUSEPORT is what spreads them across workers. */
 async function fanOut(hostname: string, attempts: number): Promise<{ serials: number[]; errors: number }> {
 	const results = await Promise.allSettled(Array.from({ length: attempts }, () => servedCert(hostname)));
 	const serials = results

--- a/integrationTests/security/qa877-tls-cert-swap.test.ts
+++ b/integrationTests/security/qa877-tls-cert-swap.test.ts
@@ -98,6 +98,11 @@ const skipSuite = process.platform === 'win32' || testsBun;
 // 1500ms updateTLS debounce). 25s gives ample margin before we conclude "did not propagate".
 const PROPAGATION_WAIT_MS = 25_000;
 const FANOUT_ATTEMPTS = 30;
+// Each worker debounces its own updateTLS() rebuild with a 1500ms timer. The schema-change leg
+// asserts a NON-event (the served cert does not change), so it must wait clearly past that debounce
+// — waiting exactly 1500ms would let a swap land just after the probe and read as "unchanged",
+// which is the very failure the leg exists to catch.
+const NON_EVENT_SETTLE_MS = 5_000;
 
 async function makeServerCertPem(keyPair: Ed25519KeyPair, serialNumber: number): Promise<string> {
 	const cert = await createCertificate({
@@ -229,7 +234,10 @@ for (const WORKERS of [1, 4]) {
 				while (Date.now() < deadline) {
 					try {
 						const res = await fetch(`${ctx.harper.httpURL}/Widget/`);
-						if (res.status !== 404) return;
+						// 404 means the route is not mounted yet; a 5xx means it is mounted but unhealthy,
+						// which is also not ready — treating it as ready turns a fixture misconfiguration
+						// into a cryptic TLS timeout further down.
+						if (res.status !== 404 && res.status < 500) return;
 					} catch {
 						/* not ready yet */
 					}
@@ -260,8 +268,11 @@ for (const WORKERS of [1, 4]) {
 			});
 
 			after(async () => {
-				await teardownHarper(ctx);
-				await rm(certsDir, { recursive: true, force: true, maxRetries: 3 });
+				try {
+					await teardownHarper(ctx);
+				} finally {
+					await rm(certsDir, { recursive: true, force: true, maxRetries: 3 });
+				}
 			});
 
 			const SERIAL_BASELINE = 87701;
@@ -324,7 +335,7 @@ for (const WORKERS of [1, 4]) {
 				);
 				// A fixed wait is right here: the assertion below is that something did NOT happen
 				// (the served cert did not change), so there is no condition to poll for.
-				await sleep(1500);
+				await sleep(NON_EVENT_SETTLE_MS);
 
 				const { serials, errors } = await fanOut(ctx.harper.hostname, FANOUT_ATTEMPTS);
 				equal(errors, 0, `unexpected handshake failures right after the schema change: ${errors}/${FANOUT_ATTEMPTS}`);

--- a/integrationTests/security/qa877-tls-cert-swap.test.ts
+++ b/integrationTests/security/qa877-tls-cert-swap.test.ts
@@ -1,0 +1,330 @@
+/**
+ * QA-877 — anchor for the cert-table object-swap gap described in #2004, and the narrowing of
+ * which triggers can actually reach it.
+ *
+ * #2004: `createTLSSelector`'s `updateTLS()` (security/keys.ts) binds its `hdb_certificate`
+ * subscription to a specific table OBJECT. Paths that replace `databases.system.hdb_certificate`
+ * with a NEW object — `resetDatabases()` (copy_db, ITC restart handling) and the LMDB→RocksDB
+ * engine migration — orphan that subscription. #1999 made `updateTLS()` detect the swap
+ * (`subscribedTable !== databases.system.hdb_certificate`) and re-subscribe, but that comparison
+ * only runs when something re-enters `updateTLS()`. After a swap the only re-entry triggers are the
+ * now-orphaned subscription (dead — bound to the OLD object), the zero-certs retry timer (armed
+ * only when the last pass resolved empty, the #1998 path), and a private-key hot reload. So a swap
+ * while `secureContexts` is NON-EMPTY would leave no pending trigger and the selector would keep
+ * serving stale contexts.
+ *
+ * WHAT THIS FILE PINS
+ *
+ * The invariant asserted here is that an ordinary, ops-API-reachable schema change does NOT reach
+ * that precondition: `create_attribute` on an unrelated table fans a schema broadcast out to every
+ * worker and each runs `resetDatabases()`, yet a cert rotation performed immediately afterwards
+ * still propagates to every worker, with zero stale certificates across 30 fresh handshakes per
+ * thread count. The reason is in resources/databases.ts: the reconciliation loop `resetDatabases()`
+ * re-runs (`getDatabases()` → `initStores()`) mutates the EXISTING Table wrapper in place unless
+ * the storage ENGINE changed for that database, and an attribute add never flips that. This
+ * narrows #2004's own phrasing for this ITC path — the schema broadcast alone is not sufficient;
+ * something must additionally force a table recreate.
+ *
+ * If this file ever goes red on the "rotation after a schema change" leg, an ordinary schema change
+ * has started forcing a real table-object swap, which makes #2004 reachable from a far more common
+ * trigger than currently understood. That is an escalation, not a flake.
+ *
+ * The broadcast itself is not asserted from here — `create_attribute`'s own success is the
+ * confirmation the schema change landed, and that the broadcast is what drives `resetDatabases()`
+ * on every worker is established by resources/databases.ts and unitTests/security/keys.test.js.
+ *
+ * A rotation with no schema change in between is included as an in-suite control (it must keep
+ * working for the schema-change leg to mean anything), and both legs run at `threads: 1` and
+ * `threads: 4` because the #586-class failure signature is per-worker divergence, invisible to a
+ * single-worker run.
+ *
+ * PROOF BOUNDARY
+ *
+ * This file does NOT reproduce the "swap while secureContexts is non-empty" precondition, and no
+ * safe in-process route to it was found. The other paths #2004 names are boot-time or out of band:
+ * the LMDB→RocksDB migration runs in `migrateOnStart()` before the HTTP listeners exist, so in any
+ * one process's lifetime the first `updateTLS()` pass necessarily populates FROM the post-migration
+ * table rather than being swapped out from under an already-populated one (and a worker-only
+ * restart hands the new thread a fresh `createTLSSelector()` closure with empty contexts too); the
+ * CLI `harper copydb system <path>` would mean a second process opening the same live store files,
+ * which is not something a test should do to a running instance. Forcing the swap in-process from a
+ * jsResource is also not available: the component loader confines a component's module resolution
+ * to its own installed directory, and that boundary is a deliberate security control.
+ *
+ * Prior art, not restated here:
+ *   - integrationTests/security/cert-reload.test.ts (#586) — plain on-disk renewal, no swap, must
+ *     reach every worker.
+ *   - integrationTests/security/cert-key-reload.test.ts — cert+key race, orthogonal to this bug.
+ *   - unitTests/security/keys.test.js ("createTLSSelector when the hdb_certificate table object is
+ *     swapped out") — whitebox proof that the #1999 fix works once SOMETHING re-enters
+ *     `updateTLS()`; it manufactures that re-entry through the OLD table, which is precisely the
+ *     gap #2004 flags as uncovered.
+ *
+ * Reproduction:
+ *   npm run build && npm run test:integration -- "integrationTests/security/qa877-tls-cert-swap.test.ts"
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual as equal } from 'node:assert';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { setTimeout as sleep } from 'node:timers/promises';
+import * as tls from 'node:tls';
+
+import {
+	setupHarperWithFixture,
+	teardownHarper,
+	killHarper,
+	startHarper,
+	sendOperation,
+	type ContextWithHarper,
+} from '@harperfast/integration-testing';
+import {
+	generateEd25519KeyPair,
+	createCertificate,
+	makeExtKeyUsageExt,
+	certToPem,
+	type Ed25519KeyPair,
+} from '../utils/security/certGenUtils.ts';
+
+const HTTPS_PORT = 9927; // fixed by the integration-testing harness (http.securePort)
+const FIXTURE_PATH = join(import.meta.dirname, 'qa877-tls-cert-swap');
+const CERT_CN = 'qa877-tls-cert-swap.harper.local';
+const SERVER_AUTH_OID = '1.3.6.1.5.5.7.3.1';
+const testsBun = process.env.HARPER_RUNTIME === 'bun';
+const skipSuite = process.platform === 'win32' || testsBun;
+
+// Generous but bounded: normal reload settles well under 5s in practice (chokidar/poll + the
+// 1500ms updateTLS debounce). 25s gives ample margin before we conclude "did not propagate".
+const PROPAGATION_WAIT_MS = 25_000;
+const FANOUT_ATTEMPTS = 30;
+
+async function makeServerCertPem(keyPair: Ed25519KeyPair, serialNumber: number): Promise<string> {
+	const cert = await createCertificate({
+		serialNumber,
+		subject: { CN: CERT_CN, O: 'QA-877 TLS Cert Swap Test' },
+		issuer: { CN: CERT_CN, O: 'QA-877 TLS Cert Swap Test' },
+		validDays: 365,
+		issuerKey: keyPair.privateKey,
+		subjectPublicKey: keyPair.publicKey,
+		extensions: [makeExtKeyUsageExt([SERVER_AUTH_OID])],
+	});
+	return certToPem(cert);
+}
+
+interface ServedCert {
+	/** Decimal serial (Node reports serialNumber as hex; normalized once here via parseInt(.., 16)
+	 * so every comparison downstream is a plain decimal `===`, avoiding hex-case footguns). */
+	serial: number;
+	fingerprint256: string;
+	subjectCN?: string;
+}
+
+/** Open one fresh TLS connection (no session reuse) and return the served peer certificate. */
+function servedCert(hostname: string): Promise<ServedCert> {
+	return new Promise((resolve, reject) => {
+		const socket = tls.connect(
+			{
+				host: hostname,
+				port: HTTPS_PORT,
+				servername: CERT_CN,
+				rejectUnauthorized: false,
+				session: undefined, // force a full handshake so the kernel can spread us across workers
+			},
+			() => {
+				const peer = socket.getPeerCertificate();
+				socket.destroy();
+				if (!peer || !peer.serialNumber) {
+					reject(new Error('no peer certificate returned'));
+					return;
+				}
+				resolve({
+					serial: parseInt(peer.serialNumber, 16),
+					fingerprint256: peer.fingerprint256,
+					subjectCN: (peer.subject as any)?.CN,
+				});
+			}
+		);
+		socket.setTimeout(5000, () => {
+			socket.destroy();
+			reject(new Error('TLS connection timed out'));
+		});
+		socket.on('error', reject);
+	});
+}
+
+/** Fan out N fresh handshakes (SO_REUSEPORT spreads them across workers) and tabulate served serials. */
+async function fanOut(hostname: string, attempts: number): Promise<{ serials: number[]; errors: number }> {
+	const results = await Promise.allSettled(Array.from({ length: attempts }, () => servedCert(hostname)));
+	const serials = results
+		.filter((r): r is PromiseFulfilledResult<ServedCert> => r.status === 'fulfilled')
+		.map((r) => r.value.serial);
+	const errors = results.length - serials.length;
+	return { serials, errors };
+}
+
+function tally(serials: number[]): string {
+	const counts = new Map<number, number>();
+	for (const s of serials) counts.set(s, (counts.get(s) ?? 0) + 1);
+	return [...counts.entries()].map(([serial, n]) => `${serial}=${n}`).join(', ');
+}
+
+/** Poll until a fresh connection serves `expectedSerial`, or the deadline passes. Returns ms taken, or -1. */
+async function waitForSerial(hostname: string, expectedSerial: number, deadlineMs: number): Promise<number> {
+	const start = Date.now();
+	const deadline = start + deadlineMs;
+	while (Date.now() < deadline) {
+		try {
+			const cert = await servedCert(hostname);
+			if (cert.serial === expectedSerial) return Date.now() - start;
+		} catch {
+			// transient — keep polling
+		}
+		await sleep(400);
+	}
+	return -1;
+}
+
+for (const WORKERS of [1, 4]) {
+	suite(
+		`QA-877 TLS cert-table swap vs rotation [threads=${WORKERS}] (#2004)`,
+		{ skip: skipSuite },
+		(ctx: ContextWithHarper) => {
+			let certsDir: string;
+			let certPath: string;
+			let keyPath: string;
+			let keyPair: Ed25519KeyPair;
+
+			async function waitForReady() {
+				const deadline = Date.now() + 120_000;
+				while (Date.now() < deadline) {
+					try {
+						const res = await fetch(`${ctx.harper.httpURL}/Widget/`);
+						if (res.status !== 404) return;
+					} catch {
+						/* not ready yet */
+					}
+					await sleep(250);
+				}
+				throw new Error('Widget route never became ready');
+			}
+
+			before(async () => {
+				certsDir = await mkdtemp(join(tmpdir(), 'qa877-tls-cert-swap-'));
+				certPath = join(certsDir, 'certificate.pem');
+				keyPath = join(certsDir, 'privateKey.pem');
+
+				keyPair = await generateEd25519KeyPair();
+				await writeFile(keyPath, keyPair.privateKeyPem);
+				await writeFile(certPath, await makeServerCertPem(keyPair, 87701));
+
+				await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+					config: {
+						threads: { count: WORKERS },
+						tls: { certificate: certPath, privateKey: keyPath },
+					},
+					// See cert-reload.test.ts: force the main-thread cert-file watcher to poll instead of
+					// relying on inotify, which is unreliable on overlayfs/tmpfs-backed temp dirs.
+					env: { CHOKIDAR_USEPOLLING: '1', CHOKIDAR_INTERVAL: '250' },
+				});
+				await waitForReady();
+			});
+
+			after(async () => {
+				await teardownHarper(ctx);
+				await rm(certsDir, { recursive: true, force: true, maxRetries: 3 });
+			});
+
+			const SERIAL_BASELINE = 87701;
+			const SERIAL_ROTATE_NO_SWAP = 87702; // control: rotation, no schema change involved
+			const SERIAL_ROTATE_AFTER_SCHEMA_CHANGE = 87703; // rotation after an ordinary schema change
+
+			test(`threads=${WORKERS}: baseline cert is served (peer cert inspected, not just "connected")`, async () => {
+				const { serials, errors } = await fanOut(ctx.harper.hostname, 10);
+				equal(errors, 0, `unexpected handshake failures: ${errors}/10`);
+				ok(
+					serials.every((s) => s === SERIAL_BASELINE),
+					`expected all connections to serve baseline serial ${SERIAL_BASELINE}, got: ${tally(serials)}`
+				);
+			});
+
+			test(`threads=${WORKERS}: rotation with no schema change propagates normally (control, mirrors #586)`, async () => {
+				await writeFile(certPath, await makeServerCertPem(keyPair, SERIAL_ROTATE_NO_SWAP));
+				const took = await waitForSerial(ctx.harper.hostname, SERIAL_ROTATE_NO_SWAP, PROPAGATION_WAIT_MS);
+				ok(took >= 0, `rotation never propagated within ${PROPAGATION_WAIT_MS}ms`);
+				console.log(`[QA-877 threads=${WORKERS}] rotation (no schema change) propagated in ${took}ms`);
+
+				const { serials, errors } = await fanOut(ctx.harper.hostname, FANOUT_ATTEMPTS);
+				equal(errors, 0, `unexpected handshake failures: ${errors}/${FANOUT_ATTEMPTS}`);
+				ok(
+					serials.every((s) => s === SERIAL_ROTATE_NO_SWAP),
+					`expected every worker to serve ${SERIAL_ROTATE_NO_SWAP} after settling, got: ${tally(serials)}`
+				);
+			});
+
+			test(`threads=${WORKERS}: an ordinary schema change (create_attribute) triggers resetDatabases() but does not disturb the currently-served cert`, async () => {
+				const result = await sendOperation(ctx.harper, {
+					operation: 'create_attribute',
+					schema: 'data',
+					table: 'Widget',
+					attribute: `qa877SchemaChange_${WORKERS}`,
+				});
+				ok(result, 'create_attribute did not succeed');
+				await sleep(1500); // let the ITC schema broadcast reach every worker's resetDatabases()
+
+				const { serials, errors } = await fanOut(ctx.harper.hostname, FANOUT_ATTEMPTS);
+				equal(errors, 0, `unexpected handshake failures right after the schema change: ${errors}/${FANOUT_ATTEMPTS}`);
+				ok(
+					serials.every((s) => s === SERIAL_ROTATE_NO_SWAP),
+					`expected ${SERIAL_ROTATE_NO_SWAP} unchanged, got: ${tally(serials)}`
+				);
+			});
+
+			test(`threads=${WORKERS}: rotation AFTER that schema change ALSO propagates normally (#2004 does not reproduce via this trigger)`, async () => {
+				await writeFile(certPath, await makeServerCertPem(keyPair, SERIAL_ROTATE_AFTER_SCHEMA_CHANGE));
+				const took = await waitForSerial(ctx.harper.hostname, SERIAL_ROTATE_AFTER_SCHEMA_CHANGE, PROPAGATION_WAIT_MS);
+
+				const { serials, errors } = await fanOut(ctx.harper.hostname, FANOUT_ATTEMPTS);
+				const staleCount = serials.filter((s) => s === SERIAL_ROTATE_NO_SWAP).length;
+				const freshCount = serials.filter((s) => s === SERIAL_ROTATE_AFTER_SCHEMA_CHANGE).length;
+				console.log(
+					`[QA-877 threads=${WORKERS}] rotation after schema change: took=${took}ms errors=${errors} ` +
+						`stale(${SERIAL_ROTATE_NO_SWAP})=${staleCount} fresh(${SERIAL_ROTATE_AFTER_SCHEMA_CHANGE})=${freshCount} ` +
+						`tally=${tally(serials)}`
+				);
+
+				// This is the headline empirical result: per the file header, an ordinary schema change
+				// does NOT swap the cert-table object (resources/databases.ts reuses the Table wrapper
+				// in place unless the storage engine itself changed), so the rotation reaches every
+				// worker just like the no-schema-change control above. If this ever starts failing, it
+				// means create_attribute's resetDatabases() call started forcing a real table-object
+				// swap — which would mean #2004 is reachable via a MUCH more common trigger than
+				// currently understood, and this finding should be revisited/promoted urgently.
+				ok(took >= 0, `rotation after an ordinary schema change never propagated within ${PROPAGATION_WAIT_MS}ms`);
+				ok(
+					serials.every((s) => s === SERIAL_ROTATE_AFTER_SCHEMA_CHANGE),
+					`expected every worker to serve ${SERIAL_ROTATE_AFTER_SCHEMA_CHANGE}, got: ${tally(serials)}`
+				);
+			});
+
+			test(`threads=${WORKERS}: a restart serves whatever is currently on disk`, async () => {
+				await killHarper(ctx);
+				await startHarper(ctx, {
+					config: {
+						threads: { count: WORKERS },
+						tls: { certificate: certPath, privateKey: keyPath },
+					},
+					env: { CHOKIDAR_USEPOLLING: '1', CHOKIDAR_INTERVAL: '250' },
+				});
+				await waitForReady();
+
+				const { serials, errors } = await fanOut(ctx.harper.hostname, 10);
+				equal(errors, 0, `unexpected handshake failures after restart: ${errors}/10`);
+				ok(
+					serials.every((s) => s === SERIAL_ROTATE_AFTER_SCHEMA_CHANGE),
+					`expected the restart to serve the on-disk cert (${SERIAL_ROTATE_AFTER_SCHEMA_CHANGE}), got: ${tally(serials)}`
+				);
+			});
+		}
+	);
+}

--- a/integrationTests/security/qa877-tls-cert-swap/config.yaml
+++ b/integrationTests/security/qa877-tls-cert-swap/config.yaml
@@ -1,0 +1,11 @@
+# QA-877 fixture — one exported table whose only job is to give the suite a real, ops-API-reachable
+# schema-changing operation (create_attribute), which is what fans the ITC schema broadcast out to
+# every worker and makes each one run resetDatabases(). See the test file header for what that is
+# used to establish about #2004.
+#
+# TLS certificates are driven entirely through harperdb-config.yaml (tls.certificate /
+# tls.privateKey), overridden per-suite via setupHarperWithFixture's `config` option, the same way
+# cert-reload.test.ts does it.
+graphqlSchema:
+  files: '*.graphql'
+rest: true

--- a/integrationTests/security/qa877-tls-cert-swap/schema.graphql
+++ b/integrationTests/security/qa877-tls-cert-swap/schema.graphql
@@ -1,0 +1,4 @@
+type Widget @table(audit: false) @export {
+	id: ID @primaryKey
+	note: String
+}


### PR DESCRIPTION
Test-only. Promotes two exploratory-QA anchors into the integration suite. No product code changes.

## `qa701-deployment-payload-ops` — the deployment payload operations (#1898)

`get_deployment_payload` / `delete_deployment_payload` merged with unit coverage only. `git grep` for either operation under `integrationTests/` returns nothing today, and `integrationTests/deploy/deploy-payload-reclaim.test.ts` — the file whose name suggests it would cover this — is a different mechanism (the *automatic* post-deploy drop of a payload over `deployment.payloadRetention.maxSize`, #1496) and never calls either operation. This suite forces `maxSize` to 200 MiB so that automatic drop can never fire, which is what makes any blob disappearance attributable to an explicit delete.

Two contracts are pinned.

**The delete reclaims disk, it does not just flip a flag.** Harper has history on this axis — #595 ("dropping a table leaves orphan blobs") and the metadata-only behavior of `drop_attribute`/`drop_table` — so both delete legs assert against the on-disk blob store rather than the row flag, at ~4.4 KB and again at 12 MB, with [`freed_bytes` required to equal `payload_size` exactly](https://github.com/HarperFast/harper/pull/2431/changes?w=1#diff-b1db9f04ccfb32638fe045ee316e8437a6ea03dd037328f65bc7e6756589268aR538). The disk checks poll for the file to vanish rather than sleeping, so a slow-but-real async unlink is not misreported as a leak.

**The authorization asymmetry is the contract, not an accident.** A non-super_user role with no `operations` grant is 403 on both operations. A role explicitly granted *both* can call `delete_deployment_payload` — that gate-2 delegation is the intended way to hand cleanup automation to a non-SU role — but is [still 403 on `get_deployment_payload`](https://github.com/HarperFast/harper/pull/2431/changes?w=1#diff-b1db9f04ccfb32638fe045ee316e8437a6ea03dd037328f65bc7e6756589268aR830), because `requireSuperUser` runs inside that handler on top of the registered permission. Pinning it means a later "consistency" cleanup that lets a role grant unlock the download goes red instead of quietly widening secret exposure.

Boundaries covered alongside: unknown `deployment_id` → 404 with a JSON error body and no download `content-disposition` leaking from the error path; delete on a non-terminal deployment → 409; get after delete → 404 rather than 500; a second delete → 200 with `freed_bytes: 0`; a running component still serving after its payload is deleted; and redeploy-after-delete minting an independent `deployment_id` whose own blob is retained while the old row stays payload-less.

## `qa877-tls-cert-swap` — narrowing what can actually reach #2004

#2004 is open: `updateTLS()` binds its `hdb_certificate` subscription to a specific table *object*, and paths replacing `databases.system.hdb_certificate` with a new object orphan that subscription. #1999 made `updateTLS()` detect the swap and re-subscribe, but the check only runs when something re-enters `updateTLS()` — so a swap while `secureContexts` is non-empty would leave no pending trigger.

The issue names `resetDatabases()` among the swapping paths. This suite pins that an ordinary, ops-API-reachable schema change does **not** get there: `create_attribute` on an unrelated table fans the schema broadcast to every worker, yet a rotation immediately afterwards still reaches every worker with zero stale certificates across 30 fresh handshakes, at `threads: 1` and `threads: 4`. The reason is in `resources/databases.ts` — the reconciliation loop `resetDatabases()` re-runs mutates the existing `Table` wrapper in place unless the storage *engine* changed for that database, which an attribute add never does; [the leg that would go red](https://github.com/HarperFast/harper/pull/2431/changes?w=1#diff-3f820a039c9d40cc99df2d085f04e1173564b5fe14e3f99c699feed97cefe63cR345) is the one to look at hardest. A rotation with no schema change runs as the control, since the schema-change leg means nothing if plain rotation is broken.

A red run on that leg is an escalation, not a flake: it would mean #2004 became reachable from a far more common trigger than currently understood.

## For the human reviewer

- **This does not fix #2004 and does not claim the bug is unreal.** The vulnerable precondition — a swap while `secureContexts` is non-empty — is not reproduced, and the file states why no safe in-process route to it was found: the LMDB→RocksDB migration runs before the HTTP listeners exist, so the first `updateTLS()` pass necessarily populates *from* the post-migration table; `harper copydb system <path>` would mean a second process opening the same live store files; and forcing the swap from a jsResource is blocked by the component loader's module-resolution sandbox. Leave #2004 open.
- **Undocumented authorization asymmetry — worth a docs follow-up.** `reference/operations-api/operations.md` lists both operations as `super_user` and says nothing about the delegation difference. An operator who grants both in a role's `operations` allowlist gets a working `delete_deployment_payload` and an unexplained 403 on `get_deployment_payload`. The behavior is deliberate and now pinned; the gap is that nothing user-facing explains it. I did not open the documentation PR as part of this test-only change — say the word and I will.
- **Two review findings declined, on evidence.** Both reviewers flagged that `node:http` and native `fetch` would break if the harness served the operations API over HTTPS, and that `HTTPS_PORT` should come from the context instead of being hardcoded. `harperLifecycle.js` builds both `httpURL` and `operationsAPIURL` as `http://` unconditionally, `HarperContext` exposes no secure-port field, and each suite gets its own loopback address so a fixed port cannot collide across concurrent suites. All six sibling `integrationTests/deploy/*.test.ts` files import `node:http` the same way, and `cert-reload.test.ts` hardcodes the same 9927 and hand-rolls the same authed `fetch`. Changing these would diverge from the files these deliberately mirror to guard against a harness change that has not happened.
- **Comment volume was raised in every round and only partly addressed.** The reviewers' position is Harper's zero-new-comments default; I trimmed the narration and reviewer-directed framing but kept a substantive header on each file. `integrationTests/README.md` requires one ("Each file must begin with a JSDoc comment describing exactly what it tests — include relevant GitHub issue or PR links"), and the QA anchors already in the tree — `qa816-purge-blast-radius`, `qa702-sse-event-data` — carry exactly this shape, including their proof-boundary sections. Happy to cut further if you read the balance differently.
- **One deviation from the gate-cleared QA snapshot.** The `qa877` candidate carried a non-asserting helper that grepped Harper's output for `signalSchemaChange called`. It printed `false` on every run because that line is trace-level and off by default — a permanently misleading signal in a file future readers will trust. I removed it and its two `console.log`s; no assertion changed, and the header now says the broadcast is not asserted from here.
- Both files keep the `qa###-` prefix and sibling fixture directory used by the QA anchors already in the tree.

## Verification

Built first — integration tests load `dist/`, not source.

```
npm run build                                             # clean
npm run test:integration -- --isolation=none \
  "integrationTests/security/qa877-tls-cert-swap.test.ts" \
  "integrationTests/deploy/qa701-deployment-payload-ops.test.ts"
  → 25/25 pass, 3 suites (qa877 runs threads=1 and threads=4 arms)
npm run lint:required                                     # clean
npx prettier --check <both files>                         # clean
npx tsc --noEmit --project integrationTests/tsconfig.json # no errors in either new file
```

The qa701 suite was additionally run three consecutive times to confirm the 409 leg reaches its assertion every time rather than skipping on a fast host. Both suites are green on this branch, whose only content is the two new files and their fixtures.

**CI: 36 pass, 2 fail.** Every integration shard passes on Node, Bun, Windows and uWS — including the Bun shards, which run qa701 (only qa877 skips under Bun). The two failures are `Unit Test (Node.js v22)` and `(Node.js v26)`, both the same assertion: `Caching > Can load cached data` at `unitTests/resources/caching.test.js:215`. That is not this PR — the diff adds six files, all under `integrationTests/`, and unit runs glob `unitTests/**`. `Unit Test (Node.js v24)` passes on this same commit, v22 already fails on this branch's base (`fb762a36`, current `main`), and #2428 is open to deflake exactly this test: it sleeps 10 ms against a 10 ms TTL to "let it expire".

Five pre-push review rounds ran; what they changed is worth knowing, because the first version of each suite could pass without testing what it claimed:

- The disk oracle identifies the blob under test **by size**, and every fixture was built at 4 KB — so a surviving unrelated blob could read as a leak of the one just deleted. Fixtures now have distinct sizes and the [precondition requires exactly one match](https://github.com/HarperFast/harper/pull/2431/changes?w=1#diff-b1db9f04ccfb32638fe045ee316e8437a6ea03dd037328f65bc7e6756589268aR191), so a future collision fails on the precondition instead of as a false `DEFECT-LEAK`.
- The 409 leg never reached the guard: `deploy_component` only responds once the row is terminal, so deleting after awaiting the deploy always hit a settled row and the assertion was skipped on every run. The deploy now runs unawaited with a [**paced upload**](https://github.com/HarperFast/harper/pull/2431/changes?w=1#diff-b1db9f04ccfb32638fe045ee316e8437a6ea03dd037328f65bc7e6756589268aR254), holding the row non-terminal for a known ~2s regardless of host speed, and the [assertion is unconditional](https://github.com/HarperFast/harper/pull/2431/changes?w=1#diff-b1db9f04ccfb32638fe045ee316e8437a6ea03dd037328f65bc7e6756589268aR488).
- The `threads: 4` arm never verified four workers started, so it could have passed vacuously against a single survivor. It now carries cert-reload.test.ts's [`system_information` guard](https://github.com/HarperFast/harper/pull/2431/changes?w=1#diff-3f820a039c9d40cc99df2d085f04e1173564b5fe14e3f99c699feed97cefe63cR264).
- Both rotation legs waited for the *first* worker to serve the new serial and then immediately required *every* worker to be current — a false-failure on a loaded runner. They now [poll the whole fan-out for convergence](https://github.com/HarperFast/harper/pull/2431/changes?w=1#diff-3f820a039c9d40cc99df2d085f04e1173564b5fe14e3f99c699feed97cefe63cR162).
- The schema-change leg asserts a non-event but waited exactly the 1500 ms each worker debounces its `updateTLS()` rebuild with, so a swap landing just after the probe would have read as "unchanged" — passing on the very behavior it exists to catch. The wait is now [a named constant clearly past the debounce](https://github.com/HarperFast/harper/pull/2431/changes?w=1#diff-3f820a039c9d40cc99df2d085f04e1173564b5fe14e3f99c699feed97cefe63cR82).

Refs #1898
Refs #2004
Refs #595

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=4 @ 3c048897789d</sub>

<sub>Human-Review-Need: 3 @ 3c048897789d</sub>
