### PR TITLE
Make MCP resource subscriptions reliable across HTTP workers

### DIFF
--- a/components/mcp/lifecycle.ts
+++ b/components/mcp/lifecycle.ts
@@ -7,7 +7,7 @@
  * server SHOULD respond with its preferred supported version so the client
  * can decide whether to connect on the older version or disconnect.
  */
-import { createSession, saveSession, type McpSessionRecord } from './session.ts';
+import { createSession, patchSession, type McpSessionRecord } from './session.ts';
 import { packageJson } from '../../utility/packageUtils.js';
 
 export const PROTOCOL_VERSION_PREFERRED = '2025-06-18';
@@ -106,6 +106,6 @@ export async function handleInitialize(
 export async function handleInitialized(session: McpSessionRecord): Promise<McpSessionRecord> {
 	if (session.initialized) return session;
 	const updated: McpSessionRecord = { ...session, initialized: true };
-	await saveSession(updated);
+	await patchSession(session.id, { initialized: true });
 	return updated;
 }

--- a/components/mcp/session.ts
+++ b/components/mcp/session.ts
@@ -148,7 +148,15 @@ export async function createSession({
  */
 export async function loadSession(id: string): Promise<McpSessionRecord | null> {
 	const record = (await (getTable() as any).get(id)) as McpSessionRecord | undefined | null;
-	if (!record) return null;
+	if (
+		!record ||
+		typeof record.protocolVersion !== 'string' ||
+		typeof record.initialized !== 'boolean' ||
+		typeof record.user !== 'string' ||
+		typeof record.createdAt !== 'number' ||
+		typeof record.lastActivity !== 'number'
+	)
+		return null;
 	return record;
 }
 

--- a/components/mcp/session.ts
+++ b/components/mcp/session.ts
@@ -34,6 +34,7 @@ const DEFAULT_IDLE_TIMEOUT_SECONDS = 1800;
  * is identical either way.)
  */
 const EVICTION_WINDOW_SECONDS = 60;
+const DEFAULT_SUBSCRIPTION_LOCK_TIMEOUT_MS = 10_000;
 
 export interface McpSessionRecord {
 	id: string;
@@ -68,6 +69,7 @@ export interface McpSessionRecord {
 }
 
 let _sessionTable: Table | undefined;
+let subscriptionLockTimeoutMs = DEFAULT_SUBSCRIPTION_LOCK_TIMEOUT_MS;
 
 /**
  * Lazily declare the system table. Called by `ensureSessionTable()` at
@@ -112,6 +114,10 @@ export function ensureSessionTable(): Table {
 /** Test seam: allow tests to inject a fake table without touching Harper. */
 export function _setSessionTableForTest(fake: Table | undefined): void {
 	_sessionTable = fake;
+}
+
+export function _setSubscriptionLockTimeoutForTest(value: number | undefined): void {
+	subscriptionLockTimeoutMs = value ?? DEFAULT_SUBSCRIPTION_LOCK_TIMEOUT_MS;
 }
 
 function getTable(): Table {
@@ -171,10 +177,23 @@ function subscriptionLockKey(id: string): string {
 
 function acquireSessionSubscriptionLock(store: Table['primaryStore'], key: string): Promise<void> {
 	return new Promise((resolve, reject) => {
+		let settled = false;
+		const timer = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			reject(new Error('Timed out acquiring MCP subscription lock'));
+		}, subscriptionLockTimeoutMs);
 		const attempt = () => {
+			if (settled) return;
 			try {
-				if (store.tryLock(key, attempt)) resolve();
+				if (store.tryLock(key, attempt)) {
+					settled = true;
+					clearTimeout(timer);
+					resolve();
+				}
 			} catch (error) {
+				settled = true;
+				clearTimeout(timer);
 				reject(error);
 			}
 		};

--- a/components/mcp/session.ts
+++ b/components/mcp/session.ts
@@ -166,7 +166,6 @@ export async function loadSession(id: string): Promise<McpSessionRecord | null> 
 	return record;
 }
 
-/** Incrementally update session fields without replacing concurrent changes. */
 export async function patchSession(id: string, changes: Partial<Omit<McpSessionRecord, 'id'>>): Promise<void> {
 	await (getTable() as any).patch({ id, ...changes });
 }

--- a/components/mcp/session.ts
+++ b/components/mcp/session.ts
@@ -165,6 +165,43 @@ export async function patchSession(id: string, changes: Partial<Omit<McpSessionR
 	await (getTable() as any).patch({ id, ...changes });
 }
 
+function subscriptionLockKey(id: string): string {
+	return `mcp-subscriptions:${id}`;
+}
+
+function acquireSessionSubscriptionLock(store: Table['primaryStore'], key: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const attempt = () => {
+			try {
+				if (store.tryLock(key, attempt)) resolve();
+			} catch (error) {
+				reject(error);
+			}
+		};
+		attempt();
+	});
+}
+
+/** Serialize durable subscription read-modify-writes across HTTP workers. */
+export async function updateSessionSubscriptions(
+	id: string,
+	update: (subscriptions: string[]) => string[] | Promise<string[]>
+): Promise<McpSessionRecord | null> {
+	const store = getTable().primaryStore;
+	const key = subscriptionLockKey(id);
+	await acquireSessionSubscriptionLock(store, key);
+	try {
+		const session = await loadSession(id);
+		if (!session) return null;
+		const subscriptions = session.subscriptions ?? [];
+		const updated = await update(subscriptions);
+		if (updated !== subscriptions) await patchSession(id, { subscriptions: updated });
+		return updated === subscriptions ? session : { ...session, subscriptions: updated };
+	} finally {
+		store.unlock(key);
+	}
+}
+
 export async function deleteSession(id: string): Promise<void> {
 	await (getTable() as any).delete(id);
 	// Tear down ancillary per-session in-memory state — the `tools/list`

--- a/components/mcp/session.ts
+++ b/components/mcp/session.ts
@@ -3,7 +3,7 @@
  *
  * Eviction is delegated to Harper's native TTL (`Table.setTTLExpiration`):
  * every write to a session record updates its `version`, which Harper uses
- * to determine expiration. So calling `saveSession(record)` on each request
+ * to determine expiration. So calling `patchSession(id, changes)` on each request
  * gives sliding-window idle semantics for free — no custom timer, no sweep.
  *
  * Spec: when a request bears an `Mcp-Session-Id` the server doesn't
@@ -63,6 +63,8 @@ export interface McpSessionRecord {
 	 * to clients that declared support. Undefined = client declared none.
 	 */
 	clientCapabilities?: Record<string, unknown>;
+	/** Node-local hint for the worker that owns the current GET-SSE stream. */
+	streamOwner?: { threadId: number; token: string };
 }
 
 let _sessionTable: Table | undefined;
@@ -90,6 +92,7 @@ function declareSessionTable(): Table {
 			{ name: 'logLevel' },
 			{ name: 'subscriptions' },
 			{ name: 'clientCapabilities' },
+			{ name: 'streamOwner' },
 		],
 	});
 }
@@ -149,12 +152,9 @@ export async function loadSession(id: string): Promise<McpSessionRecord | null> 
 	return record;
 }
 
-/**
- * Persist updated session state. Used to bump `lastActivity` (sliding-window
- * idle reset) and to flip `initialized` after `notifications/initialized`.
- */
-export async function saveSession(record: McpSessionRecord): Promise<void> {
-	await (getTable() as any).put(record);
+/** Incrementally update session fields without replacing concurrent changes. */
+export async function patchSession(id: string, changes: Partial<Omit<McpSessionRecord, 'id'>>): Promise<void> {
+	await (getTable() as any).patch({ id, ...changes });
 }
 
 export async function deleteSession(id: string): Promise<void> {
@@ -174,6 +174,6 @@ export async function deleteSession(id: string): Promise<void> {
  */
 export async function touchSession(record: McpSessionRecord): Promise<McpSessionRecord> {
 	const touched: McpSessionRecord = { ...record, lastActivity: Date.now() };
-	await saveSession(touched);
+	await patchSession(record.id, { lastActivity: touched.lastActivity });
 	return touched;
 }

--- a/components/mcp/sessionRegistry.ts
+++ b/components/mcp/sessionRegistry.ts
@@ -17,6 +17,7 @@
  * without a graceful close).
  */
 import { IterableEventQueue } from '../../resources/IterableEventQueue.ts';
+import { randomUUID } from 'node:crypto';
 import type { McpLogLevel } from './logging.ts';
 import type { AuthedUser } from './toolRegistry.ts';
 import type { McpProfile } from './transport.ts';
@@ -29,6 +30,8 @@ export interface SseEvent {
 
 export interface RegisteredSession {
 	sessionId: string;
+	/** Uniquely identifies this particular GET-SSE stream. */
+	streamToken: string;
 	profile: McpProfile;
 	user: AuthedUser;
 	queue: IterableEventQueue<SseEvent>;
@@ -98,6 +101,7 @@ export function registerSession(sessionId: string, profile: McpProfile, user: Au
 	const queue = new IterableEventQueue<SseEvent>();
 	const record: RegisteredSession = {
 		sessionId,
+		streamToken: randomUUID(),
 		profile,
 		user,
 		queue,

--- a/components/mcp/sessionRegistry.ts
+++ b/components/mcp/sessionRegistry.ts
@@ -30,7 +30,6 @@ export interface SseEvent {
 
 export interface RegisteredSession {
 	sessionId: string;
-	/** Uniquely identifies this particular GET-SSE stream. */
 	streamToken: string;
 	profile: McpProfile;
 	user: AuthedUser;

--- a/components/mcp/subscriptionRouting.ts
+++ b/components/mcp/subscriptionRouting.ts
@@ -32,6 +32,7 @@ interface Response {
 }
 
 interface ItcBridge {
+	available?: boolean;
 	sendToThread(threadId: number, event: { type: string; message: unknown }): boolean;
 	onMessageByType(type: string, listener: (event: { message?: unknown }) => void): void;
 }
@@ -59,14 +60,14 @@ function bridge(): ItcBridge {
 	try {
 		const { onMessageByType } = require('../../server/threads/manageThreads.js');
 		if (typeof threads !== 'undefined' && typeof threads.sendToThread === 'function') {
-			return { sendToThread: threads.sendToThread.bind(threads), onMessageByType };
+			return { available: true, sendToThread: threads.sendToThread.bind(threads), onMessageByType };
 		}
 	} catch (error) {
 		harperLogger.trace(`MCP subscription routing is unavailable: ${(error as Error).message}`);
-		return { sendToThread: () => false, onMessageByType: () => {} };
+		return { available: false, sendToThread: () => false, onMessageByType: () => {} };
 	}
 	harperLogger.trace('MCP subscription routing is unavailable: thread bridge is not initialized');
-	return { sendToThread: () => false, onMessageByType: () => {} };
+	return { available: false, sendToThread: () => false, onMessageByType: () => {} };
 }
 
 export function _setSubscriptionItcForTest(fake: ItcBridge | undefined): void {
@@ -97,15 +98,16 @@ export function _pendingSubscriptionRouteCount(): number {
 
 function ensureWired(): void {
 	if (wired) return;
-	wired = true;
-	bridge().onMessageByType(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_COMMAND, (event) => {
+	const itc = bridge();
+	if (itc.available === false) return;
+	itc.onMessageByType(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_COMMAND, (event) => {
 		const command = event.message as Command;
 		void handleCommand(command).catch((error) => {
 			harperLogger.error('MCP subscription command failed', error);
 			sendResponse(command, 'internal-error');
 		});
 	});
-	bridge().onMessageByType(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_RESPONSE, (event) => {
+	itc.onMessageByType(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_RESPONSE, (event) => {
 		const response = event.message as Response;
 		const entry = pending.get(response?.requestId);
 		if (!entry || response.originator !== entry.targetThreadId) return;
@@ -115,9 +117,9 @@ function ensureWired(): void {
 		pending.delete(response.requestId);
 		entry.resolve(response.result);
 	});
+	wired = true;
 }
 
-/** Attach the owner-side command listener and persist the routing hint for a new GET stream. */
 export async function claimSubscriptionOwner(sessionId: string, streamToken: string): Promise<void> {
 	ensureWired();
 	await patchSession(sessionId, { streamOwner: { threadId: currentThreadId(), token: streamToken } });

--- a/components/mcp/subscriptionRouting.ts
+++ b/components/mcp/subscriptionRouting.ts
@@ -110,10 +110,10 @@ export function _pendingSubscriptionRouteCount(): number {
 	return pending.size;
 }
 
-function ensureWired(): void {
-	if (wired) return;
+function ensureWired(): boolean {
+	if (wired) return true;
 	const itc = bridge();
-	if (itc.available === false) return;
+	if (itc.available === false) return false;
 	itc.onMessageByType(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_COMMAND, (event) => {
 		const command = event.message;
 		if (!isCommand(command)) {
@@ -136,10 +136,11 @@ function ensureWired(): void {
 		entry.resolve(response.result);
 	});
 	wired = true;
+	return true;
 }
 
 export async function claimSubscriptionOwner(sessionId: string, streamToken: string): Promise<void> {
-	ensureWired();
+	if (!ensureWired()) throw new Error('MCP subscription routing is unavailable');
 	await patchSession(sessionId, { streamOwner: { threadId: currentThreadId(), token: streamToken } });
 }
 
@@ -150,8 +151,8 @@ function countPendingForSession(sessionId: string): number {
 }
 
 export function subscriptionUser(user: AuthedUser): AuthedUser {
-	// Cross-worker subscribe authorization may rely only on this data-only principal shape.
-	// Built-in checks consume role.permission; credentials and mutable user state stay local.
+	// Preserve role permissions and scoped-token expiry for authorization rechecks;
+	// credentials and mutable user state must not cross the worker boundary.
 	return {
 		...(user.username !== undefined ? { username: user.username } : {}),
 		...(user.authExpiresAt !== undefined ? { authExpiresAt: user.authExpiresAt } : {}),
@@ -171,7 +172,7 @@ function routeRemote(
 	owner: NonNullable<McpSessionRecord['streamOwner']>,
 	command: Omit<Command, 'requestId' | 'originator' | 'streamToken'>
 ): Promise<SubscriptionRouteResult> {
-	ensureWired();
+	if (!ensureWired()) return Promise.resolve('no-live-stream');
 	if (pending.size >= MAX_PENDING || countPendingForSession(command.sessionId) >= MAX_PENDING_PER_SESSION) {
 		return Promise.resolve('internal-error');
 	}
@@ -184,18 +185,20 @@ function routeRemote(
 		timer.unref();
 		pending.set(requestId, { sessionId: command.sessionId, targetThreadId: owner.threadId, resolve, timer });
 		let sent = false;
+		let sendFailed = false;
 		try {
 			sent = bridge().sendToThread(owner.threadId, {
 				type: ITC_EVENT_TYPES.MCP_SUBSCRIPTION_COMMAND,
 				message: { ...command, requestId, originator: currentThreadId(), streamToken: owner.token },
 			});
 		} catch (error) {
+			sendFailed = true;
 			harperLogger.error('Unable to route MCP subscription command', error);
 		}
 		if (!sent) {
 			clearTimeout(timer);
 			pending.delete(requestId);
-			resolve('no-live-stream');
+			resolve(sendFailed ? 'internal-error' : 'no-live-stream');
 		}
 	});
 }

--- a/components/mcp/subscriptionRouting.ts
+++ b/components/mcp/subscriptionRouting.ts
@@ -8,11 +8,11 @@ import { getRegisteredSession } from './sessionRegistry.ts';
 import { addResourceSubscription, removeResourceSubscription } from './subscriptions.ts';
 import type { AuthedUser } from './toolRegistry.ts';
 
-const DEFAULT_RESPONSE_TIMEOUT_MS = 2_000;
+const DEFAULT_RESPONSE_TIMEOUT_MS = 30_000;
 const MAX_PENDING = 100;
 const MAX_PENDING_PER_SESSION = 25;
 
-export type SubscriptionRouteResult = 'success' | 'not-subscribable' | 'no-live-stream' | 'internal-error';
+export type SubscriptionRouteResult = 'success' | 'not-subscribable' | 'no-live-stream' | 'timeout' | 'internal-error';
 type Operation = 'subscribe' | 'unsubscribe';
 
 interface Command {
@@ -56,8 +56,17 @@ let responseTimeoutMs = DEFAULT_RESPONSE_TIMEOUT_MS;
 
 function bridge(): ItcBridge {
 	if (bridgeOverride) return bridgeOverride;
-	const { onMessageByType } = require('../../server/threads/manageThreads.js');
-	return { sendToThread: threads.sendToThread.bind(threads), onMessageByType };
+	try {
+		const { onMessageByType } = require('../../server/threads/manageThreads.js');
+		if (typeof threads !== 'undefined' && typeof threads.sendToThread === 'function') {
+			return { sendToThread: threads.sendToThread.bind(threads), onMessageByType };
+		}
+	} catch (error) {
+		harperLogger.trace(`MCP subscription routing is unavailable: ${(error as Error).message}`);
+		return { sendToThread: () => false, onMessageByType: () => {} };
+	}
+	harperLogger.trace('MCP subscription routing is unavailable: thread bridge is not initialized');
+	return { sendToThread: () => false, onMessageByType: () => {} };
 }
 
 export function _setSubscriptionItcForTest(fake: ItcBridge | undefined): void {
@@ -100,7 +109,8 @@ function ensureWired(): void {
 		const response = event.message as Response;
 		const entry = pending.get(response?.requestId);
 		if (!entry || response.originator !== entry.targetThreadId) return;
-		if (!['success', 'not-subscribable', 'no-live-stream', 'internal-error'].includes(response.result)) return;
+		if (!['success', 'not-subscribable', 'no-live-stream', 'timeout', 'internal-error'].includes(response.result))
+			return;
 		clearTimeout(entry.timer);
 		pending.delete(response.requestId);
 		entry.resolve(response.result);
@@ -122,6 +132,7 @@ function countPendingForSession(sessionId: string): number {
 function subscriptionUser(user: AuthedUser): AuthedUser {
 	return {
 		...(user.username ? { username: user.username } : {}),
+		...(user.authExpiresAt !== undefined ? { authExpiresAt: user.authExpiresAt } : {}),
 		...(user._scopedToken ? { _scopedToken: true } : {}),
 		...(user.role
 			? {
@@ -146,7 +157,7 @@ function routeRemote(
 	return new Promise((resolve) => {
 		const timer = setTimeout(() => {
 			pending.delete(requestId);
-			resolve('no-live-stream');
+			resolve('timeout');
 		}, responseTimeoutMs);
 		timer.unref();
 		pending.set(requestId, { sessionId: command.sessionId, targetThreadId: owner.threadId, resolve, timer });
@@ -167,7 +178,7 @@ function routeRemote(
 	});
 }
 
-function serializeSessionOperation<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+export function withSessionSubscriptionLock<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
 	const previous = operationChains.get(sessionId) ?? Promise.resolve();
 	const current = previous.then(operation, operation);
 	const tail = current
@@ -185,7 +196,7 @@ function serializeSessionOperation<T>(sessionId: string, operation: () => Promis
 async function executeLocal(command: Command): Promise<SubscriptionRouteResult> {
 	const registered = getRegisteredSession(command.sessionId);
 	if (!registered || registered.streamToken !== command.streamToken) return 'no-live-stream';
-	return serializeSessionOperation(command.sessionId, async () => {
+	return withSessionSubscriptionLock(command.sessionId, async () => {
 		if (command.operation === 'subscribe') {
 			if (!command.user) return 'internal-error';
 			const added = await addResourceSubscription(command.sessionId, command.uri, command.user);

--- a/components/mcp/subscriptionRouting.ts
+++ b/components/mcp/subscriptionRouting.ts
@@ -149,7 +149,7 @@ function countPendingForSession(sessionId: string): number {
 	return count;
 }
 
-function subscriptionUser(user: AuthedUser): AuthedUser {
+export function subscriptionUser(user: AuthedUser): AuthedUser {
 	// Cross-worker subscribe authorization may rely only on this data-only principal shape.
 	// Built-in checks consume role.permission; credentials and mutable user state stay local.
 	return {

--- a/components/mcp/subscriptionRouting.ts
+++ b/components/mcp/subscriptionRouting.ts
@@ -139,9 +139,13 @@ function ensureWired(): boolean {
 	return true;
 }
 
-export async function claimSubscriptionOwner(sessionId: string, streamToken: string): Promise<void> {
-	if (!ensureWired()) throw new Error('MCP subscription routing is unavailable');
+export async function claimSubscriptionOwner(sessionId: string, streamToken: string): Promise<boolean> {
+	if (!ensureWired()) {
+		await patchSession(sessionId, { streamOwner: undefined });
+		return false;
+	}
 	await patchSession(sessionId, { streamOwner: { threadId: currentThreadId(), token: streamToken } });
+	return true;
 }
 
 function countPendingForSession(sessionId: string): number {
@@ -189,7 +193,13 @@ function routeRemote(
 		try {
 			sent = bridge().sendToThread(owner.threadId, {
 				type: ITC_EVENT_TYPES.MCP_SUBSCRIPTION_COMMAND,
-				message: { ...command, requestId, originator: currentThreadId(), streamToken: owner.token },
+				message: {
+					...command,
+					...(command.user ? { user: subscriptionUser(command.user) } : {}),
+					requestId,
+					originator: currentThreadId(),
+					streamToken: owner.token,
+				},
 			});
 		} catch (error) {
 			sendFailed = true;
@@ -282,13 +292,22 @@ export async function routeResourceSubscription(args: {
 	user?: AuthedUser;
 }): Promise<SubscriptionRouteResult> {
 	const owner = args.session.streamOwner;
-	if (!owner) return 'no-live-stream';
 	const command = {
 		sessionId: args.session.id,
 		operation: args.operation,
 		uri: args.uri,
-		...(args.user ? { user: subscriptionUser(args.user) } : {}),
+		...(args.user ? { user: args.user } : {}),
 	};
+	if (!owner) {
+		const registered = getRegisteredSession(args.session.id);
+		if (!registered) return 'no-live-stream';
+		return executeLocalContained({
+			...command,
+			requestId: '',
+			originator: currentThreadId(),
+			streamToken: registered.streamToken,
+		});
+	}
 	if (owner.threadId === currentThreadId()) {
 		return executeLocalContained({
 			...command,

--- a/components/mcp/subscriptionRouting.ts
+++ b/components/mcp/subscriptionRouting.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { threadId } from 'node:worker_threads';
 import { ITC_EVENT_TYPES } from '../../utility/hdbTerms.ts';
 import harperLogger from '../../utility/logging/harper_logger.ts';
-import { loadSession, patchSession, type McpSessionRecord } from './session.ts';
+import { patchSession, updateSessionSubscriptions, type McpSessionRecord } from './session.ts';
 import { getRegisteredSession } from './sessionRegistry.ts';
 import { addResourceSubscription, removeResourceSubscription } from './subscriptions.ts';
 import type { AuthedUser } from './toolRegistry.ts';
@@ -222,15 +222,12 @@ async function executeLocal(command: Command): Promise<SubscriptionRouteResult> 
 			const added = await addResourceSubscription(command.sessionId, command.uri, command.user);
 			if (!added) return 'not-subscribable';
 			try {
-				const session = await loadSession(command.sessionId);
+				const session = await updateSessionSubscriptions(command.sessionId, (subscriptions) =>
+					subscriptions.includes(command.uri) ? subscriptions : [...subscriptions, command.uri]
+				);
 				if (!session) {
 					removeResourceSubscription(command.sessionId, command.uri);
 					return 'no-live-stream';
-				}
-				if (!session.subscriptions?.includes(command.uri)) {
-					await patchSession(command.sessionId, {
-						subscriptions: [...(session.subscriptions ?? []), command.uri],
-					});
 				}
 				return 'success';
 			} catch (error) {
@@ -238,12 +235,9 @@ async function executeLocal(command: Command): Promise<SubscriptionRouteResult> 
 				throw error;
 			}
 		}
-		const session = await loadSession(command.sessionId);
-		if (session?.subscriptions?.includes(command.uri)) {
-			await patchSession(command.sessionId, {
-				subscriptions: session.subscriptions.filter((uri) => uri !== command.uri),
-			});
-		}
+		await updateSessionSubscriptions(command.sessionId, (subscriptions) =>
+			subscriptions.includes(command.uri) ? subscriptions.filter((uri) => uri !== command.uri) : subscriptions
+		);
 		removeResourceSubscription(command.sessionId, command.uri);
 		return 'success';
 	});

--- a/components/mcp/subscriptionRouting.ts
+++ b/components/mcp/subscriptionRouting.ts
@@ -299,6 +299,7 @@ export async function routeResourceSubscription(args: {
 		...(args.user ? { user: args.user } : {}),
 	};
 	if (!owner) {
+		if (ensureWired()) return 'no-live-stream';
 		const registered = getRegisteredSession(args.session.id);
 		if (!registered) return 'no-live-stream';
 		return executeLocalContained({

--- a/components/mcp/subscriptionRouting.ts
+++ b/components/mcp/subscriptionRouting.ts
@@ -31,6 +31,20 @@ interface Response {
 	result: SubscriptionRouteResult;
 }
 
+function isCommand(value: unknown): value is Command {
+	if (!value || typeof value !== 'object') return false;
+	const command = value as Partial<Command>;
+	return (
+		typeof command.requestId === 'string' &&
+		typeof command.originator === 'number' &&
+		typeof command.sessionId === 'string' &&
+		typeof command.streamToken === 'string' &&
+		(command.operation === 'subscribe' || command.operation === 'unsubscribe') &&
+		typeof command.uri === 'string' &&
+		(command.user === undefined || (command.user !== null && typeof command.user === 'object'))
+	);
+}
+
 interface ItcBridge {
 	available?: boolean;
 	sendToThread(threadId: number, event: { type: string; message: unknown }): boolean;
@@ -101,7 +115,11 @@ function ensureWired(): void {
 	const itc = bridge();
 	if (itc.available === false) return;
 	itc.onMessageByType(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_COMMAND, (event) => {
-		const command = event.message as Command;
+		const command = event.message;
+		if (!isCommand(command)) {
+			harperLogger.warn('Ignoring malformed MCP subscription command');
+			return;
+		}
 		void handleCommand(command).catch((error) => {
 			harperLogger.error('MCP subscription command failed', error);
 			sendResponse(command, 'internal-error');

--- a/components/mcp/subscriptionRouting.ts
+++ b/components/mcp/subscriptionRouting.ts
@@ -1,0 +1,261 @@
+/** Route MCP resource-subscription commands to the worker owning the GET-SSE stream. */
+import { randomUUID } from 'node:crypto';
+import { threadId } from 'node:worker_threads';
+import { ITC_EVENT_TYPES } from '../../utility/hdbTerms.ts';
+import harperLogger from '../../utility/logging/harper_logger.ts';
+import { loadSession, patchSession, type McpSessionRecord } from './session.ts';
+import { getRegisteredSession } from './sessionRegistry.ts';
+import { addResourceSubscription, removeResourceSubscription } from './subscriptions.ts';
+import type { AuthedUser } from './toolRegistry.ts';
+
+const DEFAULT_RESPONSE_TIMEOUT_MS = 2_000;
+const MAX_PENDING = 100;
+const MAX_PENDING_PER_SESSION = 25;
+
+export type SubscriptionRouteResult = 'success' | 'not-subscribable' | 'no-live-stream' | 'internal-error';
+type Operation = 'subscribe' | 'unsubscribe';
+
+interface Command {
+	requestId: string;
+	originator: number;
+	sessionId: string;
+	streamToken: string;
+	operation: Operation;
+	uri: string;
+	user?: AuthedUser;
+}
+
+interface Response {
+	requestId: string;
+	originator: number;
+	result: SubscriptionRouteResult;
+}
+
+interface ItcBridge {
+	sendToThread(threadId: number, event: { type: string; message: unknown }): boolean;
+	onMessageByType(type: string, listener: (event: { message?: unknown }) => void): void;
+}
+
+// manageThreads assigns this connected-port array as the package-global `threads` export. Its
+// direct-send helper lives on that array, while typed listener registration is a module export.
+declare const threads: { sendToThread(threadId: number, event: { type: string; message: unknown }): boolean };
+
+interface Pending {
+	sessionId: string;
+	targetThreadId: number;
+	resolve: (result: SubscriptionRouteResult) => void;
+	timer: ReturnType<typeof setTimeout>;
+}
+
+const pending = new Map<string, Pending>();
+const operationChains = new Map<string, Promise<unknown>>();
+let wired = false;
+let bridgeOverride: ItcBridge | undefined;
+let currentThreadId = (): number => threadId;
+let responseTimeoutMs = DEFAULT_RESPONSE_TIMEOUT_MS;
+
+function bridge(): ItcBridge {
+	if (bridgeOverride) return bridgeOverride;
+	const { onMessageByType } = require('../../server/threads/manageThreads.js');
+	return { sendToThread: threads.sendToThread.bind(threads), onMessageByType };
+}
+
+export function _setSubscriptionItcForTest(fake: ItcBridge | undefined): void {
+	bridgeOverride = fake;
+	wired = false;
+}
+
+export function _setSubscriptionThreadIdForTest(value: number | undefined): void {
+	currentThreadId = value === undefined ? () => threadId : () => value;
+}
+
+export function _setSubscriptionTimeoutForTest(value: number | undefined): void {
+	responseTimeoutMs = value ?? DEFAULT_RESPONSE_TIMEOUT_MS;
+}
+
+export function _resetSubscriptionRoutingForTest(): void {
+	for (const entry of pending.values()) clearTimeout(entry.timer);
+	pending.clear();
+	operationChains.clear();
+	wired = false;
+	currentThreadId = () => threadId;
+	responseTimeoutMs = DEFAULT_RESPONSE_TIMEOUT_MS;
+}
+
+export function _pendingSubscriptionRouteCount(): number {
+	return pending.size;
+}
+
+function ensureWired(): void {
+	if (wired) return;
+	wired = true;
+	bridge().onMessageByType(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_COMMAND, (event) => {
+		const command = event.message as Command;
+		void handleCommand(command).catch((error) => {
+			harperLogger.error('MCP subscription command failed', error);
+			sendResponse(command, 'internal-error');
+		});
+	});
+	bridge().onMessageByType(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_RESPONSE, (event) => {
+		const response = event.message as Response;
+		const entry = pending.get(response?.requestId);
+		if (!entry || response.originator !== entry.targetThreadId) return;
+		if (!['success', 'not-subscribable', 'no-live-stream', 'internal-error'].includes(response.result)) return;
+		clearTimeout(entry.timer);
+		pending.delete(response.requestId);
+		entry.resolve(response.result);
+	});
+}
+
+/** Attach the owner-side command listener and persist the routing hint for a new GET stream. */
+export async function claimSubscriptionOwner(sessionId: string, streamToken: string): Promise<void> {
+	ensureWired();
+	await patchSession(sessionId, { streamOwner: { threadId: currentThreadId(), token: streamToken } });
+}
+
+function countPendingForSession(sessionId: string): number {
+	let count = 0;
+	for (const entry of pending.values()) if (entry.sessionId === sessionId) count++;
+	return count;
+}
+
+function subscriptionUser(user: AuthedUser): AuthedUser {
+	return {
+		...(user.username ? { username: user.username } : {}),
+		...(user._scopedToken ? { _scopedToken: true } : {}),
+		...(user.role
+			? {
+					role: {
+						...(user.role.role ? { role: user.role.role } : {}),
+						...(user.role.permission ? { permission: user.role.permission } : {}),
+					},
+				}
+			: {}),
+	};
+}
+
+function routeRemote(
+	owner: NonNullable<McpSessionRecord['streamOwner']>,
+	command: Omit<Command, 'requestId' | 'originator' | 'streamToken'>
+): Promise<SubscriptionRouteResult> {
+	ensureWired();
+	if (pending.size >= MAX_PENDING || countPendingForSession(command.sessionId) >= MAX_PENDING_PER_SESSION) {
+		return Promise.resolve('internal-error');
+	}
+	const requestId = randomUUID();
+	return new Promise((resolve) => {
+		const timer = setTimeout(() => {
+			pending.delete(requestId);
+			resolve('no-live-stream');
+		}, responseTimeoutMs);
+		timer.unref();
+		pending.set(requestId, { sessionId: command.sessionId, targetThreadId: owner.threadId, resolve, timer });
+		let sent = false;
+		try {
+			sent = bridge().sendToThread(owner.threadId, {
+				type: ITC_EVENT_TYPES.MCP_SUBSCRIPTION_COMMAND,
+				message: { ...command, requestId, originator: currentThreadId(), streamToken: owner.token },
+			});
+		} catch (error) {
+			harperLogger.error('Unable to route MCP subscription command', error);
+		}
+		if (!sent) {
+			clearTimeout(timer);
+			pending.delete(requestId);
+			resolve('no-live-stream');
+		}
+	});
+}
+
+function serializeSessionOperation<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+	const previous = operationChains.get(sessionId) ?? Promise.resolve();
+	const current = previous.then(operation, operation);
+	const tail = current
+		.then(
+			() => undefined,
+			() => undefined
+		)
+		.finally(() => {
+			if (operationChains.get(sessionId) === tail) operationChains.delete(sessionId);
+		});
+	operationChains.set(sessionId, tail);
+	return current;
+}
+
+async function executeLocal(command: Command): Promise<SubscriptionRouteResult> {
+	const registered = getRegisteredSession(command.sessionId);
+	if (!registered || registered.streamToken !== command.streamToken) return 'no-live-stream';
+	return serializeSessionOperation(command.sessionId, async () => {
+		if (command.operation === 'subscribe') {
+			if (!command.user) return 'internal-error';
+			const added = await addResourceSubscription(command.sessionId, command.uri, command.user);
+			if (!added) return 'not-subscribable';
+			try {
+				const session = await loadSession(command.sessionId);
+				if (!session) {
+					removeResourceSubscription(command.sessionId, command.uri);
+					return 'no-live-stream';
+				}
+				if (!session.subscriptions?.includes(command.uri)) {
+					await patchSession(command.sessionId, {
+						subscriptions: [...(session.subscriptions ?? []), command.uri],
+					});
+				}
+				return 'success';
+			} catch (error) {
+				removeResourceSubscription(command.sessionId, command.uri);
+				throw error;
+			}
+		}
+		const session = await loadSession(command.sessionId);
+		if (session?.subscriptions?.includes(command.uri)) {
+			await patchSession(command.sessionId, {
+				subscriptions: session.subscriptions.filter((uri) => uri !== command.uri),
+			});
+		}
+		removeResourceSubscription(command.sessionId, command.uri);
+		return 'success';
+	});
+}
+
+async function handleCommand(command: Command): Promise<void> {
+	let result: SubscriptionRouteResult;
+	try {
+		result = await executeLocal(command);
+	} catch (error) {
+		harperLogger.error('MCP subscription owner failed to execute command', error);
+		result = 'internal-error';
+	}
+	sendResponse(command, result);
+}
+
+function sendResponse(command: Command, result: SubscriptionRouteResult): void {
+	try {
+		bridge().sendToThread(command.originator, {
+			type: ITC_EVENT_TYPES.MCP_SUBSCRIPTION_RESPONSE,
+			message: { requestId: command.requestId, originator: currentThreadId(), result } satisfies Response,
+		});
+	} catch (error) {
+		harperLogger.trace(`Unable to return MCP subscription response: ${(error as Error).message}`);
+	}
+}
+
+export async function routeResourceSubscription(args: {
+	session: McpSessionRecord;
+	operation: Operation;
+	uri: string;
+	user?: AuthedUser;
+}): Promise<SubscriptionRouteResult> {
+	const owner = args.session.streamOwner;
+	if (!owner) return 'no-live-stream';
+	const command = {
+		sessionId: args.session.id,
+		operation: args.operation,
+		uri: args.uri,
+		...(args.user ? { user: subscriptionUser(args.user) } : {}),
+	};
+	if (owner.threadId === currentThreadId()) {
+		return executeLocal({ ...command, requestId: '', originator: currentThreadId(), streamToken: owner.token });
+	}
+	return routeRemote(owner, command);
+}

--- a/components/mcp/subscriptionRouting.ts
+++ b/components/mcp/subscriptionRouting.ts
@@ -133,13 +133,13 @@ function countPendingForSession(sessionId: string): number {
 
 function subscriptionUser(user: AuthedUser): AuthedUser {
 	return {
-		...(user.username ? { username: user.username } : {}),
+		...(user.username !== undefined ? { username: user.username } : {}),
 		...(user.authExpiresAt !== undefined ? { authExpiresAt: user.authExpiresAt } : {}),
 		...(user._scopedToken ? { _scopedToken: true } : {}),
 		...(user.role
 			? {
 					role: {
-						...(user.role.role ? { role: user.role.role } : {}),
+						...(user.role.role !== undefined ? { role: user.role.role } : {}),
 						...(user.role.permission ? { permission: user.role.permission } : {}),
 					},
 				}

--- a/components/mcp/subscriptionRouting.ts
+++ b/components/mcp/subscriptionRouting.ts
@@ -150,6 +150,8 @@ function countPendingForSession(sessionId: string): number {
 }
 
 function subscriptionUser(user: AuthedUser): AuthedUser {
+	// Cross-worker subscribe authorization may rely only on this data-only principal shape.
+	// Built-in checks consume role.permission; credentials and mutable user state stay local.
 	return {
 		...(user.username !== undefined ? { username: user.username } : {}),
 		...(user.authExpiresAt !== undefined ? { authExpiresAt: user.authExpiresAt } : {}),
@@ -217,6 +219,8 @@ async function executeLocal(command: Command): Promise<SubscriptionRouteResult> 
 	const registered = getRegisteredSession(command.sessionId);
 	if (!registered || registered.streamToken !== command.streamToken) return 'no-live-stream';
 	return withSessionSubscriptionLock(command.sessionId, async () => {
+		const current = getRegisteredSession(command.sessionId);
+		if (!current || current.streamToken !== command.streamToken) return 'no-live-stream';
 		if (command.operation === 'subscribe') {
 			if (!command.user) return 'internal-error';
 			const added = await addResourceSubscription(command.sessionId, command.uri, command.user);
@@ -243,14 +247,17 @@ async function executeLocal(command: Command): Promise<SubscriptionRouteResult> 
 	});
 }
 
-async function handleCommand(command: Command): Promise<void> {
-	let result: SubscriptionRouteResult;
+async function executeLocalContained(command: Command): Promise<SubscriptionRouteResult> {
 	try {
-		result = await executeLocal(command);
+		return await executeLocal(command);
 	} catch (error) {
 		harperLogger.error('MCP subscription owner failed to execute command', error);
-		result = 'internal-error';
+		return 'internal-error';
 	}
+}
+
+async function handleCommand(command: Command): Promise<void> {
+	const result = await executeLocalContained(command);
 	sendResponse(command, result);
 }
 
@@ -280,7 +287,12 @@ export async function routeResourceSubscription(args: {
 		...(args.user ? { user: subscriptionUser(args.user) } : {}),
 	};
 	if (owner.threadId === currentThreadId()) {
-		return executeLocal({ ...command, requestId: '', originator: currentThreadId(), streamToken: owner.token });
+		return executeLocalContained({
+			...command,
+			requestId: '',
+			originator: currentThreadId(),
+			streamToken: owner.token,
+		});
 	}
 	return routeRemote(owner, command);
 }

--- a/components/mcp/subscriptions.ts
+++ b/components/mcp/subscriptions.ts
@@ -74,23 +74,24 @@ export function dropSessionSubscriptions(sessionId: string): void {
 /**
  * Re-establish subscriptions on SSE reconnect from the durable URI list. Each is
  * best-effort: a URI that's no longer subscribable (resource removed) is skipped.
- * Returns the URIs that were successfully restored (the caller prunes the rest
- * from the durable record).
+ * Returns the URIs that should remain durable: successful subscriptions and
+ * retryable failures are retained, while confirmed non-subscribable URIs are omitted.
  */
 export async function restoreResourceSubscriptions(
 	sessionId: string,
 	uris: ReadonlyArray<string>,
 	user: AuthedUser
 ): Promise<string[]> {
-	const restored: string[] = [];
+	const retained: string[] = [];
 	for (const uri of uris) {
 		try {
-			if (await addResourceSubscription(sessionId, uri, user)) restored.push(uri);
+			if (await addResourceSubscription(sessionId, uri, user)) retained.push(uri);
 		} catch (err) {
 			harperLogger.trace(`MCP subscription restore ${uri}: ${(err as Error).message}`);
+			retained.push(uri);
 		}
 	}
-	return restored;
+	return retained;
 }
 
 /** Test seam — count of live subscriptions for a session. */

--- a/components/mcp/toolRegistry.ts
+++ b/components/mcp/toolRegistry.ts
@@ -60,6 +60,7 @@ export interface ToolDescriptor {
 /** Authenticated user object as Harper builds it (subset we touch). */
 export interface AuthedUser {
 	username?: string;
+	authExpiresAt?: number;
 	// Attribution-only principal that must not be re-resolved against hdb_user (see refreshSessionUser).
 	_scopedToken?: boolean;
 	role?: {

--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -32,16 +32,12 @@ import { decodeCursor } from './pagination.ts';
 import { seedSessionSnapshot } from './listChanged.ts';
 import { tryAdmit, resolveClientIdentity } from './rateLimit.ts';
 import { checkDurableQuota } from './quota.ts';
-import { deleteSession, loadSession, saveSession, touchSession, type McpSessionRecord } from './session.ts';
+import { deleteSession, loadSession, patchSession, touchSession, type McpSessionRecord } from './session.ts';
 import { listResources, listResourceTemplates, readResource, completeResourceArgument } from './resources.ts';
 import { ensureApplicationToolsFresh } from './tools/application.ts';
 import { getPrompt, listPrompts, completePromptArgument } from './promptRegistry.ts';
-import {
-	addResourceSubscription,
-	removeResourceSubscription,
-	dropSessionSubscriptions,
-	restoreResourceSubscriptions,
-} from './subscriptions.ts';
+import { dropSessionSubscriptions, restoreResourceSubscriptions } from './subscriptions.ts';
+import { claimSubscriptionOwner, routeResourceSubscription } from './subscriptionRouting.ts';
 import {
 	sendServerRequest,
 	routeClientResponse,
@@ -50,8 +46,8 @@ import {
 } from './serverRequests.ts';
 import {
 	registerSession,
+	unregisterSession,
 	touchRegisteredSession,
-	getRegisteredSession,
 	replaySince,
 	type SseEvent,
 } from './sessionRegistry.ts';
@@ -370,7 +366,7 @@ async function dispatchSetLevel(
 	// on the worker where the change fires. Cross-worker push is a separate,
 	// subsystem-wide design item (tracked in the MCP design-doc issue).
 	session.logLevel = level;
-	await saveSession(session);
+	await patchSession(session.id, { logLevel: level });
 	setSessionLogLevel(session.id, level);
 	return jsonResponse(200, buildSuccess(messageId, {}));
 }
@@ -403,6 +399,12 @@ async function handleGet(request: NormRequest): Promise<NormResponse> {
 		};
 	}
 	const record = registerSession(sessionId, request.profile, effectiveUser(request));
+	try {
+		await claimSubscriptionOwner(sessionId, record.streamToken);
+	} catch (error) {
+		unregisterSession(sessionId);
+		throw error;
+	}
 	// Seed the live record with any previously-set logging level so a reconnect
 	// (or a setLevel that preceded this stream) keeps delivering notifications/message.
 	// (A fresh record's logLevel is already undefined, so a direct assign is safe.)
@@ -420,7 +422,7 @@ async function handleGet(request: NormRequest): Promise<NormResponse> {
 		const restored = await restoreResourceSubscriptions(sessionId, session.subscriptions, effectiveUser(request));
 		if (restored.length !== session.subscriptions.length) {
 			session.subscriptions = restored;
-			await saveSession(session);
+			await patchSession(session.id, { subscriptions: restored });
 		}
 	}
 	// Resumability (#3.8): on reconnect with Last-Event-ID, replay buffered frames
@@ -917,26 +919,25 @@ async function dispatchResourcesSubscribe(
 			buildError(messageId, ERROR_CODES.INVALID_PARAMS, 'resources/subscribe requires params.uri')
 		);
 	}
-	// Require a live GET SSE stream: that's where notifications/resources/updated is
-	// delivered, and its 'close' is the only teardown hook for the subscription. A
-	// subscription opened without a stream would leak its audit-log iterator and
-	// drop every update silently.
-	if (!getRegisteredSession(session.id)) {
+	const result = await routeResourceSubscription({
+		session,
+		operation: 'subscribe',
+		uri,
+		user: effectiveUser(request),
+	});
+	if (result === 'no-live-stream') {
 		return jsonResponse(
 			200,
 			buildError(messageId, ERROR_CODES.INVALID_PARAMS, 'open the GET SSE stream before subscribing to resources')
 		);
 	}
-	const ok = await addResourceSubscription(session.id, uri, effectiveUser(request));
-	if (!ok) {
+	if (result === 'not-subscribable') {
 		// Only row-backed application resources are subscribable; synthetic harper://*
 		// URIs (and unknown URIs) have no change source.
 		return jsonResponse(200, buildError(messageId, ERROR_CODES.INVALID_PARAMS, `resource is not subscribable: ${uri}`));
 	}
-	// Persist the URI on the durable record so it survives an SSE reconnect.
-	if (!session.subscriptions?.includes(uri)) {
-		session.subscriptions = [...(session.subscriptions ?? []), uri];
-		await saveSession(session);
+	if (result === 'internal-error') {
+		return jsonResponse(200, buildError(messageId, ERROR_CODES.INTERNAL_ERROR, 'resource subscription failed'));
 	}
 	return jsonResponse(200, buildSuccess(messageId, {}));
 }
@@ -955,10 +956,16 @@ async function dispatchResourcesUnsubscribe(
 			buildError(messageId, ERROR_CODES.INVALID_PARAMS, 'resources/unsubscribe requires params.uri')
 		);
 	}
-	removeResourceSubscription(session.id, uri);
-	if (session.subscriptions?.includes(uri)) {
-		session.subscriptions = session.subscriptions.filter((u) => u !== uri);
-		await saveSession(session);
+	const result = await routeResourceSubscription({ session, operation: 'unsubscribe', uri });
+	if (result === 'no-live-stream') {
+		// The live owner is already gone. Remove durable state locally so a later
+		// reconnect cannot restore the cancelled subscription.
+		const fresh = await loadSession(session.id);
+		if (fresh?.subscriptions?.includes(uri)) {
+			await patchSession(session.id, { subscriptions: fresh.subscriptions.filter((u) => u !== uri) });
+		}
+	} else if (result === 'internal-error') {
+		return jsonResponse(200, buildError(messageId, ERROR_CODES.INTERNAL_ERROR, 'resource unsubscribe failed'));
 	}
 	return jsonResponse(200, buildSuccess(messageId, {}));
 }

--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -47,7 +47,6 @@ import { dropSessionSubscriptions, restoreResourceSubscriptions } from './subscr
 import {
 	claimSubscriptionOwner,
 	routeResourceSubscription,
-	subscriptionUser,
 	withSessionSubscriptionLock,
 } from './subscriptionRouting.ts';
 import {
@@ -264,8 +263,8 @@ async function handlePost(request: NormRequest): Promise<NormResponse> {
 		return { status: 403, headers: {} };
 	}
 
-	// Sliding-window idle reset. Await persistence before dispatch; loadSession
-	// rejects any partial row left by a concurrent DELETE/patch race.
+	// Adopt the persisted sliding-window update so later writes cannot roll
+	// lastActivity back; loadSession rejects partial rows from DELETE/patch races.
 	session = await touchSession(session);
 
 	// A client's response to a server→client request (#3.7): route it to the
@@ -428,24 +427,25 @@ async function handleGet(request: NormRequest): Promise<NormResponse> {
 	// Restore durable resource subscriptions (#3.6) on (re)connect. Best-effort:
 	// a URI that's no longer subscribable is dropped from the persisted list.
 	try {
-		await withSessionSubscriptionLock(sessionId, async () => {
+		const sessionPresent = await withSessionSubscriptionLock(sessionId, async () => {
 			const snapshot = await updateSessionSubscriptions(sessionId, (subscriptions) => subscriptions);
-			if (!snapshot) throw new Error('MCP session disappeared during subscription restore');
+			if (!snapshot) return false;
 			const attempted = snapshot.subscriptions ?? [];
-			if (!attempted.length) return;
-			const retained = await restoreResourceSubscriptions(
-				sessionId,
-				attempted,
-				subscriptionUser(effectiveUser(request))
-			);
-			if (retained.length === attempted.length) return;
+			if (!attempted.length) return true;
+			const retained = await restoreResourceSubscriptions(sessionId, attempted, effectiveUser(request));
+			if (retained.length === attempted.length) return true;
 			const attemptedSet = new Set(attempted);
 			const retainedSet = new Set(retained);
 			await updateSessionSubscriptions(sessionId, (subscriptions) => {
 				const updated = subscriptions.filter((uri) => !attemptedSet.has(uri) || retainedSet.has(uri));
 				return updated.length === subscriptions.length ? subscriptions : updated;
 			});
+			return true;
 		});
+		if (!sessionPresent) {
+			record.queue.emit('close');
+			return { status: 404, headers: {} };
+		}
 	} catch (error) {
 		record.queue.emit('close');
 		throw error;

--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -256,11 +256,8 @@ async function handlePost(request: NormRequest): Promise<NormResponse> {
 		return { status: 403, headers: {} };
 	}
 
-	// Sliding-window idle reset. Awaited (not fire-and-forget) so a concurrent
-	// DELETE that arrives mid-request can't be resurrected by a late put. Adopt
-	// the touched copy (fresh `lastActivity`) so any later save in this request
-	// — `handleInitialized`, `dispatchSetLevel` — persists the current activity
-	// time instead of rolling it back to the load-time value.
+	// Sliding-window idle reset. Await persistence before dispatch; loadSession
+	// rejects any partial row left by a concurrent DELETE/patch race.
 	session = await touchSession(session);
 
 	// A client's response to a server→client request (#3.7): route it to the

--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -32,7 +32,14 @@ import { decodeCursor } from './pagination.ts';
 import { seedSessionSnapshot } from './listChanged.ts';
 import { tryAdmit, resolveClientIdentity } from './rateLimit.ts';
 import { checkDurableQuota } from './quota.ts';
-import { deleteSession, loadSession, patchSession, touchSession, type McpSessionRecord } from './session.ts';
+import {
+	deleteSession,
+	loadSession,
+	patchSession,
+	touchSession,
+	updateSessionSubscriptions,
+	type McpSessionRecord,
+} from './session.ts';
 import { listResources, listResourceTemplates, readResource, completeResourceArgument } from './resources.ts';
 import { ensureApplicationToolsFresh } from './tools/application.ts';
 import { getPrompt, listPrompts, completePromptArgument } from './promptRegistry.ts';
@@ -419,13 +426,13 @@ async function handleGet(request: NormRequest): Promise<NormResponse> {
 	record.queue.once('close', () => dropSessionSubscriptions(sessionId));
 	// Restore durable resource subscriptions (#3.6) on (re)connect. Best-effort:
 	// a URI that's no longer subscribable is dropped from the persisted list.
-	await withSessionSubscriptionLock(sessionId, async () => {
-		const currentSession = await loadSession(sessionId);
-		const subscriptions = currentSession?.subscriptions;
-		if (!subscriptions?.length) return;
-		const restored = await restoreResourceSubscriptions(sessionId, subscriptions, effectiveUser(request));
-		if (restored.length !== subscriptions.length) await patchSession(sessionId, { subscriptions: restored });
-	});
+	await withSessionSubscriptionLock(sessionId, () =>
+		updateSessionSubscriptions(sessionId, async (subscriptions) => {
+			if (!subscriptions.length) return subscriptions;
+			const restored = await restoreResourceSubscriptions(sessionId, subscriptions, effectiveUser(request));
+			return restored.length === subscriptions.length ? subscriptions : restored;
+		})
+	);
 	// Resumability (#3.8): on reconnect with Last-Event-ID, replay buffered frames
 	// the client missed (those with a higher id) before live frames flow. Re-sent
 	// raw so their original event ids are preserved. Best-effort + per-worker: the
@@ -967,10 +974,9 @@ async function dispatchResourcesUnsubscribe(
 	if (result === 'no-live-stream') {
 		// The live owner is already gone. Remove durable state locally so a later
 		// reconnect cannot restore the cancelled subscription.
-		const fresh = await loadSession(session.id);
-		if (fresh?.subscriptions?.includes(uri)) {
-			await patchSession(session.id, { subscriptions: fresh.subscriptions.filter((u) => u !== uri) });
-		}
+		await updateSessionSubscriptions(session.id, (subscriptions) =>
+			subscriptions.includes(uri) ? subscriptions.filter((subscription) => subscription !== uri) : subscriptions
+		);
 	} else if (result === 'timeout') {
 		return jsonResponse(
 			200,

--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -37,7 +37,11 @@ import { listResources, listResourceTemplates, readResource, completeResourceArg
 import { ensureApplicationToolsFresh } from './tools/application.ts';
 import { getPrompt, listPrompts, completePromptArgument } from './promptRegistry.ts';
 import { dropSessionSubscriptions, restoreResourceSubscriptions } from './subscriptions.ts';
-import { claimSubscriptionOwner, routeResourceSubscription } from './subscriptionRouting.ts';
+import {
+	claimSubscriptionOwner,
+	routeResourceSubscription,
+	withSessionSubscriptionLock,
+} from './subscriptionRouting.ts';
 import {
 	sendServerRequest,
 	routeClientResponse,
@@ -418,13 +422,13 @@ async function handleGet(request: NormRequest): Promise<NormResponse> {
 	record.queue.once('close', () => dropSessionSubscriptions(sessionId));
 	// Restore durable resource subscriptions (#3.6) on (re)connect. Best-effort:
 	// a URI that's no longer subscribable is dropped from the persisted list.
-	if (session.subscriptions?.length) {
-		const restored = await restoreResourceSubscriptions(sessionId, session.subscriptions, effectiveUser(request));
-		if (restored.length !== session.subscriptions.length) {
-			session.subscriptions = restored;
-			await patchSession(session.id, { subscriptions: restored });
-		}
-	}
+	await withSessionSubscriptionLock(sessionId, async () => {
+		const currentSession = await loadSession(sessionId);
+		const subscriptions = currentSession?.subscriptions;
+		if (!subscriptions?.length) return;
+		const restored = await restoreResourceSubscriptions(sessionId, subscriptions, effectiveUser(request));
+		if (restored.length !== subscriptions.length) await patchSession(sessionId, { subscriptions: restored });
+	});
 	// Resumability (#3.8): on reconnect with Last-Event-ID, replay buffered frames
 	// the client missed (those with a higher id) before live frames flow. Re-sent
 	// raw so their original event ids are preserved. Best-effort + per-worker: the
@@ -936,6 +940,12 @@ async function dispatchResourcesSubscribe(
 		// URIs (and unknown URIs) have no change source.
 		return jsonResponse(200, buildError(messageId, ERROR_CODES.INVALID_PARAMS, `resource is not subscribable: ${uri}`));
 	}
+	if (result === 'timeout') {
+		return jsonResponse(
+			200,
+			buildError(messageId, ERROR_CODES.INTERNAL_ERROR, 'resource subscription timed out; retry the request')
+		);
+	}
 	if (result === 'internal-error') {
 		return jsonResponse(200, buildError(messageId, ERROR_CODES.INTERNAL_ERROR, 'resource subscription failed'));
 	}
@@ -964,6 +974,11 @@ async function dispatchResourcesUnsubscribe(
 		if (fresh?.subscriptions?.includes(uri)) {
 			await patchSession(session.id, { subscriptions: fresh.subscriptions.filter((u) => u !== uri) });
 		}
+	} else if (result === 'timeout') {
+		return jsonResponse(
+			200,
+			buildError(messageId, ERROR_CODES.INTERNAL_ERROR, 'resource unsubscribe timed out; retry the request')
+		);
 	} else if (result === 'internal-error') {
 		return jsonResponse(200, buildError(messageId, ERROR_CODES.INTERNAL_ERROR, 'resource unsubscribe failed'));
 	}

--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -428,17 +428,24 @@ async function handleGet(request: NormRequest): Promise<NormResponse> {
 	// Restore durable resource subscriptions (#3.6) on (re)connect. Best-effort:
 	// a URI that's no longer subscribable is dropped from the persisted list.
 	try {
-		await withSessionSubscriptionLock(sessionId, () =>
-			updateSessionSubscriptions(sessionId, async (subscriptions) => {
-				if (!subscriptions.length) return subscriptions;
-				const restored = await restoreResourceSubscriptions(
-					sessionId,
-					subscriptions,
-					subscriptionUser(effectiveUser(request))
-				);
-				return restored.length === subscriptions.length ? subscriptions : restored;
-			})
-		);
+		await withSessionSubscriptionLock(sessionId, async () => {
+			const snapshot = await updateSessionSubscriptions(sessionId, (subscriptions) => subscriptions);
+			if (!snapshot) throw new Error('MCP session disappeared during subscription restore');
+			const attempted = snapshot.subscriptions ?? [];
+			if (!attempted.length) return;
+			const retained = await restoreResourceSubscriptions(
+				sessionId,
+				attempted,
+				subscriptionUser(effectiveUser(request))
+			);
+			if (retained.length === attempted.length) return;
+			const attemptedSet = new Set(attempted);
+			const retainedSet = new Set(retained);
+			await updateSessionSubscriptions(sessionId, (subscriptions) => {
+				const updated = subscriptions.filter((uri) => !attemptedSet.has(uri) || retainedSet.has(uri));
+				return updated.length === subscriptions.length ? subscriptions : updated;
+			});
+		});
 	} catch (error) {
 		record.queue.emit('close');
 		throw error;
@@ -981,18 +988,25 @@ async function dispatchResourcesUnsubscribe(
 			buildError(messageId, ERROR_CODES.INVALID_PARAMS, 'resources/unsubscribe requires params.uri')
 		);
 	}
-	let result = await routeResourceSubscription({ session, operation: 'unsubscribe', uri });
-	if (result === 'no-live-stream') {
+	let routedSession = session;
+	let result: Awaited<ReturnType<typeof routeResourceSubscription>> = 'no-live-stream';
+	let ownerChangedAfterFinalAttempt = false;
+	for (let attempt = 0; attempt < 3; attempt++) {
+		result = await routeResourceSubscription({ session: routedSession, operation: 'unsubscribe', uri });
+		if (result !== 'no-live-stream') break;
 		const currentSession = await loadSession(session.id);
-		const owner = session.streamOwner;
+		const owner = routedSession.streamOwner;
 		const currentOwner = currentSession?.streamOwner;
-		if (
-			currentSession &&
-			currentOwner &&
-			(!owner || currentOwner.threadId !== owner.threadId || currentOwner.token !== owner.token)
-		) {
-			result = await routeResourceSubscription({ session: currentSession, operation: 'unsubscribe', uri });
-		}
+		if (!currentSession || !currentOwner) break;
+		if (owner && currentOwner.threadId === owner.threadId && currentOwner.token === owner.token) break;
+		routedSession = currentSession;
+		ownerChangedAfterFinalAttempt = attempt === 2;
+	}
+	if (result === 'no-live-stream' && ownerChangedAfterFinalAttempt) {
+		return jsonResponse(
+			200,
+			buildError(messageId, ERROR_CODES.INTERNAL_ERROR, 'resource unsubscribe owner changed; retry the request')
+		);
 	}
 	if (result === 'no-live-stream') {
 		// The live owner is already gone. Remove durable state locally so a later

--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -57,7 +57,6 @@ import {
 } from './serverRequests.ts';
 import {
 	registerSession,
-	unregisterSession,
 	touchRegisteredSession,
 	replaySince,
 	type SseEvent,
@@ -410,7 +409,7 @@ async function handleGet(request: NormRequest): Promise<NormResponse> {
 	try {
 		await claimSubscriptionOwner(sessionId, record.streamToken);
 	} catch (error) {
-		unregisterSession(sessionId);
+		record.queue.emit('close');
 		throw error;
 	}
 	// Seed the live record with any previously-set logging level so a reconnect
@@ -970,7 +969,19 @@ async function dispatchResourcesUnsubscribe(
 			buildError(messageId, ERROR_CODES.INVALID_PARAMS, 'resources/unsubscribe requires params.uri')
 		);
 	}
-	const result = await routeResourceSubscription({ session, operation: 'unsubscribe', uri });
+	let result = await routeResourceSubscription({ session, operation: 'unsubscribe', uri });
+	if (result === 'no-live-stream') {
+		const currentSession = await loadSession(session.id);
+		const owner = session.streamOwner;
+		const currentOwner = currentSession?.streamOwner;
+		if (
+			currentSession &&
+			currentOwner &&
+			(!owner || currentOwner.threadId !== owner.threadId || currentOwner.token !== owner.token)
+		) {
+			result = await routeResourceSubscription({ session: currentSession, operation: 'unsubscribe', uri });
+		}
+	}
 	if (result === 'no-live-stream') {
 		// The live owner is already gone. Remove durable state locally so a later
 		// reconnect cannot restore the cancelled subscription.

--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -47,6 +47,7 @@ import { dropSessionSubscriptions, restoreResourceSubscriptions } from './subscr
 import {
 	claimSubscriptionOwner,
 	routeResourceSubscription,
+	subscriptionUser,
 	withSessionSubscriptionLock,
 } from './subscriptionRouting.ts';
 import {
@@ -57,6 +58,7 @@ import {
 } from './serverRequests.ts';
 import {
 	registerSession,
+	getRegisteredSession,
 	touchRegisteredSession,
 	replaySince,
 	type SseEvent,
@@ -425,13 +427,23 @@ async function handleGet(request: NormRequest): Promise<NormResponse> {
 	record.queue.once('close', () => dropSessionSubscriptions(sessionId));
 	// Restore durable resource subscriptions (#3.6) on (re)connect. Best-effort:
 	// a URI that's no longer subscribable is dropped from the persisted list.
-	await withSessionSubscriptionLock(sessionId, () =>
-		updateSessionSubscriptions(sessionId, async (subscriptions) => {
-			if (!subscriptions.length) return subscriptions;
-			const restored = await restoreResourceSubscriptions(sessionId, subscriptions, effectiveUser(request));
-			return restored.length === subscriptions.length ? subscriptions : restored;
-		})
-	);
+	try {
+		await withSessionSubscriptionLock(sessionId, () =>
+			updateSessionSubscriptions(sessionId, async (subscriptions) => {
+				if (!subscriptions.length) return subscriptions;
+				const restored = await restoreResourceSubscriptions(
+					sessionId,
+					subscriptions,
+					subscriptionUser(effectiveUser(request))
+				);
+				return restored.length === subscriptions.length ? subscriptions : restored;
+			})
+		);
+	} catch (error) {
+		record.queue.emit('close');
+		throw error;
+	}
+	if (getRegisteredSession(sessionId) !== record) dropSessionSubscriptions(sessionId);
 	// Resumability (#3.8): on reconnect with Last-Event-ID, replay buffered frames
 	// the client missed (those with a higher id) before live frames flow. Re-sent
 	// raw so their original event ids are preserved. Best-effort + per-worker: the
@@ -985,9 +997,17 @@ async function dispatchResourcesUnsubscribe(
 	if (result === 'no-live-stream') {
 		// The live owner is already gone. Remove durable state locally so a later
 		// reconnect cannot restore the cancelled subscription.
-		await updateSessionSubscriptions(session.id, (subscriptions) =>
-			subscriptions.includes(uri) ? subscriptions.filter((subscription) => subscription !== uri) : subscriptions
-		);
+		try {
+			await updateSessionSubscriptions(session.id, (subscriptions) =>
+				subscriptions.includes(uri) ? subscriptions.filter((subscription) => subscription !== uri) : subscriptions
+			);
+		} catch (error) {
+			harperLogger.error('MCP resource unsubscribe durable update failed', error);
+			return jsonResponse(
+				200,
+				buildError(messageId, ERROR_CODES.INTERNAL_ERROR, 'resource unsubscribe failed; retry the request')
+			);
+		}
 	} else if (result === 'timeout') {
 		return jsonResponse(
 			200,

--- a/integrationTests/fixtures/custom-resources/resources.js
+++ b/integrationTests/fixtures/custom-resources/resources.js
@@ -1,3 +1,13 @@
+import { threadId } from 'node:worker_threads';
+
+/** Test-only endpoint used to pin HTTP requests to distinct keep-alive worker connections. */
+export class WorkerIdentity extends Resource {
+	static loadAsInstance = false;
+	get() {
+		return { threadId };
+	}
+}
+
 // WorkItem: async write-then-patch pattern (CDI RT enqueueing + AI inference result attachment)
 export class WorkItem extends tables.WorkItem {
 	// Author-opt-in custom MCP surface declared on a subclass of an exported @table (#1448).

--- a/integrationTests/mcp/sse-listchanged.test.ts
+++ b/integrationTests/mcp/sse-listchanged.test.ts
@@ -514,10 +514,10 @@ suite('MCP v1 SSE channel + list_changed delivery', (ctx: ContextWithHarper) => 
 				}
 			}
 			ok(postAgent && postConnected, 'created a POST keep-alive connection on a free local port');
-			if (postThreadId === getThreadId) {
-				t.skip(`runtime exposed one application HTTP worker to all socket probes (thread ${getThreadId})`);
-				return;
-			}
+			ok(
+				postThreadId !== getThreadId,
+				`expected a second application HTTP worker after 24 socket probes; all used thread ${getThreadId}`
+			);
 
 			const id = `cross_worker_${Date.now().toString(36)}`;
 			const uri = new URL(`/WorkItem/${id}`, ctx.harper.httpURL).href;

--- a/integrationTests/mcp/sse-listchanged.test.ts
+++ b/integrationTests/mcp/sse-listchanged.test.ts
@@ -472,8 +472,12 @@ suite('MCP v1 SSE channel + list_changed delivery', (ctx: ContextWithHarper) => 
 	});
 
 	test('N5: resource subscription routes from a sibling POST worker to the GET-SSE owner', async (t) => {
-		if (process.platform === 'win32') {
-			t.skip('Harper forces one HTTP worker on Windows');
+		if (process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun') {
+			t.skip(
+				process.platform === 'win32'
+					? 'Harper forces one HTTP worker on Windows'
+					: 'Bun assigns pinned socket probes to one HTTP worker; Node CI covers cross-worker routing'
+			);
 			return;
 		}
 		const auth = adminAuth(ctx);

--- a/integrationTests/mcp/sse-listchanged.test.ts
+++ b/integrationTests/mcp/sse-listchanged.test.ts
@@ -20,6 +20,7 @@
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual } from 'node:assert';
 import { resolve } from 'node:path';
+import { Agent, request as httpRequest } from 'node:http';
 
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 
@@ -112,6 +113,65 @@ async function mcpCall(
 		body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
 	});
 	return res.json();
+}
+
+async function requestWithAgent(
+	baseUrl: string,
+	agent: Agent,
+	path: string,
+	options: { method?: string; headers?: Record<string, string>; body?: string; localPort?: number } = {}
+): Promise<{ status: number; body: string }> {
+	return new Promise((resolveRequest, reject) => {
+		const request = httpRequest(
+			new URL(path, baseUrl),
+			{ method: options.method ?? 'GET', headers: options.headers, agent, localPort: options.localPort },
+			(response) => {
+				const chunks: Buffer[] = [];
+				response.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+				response.on('end', () =>
+					resolveRequest({ status: response.statusCode ?? 0, body: Buffer.concat(chunks).toString() })
+				);
+			}
+		);
+		request.on('error', reject);
+		if (options.body) request.end(options.body);
+		else request.end();
+	});
+}
+
+async function workerIdentity(baseUrl: string, auth: string, agent: Agent, localPort: number): Promise<number> {
+	const response = await requestWithAgent(baseUrl, agent, '/WorkerIdentity', {
+		headers: { authorization: auth },
+		localPort,
+	});
+	strictEqual(response.status, 200, `WorkerIdentity failed: ${response.status} ${response.body}`);
+	return JSON.parse(response.body).threadId;
+}
+
+async function mcpCallWithAgent(
+	baseUrl: string,
+	auth: string,
+	agent: Agent,
+	session: { sessionId: string; protocolVersion: string },
+	method: string,
+	params: Record<string, unknown>,
+	id: number,
+	localPort: number
+): Promise<any> {
+	const response = await requestWithAgent(baseUrl, agent, '/mcp', {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/json',
+			'accept': 'application/json, text/event-stream',
+			'authorization': auth,
+			'mcp-session-id': session.sessionId,
+			'mcp-protocol-version': session.protocolVersion,
+		},
+		body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+		localPort,
+	});
+	strictEqual(response.status, 200, `MCP ${method} failed: ${response.status} ${response.body}`);
+	return JSON.parse(response.body);
 }
 
 /** Upsert a WorkItem record by id through the application REST API. */
@@ -223,10 +283,102 @@ async function openSse(
 	};
 }
 
+/** Open SSE on the sole socket in `agent`, pinning the stream to that socket's worker. */
+async function openSseWithAgent(
+	baseUrl: string,
+	auth: string,
+	agent: Agent,
+	session: { sessionId: string; protocolVersion: string },
+	localPort: number,
+	headerTimeoutMs = 2500
+): Promise<{
+	status: number;
+	next: (predicate: (msg: any) => boolean, timeoutMs: number) => Promise<any | undefined>;
+	close: () => void;
+}> {
+	let request;
+	const response = (await Promise.race([
+		new Promise((resolveResponse, reject) => {
+			request = httpRequest(
+				new URL('/mcp', baseUrl),
+				{
+					method: 'GET',
+					agent,
+					localPort,
+					headers: {
+						'accept': 'text/event-stream',
+						'authorization': auth,
+						'mcp-session-id': session.sessionId,
+						'mcp-protocol-version': session.protocolVersion,
+					},
+				},
+				resolveResponse
+			);
+			request.on('error', reject);
+			request.end();
+		}),
+		new Promise((_, reject) =>
+			setTimeout(() => reject(new Error('pinned SSE headers never flushed (hung)')), headerTimeoutMs)
+		),
+	])) as import('node:http').IncomingMessage;
+
+	let buffer = '';
+	const parsed: any[] = [];
+	const waiters: Array<{ predicate: (message: any) => boolean; resolve: (message: any) => void }> = [];
+	response.on('data', (chunk) => {
+		buffer += chunk.toString();
+		let index;
+		while ((index = buffer.indexOf('\n\n')) !== -1) {
+			const frame = buffer.slice(0, index);
+			buffer = buffer.slice(index + 2);
+			const dataLine = frame.split('\n').find((line) => line.startsWith('data:'));
+			if (!dataLine) continue;
+			let message;
+			try {
+				message = JSON.parse(dataLine.slice(5).trim());
+			} catch {
+				continue;
+			}
+			parsed.push(message);
+			for (let i = waiters.length - 1; i >= 0; i--) {
+				if (waiters[i].predicate(message)) {
+					waiters[i].resolve(message);
+					waiters.splice(i, 1);
+				}
+			}
+		}
+	});
+
+	return {
+		status: response.statusCode ?? 0,
+		next(predicate, timeoutMs) {
+			const existing = parsed.find(predicate);
+			if (existing) return Promise.resolve(existing);
+			return new Promise((resolveNext) => {
+				const timer = setTimeout(() => resolveNext(undefined), timeoutMs);
+				waiters.push({
+					predicate,
+					resolve: (message) => {
+						clearTimeout(timer);
+						resolveNext(message);
+					},
+				});
+			});
+		},
+		close() {
+			response.destroy();
+			request?.destroy();
+		},
+	};
+}
+
 suite('MCP v1 SSE channel + list_changed delivery', (ctx: ContextWithHarper) => {
 	before(async () => {
 		await setupHarperWithFixture(ctx, FIXTURE_PATH, {
-			config: { mcp: { operations: { mountPath: '/mcp' }, application: { mountPath: '/mcp' } } },
+			config: {
+				threads: { count: 4 },
+				mcp: { operations: { mountPath: '/mcp' }, application: { mountPath: '/mcp' } },
+			},
 			env: {},
 		});
 	});
@@ -316,6 +468,65 @@ suite('MCP v1 SSE channel + list_changed delivery', (ctx: ContextWithHarper) => 
 			strictEqual(evt.params.uri, uri, 'notification carries the subscribed collection URI');
 		} finally {
 			sse.close();
+		}
+	});
+
+	test('N5: resource subscription routes from a sibling POST worker to the GET-SSE owner', async (t) => {
+		if (process.platform === 'win32') {
+			t.skip('Harper forces one HTTP worker on Windows');
+			return;
+		}
+		const auth = adminAuth(ctx);
+		const session = await initialize(ctx.harper.httpURL, auth);
+		const firstLocalPort = 30000 + (process.pid % 10000);
+		const getAgent = new Agent({ keepAlive: true, maxSockets: 1 });
+		const getThreadId = await workerIdentity(ctx.harper.httpURL, auth, getAgent, firstLocalPort);
+		const sse = await openSseWithAgent(ctx.harper.httpURL, auth, getAgent, session, firstLocalPort);
+		let postAgent;
+		let postThreadId = getThreadId;
+		let postLocalPort = firstLocalPort;
+		try {
+			strictEqual(sse.status, 200, 'pinned GET SSE establishes');
+			for (let attempt = 0; attempt < 24 && postThreadId === getThreadId; attempt++) {
+				postAgent?.destroy();
+				postAgent = new Agent({ keepAlive: true, maxSockets: 1 });
+				postLocalPort = firstLocalPort + attempt + 1;
+				postThreadId = await workerIdentity(ctx.harper.httpURL, auth, postAgent, postLocalPort);
+			}
+			ok(postAgent, 'created a POST keep-alive connection');
+			if (postThreadId === getThreadId) {
+				t.skip(`runtime exposed one application HTTP worker to all socket probes (thread ${getThreadId})`);
+				return;
+			}
+
+			const id = `cross_worker_${Date.now().toString(36)}`;
+			const uri = new URL(`/WorkItem/${id}`, ctx.harper.httpURL).href;
+			await putWorkItem(ctx, id, { state: 'pending', payload: 'cross-worker' });
+			const subscription = await mcpCallWithAgent(
+				ctx.harper.httpURL,
+				auth,
+				postAgent!,
+				session,
+				'resources/subscribe',
+				{ uri },
+				20,
+				postLocalPort
+			);
+			strictEqual(
+				subscription.error,
+				undefined,
+				`cross-worker resources/subscribe should succeed: ${JSON.stringify(subscription.error)}`
+			);
+			await putWorkItem(ctx, id, { state: 'done', payload: 'cross-worker' });
+			const event = await sse.next(
+				(message) => message?.method === 'notifications/resources/updated' && message?.params?.uri === uri,
+				5000
+			);
+			ok(event, 'the owner worker delivered resources/updated on the pinned GET stream');
+		} finally {
+			sse.close();
+			getAgent.destroy();
+			postAgent?.destroy();
 		}
 	});
 });

--- a/integrationTests/mcp/sse-listchanged.test.ts
+++ b/integrationTests/mcp/sse-listchanged.test.ts
@@ -478,22 +478,42 @@ suite('MCP v1 SSE channel + list_changed delivery', (ctx: ContextWithHarper) => 
 		}
 		const auth = adminAuth(ctx);
 		const session = await initialize(ctx.harper.httpURL, auth);
-		const firstLocalPort = 30000 + (process.pid % 10000);
-		const getAgent = new Agent({ keepAlive: true, maxSockets: 1 });
-		const getThreadId = await workerIdentity(ctx.harper.httpURL, auth, getAgent, firstLocalPort);
-		const sse = await openSseWithAgent(ctx.harper.httpURL, auth, getAgent, session, firstLocalPort);
+		const firstLocalPort = 20000 + (process.pid % 9000);
+		let getAgent;
+		let getThreadId;
+		let getLocalPort;
+		for (let attempt = 0; attempt < 25; attempt++) {
+			const candidateAgent = new Agent({ keepAlive: true, maxSockets: 1 });
+			try {
+				getLocalPort = firstLocalPort + attempt;
+				getThreadId = await workerIdentity(ctx.harper.httpURL, auth, candidateAgent, getLocalPort);
+				getAgent = candidateAgent;
+				break;
+			} catch (error) {
+				candidateAgent.destroy();
+				if ((error as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw error;
+			}
+		}
+		ok(getAgent && getThreadId !== undefined && getLocalPort !== undefined, 'found a free pinned GET socket');
+		const sse = await openSseWithAgent(ctx.harper.httpURL, auth, getAgent, session, getLocalPort);
 		let postAgent;
 		let postThreadId = getThreadId;
-		let postLocalPort = firstLocalPort;
+		let postLocalPort = getLocalPort;
+		let postConnected = false;
 		try {
 			strictEqual(sse.status, 200, 'pinned GET SSE establishes');
 			for (let attempt = 0; attempt < 24 && postThreadId === getThreadId; attempt++) {
 				postAgent?.destroy();
 				postAgent = new Agent({ keepAlive: true, maxSockets: 1 });
-				postLocalPort = firstLocalPort + attempt + 1;
-				postThreadId = await workerIdentity(ctx.harper.httpURL, auth, postAgent, postLocalPort);
+				postLocalPort = getLocalPort + attempt + 1;
+				try {
+					postThreadId = await workerIdentity(ctx.harper.httpURL, auth, postAgent, postLocalPort);
+					postConnected = true;
+				} catch (error) {
+					if ((error as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw error;
+				}
 			}
-			ok(postAgent, 'created a POST keep-alive connection');
+			ok(postAgent && postConnected, 'created a POST keep-alive connection on a free local port');
 			if (postThreadId === getThreadId) {
 				t.skip(`runtime exposed one application HTTP worker to all socket probes (thread ${getThreadId})`);
 				return;

--- a/unitTests/components/mcp/adapters/fastify.test.js
+++ b/unitTests/components/mcp/adapters/fastify.test.js
@@ -8,6 +8,9 @@ function makeFakeTable() {
 		async put(record) {
 			store.set(record.id, { ...record });
 		},
+		async patch(record) {
+			store.set(record.id, { ...store.get(record.id), ...record });
+		},
 		async get(id) {
 			const r = store.get(id);
 			return r ? { ...r } : undefined;

--- a/unitTests/components/mcp/adapters/harperHttp.test.js
+++ b/unitTests/components/mcp/adapters/harperHttp.test.js
@@ -11,6 +11,9 @@ function makeFakeTable() {
 		async put(record) {
 			store.set(record.id, { ...record });
 		},
+		async patch(record) {
+			store.set(record.id, { ...store.get(record.id), ...record });
+		},
 		async get(id) {
 			const r = store.get(id);
 			return r ? { ...r } : undefined;

--- a/unitTests/components/mcp/lifecycle.test.js
+++ b/unitTests/components/mcp/lifecycle.test.js
@@ -16,6 +16,9 @@ function makeFakeTable() {
 		async put(record) {
 			store.set(record.id, { ...record });
 		},
+		async patch(record) {
+			store.set(record.id, { ...store.get(record.id), ...record });
+		},
 		async get(id) {
 			const r = store.get(id);
 			return r ? { ...r } : undefined;

--- a/unitTests/components/mcp/session.test.js
+++ b/unitTests/components/mcp/session.test.js
@@ -6,6 +6,7 @@ const {
 	touchSession,
 	updateSessionSubscriptions,
 	_setSessionTableForTest,
+	_setSubscriptionLockTimeoutForTest,
 } = require('#src/components/mcp/session');
 
 function makeFakeTable() {
@@ -55,6 +56,7 @@ describe('mcp/session', () => {
 	});
 	afterEach(() => {
 		_setSessionTableForTest(undefined);
+		_setSubscriptionLockTimeoutForTest(undefined);
 	});
 
 	describe('createSession', () => {
@@ -124,6 +126,26 @@ describe('mcp/session', () => {
 	});
 
 	describe('updateSessionSubscriptions', () => {
+		it('times out without acquiring a lock later from a stale wake callback', async () => {
+			const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+			const key = `mcp-subscriptions:${session.id}`;
+			assert.equal(
+				fake.primaryStore.tryLock(key, () => {}),
+				true
+			);
+			_setSubscriptionLockTimeoutForTest(5);
+
+			await assert.rejects(
+				updateSessionSubscriptions(session.id, (subscriptions) => subscriptions),
+				/Timed out acquiring MCP subscription lock/
+			);
+			fake.primaryStore.unlock(key);
+			await new Promise(setImmediate);
+
+			await updateSessionSubscriptions(session.id, (subscriptions) => [...subscriptions, 'recovered']);
+			assert.deepEqual((await loadSession(session.id)).subscriptions, ['recovered']);
+		});
+
 		it('serializes concurrent read-modify-writes for the same session', async () => {
 			const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
 			fake.store.get(session.id).subscriptions = ['first', 'second'];

--- a/unitTests/components/mcp/session.test.js
+++ b/unitTests/components/mcp/session.test.js
@@ -2,7 +2,6 @@ const assert = require('node:assert');
 const {
 	createSession,
 	loadSession,
-	saveSession,
 	deleteSession,
 	touchSession,
 	_setSessionTableForTest,
@@ -14,6 +13,9 @@ function makeFakeTable() {
 		store,
 		async put(record) {
 			store.set(record.id, { ...record });
+		},
+		async patch(record) {
+			store.set(record.id, { ...store.get(record.id), ...record });
 		},
 		async get(id) {
 			const r = store.get(id);
@@ -64,15 +66,6 @@ describe('mcp/session', () => {
 		it('returns null when the id is unknown', async () => {
 			const loaded = await loadSession('not-a-session');
 			assert.equal(loaded, null);
-		});
-	});
-
-	describe('saveSession', () => {
-		it('persists changes', async () => {
-			const created = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
-			await saveSession({ ...created, initialized: true });
-			const reloaded = await loadSession(created.id);
-			assert.equal(reloaded.initialized, true);
 		});
 	});
 

--- a/unitTests/components/mcp/session.test.js
+++ b/unitTests/components/mcp/session.test.js
@@ -67,6 +67,11 @@ describe('mcp/session', () => {
 			const loaded = await loadSession('not-a-session');
 			assert.equal(loaded, null);
 		});
+
+		it('returns null for a partial record left by a late patch after deletion', async () => {
+			fake.store.set('deleted-session', { id: 'deleted-session', lastActivity: Date.now() });
+			assert.equal(await loadSession('deleted-session'), null);
+		});
 	});
 
 	describe('deleteSession', () => {

--- a/unitTests/components/mcp/session.test.js
+++ b/unitTests/components/mcp/session.test.js
@@ -4,13 +4,33 @@ const {
 	loadSession,
 	deleteSession,
 	touchSession,
+	updateSessionSubscriptions,
 	_setSessionTableForTest,
 } = require('#src/components/mcp/session');
 
 function makeFakeTable() {
 	const store = new Map();
+	const locks = new Set();
+	const waiters = new Map();
 	return {
 		store,
+		primaryStore: {
+			tryLock(key, callback) {
+				if (!locks.has(key)) {
+					locks.add(key);
+					return true;
+				}
+				const queued = waiters.get(key) ?? [];
+				queued.push(callback);
+				waiters.set(key, queued);
+				return false;
+			},
+			unlock(key) {
+				locks.delete(key);
+				const callback = waiters.get(key)?.shift();
+				if (callback) setImmediate(callback);
+			},
+		},
 		async put(record) {
 			store.set(record.id, { ...record });
 		},
@@ -100,6 +120,25 @@ describe('mcp/session', () => {
 			assert.equal(touched.initialized, true);
 			assert.equal(touched.user, 'alice');
 			assert.equal(touched.protocolVersion, '2025-06-18');
+		});
+	});
+
+	describe('updateSessionSubscriptions', () => {
+		it('serializes concurrent read-modify-writes for the same session', async () => {
+			const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+			fake.store.get(session.id).subscriptions = ['first', 'second'];
+			const originalPatch = fake.patch;
+			fake.patch = async (record) => {
+				if (record.subscriptions) await new Promise((resolve) => setImmediate(resolve));
+				return originalPatch.call(fake, record);
+			};
+
+			await Promise.all([
+				updateSessionSubscriptions(session.id, (subscriptions) => subscriptions.filter((uri) => uri !== 'first')),
+				updateSessionSubscriptions(session.id, (subscriptions) => subscriptions.filter((uri) => uri !== 'second')),
+			]);
+
+			assert.deepEqual((await loadSession(session.id)).subscriptions, []);
 		});
 	});
 });

--- a/unitTests/components/mcp/subscriptionRouting.test.js
+++ b/unitTests/components/mcp/subscriptionRouting.test.js
@@ -287,4 +287,62 @@ describe('mcp/subscriptionRouting', () => {
 		assert.equal(await subscribing, 'success');
 		assert.equal(subscribeStarted, true);
 	});
+
+	it('rechecks stream ownership after waiting for an earlier session operation', async () => {
+		_setSubscriptionThreadIdForTest(7);
+		const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+		const registered = registerSession(session.id, 'application', USER);
+		await claimSubscriptionOwner(session.id, registered.streamToken);
+		let releaseEarlierOperation;
+		const earlierOperation = withSessionSubscriptionLock(
+			session.id,
+			() => new Promise((resolve) => (releaseEarlierOperation = resolve))
+		);
+		let subscribeStarted = false;
+		_setSubscribeImplForTest(async () => {
+			subscribeStarted = true;
+		});
+		const subscribing = routeResourceSubscription({
+			session: await loadSession(session.id),
+			operation: 'subscribe',
+			uri: 'https://app.test/Product/3',
+			user: USER,
+		});
+		await new Promise(setImmediate);
+		registerSession(session.id, 'application', USER);
+		releaseEarlierOperation();
+		await earlierOperation;
+
+		assert.equal(await subscribing, 'no-live-stream');
+		assert.equal(subscribeStarted, false);
+	});
+
+	it('normalizes local owner failures to an internal-error result', async () => {
+		_setSubscriptionThreadIdForTest(7);
+		const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+		const registered = registerSession(session.id, 'application', USER);
+		await claimSubscriptionOwner(session.id, registered.streamToken);
+		_setSubscribeImplForTest(async () => ({
+			end() {},
+			[Symbol.asyncIterator]() {
+				return { next: () => new Promise(() => {}) };
+			},
+		}));
+		const table = fakeTable();
+		await table.put(await loadSession(session.id));
+		table.patch = async () => {
+			throw new Error('write failed');
+		};
+		_setSessionTableForTest(table);
+
+		assert.equal(
+			await routeResourceSubscription({
+				session: await loadSession(session.id),
+				operation: 'subscribe',
+				uri: 'https://app.test/Product/4',
+				user: USER,
+			}),
+			'internal-error'
+		);
+	});
 });

--- a/unitTests/components/mcp/subscriptionRouting.test.js
+++ b/unitTests/components/mcp/subscriptionRouting.test.js
@@ -1,0 +1,199 @@
+const assert = require('node:assert');
+const {
+	claimSubscriptionOwner,
+	routeResourceSubscription,
+	_setSubscriptionItcForTest,
+	_setSubscriptionThreadIdForTest,
+	_setSubscriptionTimeoutForTest,
+	_resetSubscriptionRoutingForTest,
+	_pendingSubscriptionRouteCount,
+} = require('#src/components/mcp/subscriptionRouting');
+const { ITC_EVENT_TYPES } = require('#src/utility/hdbTerms');
+const { createSession, loadSession, patchSession, _setSessionTableForTest } = require('#src/components/mcp/session');
+const { registerSession, _resetSessionRegistryForTest } = require('#src/components/mcp/sessionRegistry');
+const { _setSubscribeImplForTest } = require('#src/components/mcp/resources');
+const { _resetSubscriptionsForTest } = require('#src/components/mcp/subscriptions');
+
+const USER = { username: 'alice', role: { permission: { super_user: true } } };
+
+function fakeTable() {
+	const store = new Map();
+	return {
+		async put(record) {
+			store.set(record.id, { ...record });
+		},
+		async patch(record) {
+			store.set(record.id, { ...store.get(record.id), ...record });
+		},
+		async get(id) {
+			const record = store.get(id);
+			return record && { ...record };
+		},
+		async delete(id) {
+			store.delete(id);
+		},
+	};
+}
+
+function fakeBridge(send) {
+	const listeners = new Map();
+	return {
+		listeners,
+		onMessageByType(type, listener) {
+			listeners.set(type, listener);
+		},
+		sendToThread(target, event) {
+			return send?.(target, event, listeners) ?? true;
+		},
+	};
+}
+
+describe('mcp/subscriptionRouting', () => {
+	beforeEach(() => {
+		_setSessionTableForTest(fakeTable());
+		_setSubscriptionThreadIdForTest(1);
+	});
+
+	afterEach(() => {
+		_resetSubscriptionsForTest();
+		_resetSessionRegistryForTest();
+		_resetSubscriptionRoutingForTest();
+		_setSubscriptionItcForTest(undefined);
+		_setSessionTableForTest(undefined);
+		_setSubscribeImplForTest(undefined);
+	});
+
+	async function remoteSession() {
+		const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+		await patchSession(session.id, { streamOwner: { threadId: 7, token: 'owner-token' } });
+		return loadSession(session.id);
+	}
+
+	it('accepts a correlated response only from the expected owner thread', async () => {
+		const bridge = fakeBridge((_target, event, listeners) => {
+			assert.equal(event.message.user.password, undefined, 'credentials must not cross the worker boundary');
+			const requestId = event.message.requestId;
+			setImmediate(() => {
+				listeners.get(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_RESPONSE)({
+					message: { requestId, originator: 8, result: 'not-subscribable' },
+				});
+				listeners.get(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_RESPONSE)({
+					message: { requestId, originator: 7, result: 'success' },
+				});
+			});
+			return true;
+		});
+		_setSubscriptionItcForTest(bridge);
+		const result = await routeResourceSubscription({
+			session: await remoteSession(),
+			operation: 'subscribe',
+			uri: 'https://app.test/Product/1',
+			user: { ...USER, password: 'do-not-forward' },
+		});
+		assert.equal(result, 'success');
+		assert.equal(_pendingSubscriptionRouteCount(), 0);
+	});
+
+	it('fails quickly when the persisted owner thread is unreachable', async () => {
+		_setSubscriptionItcForTest(fakeBridge(() => false));
+		const result = await routeResourceSubscription({
+			session: await remoteSession(),
+			operation: 'subscribe',
+			uri: 'https://app.test/Product/1',
+			user: USER,
+		});
+		assert.equal(result, 'no-live-stream');
+		assert.equal(_pendingSubscriptionRouteCount(), 0);
+	});
+
+	it('bounds a sent command when the owner never responds', async () => {
+		_setSubscriptionTimeoutForTest(5);
+		_setSubscriptionItcForTest(fakeBridge(() => true));
+		const result = await routeResourceSubscription({
+			session: await remoteSession(),
+			operation: 'subscribe',
+			uri: 'https://app.test/Product/1',
+			user: USER,
+		});
+		assert.equal(result, 'no-live-stream');
+		assert.equal(_pendingSubscriptionRouteCount(), 0);
+	});
+
+	it('rejects a command whose stream token no longer owns the local registry', async () => {
+		let response;
+		const bridge = fakeBridge((_target, event) => {
+			if (event.type === ITC_EVENT_TYPES.MCP_SUBSCRIPTION_RESPONSE) response = event.message;
+			return true;
+		});
+		_setSubscriptionItcForTest(bridge);
+		_setSubscriptionThreadIdForTest(7);
+		const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+		const registered = registerSession(session.id, 'application', USER);
+		await claimSubscriptionOwner(session.id, registered.streamToken);
+		await bridge.listeners.get(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_COMMAND)({
+			message: {
+				requestId: 'r1',
+				originator: 1,
+				sessionId: session.id,
+				streamToken: 'stale-token',
+				operation: 'subscribe',
+				uri: 'https://app.test/Product/1',
+				user: USER,
+			},
+		});
+		await new Promise(setImmediate);
+		assert.equal(response.result, 'no-live-stream');
+	});
+
+	it('executes subscribe and unsubscribe on the owner and updates the durable URI list', async () => {
+		let response;
+		const bridge = fakeBridge((_target, event) => {
+			if (event.type === ITC_EVENT_TYPES.MCP_SUBSCRIPTION_RESPONSE) response = event.message;
+			return true;
+		});
+		_setSubscriptionItcForTest(bridge);
+		_setSubscriptionThreadIdForTest(7);
+		_setSubscribeImplForTest(async (_path, user) => {
+			assert.deepEqual(user, USER);
+			return {
+				end() {},
+				[Symbol.asyncIterator]() {
+					return { next: () => new Promise(() => {}) };
+				},
+			};
+		});
+		const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+		const registered = registerSession(session.id, 'application', USER);
+		await claimSubscriptionOwner(session.id, registered.streamToken);
+		const uri = 'https://app.test/Product/1';
+		bridge.listeners.get(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_COMMAND)({
+			message: {
+				requestId: 'r2',
+				originator: 1,
+				sessionId: session.id,
+				streamToken: registered.streamToken,
+				operation: 'subscribe',
+				uri,
+				user: USER,
+			},
+		});
+		for (let i = 0; i < 20 && !response; i++) await new Promise(setImmediate);
+		assert.equal(response.result, 'success');
+		assert.deepEqual((await loadSession(session.id)).subscriptions, [uri]);
+
+		response = undefined;
+		bridge.listeners.get(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_COMMAND)({
+			message: {
+				requestId: 'r3',
+				originator: 1,
+				sessionId: session.id,
+				streamToken: registered.streamToken,
+				operation: 'unsubscribe',
+				uri,
+			},
+		});
+		for (let i = 0; i < 20 && !response; i++) await new Promise(setImmediate);
+		assert.equal(response.result, 'success');
+		assert.deepEqual((await loadSession(session.id)).subscriptions, []);
+	});
+});

--- a/unitTests/components/mcp/subscriptionRouting.test.js
+++ b/unitTests/components/mcp/subscriptionRouting.test.js
@@ -169,6 +169,22 @@ describe('mcp/subscriptionRouting', () => {
 		assert.equal(response.result, 'no-live-stream');
 	});
 
+	it('ignores malformed commands without attempting a response', async () => {
+		let sent = 0;
+		const bridge = fakeBridge(() => {
+			sent++;
+			return true;
+		});
+		_setSubscriptionItcForTest(bridge);
+		const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+		await claimSubscriptionOwner(session.id, 'owner-token');
+		const listener = bridge.listeners.get(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_COMMAND);
+		assert.doesNotThrow(() => listener({ message: undefined }));
+		assert.doesNotThrow(() => listener({ message: { requestId: 'r1', originator: 1 } }));
+		await new Promise(setImmediate);
+		assert.equal(sent, 0);
+	});
+
 	it('executes subscribe and unsubscribe on the owner and updates the durable URI list', async () => {
 		let response;
 		const bridge = fakeBridge((_target, event) => {

--- a/unitTests/components/mcp/subscriptionRouting.test.js
+++ b/unitTests/components/mcp/subscriptionRouting.test.js
@@ -141,12 +141,28 @@ describe('mcp/subscriptionRouting', () => {
 		bridge.available = false;
 		_setSubscriptionItcForTest(bridge);
 		const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
-		await claimSubscriptionOwner(session.id, 'first-stream');
+		await assert.rejects(claimSubscriptionOwner(session.id, 'first-stream'), /routing is unavailable/);
 		assert.equal(bridge.listeners.size, 0);
 		bridge.available = true;
 		await claimSubscriptionOwner(session.id, 'second-stream');
 		assert.equal(bridge.listeners.has(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_COMMAND), true);
 		assert.equal(bridge.listeners.has(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_RESPONSE), true);
+	});
+
+	it('reports a send exception as an internal error rather than a missing stream', async () => {
+		_setSubscriptionItcForTest(
+			fakeBridge(() => {
+				throw new Error('could not clone command');
+			})
+		);
+		const result = await routeResourceSubscription({
+			session: await remoteSession(),
+			operation: 'subscribe',
+			uri: 'https://app.test/Product/1',
+			user: USER,
+		});
+		assert.equal(result, 'internal-error');
+		assert.equal(_pendingSubscriptionRouteCount(), 0);
 	});
 
 	it('bounds a sent command when the owner never responds', async () => {

--- a/unitTests/components/mcp/subscriptionRouting.test.js
+++ b/unitTests/components/mcp/subscriptionRouting.test.js
@@ -93,6 +93,7 @@ describe('mcp/subscriptionRouting', () => {
 	it('accepts a correlated response only from the expected owner thread', async () => {
 		const bridge = fakeBridge((_target, event, listeners) => {
 			assert.equal(event.message.user.password, undefined, 'credentials must not cross the worker boundary');
+			assert.equal(event.message.user.customClaim, undefined, 'custom principal state must remain local');
 			assert.equal(event.message.user.username, '');
 			assert.equal(event.message.user.authExpiresAt, 12345);
 			assert.equal(event.message.user.role.role, '');
@@ -118,6 +119,7 @@ describe('mcp/subscriptionRouting', () => {
 				authExpiresAt: 12345,
 				role: { ...USER.role, role: '' },
 				password: 'do-not-forward',
+				customClaim: 'local-only',
 			},
 		});
 		assert.equal(result, 'success');
@@ -155,16 +157,38 @@ describe('mcp/subscriptionRouting', () => {
 		const bridge = fakeBridge();
 		bridge.available = false;
 		_setSubscriptionItcForTest(bridge);
+		_setSubscribeImplForTest(async () => ({
+			end() {},
+			[Symbol.asyncIterator]() {
+				return { next: () => new Promise(() => {}) };
+			},
+		}));
 		const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
 		const record = registerSession(session.id, 'application', USER);
 		assert.equal(await claimSubscriptionOwner(session.id, record.streamToken), false);
 		assert.equal(
 			await routeResourceSubscription({
 				session: await loadSession(session.id),
-				operation: 'unsubscribe',
+				operation: 'subscribe',
 				uri: 'https://app.test/Product/1',
+				user: USER,
 			}),
 			'success'
+		);
+		assert.deepEqual((await loadSession(session.id)).subscriptions, ['https://app.test/Product/1']);
+	});
+
+	it('does not guess a local owner when worker routing is wired', async () => {
+		const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+		registerSession(session.id, 'application', USER);
+		assert.equal(
+			await routeResourceSubscription({
+				session: await loadSession(session.id),
+				operation: 'subscribe',
+				uri: 'https://app.test/Product/1',
+				user: USER,
+			}),
+			'no-live-stream'
 		);
 	});
 

--- a/unitTests/components/mcp/subscriptionRouting.test.js
+++ b/unitTests/components/mcp/subscriptionRouting.test.js
@@ -19,7 +19,26 @@ const USER = { username: 'alice', role: { permission: { super_user: true } } };
 
 function fakeTable() {
 	const store = new Map();
+	const locks = new Set();
+	const waiters = new Map();
 	return {
+		primaryStore: {
+			tryLock(key, callback) {
+				if (!locks.has(key)) {
+					locks.add(key);
+					return true;
+				}
+				const queued = waiters.get(key) ?? [];
+				queued.push(callback);
+				waiters.set(key, queued);
+				return false;
+			},
+			unlock(key) {
+				locks.delete(key);
+				const callback = waiters.get(key)?.shift();
+				if (callback) setImmediate(callback);
+			},
+		},
 		async put(record) {
 			store.set(record.id, { ...record });
 		},

--- a/unitTests/components/mcp/subscriptionRouting.test.js
+++ b/unitTests/components/mcp/subscriptionRouting.test.js
@@ -53,6 +53,7 @@ describe('mcp/subscriptionRouting', () => {
 	beforeEach(() => {
 		_setSessionTableForTest(fakeTable());
 		_setSubscriptionThreadIdForTest(1);
+		_setSubscriptionItcForTest(fakeBridge());
 	});
 
 	afterEach(() => {
@@ -106,6 +107,19 @@ describe('mcp/subscriptionRouting', () => {
 		});
 		assert.equal(result, 'no-live-stream');
 		assert.equal(_pendingSubscriptionRouteCount(), 0);
+	});
+
+	it('retries listener wiring after the thread bridge becomes available', async () => {
+		const bridge = fakeBridge();
+		bridge.available = false;
+		_setSubscriptionItcForTest(bridge);
+		const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+		await claimSubscriptionOwner(session.id, 'first-stream');
+		assert.equal(bridge.listeners.size, 0);
+		bridge.available = true;
+		await claimSubscriptionOwner(session.id, 'second-stream');
+		assert.equal(bridge.listeners.has(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_COMMAND), true);
+		assert.equal(bridge.listeners.has(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_RESPONSE), true);
 	});
 
 	it('bounds a sent command when the owner never responds', async () => {

--- a/unitTests/components/mcp/subscriptionRouting.test.js
+++ b/unitTests/components/mcp/subscriptionRouting.test.js
@@ -141,12 +141,31 @@ describe('mcp/subscriptionRouting', () => {
 		bridge.available = false;
 		_setSubscriptionItcForTest(bridge);
 		const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
-		await assert.rejects(claimSubscriptionOwner(session.id, 'first-stream'), /routing is unavailable/);
+		await patchSession(session.id, { streamOwner: { threadId: 7, token: 'stale-owner' } });
+		assert.equal(await claimSubscriptionOwner(session.id, 'first-stream'), false);
+		assert.equal((await loadSession(session.id)).streamOwner, undefined);
 		assert.equal(bridge.listeners.size, 0);
 		bridge.available = true;
-		await claimSubscriptionOwner(session.id, 'second-stream');
+		assert.equal(await claimSubscriptionOwner(session.id, 'second-stream'), true);
 		assert.equal(bridge.listeners.has(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_COMMAND), true);
 		assert.equal(bridge.listeners.has(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_RESPONSE), true);
+	});
+
+	it('routes locally without publishing an owner when the thread bridge is unavailable', async () => {
+		const bridge = fakeBridge();
+		bridge.available = false;
+		_setSubscriptionItcForTest(bridge);
+		const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+		const record = registerSession(session.id, 'application', USER);
+		assert.equal(await claimSubscriptionOwner(session.id, record.streamToken), false);
+		assert.equal(
+			await routeResourceSubscription({
+				session: await loadSession(session.id),
+				operation: 'unsubscribe',
+				uri: 'https://app.test/Product/1',
+			}),
+			'success'
+		);
 	});
 
 	it('reports a send exception as an internal error rather than a missing stream', async () => {

--- a/unitTests/components/mcp/subscriptionRouting.test.js
+++ b/unitTests/components/mcp/subscriptionRouting.test.js
@@ -74,7 +74,9 @@ describe('mcp/subscriptionRouting', () => {
 	it('accepts a correlated response only from the expected owner thread', async () => {
 		const bridge = fakeBridge((_target, event, listeners) => {
 			assert.equal(event.message.user.password, undefined, 'credentials must not cross the worker boundary');
+			assert.equal(event.message.user.username, '');
 			assert.equal(event.message.user.authExpiresAt, 12345);
+			assert.equal(event.message.user.role.role, '');
 			const requestId = event.message.requestId;
 			setImmediate(() => {
 				listeners.get(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_RESPONSE)({
@@ -91,7 +93,13 @@ describe('mcp/subscriptionRouting', () => {
 			session: await remoteSession(),
 			operation: 'subscribe',
 			uri: 'https://app.test/Product/1',
-			user: { ...USER, authExpiresAt: 12345, password: 'do-not-forward' },
+			user: {
+				...USER,
+				username: '',
+				authExpiresAt: 12345,
+				role: { ...USER.role, role: '' },
+				password: 'do-not-forward',
+			},
 		});
 		assert.equal(result, 'success');
 		assert.equal(_pendingSubscriptionRouteCount(), 0);

--- a/unitTests/components/mcp/subscriptionRouting.test.js
+++ b/unitTests/components/mcp/subscriptionRouting.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert');
 const {
 	claimSubscriptionOwner,
 	routeResourceSubscription,
+	withSessionSubscriptionLock,
 	_setSubscriptionItcForTest,
 	_setSubscriptionThreadIdForTest,
 	_setSubscriptionTimeoutForTest,
@@ -72,6 +73,7 @@ describe('mcp/subscriptionRouting', () => {
 	it('accepts a correlated response only from the expected owner thread', async () => {
 		const bridge = fakeBridge((_target, event, listeners) => {
 			assert.equal(event.message.user.password, undefined, 'credentials must not cross the worker boundary');
+			assert.equal(event.message.user.authExpiresAt, 12345);
 			const requestId = event.message.requestId;
 			setImmediate(() => {
 				listeners.get(ITC_EVENT_TYPES.MCP_SUBSCRIPTION_RESPONSE)({
@@ -88,7 +90,7 @@ describe('mcp/subscriptionRouting', () => {
 			session: await remoteSession(),
 			operation: 'subscribe',
 			uri: 'https://app.test/Product/1',
-			user: { ...USER, password: 'do-not-forward' },
+			user: { ...USER, authExpiresAt: 12345, password: 'do-not-forward' },
 		});
 		assert.equal(result, 'success');
 		assert.equal(_pendingSubscriptionRouteCount(), 0);
@@ -115,7 +117,7 @@ describe('mcp/subscriptionRouting', () => {
 			uri: 'https://app.test/Product/1',
 			user: USER,
 		});
-		assert.equal(result, 'no-live-stream');
+		assert.equal(result, 'timeout');
 		assert.equal(_pendingSubscriptionRouteCount(), 0);
 	});
 
@@ -195,5 +197,37 @@ describe('mcp/subscriptionRouting', () => {
 		for (let i = 0; i < 20 && !response; i++) await new Promise(setImmediate);
 		assert.equal(response.result, 'success');
 		assert.deepEqual((await loadSession(session.id)).subscriptions, []);
+	});
+
+	it('serializes owner commands behind reconnect restoration for the same session', async () => {
+		_setSubscriptionThreadIdForTest(7);
+		const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+		const registered = registerSession(session.id, 'application', USER);
+		await claimSubscriptionOwner(session.id, registered.streamToken);
+		let releaseRestore;
+		const restoreBlocked = new Promise((resolve) => (releaseRestore = resolve));
+		const restoring = withSessionSubscriptionLock(session.id, () => restoreBlocked);
+		let subscribeStarted = false;
+		_setSubscribeImplForTest(async () => {
+			subscribeStarted = true;
+			return {
+				end() {},
+				[Symbol.asyncIterator]() {
+					return { next: () => new Promise(() => {}) };
+				},
+			};
+		});
+		const subscribing = routeResourceSubscription({
+			session: await loadSession(session.id),
+			operation: 'subscribe',
+			uri: 'https://app.test/Product/2',
+			user: USER,
+		});
+		await new Promise(setImmediate);
+		assert.equal(subscribeStarted, false);
+		releaseRestore();
+		await restoring;
+		assert.equal(await subscribing, 'success');
+		assert.equal(subscribeStarted, true);
 	});
 });

--- a/unitTests/components/mcp/subscriptions.test.js
+++ b/unitTests/components/mcp/subscriptions.test.js
@@ -132,4 +132,13 @@ describe('mcp/subscriptions', () => {
 		assert.deepEqual(restored, [URI], 'only the subscribable URI is restored');
 		assert.equal(_liveSubscriptionCount('s1'), 1);
 	});
+
+	it('keeps a durable URI when restoration throws so a later reconnect can retry it', async () => {
+		_setSubscribeImplForTest(async () => {
+			throw new Error('authorization service unavailable');
+		});
+		const retained = await restoreResourceSubscriptions('s1', [URI], USER);
+		assert.deepEqual(retained, [URI]);
+		assert.equal(_liveSubscriptionCount('s1'), 0);
+	});
 });

--- a/unitTests/components/mcp/transport.test.js
+++ b/unitTests/components/mcp/transport.test.js
@@ -276,6 +276,41 @@ describe('mcp/transport', () => {
 			}
 		});
 
+		it('serves the GET stream when cross-worker routing is unavailable', async () => {
+			const originalClaim = subscriptionRouting.claimSubscriptionOwner;
+			subscriptionRouting.claimSubscriptionOwner = async () => false;
+			try {
+				const res = await handleMcpRequest(
+					makeReq({
+						method: 'GET',
+						headers: { 'mcp-session-id': sessionId, 'accept': 'text/event-stream' },
+					})
+				);
+				assert.equal(res.status, 200);
+				assert.ok(res.sseIterable);
+				res.sseIterable.emit('close');
+			} finally {
+				subscriptionRouting.claimSubscriptionOwner = originalClaim;
+			}
+		});
+
+		it('returns 404 when the durable session disappears during reconnect', async () => {
+			const originalUpdate = sessionModule.updateSessionSubscriptions;
+			sessionModule.updateSessionSubscriptions = async () => null;
+			try {
+				const res = await handleMcpRequest(
+					makeReq({
+						method: 'GET',
+						headers: { 'mcp-session-id': sessionId, 'accept': 'text/event-stream' },
+					})
+				);
+				assert.equal(res.status, 404);
+				assert.equal(getRegisteredSession(sessionId), undefined);
+			} finally {
+				sessionModule.updateSessionSubscriptions = originalUpdate;
+			}
+		});
+
 		it('closes the registered GET stream when subscription restoration fails', async () => {
 			const originalLock = subscriptionRouting.withSessionSubscriptionLock;
 			subscriptionRouting.withSessionSubscriptionLock = async () => {
@@ -295,7 +330,7 @@ describe('mcp/transport', () => {
 			}
 		});
 
-		it('restores subscriptions with the same projected principal used by subscribe', async () => {
+		it('restores subscriptions with the full local principal', async () => {
 			const uri = 'https://app.test:9926/Product/restore';
 			await patchSession(sessionId, { subscriptions: [uri] });
 			let restoredUser;
@@ -323,8 +358,8 @@ describe('mcp/transport', () => {
 			);
 			assert.equal(res.status, 200);
 			assert.equal(restoredUser.username, 'alice');
-			assert.equal(restoredUser.password, undefined);
-			assert.equal(restoredUser.customClaim, undefined);
+			assert.equal(restoredUser.password, 'do-not-forward');
+			assert.equal(restoredUser.customClaim, 'not-in-contract');
 			res.sseIterable.emit('close');
 		});
 

--- a/unitTests/components/mcp/transport.test.js
+++ b/unitTests/components/mcp/transport.test.js
@@ -1,8 +1,9 @@
 const assert = require('node:assert');
+const { threadId } = require('node:worker_threads');
 const rewire = require('rewire');
 const transport_mod = rewire('#src/components/mcp/transport');
 const { handleMcpRequest } = transport_mod;
-const { _setSessionTableForTest, createSession, loadSession, saveSession } = require('#src/components/mcp/session');
+const { _setSessionTableForTest, createSession, loadSession, patchSession } = require('#src/components/mcp/session');
 const {
 	getRegisteredSession,
 	pushSessionFrame,
@@ -46,6 +47,9 @@ function makeFakeTable() {
 		store,
 		async put(record) {
 			store.set(record.id, { ...record });
+		},
+		async patch(record) {
+			store.set(record.id, { ...store.get(record.id), ...record });
 		},
 		async get(id) {
 			const r = store.get(id);
@@ -273,10 +277,9 @@ describe('mcp/transport', () => {
 
 		it('does not roll back lastActivity when persisting the level (touchSession adopted)', async () => {
 			// Force a known-old lastActivity, then setLevel: the request's touchSession
-			// must advance it, and the level-persisting saveSession must NOT write the
+			// must advance it, and the level patch must not write the
 			// stale load-time value back (root fix — handlePost adopts the touched copy).
-			const stale = await loadSession(sessionId);
-			await saveSession({ ...stale, lastActivity: 1 });
+			await patchSession(sessionId, { lastActivity: 1 });
 			await handleMcpRequest(
 				makeReq({
 					body: jsonRpc(2, 'logging/setLevel', { level: 'info' }),
@@ -1113,9 +1116,13 @@ describe('mcp/transport', () => {
 		});
 
 		describe('resources/subscribe + resources/unsubscribe', () => {
-			beforeEach(() => {
+			beforeEach(async () => {
 				// A live GET stream is required to subscribe — register one for the session.
-				registerSession(sessionId, 'application', { username: 'alice', role: { permission: { super_user: true } } });
+				const registered = registerSession(sessionId, 'application', {
+					username: 'alice',
+					role: { permission: { super_user: true } },
+				});
+				await patchSession(sessionId, { streamOwner: { threadId, token: registered.streamToken } });
 				// Inject a fake change stream so dispatch doesn't need the real audit log.
 				// `null` for the sentinel path makes the resource non-subscribable.
 				_setSubscribeImplForTest(async (path) =>

--- a/unitTests/components/mcp/transport.test.js
+++ b/unitTests/components/mcp/transport.test.js
@@ -1363,6 +1363,34 @@ describe('mcp/transport', () => {
 				}
 			});
 
+			it('retains durable state when the unsubscribe owner keeps changing', async () => {
+				const uri = 'https://app.test:9926/Product/5';
+				await patchSession(sessionId, { subscriptions: [uri] });
+				let calls = 0;
+				const originalRoute = subscriptionRouting.routeResourceSubscription;
+				subscriptionRouting.routeResourceSubscription = async () => {
+					calls++;
+					await patchSession(sessionId, { streamOwner: { threadId: threadId + calls, token: `owner-${calls}` } });
+					return 'no-live-stream';
+				};
+				try {
+					const res = await handleMcpRequest(
+						makeReq({
+							body: jsonRpc(78, 'resources/unsubscribe', { uri }),
+							headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+						})
+					);
+					assert.equal(res.status, 200);
+					assert.equal(res.jsonBody.id, 78);
+					assert.equal(res.jsonBody.error.code, -32603);
+					assert.match(res.jsonBody.error.message, /retry/);
+					assert.equal(calls, 3);
+					assert.deepEqual((await loadSession(sessionId)).subscriptions, [uri]);
+				} finally {
+					subscriptionRouting.routeResourceSubscription = originalRoute;
+				}
+			});
+
 			it('contains a durable unsubscribe failure in the request JSON-RPC response', async () => {
 				const originalRoute = subscriptionRouting.routeResourceSubscription;
 				const originalUpdate = sessionModule.updateSessionSubscriptions;

--- a/unitTests/components/mcp/transport.test.js
+++ b/unitTests/components/mcp/transport.test.js
@@ -48,8 +48,27 @@ function makeFakeResources(entries) {
 
 function makeFakeTable() {
 	const store = new Map();
+	const locks = new Set();
+	const waiters = new Map();
 	return {
 		store,
+		primaryStore: {
+			tryLock(key, callback) {
+				if (!locks.has(key)) {
+					locks.add(key);
+					return true;
+				}
+				const queued = waiters.get(key) ?? [];
+				queued.push(callback);
+				waiters.set(key, queued);
+				return false;
+			},
+			unlock(key) {
+				locks.delete(key);
+				const callback = waiters.get(key)?.shift();
+				if (callback) setImmediate(callback);
+			},
+		},
 		async put(record) {
 			store.set(record.id, { ...record });
 		},

--- a/unitTests/components/mcp/transport.test.js
+++ b/unitTests/components/mcp/transport.test.js
@@ -23,11 +23,9 @@ const {
 	_setHttpUrlPrefixForTest,
 	_setSubscribeImplForTest,
 } = require('#src/components/mcp/resources');
-const {
-	_setSubscriptionItcForTest,
-	_setSubscriptionTimeoutForTest,
-	_resetSubscriptionRoutingForTest,
-} = require('#src/components/mcp/subscriptionRouting');
+const subscriptionRouting = require('#src/components/mcp/subscriptionRouting');
+const { _setSubscriptionItcForTest, _setSubscriptionTimeoutForTest, _resetSubscriptionRoutingForTest } =
+	subscriptionRouting;
 
 function makeFakeResources(entries) {
 	const map = new Map();
@@ -251,6 +249,30 @@ describe('mcp/transport', () => {
 			);
 			assert.equal(res.status, 200, `SSE open succeeded: ${res.status}`);
 			assert.ok(res.sseIterable, 'SSE stream returned');
+		});
+
+		it('does not close a superseding GET stream when an earlier owner claim fails', async () => {
+			let replacement;
+			const originalClaim = subscriptionRouting.claimSubscriptionOwner;
+			subscriptionRouting.claimSubscriptionOwner = async () => {
+				replacement = registerSession(sessionId, 'application', {
+					username: 'alice',
+					role: { permission: { super_user: true } },
+				});
+				throw new Error('claim failed');
+			};
+			try {
+				const res = await handleMcpRequest(
+					makeReq({
+						method: 'GET',
+						headers: { 'mcp-session-id': sessionId, 'accept': 'text/event-stream' },
+					})
+				);
+				assert.equal(res.status, 500);
+				assert.equal(getRegisteredSession(sessionId), replacement);
+			} finally {
+				subscriptionRouting.claimSubscriptionOwner = originalClaim;
+			}
 		});
 
 		it('accepts a matching MCP-Protocol-Version and returns Method-not-found for unknown methods', async () => {
@@ -1255,6 +1277,37 @@ describe('mcp/transport', () => {
 				assert.deepEqual(res.jsonBody.result, {});
 				const saved = await loadSession(sessionId);
 				assert.ok(!(saved.subscriptions ?? []).includes(uri), 'URI dropped from the record');
+			});
+
+			it('reroutes unsubscribe when the stream owner changes during the first attempt', async () => {
+				const uri = 'https://app.test:9926/Product/3';
+				await patchSession(sessionId, { subscriptions: [uri] });
+				let calls = 0;
+				const originalRoute = subscriptionRouting.routeResourceSubscription;
+				subscriptionRouting.routeResourceSubscription = async ({ session }) => {
+					calls++;
+					if (calls === 1) {
+						await patchSession(sessionId, { streamOwner: { threadId: threadId + 1, token: 'new-owner' } });
+						return 'no-live-stream';
+					}
+					assert.deepEqual(session.streamOwner, { threadId: threadId + 1, token: 'new-owner' });
+					await patchSession(sessionId, { subscriptions: [] });
+					return 'success';
+				};
+				try {
+					const res = await handleMcpRequest(
+						makeReq({
+							body: jsonRpc(76, 'resources/unsubscribe', { uri }),
+							headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+						})
+					);
+					assert.equal(res.status, 200);
+					assert.deepEqual(res.jsonBody.result, {});
+					assert.equal(calls, 2);
+					assert.deepEqual((await loadSession(sessionId)).subscriptions, []);
+				} finally {
+					subscriptionRouting.routeResourceSubscription = originalRoute;
+				}
 			});
 		});
 

--- a/unitTests/components/mcp/transport.test.js
+++ b/unitTests/components/mcp/transport.test.js
@@ -101,6 +101,7 @@ describe('mcp/transport', () => {
 		_setResourcesForTest(makeFakeResources([]));
 		_setOpenApiGeneratorForTest(() => ({ openapi: '3.0.3', info: { title: 'fake' }, paths: {} }));
 		_setHttpUrlPrefixForTest('');
+		_setSubscriptionItcForTest({ onMessageByType() {}, sendToThread: () => true });
 	});
 
 	afterEach(() => {
@@ -110,6 +111,8 @@ describe('mcp/transport', () => {
 		_setResourcesForTest(undefined);
 		_setOpenApiGeneratorForTest(undefined);
 		_setHttpUrlPrefixForTest(undefined);
+		_resetSubscriptionRoutingForTest();
+		_setSubscriptionItcForTest(undefined);
 	});
 
 	describe('POST initialize', () => {

--- a/unitTests/components/mcp/transport.test.js
+++ b/unitTests/components/mcp/transport.test.js
@@ -3,7 +3,8 @@ const { threadId } = require('node:worker_threads');
 const rewire = require('rewire');
 const transport_mod = rewire('#src/components/mcp/transport');
 const { handleMcpRequest } = transport_mod;
-const { _setSessionTableForTest, createSession, loadSession, patchSession } = require('#src/components/mcp/session');
+const sessionModule = require('#src/components/mcp/session');
+const { _setSessionTableForTest, createSession, loadSession, patchSession } = sessionModule;
 const {
 	getRegisteredSession,
 	pushSessionFrame,
@@ -273,6 +274,58 @@ describe('mcp/transport', () => {
 			} finally {
 				subscriptionRouting.claimSubscriptionOwner = originalClaim;
 			}
+		});
+
+		it('closes the registered GET stream when subscription restoration fails', async () => {
+			const originalLock = subscriptionRouting.withSessionSubscriptionLock;
+			subscriptionRouting.withSessionSubscriptionLock = async () => {
+				throw new Error('restore failed');
+			};
+			try {
+				const res = await handleMcpRequest(
+					makeReq({
+						method: 'GET',
+						headers: { 'mcp-session-id': sessionId, 'accept': 'text/event-stream' },
+					})
+				);
+				assert.equal(res.status, 500);
+				assert.equal(getRegisteredSession(sessionId), undefined);
+			} finally {
+				subscriptionRouting.withSessionSubscriptionLock = originalLock;
+			}
+		});
+
+		it('restores subscriptions with the same projected principal used by subscribe', async () => {
+			const uri = 'https://app.test:9926/Product/restore';
+			await patchSession(sessionId, { subscriptions: [uri] });
+			let restoredUser;
+			_setSubscribeImplForTest(async (_path, user) => {
+				restoredUser = user;
+				return {
+					end() {},
+					[Symbol.asyncIterator]() {
+						return { next: () => new Promise(() => {}) };
+					},
+				};
+			});
+
+			const res = await handleMcpRequest(
+				makeReq({
+					method: 'GET',
+					userObject: {
+						username: 'alice',
+						password: 'do-not-forward',
+						customClaim: 'not-in-contract',
+						role: { permission: { super_user: true } },
+					},
+					headers: { 'mcp-session-id': sessionId, 'accept': 'text/event-stream' },
+				})
+			);
+			assert.equal(res.status, 200);
+			assert.equal(restoredUser.username, 'alice');
+			assert.equal(restoredUser.password, undefined);
+			assert.equal(restoredUser.customClaim, undefined);
+			res.sseIterable.emit('close');
 		});
 
 		it('accepts a matching MCP-Protocol-Version and returns Method-not-found for unknown methods', async () => {
@@ -1307,6 +1360,30 @@ describe('mcp/transport', () => {
 					assert.deepEqual((await loadSession(sessionId)).subscriptions, []);
 				} finally {
 					subscriptionRouting.routeResourceSubscription = originalRoute;
+				}
+			});
+
+			it('contains a durable unsubscribe failure in the request JSON-RPC response', async () => {
+				const originalRoute = subscriptionRouting.routeResourceSubscription;
+				const originalUpdate = sessionModule.updateSessionSubscriptions;
+				subscriptionRouting.routeResourceSubscription = async () => 'no-live-stream';
+				sessionModule.updateSessionSubscriptions = async () => {
+					throw new Error('lock timed out');
+				};
+				try {
+					const res = await handleMcpRequest(
+						makeReq({
+							body: jsonRpc(77, 'resources/unsubscribe', { uri: 'https://app.test:9926/Product/4' }),
+							headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+						})
+					);
+					assert.equal(res.status, 200);
+					assert.equal(res.jsonBody.id, 77);
+					assert.equal(res.jsonBody.error.code, -32603);
+					assert.match(res.jsonBody.error.message, /retry/);
+				} finally {
+					subscriptionRouting.routeResourceSubscription = originalRoute;
+					sessionModule.updateSessionSubscriptions = originalUpdate;
 				}
 			});
 		});

--- a/unitTests/components/mcp/transport.test.js
+++ b/unitTests/components/mcp/transport.test.js
@@ -23,6 +23,11 @@ const {
 	_setHttpUrlPrefixForTest,
 	_setSubscribeImplForTest,
 } = require('#src/components/mcp/resources');
+const {
+	_setSubscriptionItcForTest,
+	_setSubscriptionTimeoutForTest,
+	_resetSubscriptionRoutingForTest,
+} = require('#src/components/mcp/subscriptionRouting');
 
 function makeFakeResources(entries) {
 	const map = new Map();
@@ -1184,6 +1189,30 @@ describe('mcp/transport', () => {
 					})
 				);
 				assert.equal(res.jsonBody.error.code, -32602);
+			});
+
+			it('returns a retryable internal error when subscription routing times out', async () => {
+				_setSubscriptionItcForTest({
+					onMessageByType() {},
+					sendToThread() {
+						return true;
+					},
+				});
+				_setSubscriptionTimeoutForTest(5);
+				await patchSession(sessionId, { streamOwner: { threadId: threadId + 1, token: 'remote-owner' } });
+				try {
+					const res = await handleMcpRequest(
+						makeReq({
+							body: jsonRpc(73, 'resources/subscribe', { uri: 'https://app.test:9926/Product/1' }),
+							headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+						})
+					);
+					assert.equal(res.jsonBody.error.code, -32603);
+					assert.match(res.jsonBody.error.message, /timed out; retry/);
+				} finally {
+					_resetSubscriptionRoutingForTest();
+					_setSubscriptionItcForTest(undefined);
+				}
 			});
 
 			it('unsubscribe removes the URI from the durable record', async () => {

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -952,6 +952,8 @@ export const ITC_EVENT_TYPES = {
 	// MCP §3.7: route a client's response to a server→client request back to the
 	// worker awaiting it (the response POST can land on any worker).
 	MCP_CLIENT_RESPONSE: 'mcp_client_response',
+	MCP_SUBSCRIPTION_COMMAND: 'mcp_subscription_command',
+	MCP_SUBSCRIPTION_RESPONSE: 'mcp_subscription_response',
 	// #1736: components load per-worker, so a `server.registerOperation()` made there lands in
 	// a worker-local OPERATION_FUNCTION_MAP the main-thread ops-API dispatcher can't see. A
 	// worker announces each registration (OPERATION_REGISTERED) so the main thread can forward


### PR DESCRIPTION
MCP resource subscriptions now follow the session's active GET-SSE stream across HTTP workers through a [fenced owner claim](https://github.com/HarperFast/harper/pull/2436/changes?w=1#diff-c5ddd1396c67f379c806e4d4a1a541c5a397a3d0bae065fa7e9f7c5174a6f2e5R142), so `resources/subscribe` and `resources/unsubscribe` no longer depend on both requests landing on the same worker. The [routing path](https://github.com/HarperFast/harper/pull/2436/changes?w=1#diff-c5ddd1396c67f379c806e4d4a1a541c5a397a3d0bae065fa7e9f7c5174a6f2e5R288) keeps the full local principal, projects only the fields needed across ITC, and rejects stale ownership commands. [Storage-native serialization](https://github.com/HarperFast/harper/pull/2436/changes?w=1#diff-5ce7e54ce486dd20d10ae91fce54934359f223bfd40ea9172ad8b1961fbea800R177) prevents concurrent subscription changes from losing durable updates.

Fixes #1751.

## For the human reviewer

1. The active GET worker and a random stream token are persisted on the non-replicating MCP session row when the [SSE stream registers its owner](https://github.com/HarperFast/harper/pull/2436/changes?w=1#diff-e5236f0b6a86eebec569f8afdf37573234af03cef53c3817950a0fdf12a14497R409). POST workers route directly to that owner, and the live token rejects stale commands. When ITC is unavailable, the owner claim is cleared and only the local unwired worker may use its registry entry.
2. Routed operations have an ambiguous outcome at the 30-second timeout boundary, so the [JSON-RPC response asks the client to retry](https://github.com/HarperFast/harper/pull/2436/changes?w=1#diff-e5236f0b6a86eebec569f8afdf37573234af03cef53c3817950a0fdf12a14497R965). Exactly-once operation IDs would add durable protocol state for a rare outcome and can be added later without changing successful requests.
3. Durable subscription mutations use Harper's native per-record-store lock across workers rather than a persisted CAS/version field. The acquire is bounded and failures become retryable JSON-RPC errors. This keeps the session schema and protocol unchanged across RocksDB and LMDB.

## Verification

- `npm run build` — passed.
- Focused MCP unit suite (`session`, `subscriptionRouting`, `subscriptions`, `transport`) — 129 passing.
- Changed-file lint, Prettier, and `git diff --check` — passed.
- Final independent Claude review — no remaining code findings.
- Full repository lint currently reports 14 unrelated pre-existing warnings outside the changed files.
- The local MCP integration harness cannot start because this macOS host lacks the required `127.0.0.2`–`127.0.0.32` loopback aliases. The [cross-worker assertion](https://github.com/HarperFast/harper/pull/2436/changes?w=1#diff-c25120786d28a66e0f070f72886b8d52437371ce190dda660dc4eec2f2a01234R474) passed in the Node integration shard and remains fail-closed there. Bun skips this socket-placement proof because all pinned probes are assigned to one HTTP worker.

Comment generated by kAIle (GPT-5.6)

Complexity: complicated

<sub>Review-Coverage: authored=codex; ran=claude; declined=gemini,cursor-grok,cursor-composer,domain; rounds=2 @ 5c60fea0e5e9</sub>

<sub>Human-Review-Need: 4 @ 5c60fea0e5e9</sub>
