### PR TITLE
Backport #2409 to v5.2: stamp localTime on RocksDB log reads so subscription catch-up delivers patch values (#2444)

### DIFF
--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -117,7 +117,14 @@ export class RocksTransactionLogStore extends EventEmitter {
 			}
 			entryBinary = createAuditEntry(auditRecord, position);
 		}
-		if (this.listenerCount('aftercommit')) (options.transaction.logEntries ??= []).push(auditRecord);
+		if (this.listenerCount('aftercommit')) {
+			if (!(auditRecord instanceof Uint8Array)) {
+				const txnTimestamp = options.transaction.getTimestamp?.();
+				if (txnTimestamp != null) auditRecord.localTime = txnTimestamp;
+				auditRecord.recordVersion = auditRecord.version;
+			}
+			(options.transaction.logEntries ??= []).push(auditRecord);
+		}
 		// One commit hook per transaction handles both deferred side effects — the `aftercommit` emit and the
 		// per-(log, table) structureVersion watermark advances — so they apply only after a durable commit (never
 		// on an aborted/discarded transaction). This store is the sole setter of transaction.onCommit.
@@ -414,7 +421,10 @@ export class RocksTransactionLogStore extends EventEmitter {
 					position += 8;
 				}
 				const auditRecord = readAuditEntry(data, position, undefined);
+				// version stays the log key (replication resume relies on version === log key);
+				// the record's own version survives as recordVersion
 				auditRecord.version = timestamp;
+				auditRecord.localTime = timestamp;
 				auditRecord.endTxn = endTxn;
 				auditRecord.previousResidencyId = previousResidencyId;
 				auditRecord.previousVersion = previousVersion;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -4133,7 +4133,8 @@ export function makeTable(options) {
 							// been written, so are fresh in memory.
 							const entry: Entry = primaryStore.getEntry(id);
 							if (entry) {
-								if (entry.version !== auditRecord.version) return; // out of order event, with old update, don't send anything
+								// staleness is a record-version comparison; auditRecord.version is the log key on RocksDB
+								if (entry.version !== (auditRecord.recordVersion ?? auditRecord.version)) return; // out of order event, with old update, don't send anything
 								value = entry.value;
 								type = entry.metadataFlags & INVALIDATED ? 'invalidate' : value ? 'put' : 'delete';
 							} else {

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -34,7 +34,8 @@ initSync();
 
 export type AuditRecord = {
 	version: number;
-	localTime: number; // only to be used by LMDB (from the key)
+	recordVersion?: number; // the record's own version; on RocksDB reads `version` becomes the log key, so record identity uses this
+	localTime: number; // log position: LMDB audit-store key; RocksDB transaction-log timestamp
 	type: string;
 	encodedRecord?: Buffer;
 	extendedType?: number;
@@ -620,6 +621,7 @@ export function readAuditEntry(buffer: Uint8Array, start = 0, end = undefined): 
 				return buffer.subarray(recordIdStart, recordIdEnd);
 			},
 			version,
+			recordVersion: version,
 			previousVersion,
 			get user() {
 				try {

--- a/resources/transactionBroadcast.ts
+++ b/resources/transactionBroadcast.ts
@@ -180,6 +180,9 @@ function notifyFromTransactionData(subscriptions, auditLogIterable?, allowYield 
 			const auditRecord = result.value;
 			const timestamp: number = auditRecord.localTime ?? auditRecord.version;
 			subscriptions.lastTxnTime = timestamp;
+			// the transaction extent: RocksDB entries committed together share the log key (record
+			// versions may differ); LMDB's localTime is a per-entry audit key, so version delimits there
+			const txnKey = auditStore.reusableIterable ? timestamp : auditRecord.version;
 			if (ACTIONS_OF_INTEREST.includes(auditRecord.type)) {
 				const tableSubscriptions = subscriptions[auditRecord.tableId];
 				if (tableSubscriptions) {
@@ -204,7 +207,7 @@ function notifyFromTransactionData(subscriptions, auditLogIterable?, allowYield 
 								}
 								try {
 									let beginTxn;
-									if (subscription.supportsTransactions && subscription.txnInProgress !== auditRecord.version) {
+									if (subscription.supportsTransactions && subscription.txnInProgress !== txnKey) {
 										// if the subscriber supports transactions, we mark this as the beginning of a new transaction
 										// tracking the subscription so that we can delimit the transaction on next transaction
 										// (with a beginTxn flag, which may be on an endTxn event)
@@ -214,10 +217,7 @@ function notifyFromTransactionData(subscriptions, auditLogIterable?, allowYield 
 											if (!subscribersWithTxns) subscribersWithTxns = [subscription];
 											else subscribersWithTxns.push(subscription);
 										}
-										// the version defines the extent of a transaction, all audit records with the same version
-										// are part of the same transaction, and when the version changes, we know it is a new
-										// transaction
-										subscription.txnInProgress = auditRecord.version;
+										subscription.txnInProgress = txnKey;
 									}
 									subscription.listener(recordId, auditRecord, timestamp, beginTxn);
 								} catch (error) {

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -159,6 +159,28 @@ describe('Subscription replay', () => {
 			// concurrent writes during replay should still come out in chronological order
 			assertChronological(events, 'startTime branch with concurrent writes out of order');
 		});
+
+		// harper#2444: rocksdb's transaction-log reader didn't stamp localTime on decoded audit
+		// records, so replay's getValue(store, fullRecord, auditRecord.localTime) had no
+		// reconstruction time for partial-record (patch) entries and delivered them with
+		// value: undefined — catch-up consumers dropped every partial update made while offline.
+		it('delivers a patch written while unsubscribed as a full-value event on catch-up', async () => {
+			const id = 9100;
+			await StartTimeTable.put(id, { name: 'patch_base' });
+			const startTime = StartTimeTable.primaryStore.getEntry(id).version;
+			await StartTimeTable.patch(id, { name: 'patch_updated' });
+			const subscription = await StartTimeTable.subscribe({ startTime, isCollection: true, omitCurrent: true });
+			const events = await collect(subscription, 100);
+			subscription.return?.();
+
+			const patchEvent = events.filter((e) => e.id === id).pop();
+			assert.ok(patchEvent, 'the patch made after startTime must be replayed');
+			assert.ok(
+				patchEvent.value != null,
+				`replayed ${patchEvent.type} event must carry a usable value, got ${patchEvent.value}`
+			);
+			assert.equal(patchEvent.value.name, 'patch_updated');
+		});
 	});
 
 	describe('count branch (collection with previousCount)', () => {

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -13,9 +13,8 @@ require('#src/server/serverHelpers/serverUtilities');
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 
 function assertChronological(events, msg = 'events out of order') {
-	// Use `version` because lmdb populates localTime on cursor sends but rocksdb doesn't; both
-	// backends set version on the audit record to the commit timestamp, so version is the
-	// portable "time" key.
+	// Use `version`: both backends set it to the commit timestamp on cursor sends (rocksdb now
+	// also populates localTime with the log key, but version remains the portable "time" key).
 	for (let i = 1; i < events.length; i++) {
 		assert.ok(
 			events[i].version >= events[i - 1].version,

--- a/unitTests/resources/transactionBroadcastGrouping.test.js
+++ b/unitTests/resources/transactionBroadcastGrouping.test.js
@@ -1,0 +1,83 @@
+// Transaction delimiting in the broadcaster is engine-aware: RocksDB entries committed together
+// share the log key while their record versions may differ (a source fill's version can be a
+// source-reported lastModified); LMDB's localTime is a per-entry audit key, so there the shared
+// version delimits the transaction. These drive the real same-thread aftercommit path.
+require('../testUtils');
+const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
+const { addSubscription } = require('#src/resources/transactionBroadcast');
+const { waitFor } = require('../waitFor.js');
+
+function makeFakeStores(path, reusableIterable) {
+	const auditStore = new EventEmitter();
+	auditStore.env = {};
+	auditStore.reusableIterable = reusableIterable;
+	const primaryStore = { path, tableId: 1 };
+	return { primaryStore, auditStore };
+}
+
+function subscribeCollecting(table) {
+	const events = [];
+	const subscription = addSubscription(
+		table,
+		null,
+		(recordId, auditRecord, timestamp, beginTxn) => {
+			events.push({ id: recordId, type: auditRecord.type, beginTxn });
+		},
+		0,
+		{ crossThreads: false }
+	);
+	subscription.includeDescendants = true;
+	subscription.supportsTransactions = true;
+	return { events, subscription };
+}
+
+describe('transactionBroadcast transaction grouping', () => {
+	it('groups RocksDB entries by the shared log key even when record versions differ', async function () {
+		const table = makeFakeStores('/fake/broadcast-grouping-rocks', true);
+		const { events, subscription } = subscribeCollecting(table);
+		try {
+			const logKey = Date.now();
+			table.auditStore.emit('aftercommit', [
+				{ type: 'put', tableId: 1, recordId: 'a', version: logKey, recordVersion: logKey, localTime: logKey },
+				// a source fill in the same commit: backdated record version, same log key
+				{
+					type: 'put',
+					tableId: 1,
+					recordId: 'b',
+					version: logKey - 5000,
+					recordVersion: logKey - 5000,
+					localTime: logKey,
+				},
+			]);
+			await waitFor(() => events.length === 3, { message: 'both entries and the end_txn should be delivered' });
+			assert.deepEqual(events, [
+				{ id: 'a', type: 'put', beginTxn: true },
+				{ id: 'b', type: 'put', beginTxn: undefined },
+				{ id: null, type: 'end_txn', beginTxn: true },
+			]);
+		} finally {
+			subscription.end();
+		}
+	});
+
+	it('groups LMDB entries by the shared version across distinct per-entry audit keys', async function () {
+		const table = makeFakeStores('/fake/broadcast-grouping-lmdb', false);
+		const { events, subscription } = subscribeCollecting(table);
+		try {
+			const version = Date.now();
+			table.auditStore.emit('aftercommit', [
+				{ type: 'put', tableId: 1, recordId: 'c', version, localTime: version + 1 },
+				{ type: 'put', tableId: 1, recordId: 'd', version, localTime: version + 2 },
+			]);
+			await waitFor(() => events.length === 3, { message: 'both entries and the end_txn should be delivered' });
+			assert.deepEqual(events, [
+				{ id: 'c', type: 'put', beginTxn: true },
+				{ id: 'd', type: 'put', beginTxn: undefined },
+				{ id: null, type: 'end_txn', beginTxn: true },
+			]);
+		} finally {
+			subscription.end();
+		}
+	});
+});


### PR DESCRIPTION
Backports b3235b8c6 (#2409) onto `v5.2` to fix #2444: on the 5.2.x line, RocksDB subscription catch-up (`subscribe({ startTime })` and `previousCount` backfill) delivers `patch`/`invalidate` audit entries with `value: undefined`, so resumed consumers (MQTT durable sessions, SSE/WS reconnects, component gateways) silently drop every partial-update write from their offline window. The operative line is the reader stamping `auditRecord.localTime = timestamp`, which gives replay's `getValue(store, fullRecord, auditRecord.localTime)` a reconstruction time for partial-record entries.

Manual cherry-pick rather than a re-milestone of #2409: that PR is already merged, and a `milestoned` event would have the workflow reset this branch under the conflict resolution.

**Conflict resolution** (`unitTests/resources/caching.test.js`): kept the `v5.2` side. The conflict block is the `ConflictCachingTable` suite from #2065 (source-reported fill versions), which is not on `v5.2` — that includes the original commit's own new caching test (`delivers a subscription event for a fill whose source-reported version predates the log position`), which asserts `entry.version === reportedVersion` and cannot pass without #2065. The rest of the commit is engine-generic and null-guarded (`getTimestamp?.()`, `recordVersion ?? version`), and applies cleanly.

**Why the `Table.ts` staleness hunk carries no test here**: the `recordVersion ?? version` comparison guards a state — a record whose stored version differs from its transaction-log key — that only #2065's source-reported fill versions can produce. On this branch every write's record version *is* the transaction timestamp that keys the log (verified empirically: an explicitly timestamped put stamps the transaction too, and with the comparison reverted to the old `entry.version !== auditRecord.version` form, live delivery is unchanged). The hunk is a provable no-op on `v5.2`, kept for upstream parity so future cherry-picks onto this line don't conflict; the branch-reachable half of #2409 (the reader's `localTime` stamp fixing catch-up replay, #2444) is what the new regression test pins, and the broadcaster-level `recordVersion` grouping is covered by `transactionBroadcastGrouping.test.js`.

**Added on top**: a regression test in `subscriptionReplay.test.js` pinning the #2444 contract — a `patch` written after a subscriber's checkpoint must replay as a full-value event (passes on both engines with the fix; fails on `v5.2` without it).

Tested locally (Node 24, `npm run build` then mocha):
- `subscriptionReplay.test.js` + `transactionBroadcastGrouping.test.js`: 30 passing / 9 pending (RocksDB), 38 passing / 1 failing (LMDB) — the one LMDB failure (`FIRST-subscription-on-fresh-DB while writes are in flight`) reproduces identically on pristine `origin/v5.2`, pre-existing.
- `caching.test.js`: 20 passing (RocksDB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
