### PR TITLE
Give the #1854 RocksDB oracle a checkpoint it cannot race

### DIFF
--- a/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
+++ b/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
@@ -33,10 +33,10 @@
  * `createCheckpoint()` flushes the memtable — which the oracle needs anyway, since Harper opens
  * table/index column families with `disableWAL` defaulting to true (resources/databases.ts
  * openRocksDatabase) and a committed write can otherwise sit only in the writer's memtable. One
- * checkpoint covers every column family at a single point in time, so no arm can read two families
- * from two different instants. `refreshOracle()` takes a fresh one and reopens every handle before
- * each raw read, and the 'oracle proof' tests below demonstrate — rather than assert — that the
- * oracle really reads that snapshot, and that it detects a phantom the join cannot, on both tables.
+ * checkpoint operation covers every column family, rather than opening each one separately at
+ * unrelated instants. `refreshOracle()` takes a fresh one and reopens every handle before each raw
+ * read, and the 'oracle proof' tests below demonstrate — rather than assert — that the oracle
+ * really reads that snapshot, and that it detects a phantom the join cannot, on both tables.
  *
  * Reproduction:
  *   npm run test:integration -- "integrationTests/database/delete-index-atomicity-rocksdb.test.ts"
@@ -215,12 +215,13 @@ suite(
 			const body = await res.text();
 			strictEqual(res.status, 200, `snapshot control should succeed; got ${res.status} ${body.slice(0, 300)}`);
 			const published = JSON.parse(body).path;
+			const expected = resolve(ctx.harper.dataRootDir, SNAPSHOT_DIR, String(snapshotSeq));
+			if (published === expected) snapshotPath = published;
 			strictEqual(
 				published,
-				join(ctx.harper.dataRootDir, SNAPSHOT_DIR, String(snapshotSeq)),
+				expected,
 				'the oracle must only ever open a checkpoint at the path the fixture derives for this sequence'
 			);
-			snapshotPath = published;
 		}
 		function openDbi(name: string): RocksDatabase {
 			// Reading the live directory instead would reintroduce the compaction race the checkpoint
@@ -291,8 +292,8 @@ suite(
 				'the checkpoint must contain the write that preceded it'
 			);
 
-			// Flushed, so snapshot-2 is durably in the live directory's own SSTs: the only thing that
-			// can keep the oracle from seeing it now is that the oracle is not reading that directory.
+			// A held checkpoint stays frozen after the live database advances; the next refresh below
+			// must replace it with a checkpoint that includes the new write.
 			await seed('ItemF', [{ id: 'snapshot-2', category: 'SNAPSHOT' }]);
 			const flushed = await postJSON('/Flush/', {});
 			strictEqual(flushed.status, 200, 'flush control should succeed');

--- a/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
+++ b/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
@@ -62,6 +62,9 @@ const MAX_TXN_OPEN_MS = 1000;
 // on elapsed wall-clock.
 const HOLD_MS = 15_000;
 const LOG_FILES = ['hdb.log', 'stdout.log', 'stderr.log'];
+// Where the fixture puts a checkpoint; derived independently here so that a fixture regression
+// handing back a live directory fails the assertion in refreshOracle() rather than being opened.
+const SNAPSHOT_DIR = 'oracle-snapshots';
 const skipSuite = process.platform === 'win32';
 
 suite(
@@ -139,8 +142,11 @@ suite(
 
 		after(async () => {
 			closeOracleHandles();
-			await removeSnapshot();
-			await teardownHarper(ctx);
+			try {
+				await removeSnapshot();
+			} finally {
+				await teardownHarper(ctx);
+			}
 		});
 
 		function postJSON(path: string, body: unknown): Promise<Response> {
@@ -208,8 +214,12 @@ suite(
 			const res = await postJSON('/Snapshot/', { seq: ++snapshotSeq });
 			const body = await res.text();
 			strictEqual(res.status, 200, `snapshot control should succeed; got ${res.status} ${body.slice(0, 300)}`);
+			strictEqual(
+				JSON.parse(body).path,
+				join(ctx.harper.dataRootDir, SNAPSHOT_DIR, String(snapshotSeq)),
+				'the oracle must only ever open a checkpoint at the path the fixture derives for this sequence'
+			);
 			snapshotPath = JSON.parse(body).path;
-			ok(snapshotPath, `snapshot control must return the checkpoint path; got ${body.slice(0, 300)}`);
 		}
 		function openDbi(name: string): RocksDatabase {
 			// Reading the live directory instead would reintroduce the compaction race the checkpoint
@@ -269,7 +279,7 @@ suite(
 			await seed('ItemF', [{ id: 'snapshot-1', category: 'SNAPSHOT' }]);
 			await refreshOracle();
 			const firstSnapshot = snapshotPath!;
-			ok(firstSnapshot && firstSnapshot !== rootPath, `the oracle must open a checkpoint, not ${rootPath}`);
+			ok(firstSnapshot !== rootPath, `the oracle must open a checkpoint, not ${rootPath}`);
 			strictEqual(
 				openDbi('ItemF/category').path,
 				firstSnapshot,

--- a/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
+++ b/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
@@ -25,22 +25,27 @@
  * the raw primary column family cannot answer it. It also covers the monitor-fired abort (Arm A)
  * alongside #1869's request-thrown abort (Arm B).
  *
- * A RocksDB `readOnly: true` open is a point-in-time snapshot of the SSTs as of that open, not a
- * live view like LMDB's shared mmap, and Harper opens table/index column families with
- * `disableWAL` defaulting to true (resources/databases.ts openRocksDatabase), so a committed
- * write can still sit only in the writer's memtable. An oracle that skips either step reports a
- * clean run from flush timing rather than from real consistency, so `refreshOracle()` flushes
- * through the fixture and reopens every handle before each raw read, and the 'oracle proof'
- * tests below demonstrate — rather than assert — that it detects a phantom the join cannot, on
- * both tables.
+ * The oracle reads a RocksDB checkpoint, never the live database directory. `readOnly: true` maps
+ * to `rocksdb::DB::OpenForReadOnly`, which replays the MANIFEST into a file list and then opens
+ * those files while holding no reference on any of them, so a compaction in the process under test
+ * can unlink one inside that window and the open fails as MANIFEST corruption
+ * (HarperFast/rocksdb-js#812). Nothing writes to a checkpoint, so the race cannot happen there, and
+ * `createCheckpoint()` flushes the memtable — which the oracle needs anyway, since Harper opens
+ * table/index column families with `disableWAL` defaulting to true (resources/databases.ts
+ * openRocksDatabase) and a committed write can otherwise sit only in the writer's memtable. One
+ * checkpoint covers every column family at a single point in time, so no arm can read two families
+ * from two different instants. `refreshOracle()` takes a fresh one and reopens every handle before
+ * each raw read, and the 'oracle proof' tests below demonstrate — rather than assert — that the
+ * oracle really reads that snapshot, and that it detects a phantom the join cannot, on both tables.
  *
  * Reproduction:
  *   npm run test:integration -- "integrationTests/database/delete-index-atomicity-rocksdb.test.ts"
  */
 import { suite, test, before, after } from 'node:test';
-import { ok, rejects, strictEqual } from 'node:assert';
+import { ok, strictEqual } from 'node:assert';
 import { resolve, join } from 'node:path';
 import { readFileSync, existsSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { RocksDatabase } from '@harperfast/rocksdb-js';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
@@ -57,13 +62,7 @@ const MAX_TXN_OPEN_MS = 1000;
 // on elapsed wall-clock.
 const HOLD_MS = 15_000;
 const LOG_FILES = ['hdb.log', 'stdout.log', 'stderr.log'];
-const ORACLE_OPEN_ATTEMPTS = 6;
-const ORACLE_OPEN_BACKOFF_MS = 50;
 const skipSuite = process.platform === 'win32';
-
-function errorMessage(error: unknown): string {
-	return String((error as Error)?.message ?? error);
-}
 
 suite(
 	'#1854 audit:false delete must not orphan secondary-index entries (raw RocksDB oracle)',
@@ -73,6 +72,8 @@ suite(
 		let httpURL: string;
 		const procChunks: string[] = [];
 		let rootPath: string;
+		let snapshotPath: string | undefined;
+		let snapshotSeq = 0;
 		const dbiCache = new Map<string, RocksDatabase>();
 
 		before(async () => {
@@ -111,7 +112,7 @@ suite(
 					}
 					lastProbeError = `status ${probe.status}`;
 				} catch (error) {
-					lastProbeError = errorMessage(error);
+					lastProbeError = String((error as Error)?.message ?? error);
 				}
 				await sleep(250);
 			}
@@ -127,7 +128,9 @@ suite(
 			strictEqual(itemT.audit, true, 'ItemT must be audit:true to serve as the control arm');
 
 			// The RocksDB root store for a database is a directory (not a single file as on LMDB) at
-			// `{dataRootDir}/database/{name}`, shared by every table and index column family in it.
+			// `{dataRootDir}/database/{name}`, shared by every table and index column family in it. The
+			// oracle checkpoints it rather than opening it; this is the writer's copy, and the negative
+			// the snapshot proof below asserts against.
 			rootPath = join(ctx.harper.dataRootDir, 'database', SCHEMA);
 			const dirDeadline = Date.now() + 30_000;
 			while (!existsSync(rootPath) && Date.now() < dirDeadline) await sleep(200);
@@ -136,6 +139,7 @@ suite(
 
 		after(async () => {
 			closeOracleHandles();
+			await removeSnapshot();
 			await teardownHarper(ctx);
 		});
 
@@ -180,10 +184,6 @@ suite(
 			return false;
 		}
 
-		async function flushThroughFixture(): Promise<void> {
-			const res = await postJSON('/Flush/', {});
-			strictEqual(res.status, 200, 'flush control should succeed');
-		}
 		function closeOracleHandles(): void {
 			for (const db of dbiCache.values()) {
 				try {
@@ -194,63 +194,29 @@ suite(
 			}
 			dbiCache.clear();
 		}
-		/** Must precede every raw read; see the file header for why both halves are required. */
+		/** Removing before taking the next one bounds the hardlinked SSTs a snapshot pins to one. */
+		async function removeSnapshot(): Promise<void> {
+			if (!snapshotPath) return;
+			const stale = snapshotPath;
+			snapshotPath = undefined;
+			await rm(stale, { recursive: true, force: true });
+		}
+		/** Must precede every raw read; see the file header for why the oracle reads a checkpoint. */
 		async function refreshOracle(): Promise<void> {
-			await flushThroughFixture();
 			closeOracleHandles();
+			await removeSnapshot();
+			const res = await postJSON('/Snapshot/', { seq: ++snapshotSeq });
+			const body = await res.text();
+			strictEqual(res.status, 200, `snapshot control should succeed; got ${res.status} ${body.slice(0, 300)}`);
+			snapshotPath = JSON.parse(body).path;
+			ok(snapshotPath, `snapshot control must return the checkpoint path; got ${body.slice(0, 300)}`);
 		}
-		/**
-		 * The one open failure worth reopening for: a compaction in the Harper process under test
-		 * unlinked an SST while this handle was opening. `readOnly: true` maps to
-		 * `rocksdb::DB::OpenForReadOnly`, which replays the MANIFEST into a file list and then opens
-		 * those files while holding no reference on any of them, so a file the list names can already
-		 * be gone. RocksDB's `The file MANIFEST-NNNNNN may be corrupted` wording means exactly that
-		 * here and nothing is damaged: the keys live on in the compaction's output file.
-		 * HarperFast/rocksdb-js#812 is the durable fix — a secondary-mode open, which pins the files
-		 * it lists.
-		 *
-		 * Deliberately unmatched: `Database does not exist`, which is what rocksdb-js reports for
-		 * *every* `IsIOError()` out of a read-only open (src/binding/database/db_descriptor.cpp),
-		 * file name and errno discarded. Retrying it would fold EACCES, EMFILE and a disk read error
-		 * into a six-attempt wait ending in a compaction-race message none of them caused; every
-		 * failure this race has produced so far carries the full text above instead.
-		 */
-		function isCompactionRaceOpenError(error: unknown): boolean {
-			const message = errorMessage(error);
-			return message.includes('No such file or directory') && /\b\d+\.sst\b/.test(message);
-		}
-		async function openWithCompactionRetry<T>(label: string, open: (attempt: number) => T | Promise<T>): Promise<T> {
-			let lastError: unknown;
-			for (let attempt = 1; attempt <= ORACLE_OPEN_ATTEMPTS; attempt++) {
-				if (attempt > 1) await sleep(ORACLE_OPEN_BACKOFF_MS * 2 ** (attempt - 2));
-				try {
-					const opened = await open(attempt);
-					if (attempt > 1)
-						console.log(
-							`[#1854 oracle] read-only open of ${label} recovered on attempt ${attempt}/${ORACLE_OPEN_ATTEMPTS} after: ${errorMessage(lastError)}`
-						);
-					return opened;
-				} catch (error) {
-					if (!isCompactionRaceOpenError(error)) throw error;
-					lastError = error;
-				}
-			}
-			throw new Error(
-				`oracle could not open ${label} read-only in ${ORACLE_OPEN_ATTEMPTS} attempts; the last RocksDB error is the cause`,
-				{ cause: lastError }
-			);
-		}
-		async function openDbi(name: string): Promise<RocksDatabase> {
-			const cached = dbiCache.get(name);
-			if (cached) return cached;
-			const db = await openWithCompactionRetry(`column family "${name}"`, async (attempt) => {
-				// Re-flushed before each reopen so the snapshot that finally opens still post-dates
-				// every write under test, whatever the retries cost.
-				if (attempt > 1) await flushThroughFixture();
-				return RocksDatabase.open(rootPath, { name, readOnly: true });
-			});
-			dbiCache.set(name, db);
-			return db;
+		function openDbi(name: string): RocksDatabase {
+			// Reading the live directory instead would reintroduce the compaction race the checkpoint
+			// exists to remove, so an unrefreshed oracle is a test bug, not a fallback.
+			if (!snapshotPath) throw new Error('oracle read before refreshOracle(): there is no checkpoint to read');
+			if (!dbiCache.has(name)) dbiCache.set(name, RocksDatabase.open(snapshotPath, { name, readOnly: true }));
+			return dbiCache.get(name)!;
 		}
 		/**
 		 * Whether a live record exists under this primary key, via a direct point lookup that no
@@ -277,16 +243,15 @@ suite(
 		 * with a null value; the plain RocksDatabase class decodes that key here, with no Harper
 		 * subclass interpreting it.
 		 */
-		async function rawIndexEntries(table: string, attribute: string): Promise<Array<{ key: string; id: string }>> {
-			const dbi = await openDbi(`${table}/${attribute}`);
-			return [...dbi.getRange()].map((e: { key: [unknown, unknown] }) => ({
+		function rawIndexEntries(table: string, attribute: string): Array<{ key: string; id: string }> {
+			return [...openDbi(`${table}/${attribute}`).getRange()].map((e: { key: [unknown, unknown] }) => ({
 				key: String(e.key[0]),
 				id: String(e.key[1]),
 			}));
 		}
 		/** Index entries whose id has no live record — the dangling entries #1854 produced. */
 		async function findPhantoms(table: string, attribute: string): Promise<Array<{ key: string; id: string }>> {
-			const entries = await rawIndexEntries(table, attribute);
+			const entries = rawIndexEntries(table, attribute);
 			const live = new Map<string, boolean>();
 			for (const e of entries) if (!live.has(e.id)) live.set(e.id, await hasLiveRecord(table, e.id));
 			return entries.filter((e) => !live.get(e.id));
@@ -297,52 +262,46 @@ suite(
 			strictEqual(res.status, 200, `seeding ${table} must succeed, or every assertion below is vacuous`);
 		}
 
-		test('the oracle reopens only for the compaction race, and fails fast on anything else', async () => {
-			// Verbatim RocksDB messages: the first is what the flake actually threw, the second is what
-			// rocksdb-js collapses every read-only IO error into (see isCompactionRaceOpenError).
-			const missingSst = new Error(
-				`Corruption: Corruption: IO error: No such file or directory: While open a file for random read: ${rootPath}/000046.sst: No such file or directory  The file ${rootPath}/MANIFEST-000005 may be corrupted.`
+		// No assertion about the data can show which directory the handles were opened against: one
+		// left pointing at the live database returns the same rows and differs only by being able to
+		// lose its open to a compaction — the failure this suite exists to stop reproducing.
+		test('oracle proof: the raw handles read an immutable checkpoint, not the live database', async () => {
+			await seed('ItemF', [{ id: 'snapshot-1', category: 'SNAPSHOT' }]);
+			await refreshOracle();
+			const firstSnapshot = snapshotPath!;
+			ok(firstSnapshot && firstSnapshot !== rootPath, `the oracle must open a checkpoint, not ${rootPath}`);
+			strictEqual(
+				openDbi('ItemF/category').path,
+				firstSnapshot,
+				'the raw column-family handle must be opened against that checkpoint'
 			);
-			const collapsed = new Error('Database does not exist');
+			ok(
+				rawIndexEntries('ItemF', 'category').some((e) => e.key === 'SNAPSHOT' && e.id === 'snapshot-1'),
+				'the checkpoint must contain the write that preceded it'
+			);
 
-			let attempts = 0;
-			const opened = await openWithCompactionRetry('the retry contract', () => {
-				attempts++;
-				if (attempts <= 2) throw missingSst;
-				return 'opened';
-			});
-			strictEqual(opened, 'opened', 'the oracle must reopen past a compaction race');
-			strictEqual(attempts, 3, 'and must stop reopening the moment an open succeeds');
+			// Flushed, so snapshot-2 is durably in the live directory's own SSTs: the only thing that
+			// can keep the oracle from seeing it now is that the oracle is not reading that directory.
+			await seed('ItemF', [{ id: 'snapshot-2', category: 'SNAPSHOT' }]);
+			const flushed = await postJSON('/Flush/', {});
+			strictEqual(flushed.status, 200, 'flush control should succeed');
+			ok(
+				!rawIndexEntries('ItemF', 'category').some((e) => e.id === 'snapshot-2'),
+				'a held checkpoint must not see a write that landed after it'
+			);
 
-			for (const failFast of [
-				new Error(
-					`Corruption: block checksum mismatch: stored = 2454123, computed = 88123  in ${rootPath}/000046.sst offset 0 size 1234`
-				),
-				new Error('Invalid argument: Column family not found: ItemF/category'),
-				collapsed,
-			]) {
-				attempts = 0;
-				await rejects(
-					openWithCompactionRetry('the retry contract', () => {
-						attempts++;
-						throw failFast;
-					}),
-					(error: Error) => error === failFast,
-					`the oracle must surface "${failFast.message.slice(0, 40)}" unchanged`
-				);
-				strictEqual(attempts, 1, 'and must not reopen for it');
+			await refreshOracle();
+			ok(snapshotPath !== firstSnapshot, 'each refresh must take a fresh checkpoint');
+			ok(!existsSync(firstSnapshot), 'and must remove the one it replaces, so the SSTs it pins are bounded');
+			ok(
+				rawIndexEntries('ItemF', 'category').some((e) => e.id === 'snapshot-2'),
+				'the fresh checkpoint must include it'
+			);
+
+			for (const id of ['snapshot-1', 'snapshot-2']) {
+				const res = await postJSON('/DeleteOne/', { table: 'ItemF', id });
+				strictEqual(res.status, 200, `cleanup delete of ${id} should succeed`);
 			}
-
-			attempts = 0;
-			await rejects(
-				openWithCompactionRetry('the retry contract', () => {
-					attempts++;
-					throw missingSst;
-				}),
-				(error: Error) => error.cause === missingSst,
-				'an exhausted budget must still carry the original RocksDB error'
-			);
-			strictEqual(attempts, ORACLE_OPEN_ATTEMPTS, 'and must be bounded');
 		});
 
 		// Run against both tables: an audit:true control arm whose oracle has never been shown to
@@ -351,7 +310,7 @@ suite(
 			test(`oracle proof (${table}): sees a seeded index entry, and sees it vanish on a normal delete`, async () => {
 				await seed(table, [{ id: 'proof-1', category: 'PROOF' }]);
 				await refreshOracle();
-				let entries = (await rawIndexEntries(table, 'category')).filter((e) => e.key === 'PROOF');
+				let entries = rawIndexEntries(table, 'category').filter((e) => e.key === 'PROOF');
 				strictEqual(entries.length, 1, 'oracle should see exactly 1 raw index entry for PROOF after seed');
 				strictEqual(entries[0].id, 'proof-1', 'raw index entry should point at proof-1');
 				ok(await hasLiveRecord(table, 'proof-1'), 'proof-1 should be a live record after seed');
@@ -360,7 +319,7 @@ suite(
 				strictEqual(res.status, 200, 'ordinary delete should succeed');
 
 				await refreshOracle();
-				entries = (await rawIndexEntries(table, 'category')).filter((e) => e.key === 'PROOF');
+				entries = rawIndexEntries(table, 'category').filter((e) => e.key === 'PROOF');
 				strictEqual(entries.length, 0, 'oracle should see the PROOF index entry vanish after a normal delete');
 				ok(!(await hasLiveRecord(table, 'proof-1')), 'proof-1 should no longer be a live record after a normal delete');
 			});
@@ -415,7 +374,7 @@ suite(
 					await refreshOracle();
 					ok(await hasLiveRecord(table, removeId), `${removeId} must exist before the held transaction deletes it`);
 					ok(
-						(await rawIndexEntries(table, 'category')).some((e) => e.key === 'ARMA-DEL' && e.id === removeId),
+						rawIndexEntries(table, 'category').some((e) => e.key === 'ARMA-DEL' && e.id === removeId),
 						`${removeId} must be indexed before the held transaction deletes it`
 					);
 
@@ -458,7 +417,7 @@ suite(
 
 					await refreshOracle();
 					const phantoms = await findPhantoms(table, 'category');
-					const indexEntries = await rawIndexEntries(table, 'category');
+					const indexEntries = rawIndexEntries(table, 'category');
 					// Whether the update landed depends on which side of the abort it fell on, so the check
 					// is only that a surviving row is reachable through the index at all.
 					const missing: string[] = [];
@@ -507,7 +466,7 @@ suite(
 				await refreshOracle();
 				ok(await hasLiveRecord(table, id), `${id} must exist before the aborted delete`);
 				ok(
-					(await rawIndexEntries(table, 'category')).some((e) => e.key === 'ARMB' && e.id === id),
+					rawIndexEntries(table, 'category').some((e) => e.key === 'ARMB' && e.id === id),
 					`${id} must be indexed before the aborted delete`
 				);
 
@@ -522,7 +481,7 @@ suite(
 
 				await refreshOracle();
 				const primaryHasId = await hasLiveRecord(table, id);
-				const indexHasEntry = (await rawIndexEntries(table, 'category')).some((e) => e.key === 'ARMB' && e.id === id);
+				const indexHasEntry = rawIndexEntries(table, 'category').some((e) => e.key === 'ARMB' && e.id === id);
 
 				console.log(
 					`\n[#1854 Arm B ${table}] status=${res.status} primaryHasId=${primaryHasId} indexHasEntry=${indexHasEntry}`

--- a/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
+++ b/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
@@ -214,12 +214,13 @@ suite(
 			const res = await postJSON('/Snapshot/', { seq: ++snapshotSeq });
 			const body = await res.text();
 			strictEqual(res.status, 200, `snapshot control should succeed; got ${res.status} ${body.slice(0, 300)}`);
+			const published = JSON.parse(body).path;
 			strictEqual(
-				JSON.parse(body).path,
+				published,
 				join(ctx.harper.dataRootDir, SNAPSHOT_DIR, String(snapshotSeq)),
 				'the oracle must only ever open a checkpoint at the path the fixture derives for this sequence'
 			);
-			snapshotPath = JSON.parse(body).path;
+			snapshotPath = published;
 		}
 		function openDbi(name: string): RocksDatabase {
 			// Reading the live directory instead would reintroduce the compaction race the checkpoint

--- a/integrationTests/database/delete-index-atomicity-rocksdb/resources.js
+++ b/integrationTests/database/delete-index-atomicity-rocksdb/resources.js
@@ -68,8 +68,9 @@ export class Snapshot extends Resource {
 	static loadAsInstance = false;
 	async post(query, body) {
 		const b = body || query || {};
-		const seq = Number(b.seq);
-		if (!Number.isInteger(seq) || seq < 0)
+		const seq = b.seq;
+		// Not Number(b.seq): that coerces true, null and [] to a valid-looking 1 or 0.
+		if (typeof seq !== 'number' || !Number.isInteger(seq) || seq < 0)
 			throw new Error(`Snapshot control invalid: seq must be a non-negative integer, got ${JSON.stringify(b.seq)}`);
 		const rootStore = getTable('ItemF').primaryStore.rootStore;
 		if (typeof rootStore?.createCheckpoint !== 'function')

--- a/integrationTests/database/delete-index-atomicity-rocksdb/resources.js
+++ b/integrationTests/database/delete-index-atomicity-rocksdb/resources.js
@@ -1,15 +1,18 @@
 // Workload drivers for delete-index-atomicity-rocksdb.test.ts. The oracle lives outside this
-// process — the test opens the raw RocksDB directory with its own read-only handles — so these
-// routes only drive the workload and expose the flush the oracle needs.
+// process — the test opens raw read-only handles of its own — so these routes only drive the
+// workload and publish the checkpoint the oracle reads.
 //
-// A RocksDB readOnly:true open is a point-in-time snapshot of the SSTs as of that open, not a
-// live view like LMDB's shared mmap, and Harper opens table/index column families with
-// disableWAL defaulting true (resources/databases.ts openRocksDatabase), so a committed write
-// can still sit only in the writer's memtable. Without an explicit flush an external reader
-// reports a clean run from flush timing rather than from real consistency. `flushDatabases()` is
-// not reachable from component code (security/jsLoader.ts exposes a curated allowlist), so
-// /Flush/ calls `.flush()` on a table's primaryStore instead; RocksDB's flush is atomic across
-// every column family sharing the directory, so one call covers both tables and all indices.
+// A readOnly:true open of the live directory races the compactions this process is running: it
+// replays the MANIFEST into a file list and then opens those files holding no reference on any of
+// them (HarperFast/rocksdb-js#812). /Snapshot/ hands the oracle a checkpoint instead, which nothing
+// writes to. Its memtable flush is what makes the copy trustworthy: Harper opens table/index column
+// families with disableWAL defaulting true (resources/databases.ts openRocksDatabase), so a
+// committed write can otherwise sit only in this process's memtable and an external reader would
+// report a clean run from flush timing rather than from real consistency.
+
+import { resolve } from 'node:path';
+
+const SNAPSHOT_DIR = 'oracle-snapshots';
 
 function sleep(ms) {
 	return new Promise((r) => setTimeout(r, ms));
@@ -38,6 +41,12 @@ export class TableInfo extends Resource {
 	}
 }
 
+// Moves the live database forward without touching the oracle's checkpoint, which is how the test
+// proves the oracle reads the checkpoint: a write that is durably in the live directory's SSTs and
+// still invisible to the oracle can only mean the oracle is not reading that directory.
+// `flushDatabases()` is not reachable from component code (security/jsLoader.ts exposes a curated
+// allowlist), so this calls `.flush()` on a table's primaryStore; RocksDB's flush is atomic across
+// every column family sharing the directory, so one call covers both tables and all indices.
 export class Flush extends Resource {
 	static loadAsInstance = false;
 	async post() {
@@ -46,6 +55,28 @@ export class Flush extends Resource {
 			throw new Error('Flush control invalid: primaryStore.flush() not available (not RocksDB?)');
 		await t.primaryStore.flush();
 		return { ok: true };
+	}
+}
+
+// The oracle's read target: a hardlinked, point-in-time copy of every column family, flushed as
+// part of being taken (resources/branchDatabase.ts materializes application branches the same way).
+// The target is derived here from the store's own path rather than taken from the request, so no
+// caller can aim a native filesystem operation somewhere the test does not own or clean up. It sits
+// beside `database/` rather than inside it, which is the only directory scanned for databases
+// (resources/databases.ts), so a snapshot can never be loaded as one.
+export class Snapshot extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const seq = Number(b.seq);
+		if (!Number.isInteger(seq) || seq < 0)
+			throw new Error(`Snapshot control invalid: seq must be a non-negative integer, got ${JSON.stringify(b.seq)}`);
+		const rootStore = getTable('ItemF').primaryStore.rootStore;
+		if (typeof rootStore?.createCheckpoint !== 'function')
+			throw new Error('Snapshot control invalid: rootStore.createCheckpoint() not available (not RocksDB?)');
+		const path = resolve(rootStore.path, '..', '..', SNAPSHOT_DIR, String(seq));
+		await rootStore.createCheckpoint(path);
+		return { ok: true, path };
 	}
 }
 

--- a/integrationTests/database/delete-index-atomicity-rocksdb/resources.js
+++ b/integrationTests/database/delete-index-atomicity-rocksdb/resources.js
@@ -41,9 +41,9 @@ export class TableInfo extends Resource {
 	}
 }
 
-// Moves the live database forward without touching the oracle's checkpoint, which is how the test
-// proves the oracle reads the checkpoint: a write that is durably in the live directory's SSTs and
-// still invisible to the oracle can only mean the oracle is not reading that directory.
+// Moves the live database forward without touching the held checkpoint, so the test can prove that
+// the next refresh replaces it with one containing the new write. The handle-path assertion proves
+// that the oracle reads the checkpoint rather than the live directory.
 // `flushDatabases()` is not reachable from component code (security/jsLoader.ts exposes a curated
 // allowlist), so this calls `.flush()` on a table's primaryStore; RocksDB's flush is atomic across
 // every column family sharing the directory, so one call covers both tables and all indices.


### PR DESCRIPTION
Before #2429, `integrationTests/database/delete-index-atomicity-rocksdb.test.ts` intermittently failed across the integration matrix because its independent `readOnly: true` oracle opened the live RocksDB directory while compaction could unlink an SST named by the MANIFEST. #2429 stopped the bleeding with a bounded error-signature retry; this rebased PR replaces that retry with an immutable checkpoint, removing the race by construction while preserving the raw-storage oracle and every Arm A / Arm B assertion.

[`/Snapshot/` publishes the checkpoint](https://github.com/HarperFast/harper/pull/2452/changes?w=1#diff-ab464a4348bd6feff2b58d88e80ec6d2e571aa9558f0a3b0bee7e7728ecfad0aR67) through `createCheckpoint()`, and [`openDbi()` refuses any live-directory fallback](https://github.com/HarperFast/harper/pull/2452/changes?w=1#diff-5097b51cdc22ddf502301cd56053dc01c2199c4051a6eb408c7b6213fa62a266R226). Nothing writes to a checkpoint, so there is no missing-SST open race, error matcher, retry budget, or follow-up needed when HarperFast/rocksdb-js#812's secondary-mode open lands. Taking the checkpoint also flushes the memtable required by this `disableWAL` fixture and captures all column families through one operation instead of separate read-only opens at unrelated instants; the suite is quiescent whenever it refreshes the oracle.

[`refreshOracle()` closes handles and removes the previous checkpoint before publishing the next](https://github.com/HarperFast/harper/pull/2452/changes?w=1#diff-5097b51cdc22ddf502301cd56053dc01c2199c4051a6eb408c7b6213fa62a266R211), bounding pinned hardlinks to one. It [retains a returned path for recursive teardown only when it exactly matches the expected per-sequence checkpoint](https://github.com/HarperFast/harper/pull/2452/changes?w=1#diff-5097b51cdc22ddf502301cd56053dc01c2199c4051a6eb408c7b6213fa62a266R219), so a fixture regression fails before any handle opens it without risking removal of an invalid location. The [target is derived fixture-side from the store](https://github.com/HarperFast/harper/pull/2452/changes?w=1#diff-ab464a4348bd6feff2b58d88e80ec6d2e571aa9558f0a3b0bee7e7728ecfad0aR78) and sits beside `database/`, outside the directories scanned as databases.

The [snapshot proof pins the raw handle's `.path` to the checkpoint](https://github.com/HarperFast/harper/pull/2452/changes?w=1#diff-5097b51cdc22ddf502301cd56053dc01c2199c4051a6eb408c7b6213fa62a266R285), proves that the checkpoint contains the preceding unflushed write, stays frozen after the live database advances, and is replaced by a refresh that sees the new write. The oracle remains a second `@harperfast/rocksdb-js` handle decoding composite `[indexedValue, primaryKey]` keys directly; no Harper query surface substitutes for the index-side observation.

## For the human reviewer

1. **Checkpoint instead of the now-merged live-open retry.** This rebase deliberately removes #2429's bounded classify-and-reopen loop rather than stacking both mechanisms. Keeping #2429 is smaller, and waiting for HarperFast/rocksdb-js#812 would avoid fixture checkpoint scaffolding; the checkpoint is chosen because it eliminates the race and error-shape coupling now, with no measurable suite-time cost. Reversal is localized to the fixture route and oracle helpers. Design framing cleared before implementation: `Framing-Verdict: chosen-approach-sound`.
2. **Checkpointed index entries compared with live HTTP primary liveness.** Decoding the primary column family from the same checkpoint would avoid split-time observation, but audited deletes store `null` tombstones under the same key at a variable payload offset. `hasLiveRecord()` therefore uses a direct primary-key HTTP lookup while the index side stays raw; this is safe because the arms issue no client traffic between `refreshOracle()` and `findPhantoms()`. A future background workload in this fixture would require revisiting that assumption.
3. **Remove the old checkpoint before creating the new one.** Publishing first would preserve the last snapshot if refresh fails and improve failure forensics; removing first keeps hardlinked SSTs bounded to one checkpoint. The harness uses a fresh temporary data root per run, and the choice is easy to reverse if debugging value outweighs the disk bound.

## Verification

Route: the changed integration test against live Harper/RocksDB instances, plus its client-surface companion anchor.

- The original stress campaign reproduced the base failure twice in 36 runs at 12-way parallelism, then completed 144/144 at the reproducing load, 36/36 at 6-way, and 12/12 at 3-way with the checkpoint implementation: 192 runs, zero race signatures, with 36-run wall time effectively unchanged (114 seconds on base versus 115–121 seconds with checkpoints).
- After rebasing onto `main` with #2429, `npm run build` passed and `npm run test:integration -- "integrationTests/database/delete-index-atomicity-rocksdb.test.ts"` passed three times at the final behavior: 9/9 each, 27/27 total. These runs also settle the reviewed question that the pinned rocksdb-js binding creates the checkpoint parent.
- `npm run test:integration -- "integrationTests/resources/audit-false-delete-rollback.test.ts"`: 2/2 passed.
- `npx prettier --check integrationTests/database/delete-index-atomicity-rocksdb.test.ts integrationTests/database/delete-index-atomicity-rocksdb/resources.js`, `npm run lint:required`, and `git diff --check`: passed.
- The earlier #1869 sensitivity run remains applicable: reverting the transaction option made Arm A and Arm B on `ItemF` fail with the expected orphan while the `audit:true` controls and oracle proofs stayed green; the rebase preserves those assertions unchanged.
- `test:integration:all`, `test:unit:main`, and `test:unit:resources` were not rerun for this test-only rebase; CI remains the full-suite signal.

Refs #1854, #2400, HarperFast/rocksdb-js#812

Complexity: medium

<sub>Review-Coverage: authored=codex; ran=cursor-composer,claude; adjudicated=domain; blocked=gemini(auth); declined=cursor-grok; rounds=2 @ c4d173b786ba</sub>

<sub>Human-Review-Need: 3 (decisions: checkpoint-over-live-retry, snapshot-index-live-primary, replace-before-create) @ c4d173b786ba</sub>
