### PR TITLE
Record a write-ahead audit retention floor, raised before every prune (infrastructure for #2448)

### DIFF
--- a/dataLayer/harperBridge/ResourceBridge.ts
+++ b/dataLayer/harperBridge/ResourceBridge.ts
@@ -25,6 +25,7 @@ import type {
 import { collapseData } from '../../resources/tracked.ts';
 import { errorToString } from '../../utility/logging/harper_logger.ts';
 import { RocksDatabase } from '@harperfast/rocksdb-js';
+import { boundedAuditPruneEnd, raiseAuditFloor } from '../../resources/auditStore.ts';
 import { BridgeMethods } from './BridgeMethods.ts';
 import lmdbGetBackup from './lmdbBridge/lmdbMethods/lmdbGetBackup.js';
 import { createBackupStream, resolveSingleRootStore } from '../rocksdbBackup.ts';
@@ -520,8 +521,30 @@ export class ResourceBridge extends BridgeMethods {
 			deleteObj.timestamp instanceof Date
 				? deleteObj.timestamp.getTime()
 				: typeof deleteObj.timestamp === 'string'
-					? Number.parseInt(deleteObj.timestamp)
+					? // Number, not Number.parseInt: parseInt takes a numeric PREFIX, so '9999999999999oops'
+						// parsed to a year-2286 bound that satisfied every check below and purged the whole log,
+						// and '1e3' silently became 1 (#2458). Number rejects both as NaN. The
+						// empty/whitespace case is explicit because Number('') and Number('   ') are 0, which
+						// parseInt correctly refused.
+						deleteObj.timestamp.trim() === ''
+						? Number.NaN
+						: Number(deleteObj.timestamp)
 					: deleteObj.timestamp;
+		// Neither NaN nor a non-finite bound is harmless: audit keys are raw float64, so NaN and negatives
+		// sort above every real timestamp and the prune range spans the whole log, while Infinity purges
+		// everything AND records the unknown sentinel — which `raiseAuditFloor` will never lift again. So
+		// require a finite, non-negative number and reject anything else as the operator input error it is,
+		// rather than letting raiseAuditFloor stop it with a bare Error that reports as a server fault.
+		// `Number.isFinite` does the type check too: it never coerces, so a non-number is false.
+		if (!Number.isFinite(before) || before < 0 || Object.is(before, -0))
+			throw handleHDBError(
+				new Error(),
+				`'timestamp' must be a non-negative epoch time or Date, received: ${String(deleteObj.timestamp)}`,
+				400,
+				undefined,
+				undefined,
+				true
+			);
 		const databaseName = deleteObj.database || deleteObj.schema || DEFAULT_DATABASE;
 		const table = getTable(deleteObj);
 		// A nonexistent table must not fall through to the no-table branch below — on RocksDB that
@@ -544,7 +567,16 @@ export class ResourceBridge extends BridgeMethods {
 			if (tables) {
 				for (const table of Object.values(tables)) {
 					if (table.primaryStore instanceof RocksDatabase) {
-						const deleted = table.primaryStore.purgeLogs({ before, includeEntryCounts: true });
+						// Clamp before recording: an operator-supplied bound has no ceiling of its own, and a
+						// floor above everything reachable never comes down — `raiseAuditFloor` only raises and
+						// `establishAuditFloor` skips a store that has a record. `Date.now() * 1000`, or a bare
+						// '9999999999999', would otherwise pin this whole database's floor in the year 2286+,
+						// retiring the floor for every table in it, including cursors saved after
+						// this call (#2458). The purge takes the same clamped bound, so it cannot remove an entry
+						// the floor does not cover.
+						const pruneEnd = boundedAuditPruneEnd(table.auditStore, before);
+						raiseAuditFloor(table.auditStore, pruneEnd);
+						const deleted = table.primaryStore.purgeLogs({ before: pruneEnd, includeEntryCounts: true });
 						totalResults.log_files_deleted += deleted.length;
 						totalResults.entries_deleted += deleted.reduce((acc, file) => acc + file.entries, 0);
 						break;

--- a/dataLayer/harperBridge/ResourceBridge.ts
+++ b/dataLayer/harperBridge/ResourceBridge.ts
@@ -528,12 +528,11 @@ export class ResourceBridge extends BridgeMethods {
 						? Number.NaN
 						: Number(deleteObj.timestamp)
 					: deleteObj.timestamp;
-		// Neither NaN nor a non-finite bound is harmless: audit keys are raw float64, so NaN and negatives
-		// sort above every real timestamp and the prune range spans the whole log, while Infinity purges
-		// everything AND records the unknown sentinel — which `raiseAuditFloor` will never lift again. So
-		// require a finite, non-negative number and reject anything else as the operator input error it is,
-		// rather than letting raiseAuditFloor stop it with a bare Error that reports as a server fault.
-		// `Number.isFinite` does the type check too: it never coerces, so a non-number is false.
+		// Audit keys are raw float64, so NaN and negatives sort above every real timestamp and a prune range
+		// ending there spans the whole log, while Infinity records the unknown sentinel that `raiseAuditFloor`
+		// never lifts. Require a finite, non-negative number and report anything else as the operator input
+		// error it is, rather than letting raiseAuditFloor surface it as a server fault. `Number.isFinite`
+		// never coerces, so it is the type check as well.
 		if (!Number.isFinite(before) || before < 0 || Object.is(before, -0))
 			throw handleHDBError(
 				new Error(),
@@ -566,12 +565,10 @@ export class ResourceBridge extends BridgeMethods {
 				for (const table of Object.values(tables)) {
 					if (table.primaryStore instanceof RocksDatabase) {
 						// Clamp before recording: an operator-supplied bound has no ceiling of its own, and a
-						// floor above everything reachable never comes down — `raiseAuditFloor` only raises and
-						// `establishAuditFloor` skips a store that has a record. `Date.now() * 1000`, or a bare
-						// '9999999999999', would otherwise pin this whole database's floor in the year 2286+,
-						// retiring the floor for every table in it, including cursors saved after
-						// this call (#2458). The purge takes the same clamped bound, so it cannot remove an entry
-						// the floor does not cover.
+						// floor above everything reachable never comes down (`raiseAuditFloor` only raises and
+						// `establishAuditFloor` skips a store that has a record), so a far-future bound would
+						// retire the floor for every table in this database. The purge takes the same clamped
+						// bound, so it cannot remove an entry the floor does not cover.
 						const pruneEnd = boundedAuditPruneEnd(table.auditStore, before);
 						raiseAuditFloor(table.auditStore, pruneEnd);
 						const deleted = table.primaryStore.purgeLogs({ before: pruneEnd, includeEntryCounts: true });

--- a/dataLayer/harperBridge/ResourceBridge.ts
+++ b/dataLayer/harperBridge/ResourceBridge.ts
@@ -528,11 +528,10 @@ export class ResourceBridge extends BridgeMethods {
 						? Number.NaN
 						: Number(deleteObj.timestamp)
 					: deleteObj.timestamp;
-		// Audit keys are raw float64, so NaN and negatives sort above every real timestamp and a prune range
-		// ending there spans the whole log, while Infinity records the unknown sentinel that `raiseAuditFloor`
-		// never lifts. Require a finite, non-negative number and report anything else as the operator input
-		// error it is, rather than letting raiseAuditFloor surface it as a server fault. `Number.isFinite`
-		// never coerces, so it is the type check as well.
+		// Audit keys are raw float64: NaN and negatives sort above every real timestamp (a range ending
+		// there spans the whole log), and Infinity records the unknown sentinel raiseAuditFloor never lifts.
+		// Reject anything but a finite non-negative number here, as the 400 it is rather than a server
+		// fault. `Number.isFinite` never coerces, so it is the type check too.
 		if (!Number.isFinite(before) || before < 0 || Object.is(before, -0))
 			throw handleHDBError(
 				new Error(),

--- a/dataLayer/harperBridge/ResourceBridge.ts
+++ b/dataLayer/harperBridge/ResourceBridge.ts
@@ -521,11 +521,9 @@ export class ResourceBridge extends BridgeMethods {
 			deleteObj.timestamp instanceof Date
 				? deleteObj.timestamp.getTime()
 				: typeof deleteObj.timestamp === 'string'
-					? // Number, not Number.parseInt: parseInt takes a numeric PREFIX, so '9999999999999oops'
-						// parsed to a year-2286 bound that satisfied every check below and purged the whole log,
-						// and '1e3' silently became 1 (#2458). Number rejects both as NaN. The
-						// empty/whitespace case is explicit because Number('') and Number('   ') are 0, which
-						// parseInt correctly refused.
+					? // Number, not Number.parseInt: parseInt takes a numeric PREFIX ('9999999999999oops' is a
+						// year-2286 bound to it, '1e3' is 1) where Number rejects both as NaN. Empty/whitespace is
+						// explicit because Number('') and Number('   ') are 0.
 						deleteObj.timestamp.trim() === ''
 						? Number.NaN
 						: Number(deleteObj.timestamp)

--- a/resources/DESIGN.md
+++ b/resources/DESIGN.md
@@ -86,6 +86,7 @@ One giant `makeTable()` factory that returns a `TableResource extends Resource` 
 | Where does versioning / conflict resolution happen?                            | `Table.ts → _writeUpdate` (`#section: write-path-internals`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | How does `search()` choose an index?                                           | `Table.ts → search` (`#section: search-query`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | How are subscriptions replayed?                                                | `Table.ts → subscribe` (`#section: pub-sub`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| Can a saved audit cursor still catch up, or has its history been pruned?       | `auditStore.ts → getAuditFloor` — internal; there is deliberately no public accessor (harper#2458). **No resume path consumes it yet** — harper#2448 is to have `Table.subscribe` read it inside the resume, so the check and the replay cannot drift apart; until then a `startTime` below the floor is still silently truncated. Returns the database-scoped floor: a cursor below it must resync, and `Infinity` means the floor is unknown (fails closed). `cursor >= floor` means only that no prune that ran _with a floor recorded_ removed history _after_ the cursor (nothing is promised below the FLOOR — that history is what a prune takes; `[floor, cursor)` is below the cursor but still covered). Two things it cannot see: history a legacy prune removed _before_ the floor existed, which a clock rollback can leave the stamped starting floor below; and a `restore_backup`/checkpoint rollback, since it is not a generation check (harper#2451). See "Audit retention floor" below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | How is the response body shaped (select clause)?                               | `Table.ts → transformEntryForSelect` (`#section: search-query`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | Where is record-level TTL evaluated?                                           | `Table.ts → setTTLExpiration` (`#section: lifecycle-admin`); `Updatable.getExpiresAt` (`#section: setup-and-factory`). Stored expiry metadata is resolved in the `_writeUpdate` commit closure: `options.expiresAt ?? context.expiresAt ?? (record @expiresAt field, if finite &amp; ≥ 0) ?? table default`. This metadata drives read-hiding + the cleanup sweep. The `@expiresAt` attribute is authoritative for **direct** put/patch only; cache/source fills persist via `recordUpdater` and derive expiry from `sourceContext.expiresAt` (source freshness / table default), not the field.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | Why does `search()` hide a row that's past its TTL but not yet swept?          | `Table.ts → transformEntryForSelect` unconditionally treats `entry.expiresAt < Date.now()` as gone (lazy eviction on read) — correct for a SELECT, but a mutation locating rows to overwrite needs the opposite: pass `target.includeExpired = true` (read by the SQL engine's `runUpdate`/`runDelete` via `SqlEngineContext.includeExpiredRows`) to treat such a row as a live match, matching the leniency a direct by-id `put`/`patch` already has (they skip this check entirely, since `Resource.patch`'s static options don't request `ensureLoaded`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
@@ -151,6 +152,98 @@ Consequences worth knowing:
 **Async false-mode read gates preserve the streaming contract.** `Table.search` returns an `ExtendedIterable` carrying the internal `SEARCH_AUTHORIZATION` promise. Static `Resource.search` and `query` await that verdict before returning a response; on success the wrapper initializes the real search before the transaction settles so its normal read snapshot stays reserved until iteration completes. The marker follows supported iterable transforms and retains `selectApplied`/`getColumns`, so async or mapped delegation cannot turn a denial into a truncated successful response.
 
 **False-mode collection write gates stay per dispatch.** Built-in array PUT, query DELETE, and publish perform one request-scoped `allowUpdate`, `allowDelete`, or `allowCreate` verdict respectively. After query DELETE authorizes, it scans with a private cloned target whose permission check is disabled; the caller target stays untouched, and concurrent reads using it still run `allowRead`. Static publish overload routing marks the fresh per-dispatch resource receiver in `staticResourceDispatch.ts`, so copied targets and delayed delegation retain the `(target, message)` signature without putting reusable state on caller objects.
+
+---
+
+## Audit retention floor
+
+`Table.subscribe`'s `startTime` replay just begins wherever the audit log now begins, so a consumer
+resuming below the retention horizon is silently handed a short replay. The floor is the primitive
+that makes that detectable (harper#2447). It is internal, with deliberately no public accessor, and **nothing
+consumes it yet**: harper#2448 is to put the check inside `Table.subscribe` itself — the same shape as
+replication's `shouldForceBaseCopyForRetention`, and the only one where the floor cannot move between
+being read and being acted on. Until then the short replay above is unchanged.
+
+**The invariant: every path that prunes audit history raises the floor BEFORE removing anything.**
+There are five, and the ordering is the whole guarantee — a floor written after the removal is lost
+if the process dies in between, and the surviving lower floor then certifies a cursor whose history
+is gone. Over-reporting (a floor covering more than the prune actually removed) costs a consumer one
+unnecessary resync; under-reporting loses its data with no signal. So `raiseAuditFloor` is called
+first and a throw from it is what stops the prune.
+
+| Prune path                                                                   | Engine                                                                      |
+| ---------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `scheduleAuditCleanup` retention loop (`auditStore.ts`)                      | LMDB                                                                        |
+| `scheduleAuditCleanup` → `purgeLogs`                                         | RocksDB                                                                     |
+| `purgeAgedLogs` (boot/recovery, called from `replayLogs.ts`)                 | RocksDB                                                                     |
+| `Table.deleteHistory`                                                        | LMDB (`RocksTransactionLogStore.remove()` is a no-op, so it must NOT raise) |
+| `delete_transaction_logs_before` whole-database branch (`ResourceBridge.ts`) | RocksDB                                                                     |
+
+Seven things that are easy to get wrong here:
+
+- **The floor cannot be derived from the surviving log.** For four of the five paths the oldest
+  surviving entry would do, because they prune a database-wide time prefix. `Table.deleteHistory`
+  does not: it removes one table's entries out of a database-scoped log, so a sibling's entry
+  survives _below_ the newest entry it removed. Measured, LMDB: highest removed `…147.797`, oldest
+  surviving `…143.309` — a log-derived floor would have certified a cursor at `…145`.
+- **The record's presence is the trust marker.** `Symbol.for('audit-floor')` is a different key from
+  `last-removed`, which is still live and still maintained by the LMDB retention loop (#2338 hardened
+  its write path and added tests for the retry-carry — do not remove it). They coexist because they
+  answer different questions: `last-removed` records where the LMDB loop got to, after the fact,
+  while the floor is written ahead of every one of the five prune paths and its commit is verified.
+  A value found under `last-removed` therefore cannot be told apart from one carrying those
+  guarantees, which is why the floor needs its own key rather than reusing it.
+- **A store with no floor record is a store whose retention history we cannot account for.** That
+  includes the empty audit store an LMDB→RocksDB migration leaves behind, since `bin/copyDb.ts`
+  deliberately does not migrate it, and the audit-DBI-less result of a table-scoped backup taken
+  without `include_audit` — so `openAuditStore` stamps `max(Date.now(), newest retained key)` as a
+  one-time resync epoch. There is no permissive-baseline case: creating the audit DBI proves the
+  DBI was absent, not that the database is new.
+- **That epoch is a guess, and it is recorded as one.** Its bound is surviving state, which cannot see
+  history a selective prune already removed: a legacy `deleteHistory` takes one table's entries out of
+  the shared log, so a table that held the newest entries can leave the newest _survivor_ older than
+  entries that are gone, and a clock rolled back between the two stamps a floor below them (#2458).
+  Refusing to stamp is worse — `AUDIT_FLOOR_UNKNOWN` is absorbing (`raiseAuditFloor` cannot lift it,
+  `establishAuditFloor` skips any existing record), so it would make every upgraded deployment fail
+  closed forever. So `establishAuditFloor` writes the epoch under `Symbol.for('audit-floor-bootstrap')`
+  first, then stamps the floor from what that record holds.
+
+  **The record's presence is the signal; comparing it against the floor is not.** A store carrying one
+  has an unverified pre-tracking window for as long as the record exists, however far the floor has
+  since moved — a prune raising the floor above the epoch certifies only what that prune removed, and
+  says nothing about history removed before tracking began, which may sit _above_ the epoch, since that
+  is precisely what the guess could not see. Worked example: a v4-era `deleteHistory` removes tableA up
+  to t=1000 while sibling tableB's newest survivor is 900; a rolled-back clock stamps bootstrap=900 and
+  floor=900; a later retention pass raises the floor to 950. A repair keyed on `floor > bootstrap` would
+  read 950 > 900, call it earned, and leave a consumer at cursor 970 certified over tableA's missing
+  950–1000. So the mark is retired by a database generation (#2451), never by a floor that climbed past
+  it; what the recorded _value_ is for is telling that repair how far the guess reached.
+
+  Two properties it does depend on. **Ordering:** the record is written first, so a crash between the
+  two writes leaves a record with no floor, which the next open retries because the early return tests
+  the _floor_. **Undecodable bytes are overwritten** rather than kept — unlike the floor, where a
+  present record may be a deliberate `AUDIT_FLOOR_UNKNOWN` and rewriting it would lower a floor.
+  Keeping torn bytes pinned the store to unknown _forever_: the resolver skipped the write because a
+  record existed, the read back failed identically on every later open, and no retry could succeed.
+
+- **`getHistory` is not in the floor's time domain.** The floor is an audit-log key, which is what
+  `subscribe`'s events carry as `localTime`; `getHistory` reports each entry's origin `version` under
+  that same name, and a backdated or replicated write makes the two differ. A cursor saved from
+  `getHistory` cannot be compared against the floor.
+- **On RocksDB the floor tracks the configured retention horizon, not retained reality.** Whole-log-file
+  purge granularity means the branch cannot know which entries a purge will drop, and the floor is
+  written first, so each pass advances it to `Date.now() - auditRetention/(1+priority²)` whether a
+  file was dropped or not. Entries below that horizon are often still on disk, and a cursor among
+  them is told to resync — conservative in the safe direction only. LMDB can see a single eligible
+  entry, so it raises off the first one it finds instead.
+- **Untrustworthy metadata resolves to `Infinity`, not to a number.** A wrong-length record, or eight
+  bytes decoding to NaN/negative, must not become a floor: `cursor < NaN` is false, so a consumer
+  spelling the check that way would read corrupt metadata as safe.
+- **A restore is outside what the floor can see.** `restore_backup` reinstalls the backup's floor
+  along with everything else, so a cursor from after the backup point reads as safe against it. The
+  audit floor is one of three carriers of resumable state a restore rolls back (record versions and
+  per-node `Symbol.for('seq')` records are the others), so this wants a database-level generation
+  rather than a fix in this one field — harper#2451.
 
 ---
 

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -6116,7 +6116,7 @@ export function makeTable(options) {
 							isRocksDB && version != null
 								? resolveAuditHead(key, version, entry.nodeId, entry.additionalAuditRefs).txnLogKey
 								: localTime;
-						if (value === null && version != null && auditTime < endTime) {
+						if (value === null && version != null && auditTime < pruneEnd) {
 							const backpressure = queueRemoval(
 								() => primaryStore.remove(key, version),
 								'Error removing deleted record during deleteHistory'

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -6071,14 +6071,11 @@ export function makeTable(options) {
 			let entriesDeleted = 0;
 			// LMDB only: RocksTransactionLogStore.remove() is a no-op, so a RocksDB deleteHistory removes
 			// nothing and must not claim it did.
-			// A request unbounded ABOVE must not become a floor unbounded above: `raiseAuditFloor` only
-			// raises and `establishAuditFloor` skips a store that has a record, so a floor above anything
-			// reachable never comes down — for this whole database, every sibling table included,
-			// permanently (#2458). Infinity is the absorbing unknown sentinel and the worst case, but a
-			// finite year-2286 bound is the same defect by degree, and entries written after this call
-			// would land below such a floor. `boundedAuditPruneEnd` clamps any cutoff to just above the
-			// newest key in the log, and the scan below uses that same value as its range end, so the
-			// prune provably cannot remove an entry the floor does not cover.
+			// A bound above everything reachable must not be recorded as the floor: the floor only rises
+			// and a store with a record is never re-stamped, so it would never come down, for every table in
+			// this database. `boundedAuditPruneEnd` clamps the cutoff to just above the newest key in the
+			// log, and the scan below uses that same value as its range end, so the prune cannot remove an
+			// entry the floor does not cover.
 			let pruneEnd = endTime;
 			if (!isRocksDB) {
 				pruneEnd = boundedAuditPruneEnd(auditStore, endTime);

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -80,7 +80,7 @@ import { Addition, assignTrackedAccessors, updateAndFreeze, hasChanges, GenericT
 import { transaction, contextStorage } from './transaction.ts';
 import { MAXIMUM_KEY, writeKey, compareKeys } from 'ordered-binary';
 import { getWorkerIndex, getWorkerCount } from '../server/threads/manageThreads.js';
-import { HAS_BLOBS, auditRetention, removeAuditEntry } from './auditStore.ts';
+import { HAS_BLOBS, auditRetention, removeAuditEntry, raiseAuditFloor, boundedAuditPruneEnd } from './auditStore.ts';
 import { buildEmbedBefore, createDefaultEmbedder, type EmbedAttribute, type Embedder } from './models/embedHook.ts';
 import { autoCast, autoCastBooleanStrict } from '../utility/common_utils.ts';
 import {
@@ -6069,10 +6069,27 @@ export function makeTable(options) {
 			}
 			const drainRemovals = () => Promise.all(inFlightRemovals);
 			let entriesDeleted = 0;
+			// LMDB only: RocksTransactionLogStore.remove() is a no-op, so a RocksDB deleteHistory removes
+			// nothing and must not claim it did.
+			// A request unbounded ABOVE must not become a floor unbounded above: `raiseAuditFloor` only
+			// raises and `establishAuditFloor` skips a store that has a record, so a floor above anything
+			// reachable never comes down — for this whole database, every sibling table included,
+			// permanently (#2458). Infinity is the absorbing unknown sentinel and the worst case, but a
+			// finite year-2286 bound is the same defect by degree, and entries written after this call
+			// would land below such a floor. `boundedAuditPruneEnd` clamps any cutoff to just above the
+			// newest key in the log, and the scan below uses that same value as its range end, so the
+			// prune provably cannot remove an entry the floor does not cover.
+			let pruneEnd = endTime;
+			if (!isRocksDB) {
+				pruneEnd = boundedAuditPruneEnd(auditStore, endTime);
+				raiseAuditFloor(auditStore, pruneEnd);
+			}
 			try {
 				for (const auditRecord of auditStore.getRange({
-					start: 1, // must not be zero; see getHistory below for why
-					end: endTime,
+					// must not be zero: 0 encodes to all zero bytes and so overlaps the symbol keys, as in
+					// getHistory below
+					start: 1,
+					end: pruneEnd,
 				})) {
 					await rest(); // yield to other async operations
 					if (auditRecord.tableId !== tableId) continue;

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -10,6 +10,7 @@ import { getRecordAtTime } from './crdt.ts';
 import { decodeFromDatabase } from './blob.ts';
 import { onStorageReclamation } from '../server/storageReclamation.ts';
 import { RocksDatabase } from '@harperfast/rocksdb-js';
+import { asBinary } from 'lmdb';
 import { RocksTransactionLogStore } from './RocksTransactionLogStore.ts';
 import { isReadOnlyMode } from './databases.ts';
 
@@ -124,6 +125,33 @@ let warnedUndecodableHeader = false;
 const warnedPendingPreviousVersion = new Set<string>();
 const FLOAT_TARGET = new Float64Array(1);
 const FLOAT_BUFFER = new Uint8Array(FLOAT_TARGET.buffer);
+/**
+ * Key of this database's audit retention floor — the staleness horizon `getAuditFloor` reports.
+ * Its *presence* is what marks the floor trustworthy, which is why it is not the `last-removed`
+ * marker above: that one is written after its removals and by only one of the five prune paths, so a
+ * value found there cannot be told apart from one carrying the write-ahead and monotonicity
+ * guarantees `raiseAuditFloor` provides. The two coexist deliberately and answer different
+ * questions.
+ */
+const AUDIT_FLOOR_KEY = Symbol.for('audit-floor');
+// The epoch `establishAuditFloor` stamped, kept for the life of the store. Its PRESENCE marks the
+// floor's provenance as unverified — a guess bounded by what survived, which cannot see history a
+// legacy prune removed before tracking began — and nothing short of a database generation (#2451)
+// retires that mark. In particular no comparison does: a later prune that raises the floor above this
+// value certifies only what it removed, so `floor > bootstrap` says nothing about the older gap. The
+// stored number records only how far the guess reached, for that repair to consume. Never raised,
+// never removed. See `establishAuditFloor`.
+const AUDIT_FLOOR_BOOTSTRAP_KEY = Symbol.for('audit-floor-bootstrap');
+/**
+ * The floor's own eight bytes, deliberately NOT the FLOAT_TARGET/FLOAT_BUFFER pair the `last-removed`
+ * marker uses: decoding a floor writes into its buffer on every read, including the pre-check on each
+ * prune, while `updateLastRemoved` hands the shared buffer to an async `put` it has not yet consumed.
+ * Sharing them would let a floor read rewrite a marker still in flight.
+ */
+const FLOOR_TARGET = new Float64Array(1);
+const FLOOR_BUFFER = new Uint8Array(FLOOR_TARGET.buffer);
+/** No trustworthy floor: the highest possible floor, so every cursor compares as stale. */
+const AUDIT_FLOOR_UNKNOWN = Infinity;
 
 /** Last resort on a detached path: a failing log sink must not itself become an unhandled rejection. */
 function warnContained(message: string, error: unknown) {
@@ -162,6 +190,7 @@ export function openAuditStore(rootStore) {
 	}
 	rootStore.auditStore = auditStore;
 	auditStore.rootStore = rootStore;
+	establishAuditFloor(auditStore);
 	auditStore.tableStores = [];
 	const deleteCallbacks = [];
 	auditStore.addDeleteRemovalCallback = function (tableId, table, callback) {
@@ -235,25 +264,39 @@ export function openAuditStore(rootStore) {
 				let lastKey: any;
 				try {
 					if (isRocksAuditStore) {
-						auditStore.rootStore.purgeLogs({
-							before: Date.now() - auditRetention / (1 + passCleanupPriority * passCleanupPriority),
-						});
+						const before = Date.now() - auditRetention / (1 + passCleanupPriority * passCleanupPriority);
+						raiseAuditFloor(auditStore, before);
+						auditStore.rootStore.purgeLogs({ before });
 					} else {
 						// Driven explicitly rather than with for-of: this loop suspends on the awaits below, and a
 						// close landing mid-pass closes the env under it. for-of calls next() before the body, so a
 						// check inside the body advances the cursor first — the guard has to precede every next().
+						// remove up until the audit retention time, reducing audit retention time if cleanup is higher priority
+						const end = Date.now() - auditRetention / (1 + passCleanupPriority * passCleanupPriority);
+						// Probe before raising, so an idle database does not write a floor transaction on every
+						// pass forever. `end` is fixed and audit keys only move forward, so an empty probe means
+						// the loop below finds nothing either.
 						const entries = auditStore
 							.getRange({
 								start: 1, // must not be zero or it will be interpreted as null and overlap with symbols in search
 								snapshot: false,
-								end: Date.now() - auditRetention / (1 + passCleanupPriority * passCleanupPriority), // remove up until the audit retention time, reducing audit retention time if cleanup is higher priority
+								end,
 							})
 							[Symbol.iterator]();
 						try {
+							// Raised off the first eligible entry rather than a separate probe range: one cursor,
+							// so a pass over an idle database writes no floor at all, and nothing else observing
+							// this range sees an extra advance. Still strictly before any removal — see
+							// raiseAuditFloor.
+							let floorRaised = false;
 							while (!cleanupStopped && !storeClosing()) {
 								const entry = entries.next();
 								if (entry.done) break;
 								const auditRecord = entry.value;
+								if (!floorRaised) {
+									raiseAuditFloor(auditStore, end);
+									floorRaised = true;
+								}
 								try {
 									// awaited so a rejection (not just a synchronous throw) is caught here instead of
 									// escaping as an unhandled rejection once a later iteration's promise replaces this one
@@ -435,6 +478,372 @@ export function getLastRemoved(auditStore) {
 		return FLOAT_TARGET[0];
 	}
 }
+/**
+ * Read the recorded floor, normalizing anything we cannot trust to AUDIT_FLOOR_UNKNOWN. Reads bytes
+ * rather than going through the store's value decoder, which would read these eight raw float bytes
+ * as an audit entry (and as msgpack on RocksDB). Callers get a number in every case: a NaN or
+ * negative floor read as a number would make one of `cursor >= floor` / `cursor < floor` report
+ * safety, and which of the two a consumer writes must not decide whether corrupt metadata fails
+ * closed.
+ */
+function decodeAuditFloor(stored: any): number {
+	// RocksDB's getBinarySync is typed to also return a length; anything that is not exactly the
+	// eight bytes we write is metadata written by something else.
+	if (stored?.byteLength !== 8) return AUDIT_FLOOR_UNKNOWN;
+	FLOOR_BUFFER.set(stored);
+	const floor = FLOOR_TARGET[0];
+	// `Object.is` for -0, which passes `>= 0` and would then read as a permissive zero — every cursor
+	// safe — from bytes with the sign bit set that nothing here writes. raiseAuditFloor rejects the
+	// same value as a cutoff; the read side has to agree or corrupt metadata fails open.
+	if (!Number.isFinite(floor) || floor < 0 || Object.is(floor, -0)) return AUDIT_FLOOR_UNKNOWN;
+	return floor;
+}
+
+/**
+ * Did the floor write land? A record has to be PRESENT, not merely decode to the value we wrote:
+ * `decodeAuditFloor(undefined)` is the unknown sentinel too, so on a floorless store — where the
+ * resolver writes exactly that sentinel — comparing decoded values alone reported a commit for a
+ * write that never happened, and the caller pruned with nothing persisted.
+ */
+function floorWriteLanded(stored: any, floor: number): boolean {
+	return stored !== undefined && decodeAuditFloor(stored) === floor;
+}
+
+/** Own eight bytes per write: the store must never be handed a live view of the reused module buffer. */
+function encodeAuditFloor(floor: number): Uint8Array {
+	FLOOR_TARGET[0] = floor;
+	return FLOOR_BUFFER.slice();
+}
+
+/**
+ * Read-modify-write the floor under one store transaction. `resolve` receives the recorded floor
+ * (AUDIT_FLOOR_UNKNOWN when there is none) and returns the value to store, or undefined to leave it
+ * alone. `key` selects the record: the floor itself, or the bootstrap-provenance record beside it,
+ * which wants the same verified commit rather than a second write path.
+ *
+ * The transaction is the point: pruning is not confined to one worker — the retention loop,
+ * a boot purge, `deleteHistory` and `delete_transaction_logs_before` can all advance the floor — and
+ * two unsynchronized read-then-writes can interleave so the lower cutoff lands last, leaving a floor
+ * below history the higher one already removed. In read-only mode nothing is written, which is
+ * consistent because nothing is pruned there either.
+ */
+function updateAuditFloor(
+	auditStore: any,
+	resolve: (current: number, recorded: boolean) => number | undefined,
+	key: symbol = AUDIT_FLOOR_KEY
+): void {
+	// A legacy `auditPath` layout is opened as its own standalone LMDB root (databases.ts) and has no
+	// `.rootStore`, so it owns the transaction itself.
+	const transactionOwner = auditStore?.rootStore ?? auditStore;
+	if (!transactionOwner?.transactionSync)
+		throw new Error('Cannot record the audit retention floor: this database has no audit store');
+	// Both branches read their own write back and report `false` on mismatch, and the caller demands an
+	// explicit `true`. Both halves are load-bearing: a RocksDB transactionSync returns undefined for a
+	// swallowed abort rather than throwing (see RecordEncoder.saveStructures), and a write that fails
+	// without throwing is otherwise indistinguishable from one that landed — a caller pruning against a
+	// floor never recorded. Reads inside a write transaction see their own writes on both engines, so
+	// the read-back observes what commit will make durable.
+	const committed =
+		auditStore instanceof RocksTransactionLogStore
+			? transactionOwner.transactionSync(
+					(txn) => {
+						const stored = txn.getBinarySync(key);
+						const floor = resolve(decodeAuditFloor(stored), stored !== undefined);
+						if (floor !== undefined) {
+							txn.putSync(key, asBinary(encodeAuditFloor(floor)));
+							if (!floorWriteLanded(txn.getBinarySync(key), floor)) return false;
+						}
+						return true;
+					},
+					{ retryOnBusy: true }
+				)
+			: transactionOwner.transactionSync(() => {
+					const stored = auditStore.getBinary(key);
+					const floor = resolve(decodeAuditFloor(stored), stored !== undefined);
+					// `put` rather than `putSync`, and inside the transaction: lmdb's putSync is itself
+					// `put(...) === SYNC_PROMISE_SUCCESS`, so it drops whatever put returns — and a put that
+					// hands back a real rejection (a replaced one, as the marker-failure fixtures install)
+					// leaks it with no owner. Within a write transaction put writes synchronously and returns
+					// an already-resolved sentinel, so the value is visible immediately either way and this
+					// only takes ownership of the failure case.
+					// asBinary: a legacy standalone audit root's encoder has no Uint8Array passthrough, so raw
+					// bytes would reach createAuditEntry and throw. This bypasses both encoders.
+					if (floor !== undefined) {
+						auditStore
+							.put(key, asBinary(encodeAuditFloor(floor)))
+							?.catch?.((error) => warnContained('Error writing the audit retention floor', error));
+						if (!floorWriteLanded(auditStore.getBinary(key), floor)) return false;
+					}
+					return true;
+				});
+	if (committed !== true) throw new Error('The audit retention floor transaction did not commit');
+}
+
+/**
+ * The bound a prune should use — and record — in place of an unbounded cutoff.
+ *
+ * `Infinity` is a legitimate thing for a caller to *mean* ("remove all of it") and a ruinous thing to
+ * store: it is the unknown sentinel, and the sentinel is absorbing. `raiseAuditFloor`'s lock-free
+ * pre-check skips any present record no cutoff exceeds, and `establishAuditFloor` skips any store that
+ * has one, so a floor at `Infinity` never comes back down — for the whole database, including sibling
+ * tables whose own history was never touched. One `deleteHistory(Infinity)` would otherwise retire the
+ * accessor for that database permanently (#2458).
+ *
+ * So bound it by what exists: strictly above the newest key currently in the log, and never below the
+ * clock. Nothing already written can escape that bound, and a caller that passes it as the prune's
+ * range end as well as its floor cannot remove anything the floor does not cover — which is what makes
+ * the write-ahead ordering hold without an infinite bound. An entry written *after* this returns is
+ * simply not history the call asked to remove.
+ *
+ * `Infinity` is only the extreme case. Any cutoff above this bound is the same defect by degree: a
+ * finite year-2286 bound (`Date.now() * 1000`, or a bare `'9999999999999'`) is equally unreachable
+ * and equally permanent, and entries written after the prune then land *below* the recorded floor,
+ * so the floor's promise — nothing after it was pruned — is false about history that is still there.
+ * Every cutoff is therefore clamped, not just the unbounded one.
+ *
+ * Non-numbers, NaN, negatives and `-0` fall through unchanged to `raiseAuditFloor`, which rejects
+ * them: the numeric ones are ordered keys the prune range would honor, not bounds anyone meant, and a
+ * non-number is guarded explicitly because `>` would otherwise coerce it into a bound the floor
+ * accepts. `cutoff > bound` rather than `Math.min` keeps NaN falling through too.
+ *
+ * On RocksDB `getKeys` is unimplemented and returns `[]`, so the bound reduces to `Date.now()`. A
+ * key above the clock therefore survives a purge that asked for it on that engine. That is the safe
+ * direction: the entry is kept and the floor stays honest, where the alternative removes history the
+ * floor does not cover.
+ */
+export function boundedAuditPruneEnd(auditStore: any, cutoff: number): number {
+	// Non-numbers pass through untouched for `raiseAuditFloor` to reject. `>` coerces, so without this
+	// a numeric STRING ('9999999999999', 'Infinity') or a future Date compared true against the bound
+	// and came back AS the bound — a number raiseAuditFloor accepts — so an input it used to reject as
+	// a type error became a whole-log prune (#2458, kriszyp).
+	if (typeof cutoff !== 'number') return cutoff;
+	let bound = Date.now();
+	for (const newest of auditStore.getKeys({ reverse: true, limit: 1 })) {
+		if (typeof newest === 'number' && newest >= bound) bound = newest + 1;
+	}
+	return cutoff > bound ? bound : cutoff;
+}
+
+/**
+ * Raise the floor to `cutoff`, the exclusive lower bound of the history a prune is about to make
+ * unreachable.
+ *
+ * **Call this before removing anything.** A floor written after the removal is lost if the process
+ * dies in between, and the surviving lower floor then certifies a cursor whose history is gone.
+ * Ordering it first also means it covers a prune that removes less than `cutoff` spans — a RocksDB
+ * purge that finds no whole droppable file, a retention pass that stops at MAX_DELETES_PER_CLEANUP
+ * with a large backlog still eligible. Over-reporting costs a consumer one unnecessary resync;
+ * under-reporting loses its data silently. For the three retention paths the over-report is bounded
+ * by the thing that already bounds the promise — they pass `Date.now() - auditRetention`, so the
+ * floor cannot climb above the horizon `logging.auditRetention` already declines to retain past. The
+ * two operator-supplied bounds (`deleteHistory`, and the bridge's whole-database purge) have no such
+ * ceiling of their own and must be run through `boundedAuditPruneEnd` first; a bound above everything
+ * reachable would otherwise be recorded verbatim and never come down.
+ *
+ * Throws if the floor cannot be persisted, which is why it is called first — the throw is what stops
+ * the prune from proceeding unrecorded. Never lowers the floor, so a narrower prune cannot undo a
+ * wider one, and a store whose floor is unknown stays unknown rather than being talked down to a
+ * cutoff that says nothing about the history it has already lost.
+ */
+export function raiseAuditFloor(auditStore: any, cutoff: number): void {
+	// Throw rather than no-op on a bound we will not store. A NaN or negative cutoff is NOT harmless
+	// here: transactionKeyEncoder writes keys as raw float64, so NaN (0x7FF8…) and negatives (sign bit
+	// set) sort ABOVE every real timestamp, and `getRange({ start: 1, end: NaN })` therefore spans the
+	// whole log. `delete_transaction_logs_before` reaches that via Number.parseInt on a non-numeric
+	// timestamp, so silently declining the floor update would leave the prune deleting everything.
+	// Infinity is accepted and IS stored, decoding back to "unknown" — but no production caller passes
+	// it any more, because storing it retires the accessor for the whole database (see
+	// `boundedAuditPruneEnd`, which `deleteHistory` uses to bound an unbounded request, and the 400 the
+	// bridge returns for one). Kept accepted rather than rejected so the sentinel stays reachable for a
+	// caller that genuinely cannot bound its prune; there is currently no such caller.
+	// `-0` and a non-number slip past a naive `< 0` check but are still ordered keys the range honors:
+	// -0 sets the float64 sign bit and a non-number takes the ordered-binary branch of the key encoder,
+	// so both sort outside the timestamp space the prune means to bound.
+	if (typeof cutoff !== 'number' || Number.isNaN(cutoff) || cutoff < 0 || Object.is(cutoff, -0))
+		throw new Error(`Invalid audit prune bound: ${String(cutoff)}`);
+	// Read-only mode does not exempt a prune from recording its floor; it means the prune must not
+	// happen. Only scheduleAuditCleanup and purgeAgedLogs check read-only themselves, so for
+	// deleteHistory and the whole-database purge this throw is the guard.
+	if (isReadOnlyMode()) throw new Error('Cannot record the audit retention floor: the database is read-only');
+	// Lock-free pre-check, getBinary-guarded so this optimization never decides the error a store with
+	// no audit store reports. Most calls cannot move the floor (a RocksDB reclamation pass on an idle
+	// database, a cutoff below one a wider prune already set), and taking the env write lock to
+	// discover that serializes every worker's boot and reclamation on it. The in-transaction guards
+	// below stay authoritative.
+	// Skips only the case it can prove is a no-op: a record that exists and already sits at or above
+	// the cutoff. An absent record is NOT decided here — the presence question is settled inside the
+	// transaction below, because another worker's establishAuditFloor can land between this read and
+	// that write.
+	if (auditStore?.getBinary) {
+		const stored = auditStore.getBinary(AUDIT_FLOOR_KEY);
+		if (stored !== undefined && !(cutoff > decodeAuditFloor(stored))) return;
+	}
+	updateAuditFloor(auditStore, (current, recorded) => {
+		// Still no record, and we are about to prune: persist the unknown sentinel. Leaving no marker
+		// lets the next open stamp a FINITE epoch, and a prune bound above that epoch (a future
+		// `endTime`, or a rolled-back clock) then certifies cursors whose history this prune deleted.
+		// Unknown is the honest value, because a store with no record may have been pruned before this
+		// run too.
+		if (!recorded) return AUDIT_FLOOR_UNKNOWN;
+		// A record appeared while we were getting here, so this is an ordinary monotonic raise: pruning
+		// to `cutoff` against a floor left below it is exactly the silent gap this function prevents.
+		return cutoff > current ? cutoff : undefined;
+	});
+}
+
+/**
+ * Give a database a trustworthy floor if it has none: the current time, as a one-time resync epoch.
+ *
+ * The floor record's *presence* is the trust marker, so a store without one is a store whose
+ * retention history we cannot account for. It may have been pruned by a version that recorded no
+ * floor; it may be the empty audit store an LMDB→RocksDB migration deliberately leaves behind
+ * (`bin/copyDb.ts` does not migrate it, so the records and their resumable cursors outlive their
+ * history); or it may be a database restored from a table-scoped backup taken without
+ * `include_audit`, which carries records but no audit DBI. Cursors from before this moment are
+ * therefore reported stale — not because we know they are, but because we do not know they are not.
+ *
+ * There is no "brand new store, use a permissive baseline" case: creating the audit DBI proves only
+ * that the DBI was absent, which the audit-less backup above also produces. Being conservative on a
+ * genuinely new database costs nothing, since its entries are all written after this instant.
+ *
+ * In read-only mode nothing is written and the floor stays unknown — the fail-closed answer for a
+ * process that cannot record what it does not know.
+ *
+ * **The epoch is also recorded under its own key, so this bootstrap is repairable.** The epoch is a
+ * guess bounded by surviving state, and surviving state cannot see history a selective prune already
+ * removed (see the clock note below). The record marks the store as one that carried a guess, and
+ * preserves the value guessed — the two facts a later release needs to raise such a floor to
+ * something it can stand behind. See "Audit retention floor" in DESIGN.md for the full reading.
+ *
+ * **The mark is the signal, not a comparison against the floor.** A store carrying this record has an
+ * unverified pre-tracking window for as long as it exists, however far the floor has since moved: a
+ * prune raising the floor above the epoch certifies only what that prune removed, and says nothing
+ * about history removed before tracking began — which may sit above the epoch, since that is exactly
+ * the case the guess cannot see. Retiring the mark takes a database generation (harper#2451), not a
+ * floor that has climbed past it.
+ *
+ * Ordering. The provenance record is written **first**, so a crash between the two writes leaves a
+ * record with no floor — which the next open retries, since the early return above tests the floor.
+ * The epoch actually stamped is always read back from the record rather than taken from this call's
+ * own `Date.now()`, so a worker whose record lost the race adopts the winner's value and the two
+ * always agree. Re-adopting an older record is sound: nothing was pruned in the meantime, or a prune
+ * would have written the floor this function returns early on.
+ */
+export function establishAuditFloor(auditStore: any): void {
+	if (isReadOnlyMode()) return;
+	// Every read and write in here is inside the try: the contract is that a database open never fails
+	// over this metadata, and a throwing getBinary/getKeys would escape to initStores just as a
+	// throwing write would.
+	try {
+		// Absence of the record, not `getAuditFloor() === AUDIT_FLOOR_UNKNOWN`: a record that exists but
+		// decodes to unknown — corrupt bytes, or the Infinity a prune-everything stored — is already the
+		// fail-closed answer, and stamping over it would LOWER a floor that is never supposed to lower.
+		// The check is repeated inside the transaction (the `recorded` argument), because between this
+		// read and that write another worker's prune can store exactly such a value; this read only keeps
+		// the common case — a floor already established, every worker, every database, every boot — off
+		// the env write lock.
+		if (auditStore.getBinary(AUDIT_FLOOR_KEY) !== undefined) return;
+		// Not bare Date.now(): a clock that has rolled back would bootstrap a floor BELOW history this
+		// database may already have pruned, certifying a stale cursor. The newest retained entry is a
+		// lower bound the clock cannot argue with — everything at or above it is demonstrably still here —
+		// so take whichever is later.
+		//
+		// It narrows that hole; it does not close it, because the bound covers what SURVIVES rather than
+		// what existed. A legacy `deleteHistory` removes one table's entries below its endTime out of the
+		// shared log, so a table whose entries were the newest and all fell below that bound leaves the
+		// log's newest survivor being a sibling's OLDER entry — removed history above every surviving key.
+		// A clock rolled back to between the two then stamps an epoch below entries that are gone, and a
+		// cursor in that window resumes over the gap (#2458). Also unclosed:
+		// RocksTransactionLogStore.getKeys() is unimplemented, so on that engine this reduces to
+		// Date.now() outright.
+		//
+		// Neither is a reason to refuse to stamp — the unknown sentinel is absorbing, so that would make
+		// every upgraded deployment fail closed forever (a recorded ruling in #2458). They are the reason
+		// the guess is RECORDED as a guess: written first, so it cannot be lost behind a floor that
+		// outlives it, and left in place afterwards so the repair reading stays available.
+		let fresh = Date.now();
+		for (const newest of auditStore.getKeys({ reverse: true, limit: 1 })) {
+			if (typeof newest === 'number' && newest > fresh) fresh = newest;
+		}
+		// A READABLE record is kept, so the epoch read back below is whatever landed first and the floor
+		// always matches it. An unreadable one is replaced: unlike the floor, where a present record may
+		// be a deliberate AUDIT_FLOOR_UNKNOWN and overwriting it would lower a floor, this record is only
+		// a comparison basis, and undecodable bytes carry nothing worth keeping. Declining to replace
+		// them pinned the store's floor to unknown forever — the resolver would skip the write on every
+		// later open, the read back would fail identically, and no retry could ever succeed, which is the
+		// fail-closed-forever state this bootstrap exists to avoid.
+		updateAuditFloor(
+			auditStore,
+			(current, recorded) => (recorded && Number.isFinite(current) ? undefined : fresh),
+			AUDIT_FLOOR_BOOTSTRAP_KEY
+		);
+		const epoch = decodeAuditFloor(auditStore.getBinary(AUDIT_FLOOR_BOOTSTRAP_KEY));
+		// Never stamp a floor whose provenance cannot be read: that is the one state a later repair cannot
+		// act on. Unreachable in principle, since `updateAuditFloor` throws if its write did not land.
+		if (!Number.isFinite(epoch)) return;
+		updateAuditFloor(auditStore, (_current, recorded) => (recorded ? undefined : epoch));
+	} catch (error) {
+		// An unrecorded floor already reads as unknown, which is the fail-closed answer; aborting startup
+		// instead would turn a metadata failure into an outage. The next open retries.
+		warnContained('Error initializing the audit retention floor', error);
+	}
+}
+
+/**
+ * The floor of this database's retained audit history: every audit entry at or after the returned
+ * time is still retained, so a consumer whose last-processed audit-log cursor is `>=` it can resume
+ * incrementally, and one below it must resync — it may have lost nothing, but the floor cannot
+ * certify it either way. Returns `Infinity` when
+ * the floor is unknown, which fails closed — no cursor compares as safe.
+ *
+ * **One exception, and it is the only one: history removed before the floor existed.** Every prune
+ * that runs with a floor recorded is covered — it raises the floor first, so it cannot remove an entry
+ * the floor does not cover. But the first open stamps a floor from what *survives*
+ * (`establishAuditFloor`), and a legacy `Table.deleteHistory` that removed a table's newest entries,
+ * followed by a clock rollback, leaves that stamp below history that is gone; a cursor in the window
+ * is then certified over the gap. So the guarantee is one-directional for tracked prunes and silent
+ * about untracked ones. Only a database generation can close that (harper#2451).
+ *
+ * The time domain is the audit-log key: what `subscribe`'s events carry as `localTime` and what MQTT
+ * durable sessions persist as `startTime`, so those compare against the floor directly.
+ * **`getHistory` is not in that domain** — it reports each entry's origin `version` under the name
+ * `localTime`, which a backdated or replicated write makes differ from the audit-log key. A cursor
+ * saved from `getHistory` is not comparable to this floor.
+ *
+ * **Database-scoped**, and deliberately conservative: the audit store is per-database and its
+ * entries carry a `tableId`, so a per-table floor would need a scan for the first entry matching
+ * that table. For a valid cursor, `cursor >= floor` therefore means no entry of *any* table in the
+ * database was removed *after* the cursor. What it never promises is anything below the FLOOR — that
+ * history is exactly what a prune takes. Below the *cursor* is not the same set: for a cursor strictly
+ * above the floor, `[floor, cursor)` sits below the cursor and is still covered by the guarantee. `Table.deleteHistory`
+ * prunes one table out of that shared log and raises the whole database's floor, which can overstate
+ * the floor for its siblings.
+ *
+ * **A moment-in-time observation.** Retention can advance between this call and whatever the caller
+ * does with the answer, so a check-then-resume sequence has a window where the floor moves under it.
+ * Closing that requires validating the cursor inside the resume itself (harper#2448); until then a
+ * lost race degrades to the truncation that happens today, never to anything worse.
+ *
+ * **On RocksDB the floor tracks the configured horizon, not retained reality.** That branch purges at
+ * whole-log-file granularity, so it cannot know before the fact which entries a purge will drop, and
+ * the floor has to be written first — so every retention pass advances it to
+ * `Date.now() - auditRetention / (1 + priority²)` whether or not a file was dropped. Entries below
+ * that horizon are routinely still on disk, and a consumer holding a cursor among them is told to
+ * resync. Conservative in the one safe direction, and the reason the LMDB branch (which can see a
+ * single eligible entry) instead raises off the first one it finds.
+ *
+ * **Not covered: copying a database's state without its history.** `restore_backup` replaces a
+ * database with the backup's, floor and all, and a RocksDB checkpoint (a branch database) copies the
+ * floor record but no transaction logs — so in both cases a cursor from after the copy point sits
+ * above a floor that is present, and therefore trusted, for history that is not there. Nothing here
+ * can detect that on its own, and it is not the audit log's problem alone: the same copy rolls back
+ * record versions and per-node replication sequence state, so making this one field honest while
+ * those stay stale would not give a consumer a coherent answer. It needs a database-level epoch —
+ * harper#2451.
+ */
+export function getAuditFloor(auditStore: any): number {
+	return decodeAuditFloor(auditStore.getBinary(AUDIT_FLOOR_KEY));
+}
 export function setAuditRetention(retentionTime, defaultDelay = DEFAULT_AUDIT_CLEANUP_DELAY) {
 	auditRetention = retentionTime;
 	DEFAULT_AUDIT_CLEANUP_DELAY = defaultDelay;
@@ -452,7 +861,10 @@ export function setAuditRetention(retentionTime, defaultDelay = DEFAULT_AUDIT_CL
 export function purgeAgedLogs(rootStore: RocksDatabase): string[] {
 	// Mirror the read-only guard in scheduleAuditCleanup: never delete log files in read-only mode.
 	if (isReadOnlyMode()) return [];
-	return rootStore.purgeLogs({ before: Date.now() - auditRetention });
+	const before = Date.now() - auditRetention;
+	// The audit store is reachable this early because initStores opens it before replayLogs runs this.
+	raiseAuditFloor((rootStore as any).auditStore, before);
+	return rootStore.purgeLogs({ before });
 }
 
 const HAS_RECORD = 16;

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -134,13 +134,11 @@ const FLOAT_BUFFER = new Uint8Array(FLOAT_TARGET.buffer);
  * questions.
  */
 const AUDIT_FLOOR_KEY = Symbol.for('audit-floor');
-// The epoch `establishAuditFloor` stamped, kept for the life of the store. Its PRESENCE marks the
-// floor's provenance as unverified — a guess bounded by what survived, which cannot see history a
-// legacy prune removed before tracking began — and nothing short of a database generation (#2451)
-// retires that mark. In particular no comparison does: a later prune that raises the floor above this
-// value certifies only what it removed, so `floor > bootstrap` says nothing about the older gap. The
-// stored number records only how far the guess reached, for that repair to consume. Never raised,
-// never removed. See `establishAuditFloor`.
+// The epoch `establishAuditFloor` stamped, never raised or removed. Its PRESENCE marks the floor as
+// unverified provenance — a guess bounded by what survived, blind to history a legacy prune removed
+// before tracking began — until a database generation (#2451) retires the mark. No comparison does:
+// a later prune certifies only what it removed, so `floor > bootstrap` says nothing about the older
+// gap. The value records how far the guess reached, for that repair. See `establishAuditFloor`.
 const AUDIT_FLOOR_BOOTSTRAP_KEY = Symbol.for('audit-floor-bootstrap');
 /**
  * The floor's own eight bytes, deliberately NOT the FLOAT_TARGET/FLOAT_BUFFER pair the `last-removed`
@@ -521,11 +519,9 @@ function encodeAuditFloor(floor: number): Uint8Array {
  * alone. `key` selects the record: the floor itself, or the bootstrap-provenance record beside it,
  * which wants the same verified commit rather than a second write path.
  *
- * The transaction is the point: pruning is not confined to one worker — the retention loop,
- * a boot purge, `deleteHistory` and `delete_transaction_logs_before` can all advance the floor — and
- * two unsynchronized read-then-writes can interleave so the lower cutoff lands last, leaving a floor
- * below history the higher one already removed. In read-only mode nothing is written, which is
- * consistent because nothing is pruned there either.
+ * The transaction is the point: several paths advance the floor from different workers, and two
+ * unsynchronized read-then-writes can interleave so the lower cutoff lands last — a floor below
+ * history the higher one already removed. Read-only mode writes nothing, and prunes nothing.
  */
 function updateAuditFloor(
 	auditStore: any,
@@ -629,15 +625,12 @@ export function boundedAuditPruneEnd(auditStore: any, cutoff: number): number {
  *
  * **Call this before removing anything.** A floor written after the removal is lost if the process
  * dies in between, and the surviving lower floor then certifies a cursor whose history is gone.
- * Ordering it first also means it covers a prune that removes less than `cutoff` spans — a RocksDB
- * purge that finds no whole droppable file, a retention pass that stops at MAX_DELETES_PER_CLEANUP
- * with a large backlog still eligible. Over-reporting costs a consumer one unnecessary resync;
- * under-reporting loses its data silently. For the three retention paths the over-report is bounded
- * by the thing that already bounds the promise — they pass `Date.now() - auditRetention` (never below 0), so the
- * floor cannot climb above the horizon `logging.auditRetention` already declines to retain past. The
- * two operator-supplied bounds (`deleteHistory`, and the bridge's whole-database purge) have no such
- * ceiling of their own and must be run through `boundedAuditPruneEnd` first; a bound above everything
- * reachable would otherwise be recorded verbatim and never come down.
+ * Ordering it first also covers a prune that removes less than `cutoff` spans (a RocksDB purge with
+ * no whole droppable file, a retention pass stopping at MAX_DELETES_PER_CLEANUP): over-reporting costs
+ * one unnecessary resync, under-reporting loses data silently. The retention paths bound that
+ * over-report at the configured horizon (`Date.now() - auditRetention`, never below 0); the two
+ * operator-supplied bounds have no ceiling of their own and go through `boundedAuditPruneEnd` first,
+ * since a bound above everything reachable would be recorded verbatim and never come down.
  *
  * Throws if the floor cannot be persisted, which is why it is called first — the throw is what stops
  * the prune from proceeding unrecorded. Never lowers the floor, so a narrower prune cannot undo a
@@ -645,19 +638,13 @@ export function boundedAuditPruneEnd(auditStore: any, cutoff: number): number {
  * cutoff that says nothing about the history it has already lost.
  */
 export function raiseAuditFloor(auditStore: any, cutoff: number): void {
-	// Throw rather than no-op on a bound we will not store. A NaN or negative cutoff is NOT harmless
-	// here: transactionKeyEncoder writes keys as raw float64, so NaN (0x7FF8…) and negatives (sign bit
-	// set) sort ABOVE every real timestamp, and `getRange({ start: 1, end: NaN })` therefore spans the
-	// whole log. `delete_transaction_logs_before` reaches that via Number.parseInt on a non-numeric
-	// timestamp, so silently declining the floor update would leave the prune deleting everything.
-	// Infinity is accepted and IS stored, decoding back to "unknown" — but no production caller passes
-	// it any more, because storing it retires the accessor for the whole database (see
-	// `boundedAuditPruneEnd`, which `deleteHistory` uses to bound an unbounded request, and the 400 the
-	// bridge returns for one). Kept accepted rather than rejected so the sentinel stays reachable for a
-	// caller that genuinely cannot bound its prune; there is currently no such caller.
-	// `-0` and a non-number slip past a naive `< 0` check but are still ordered keys the range honors:
-	// -0 sets the float64 sign bit and a non-number takes the ordered-binary branch of the key encoder,
-	// so both sort outside the timestamp space the prune means to bound.
+	// Throw rather than no-op on a bound we will not store: audit keys are raw float64, so NaN and
+	// negatives (sign bit set) sort ABOVE every real timestamp and a range ending there spans the whole
+	// log — declining the floor silently would leave the prune deleting everything. `-0` and a non-number
+	// slip past a naive `< 0` check but are still ordered keys the range honors, so they are rejected too.
+	// Infinity is accepted and stored, decoding back to "unknown": every production caller clamps before
+	// reaching here (`boundedAuditPruneEnd`, the bridge's 400), so it stays reachable only for a caller
+	// that genuinely cannot bound its prune.
 	if (typeof cutoff !== 'number' || Number.isNaN(cutoff) || cutoff < 0 || Object.is(cutoff, -0))
 		throw new Error(`Invalid audit prune bound: ${String(cutoff)}`);
 	// Read-only mode does not exempt a prune from recording its floor; it means the prune must not

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -560,10 +560,9 @@ function updateAuditFloor(
 			: transactionOwner.transactionSync(() => {
 					const stored = auditStore.getBinary(key);
 					const floor = resolve(decodeAuditFloor(stored), stored !== undefined);
-					// `put` rather than `putSync`, and inside the transaction: lmdb's putSync is itself
-					// `put(...) === SYNC_PROMISE_SUCCESS`, so it drops whatever put returns — and a put that
-					// hands back a real rejection (a replaced one, as the marker-failure fixtures install)
-					// leaks it with no owner. Within a write transaction put writes synchronously and returns
+					// `put` rather than `putSync`, and inside the transaction: lmdb's putSync is
+					// `put(...) === SYNC_PROMISE_SUCCESS`, so it drops whatever put returns, and a rejected put
+					// would leak with no owner. Within a write transaction put writes synchronously and returns
 					// an already-resolved sentinel, so the value is visible immediately either way and this
 					// only takes ownership of the failure case.
 					// asBinary: a legacy standalone audit root's encoder has no Uint8Array passthrough, so raw

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -264,7 +264,7 @@ export function openAuditStore(rootStore) {
 				let lastKey: any;
 				try {
 					if (isRocksAuditStore) {
-						const before = Date.now() - auditRetention / (1 + passCleanupPriority * passCleanupPriority);
+						const before = retentionCutoff(1 + passCleanupPriority * passCleanupPriority);
 						raiseAuditFloor(auditStore, before);
 						auditStore.rootStore.purgeLogs({ before });
 					} else {
@@ -272,7 +272,7 @@ export function openAuditStore(rootStore) {
 						// close landing mid-pass closes the env under it. for-of calls next() before the body, so a
 						// check inside the body advances the cursor first — the guard has to precede every next().
 						// remove up until the audit retention time, reducing audit retention time if cleanup is higher priority
-						const end = Date.now() - auditRetention / (1 + passCleanupPriority * passCleanupPriority);
+						const end = retentionCutoff(1 + passCleanupPriority * passCleanupPriority);
 						// Probe before raising, so an idle database does not write a floor transaction on every
 						// pass forever. `end` is fixed and audit keys only move forward, so an empty probe means
 						// the loop below finds nothing either.
@@ -613,9 +613,9 @@ function updateAuditFloor(
  */
 export function boundedAuditPruneEnd(auditStore: any, cutoff: number): number {
 	// Non-numbers pass through untouched for `raiseAuditFloor` to reject. `>` coerces, so without this
-	// a numeric STRING ('9999999999999', 'Infinity') or a future Date compared true against the bound
-	// and came back AS the bound — a number raiseAuditFloor accepts — so an input it used to reject as
-	// a type error became a whole-log prune (#2458, kriszyp).
+	// a numeric STRING ('9999999999999', 'Infinity') or a future Date compares true against the bound
+	// and comes back AS the bound — a number raiseAuditFloor accepts — turning a type error into a
+	// whole-log prune.
 	if (typeof cutoff !== 'number') return cutoff;
 	let bound = Date.now();
 	for (const newest of auditStore.getKeys({ reverse: true, limit: 1 })) {
@@ -634,7 +634,7 @@ export function boundedAuditPruneEnd(auditStore: any, cutoff: number): number {
  * purge that finds no whole droppable file, a retention pass that stops at MAX_DELETES_PER_CLEANUP
  * with a large backlog still eligible. Over-reporting costs a consumer one unnecessary resync;
  * under-reporting loses its data silently. For the three retention paths the over-report is bounded
- * by the thing that already bounds the promise — they pass `Date.now() - auditRetention`, so the
+ * by the thing that already bounds the promise — they pass `Date.now() - auditRetention` (never below 0), so the
  * floor cannot climb above the horizon `logging.auditRetention` already declines to retain past. The
  * two operator-supplied bounds (`deleteHistory`, and the bridge's whole-database purge) have no such
  * ceiling of their own and must be run through `boundedAuditPruneEnd` first; a bound above everything
@@ -758,7 +758,7 @@ export function establishAuditFloor(auditStore: any): void {
 		// Date.now() outright.
 		//
 		// Neither is a reason to refuse to stamp — the unknown sentinel is absorbing, so that would make
-		// every upgraded deployment fail closed forever (a recorded ruling in #2458). They are the reason
+		// every upgraded deployment fail closed forever. They are the reason
 		// the guess is RECORDED as a guess: written first, so it cannot be lost behind a floor that
 		// outlives it, and left in place afterwards so the repair reading stays available.
 		let fresh = Date.now();
@@ -850,6 +850,18 @@ export function setAuditRetention(retentionTime, defaultDelay = DEFAULT_AUDIT_CL
 }
 
 /**
+ * The retention cutoff a prune uses: `Date.now() - auditRetention`, scaled down by `divisor` for a
+ * higher-priority pass, and never below 0. A retention above ~55.7 years (or `Infinity`, to keep
+ * logs indefinitely) would otherwise go negative, and a negative bound is not "nothing eligible" —
+ * `raiseAuditFloor` rejects it, so every boot purge and retention pass would warn and the floor
+ * would never be raised on that install. At 0 the pass is a harmless no-op: nothing sits before
+ * the epoch, and a floor that already exists is never lowered to it.
+ */
+function retentionCutoff(divisor = 1): number {
+	return Math.max(0, Date.now() - auditRetention / divisor);
+}
+
+/**
  * One-shot purge of transaction-log files already older than the audit retention window,
  * intended to run during startup/recovery before transaction-log replay. The steady-state
  * cleanup loop (scheduleAuditCleanup) only starts once a worker reaches steady state, so a node
@@ -861,7 +873,7 @@ export function setAuditRetention(retentionTime, defaultDelay = DEFAULT_AUDIT_CL
 export function purgeAgedLogs(rootStore: RocksDatabase): string[] {
 	// Mirror the read-only guard in scheduleAuditCleanup: never delete log files in read-only mode.
 	if (isReadOnlyMode()) return [];
-	const before = Date.now() - auditRetention;
+	const before = retentionCutoff();
 	// The audit store is reachable this early because initStores opens it before replayLogs runs this.
 	raiseAuditFloor((rootStore as any).auditStore, before);
 	return rootStore.purgeLogs({ before });

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -29,7 +29,13 @@ import { workerData } from 'worker_threads';
 import harperLogger from '../utility/logging/harper_logger.ts';
 const { forComponent } = harperLogger;
 import * as manageThreads from '../server/threads/manageThreads.js';
-import { openAuditStore, readAuditEntry, createAuditEntry, type AuditRecord } from './auditStore.ts';
+import {
+	establishAuditFloor,
+	openAuditStore,
+	readAuditEntry,
+	createAuditEntry,
+	type AuditRecord,
+} from './auditStore.ts';
 import { handleLocalTimeForGets } from './RecordEncoder.ts';
 import { databasePaths, deleteRootBlobPathsForDB } from './blob.ts';
 import { removeStorageReclamation } from '../server/storageReclamation.ts';
@@ -1033,6 +1039,9 @@ function initStores(
 					}) as any;
 				}
 				auditStore.isLegacy = true;
+				// A legacy standalone audit root skips openAuditStore, so give it a floor here or it
+				// reports its retention horizon as permanently unknown.
+				establishAuditFloor(auditStore);
 			}
 		} else {
 			auditStore = openAuditStore(rootStore);

--- a/unitTests/resources/auditFloor.test.js
+++ b/unitTests/resources/auditFloor.test.js
@@ -1,0 +1,773 @@
+/**
+ * The audit staleness floor (harper#2447). A consumer resuming incremental audit-log consumption
+ * from a saved cursor has to be able to tell a complete catch-up from a truncated one;
+ * `getAuditFloor` is the primitive that answers it — internal, with deliberately no public accessor;
+ * `Table.subscribe` is to consume it inside the resume (harper#2448), and nothing does yet — and the
+ * invariant these tests defend
+ * is one-directional: the floor may ask for a resync that was not strictly necessary, but it must
+ * never certify a cursor a prune has already truncated. Pruning is the whole of what it covers — a
+ * state copy that rolls a database back (`restore_backup`, a RocksDB checkpoint) reinstalls an older
+ * floor along with everything else, and needs a database generation instead (harper#2451).
+ */
+const assert = require('node:assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const {
+	getAuditFloor,
+	establishAuditFloor,
+	raiseAuditFloor,
+	purgeAgedLogs,
+	setAuditRetention,
+	auditRetention,
+} = require('#src/resources/auditStore');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+// the floor is read off a table's (database-scoped) audit store; there is no Table-level accessor
+const floorOf = (tbl) => getAuditFloor(tbl.auditStore);
+const os = require('node:os');
+const path = require('node:path');
+const { waitFor } = require('../waitFor');
+require('#src/server/serverHelpers/serverUtilities');
+
+const AUDIT_FLOOR_KEY = Symbol.for('audit-floor');
+const AUDIT_FLOOR_BOOTSTRAP_KEY = Symbol.for('audit-floor-bootstrap');
+const ORIGINAL_CLEANUP_DELAY = 10_000; // setAuditRetention's own default, which it does not expose
+
+// A cursor records the last position already processed, so a cursor AT the floor is safe.
+const canResumeFrom = (cursor, floor) => cursor >= floor;
+
+function auditEntries(auditStore) {
+	const entries = [];
+	for (const record of auditStore.getRange({ start: 1 })) {
+		// `txnLogKey`, not `version`: the floor lives in the audit-LOG-key domain, and #2412 stage 0b
+		// split the two apart on the raw record (they coincide only when a write's record version is
+		// its own commit timestamp). Comparing `version` against the floor is precisely the
+		// `getHistory`-cursor mistake `getAuditFloor`'s contract warns about, and it would
+		// diverge silently on a source fill.
+		entries.push({ tableId: record.tableId, logKey: record.txnLogKey });
+	}
+	return entries;
+}
+
+/** The epoch `establishAuditFloor` recorded as a guess, or undefined when it recorded none. */
+function bootstrapEpoch(auditStore) {
+	const stored = auditStore.getBinary(AUDIT_FLOOR_BOOTSTRAP_KEY);
+	return stored === undefined ? undefined : new Float64Array(stored.slice().buffer)[0];
+}
+
+/** Clear a record on either engine: on RocksDB the floor lives in the root store, whose log store's own remove() is a no-op. */
+async function clearRecord(auditStore, key) {
+	const root = auditStore.rootStore;
+	if (typeof root?.removeSync === 'function') root.removeSync(key);
+	await auditStore.remove(key);
+}
+
+function encodeFloorBytes(value) {
+	const target = new Float64Array(1);
+	target[0] = value;
+	return new Uint8Array(target.buffer.slice(0));
+}
+
+/**
+ * A table in a database of its own. The floor is database-scoped, so a test that moves it would
+ * otherwise decide what every later test starts from — and a floor pushed into the future silently
+ * turns a later `raiseAuditFloor` into a no-op.
+ */
+function tableInOwnDatabase(name) {
+	return table({
+		table: name,
+		database: `auditFloor_${name}`,
+		attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+	});
+}
+
+describe('audit staleness floor', () => {
+	let Audited, Sibling, originalRetention;
+
+	before(async () => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		originalRetention = auditRetention;
+		const attributes = [{ name: 'id', isPrimaryKey: true }, { name: 'name' }];
+		Audited = table({ table: 'FloorAudited', database: 'auditFloorDB', attributes });
+		Sibling = table({ table: 'FloorSibling', database: 'auditFloorDB', attributes });
+	});
+
+	after(() => {
+		// both arguments: the second sets the module-global default cleanup delay, and restoring only the
+		// retention leaves every audit store opened later in this mocha process looping at 1 ms
+		setAuditRetention(originalRetention, ORIGINAL_CLEANUP_DELAY);
+	});
+
+	it('gives a new database a floor that admits every cursor it could have produced', async () => {
+		const floor = floorOf(Audited);
+		assert.ok(Number.isFinite(floor), `a freshly opened database should have a known floor, got ${floor}`);
+		await Audited.put('admits-1', { name: 'one' });
+		await Audited.put('admits-2', { name: 'two' });
+		for (const entry of auditEntries(Audited.auditStore)) {
+			assert.ok(
+				canResumeFrom(entry.logKey, floor),
+				`entry at ${entry.logKey} is retained but reads as below the floor ${floor}`
+			);
+		}
+	});
+
+	it('reports the same database-scoped floor to every table in the database', () => {
+		assert.strictEqual(floorOf(Audited), floorOf(Sibling));
+	});
+
+	it('does not leak a floor across databases', () => {
+		const raised = tableInOwnDatabase('Raised');
+		const untouched = tableInOwnDatabase('Untouched');
+		const before = floorOf(untouched);
+		const cutoff = Date.now() + 60_000;
+		raiseAuditFloor(raised.auditStore, cutoff);
+		assert.strictEqual(floorOf(raised), cutoff, 'precondition: the raise landed');
+		assert.strictEqual(floorOf(untouched), before, "raising one database's floor must not move another's");
+	});
+
+	describe('untrustworthy metadata fails closed', () => {
+		// A NaN floor in particular makes one of the two natural spellings of the check
+		// ("cursor < floor means stale") read as safe, so none of these may return a number.
+		const cases = [
+			['a truncated record', new Uint8Array(4)],
+			['an oversized record', new Uint8Array(12)],
+			['an empty record', new Uint8Array(0)],
+			['NaN', encodeFloorBytes(NaN)],
+			['negative infinity', encodeFloorBytes(-Infinity)],
+			['a negative time', encodeFloorBytes(-1)],
+			['negative zero', encodeFloorBytes(-0)],
+		];
+
+		let Metadata, trustedFloor;
+		before(() => {
+			Metadata = tableInOwnDatabase('Metadata');
+			trustedFloor = floorOf(Metadata);
+			assert.ok(Number.isFinite(trustedFloor), 'precondition: the floor starts trustworthy');
+		});
+
+		afterEach(() => {
+			Metadata.auditStore.putSync(AUDIT_FLOOR_KEY, encodeFloorBytes(trustedFloor));
+			assert.strictEqual(floorOf(Metadata), trustedFloor, 'restored between cases');
+		});
+
+		for (const [label, bytes] of cases) {
+			it(`returns Infinity for ${label}, without throwing`, () => {
+				Metadata.auditStore.putSync(AUDIT_FLOOR_KEY, bytes);
+				const floor = floorOf(Metadata);
+				assert.strictEqual(floor, Infinity, `${label} should read as unknown`);
+				assert.strictEqual(canResumeFrom(0, floor), false);
+				assert.strictEqual(canResumeFrom(Date.now(), floor), false);
+				assert.strictEqual(canResumeFrom(Number.MAX_VALUE, floor), false);
+			});
+		}
+
+		for (const [label, cutoff] of [
+			['negative zero', -0],
+			['a string', '123'],
+			['null', null],
+		]) {
+			it(`throws on ${label} as a cutoff, which the prune range would still honor`, () => {
+				const target = tableInOwnDatabase(`Bound${String(label).replace(/\W/g, '')}`);
+				const before = floorOf(target);
+				assert.throws(() => raiseAuditFloor(target.auditStore, cutoff), /Invalid audit prune bound/);
+				assert.strictEqual(floorOf(target), before);
+			});
+		}
+
+		it('bootstraps above the newest retained entry, not below it, when the clock has rolled back', async function () {
+			if (Audited.auditStore.reusableIterable) return this.skip(); // RocksDB getKeys is unimplemented
+			const { establishAuditFloor } = require('#src/resources/auditStore');
+			const rolled = tableInOwnDatabase('RolledBack');
+			const future = Date.now() + 3_600_000;
+			rolled.auditStore.putSync(future, new Uint8Array(0));
+			// A store that has NEVER bootstrapped, which is the only case this bound applies to: both
+			// records absent. Clearing the floor alone leaves the provenance record its open already wrote,
+			// and `establishAuditFloor` then adopts that epoch rather than deriving a fresh one — correct,
+			// and deliberately not bounded by the newest key: the record has to hold the epoch the floor was
+			// actually stamped to, or its value stops being the guess a later repair reads.
+			await clearRecord(rolled.auditStore, AUDIT_FLOOR_BOOTSTRAP_KEY);
+			await clearRecord(rolled.auditStore, AUDIT_FLOOR_KEY);
+			assert.strictEqual(floorOf(rolled), Infinity, 'precondition: no floor recorded');
+			assert.strictEqual(bootstrapEpoch(rolled.auditStore), undefined, 'precondition: never bootstrapped');
+			establishAuditFloor(rolled.auditStore);
+			assert.ok(
+				floorOf(rolled) >= future,
+				`floor ${floorOf(rolled)} must not sit below the newest retained entry ${future}`
+			);
+		});
+
+		it('does not stamp over a record that decodes to unknown', () => {
+			// establishAuditFloor keys off the record's ABSENCE. Keying off the decoded value instead would
+			// let a reopen replace a deliberately-stored Infinity (or corrupt bytes) with Date.now(),
+			// lowering a floor the contract says never lowers.
+			const { establishAuditFloor } = require('#src/resources/auditStore');
+			Metadata.auditStore.putSync(AUDIT_FLOOR_KEY, encodeFloorBytes(Infinity));
+			assert.strictEqual(floorOf(Metadata), Infinity);
+			establishAuditFloor(Metadata.auditStore);
+			assert.strictEqual(floorOf(Metadata), Infinity, 'reopen must not lower it');
+		});
+
+		// The bootstrap epoch is a guess bounded by surviving state, and surviving state cannot see history
+		// a selective prune already removed (#2458). It is recorded AS a guess: the record's PRESENCE marks
+		// the store, its value says how far the guess reached, and only a database generation (#2451)
+		// retires the mark — a floor that has climbed past the epoch does not. These pin what that rests
+		// on. Both engines: the record is written on both, and only the clock-rollback bound above is
+		// LMDB-only.
+		describe('bootstrap provenance', () => {
+			it('records the epoch it stamped, equal to the floor it stamped', () => {
+				const fresh = tableInOwnDatabase('Provenance');
+				const floor = floorOf(fresh);
+				assert.ok(Number.isFinite(floor), 'precondition: opening the database stamped a floor');
+				assert.strictEqual(bootstrapEpoch(fresh.auditStore), floor, 'the guess must be recorded as what it is');
+			});
+
+			it('leaves the record where it is when a real prune raises the floor', () => {
+				// The record preserves the guessed value, so it must not drift with the floor — that value is
+				// what tells a later repair how far the guess reached. Note what it does NOT license: a floor
+				// above the record is no evidence the store is safe, since a prune certifies only the history
+				// it removed and pre-tracking removals can sit above the epoch (#2458).
+				const pruned = tableInOwnDatabase('ProvenancePruned');
+				const stamped = floorOf(pruned);
+				const cutoff = stamped + 60_000;
+				raiseAuditFloor(pruned.auditStore, cutoff);
+				assert.strictEqual(floorOf(pruned), cutoff, 'precondition: the prune raised the floor');
+				assert.strictEqual(bootstrapEpoch(pruned.auditStore), stamped, 'the record must not follow it up');
+			});
+
+			it('adopts an orphaned record instead of stamping a fresh epoch', async () => {
+				// The record is written BEFORE the floor, so a crash in between leaves exactly this state. The
+				// next open has to stamp the floor the record already claims, or the recorded value stops
+				// being the epoch the floor was built from.
+				const orphaned = tableInOwnDatabase('ProvenanceOrphan');
+				const older = Date.now() - 1_000_000;
+				orphaned.auditStore.putSync(AUDIT_FLOOR_BOOTSTRAP_KEY, encodeFloorBytes(older));
+				await clearRecord(orphaned.auditStore, AUDIT_FLOOR_KEY);
+				assert.strictEqual(floorOf(orphaned), Infinity, 'precondition: no floor record');
+				establishAuditFloor(orphaned.auditStore);
+				assert.strictEqual(floorOf(orphaned), older, 'the floor must carry the recorded epoch');
+				assert.strictEqual(bootstrapEpoch(orphaned.auditStore), older, 'and the record must be unchanged');
+			});
+
+			it('records nothing for a store that already has a floor', async () => {
+				// The early return is on the FLOOR's absence, so a store whose floor predates this record does
+				// not acquire a guess it never made — which would read as suspect and cost a needless resync.
+				const existing = tableInOwnDatabase('ProvenanceExisting');
+				assert.ok(Number.isFinite(floorOf(existing)), 'precondition: a floor is recorded');
+				await clearRecord(existing.auditStore, AUDIT_FLOOR_BOOTSTRAP_KEY);
+				establishAuditFloor(existing.auditStore);
+				assert.strictEqual(bootstrapEpoch(existing.auditStore), undefined, 'no record may appear');
+			});
+
+			it('replaces an unreadable record rather than pinning the floor to unknown forever', async () => {
+				// Keeping undecodable bytes was fail-closed FOREVER, not recoverably: the resolver skipped the
+				// write because a record existed, the read back failed the same way on every later open, and
+				// no retry could ever succeed. The record is a comparison basis, not a floor, so unreadable
+				// bytes carry nothing worth keeping — unlike the floor, where a present record may be a
+				// deliberate unknown sentinel.
+				const corrupt = tableInOwnDatabase('ProvenanceCorrupt');
+				corrupt.auditStore.putSync(AUDIT_FLOOR_BOOTSTRAP_KEY, new Uint8Array(4));
+				await clearRecord(corrupt.auditStore, AUDIT_FLOOR_KEY);
+				establishAuditFloor(corrupt.auditStore);
+				const floor = floorOf(corrupt);
+				assert.ok(Number.isFinite(floor), `the floor must be stamped, got ${floor}`);
+				assert.strictEqual(bootstrapEpoch(corrupt.auditStore), floor, 'and the record rewritten to match');
+			});
+		});
+
+		it('persists the unknown sentinel when a prune finds no floor record at all', async () => {
+			// Returning without a marker would let the next open stamp a FINITE epoch, and a prune bound
+			// above it — a future endTime, or a rolled-back clock — would then certify cursors whose history
+			// this prune deleted.
+			const floorless = tableInOwnDatabase('Floorless');
+			// On RocksDB the floor lives in the root store and the log store's own remove() is a no-op,
+			// so clearing it goes through the root store there.
+			const floorlessRoot = floorless.auditStore.rootStore;
+			if (typeof floorlessRoot.removeSync === 'function') floorlessRoot.removeSync(AUDIT_FLOOR_KEY);
+			await floorless.auditStore.remove(AUDIT_FLOOR_KEY);
+			assert.strictEqual(floorless.auditStore.getBinary(AUDIT_FLOOR_KEY), undefined, 'precondition: no floor record');
+			raiseAuditFloor(floorless.auditStore, Date.now());
+			assert.notStrictEqual(
+				floorless.auditStore.getBinary(AUDIT_FLOOR_KEY),
+				undefined,
+				'the prune must leave a record behind'
+			);
+			assert.strictEqual(floorOf(floorless), Infinity, 'and it must read as unknown');
+			// and a later open must not talk it back down to a finite epoch
+			const { establishAuditFloor } = require('#src/resources/auditStore');
+			establishAuditFloor(floorless.auditStore);
+			assert.strictEqual(floorOf(floorless), Infinity);
+		});
+
+		it('raises normally when a floor appears between the pre-check and the transaction', () => {
+			// The pre-check is lock-free, so another worker's establishAuditFloor can land in the window.
+			// Treating that as "still absent" would write the unknown sentinel — or, worse, write nothing and
+			// let the prune run against a floor left below its cutoff. Simulated by hiding the record from
+			// the pre-check read only; the transaction sees the real store.
+			const raced = tableInOwnDatabase('Raced');
+			const established = floorOf(raced);
+			assert.ok(Number.isFinite(established), 'precondition: a real floor is recorded');
+			const cutoff = established + 60_000;
+			const store = raced.auditStore;
+			const realGetBinary = store.getBinary.bind(store);
+			let hidden = false;
+			store.getBinary = (key) => {
+				if (!hidden && key === AUDIT_FLOOR_KEY) {
+					hidden = true;
+					return undefined; // the pre-check observes no record
+				}
+				return realGetBinary(key);
+			};
+			try {
+				raiseAuditFloor(store, cutoff);
+			} finally {
+				store.getBinary = realGetBinary;
+			}
+			assert.strictEqual(
+				floorOf(raced),
+				cutoff,
+				'the raced-in record must take the monotonic raise, not the unknown sentinel'
+			);
+		});
+
+		it('leaves an unknown floor unknown when a prune tries to raise it', () => {
+			// A cutoff says nothing about the history the store lost before we started tracking it.
+			Metadata.auditStore.putSync(AUDIT_FLOOR_KEY, new Uint8Array(4));
+			raiseAuditFloor(Metadata.auditStore, Date.now());
+			assert.strictEqual(floorOf(Metadata), Infinity);
+		});
+	});
+
+	describe('raiseAuditFloor', () => {
+		let Monotonic;
+		before(() => {
+			Monotonic = tableInOwnDatabase('Monotonic');
+		});
+
+		it('never lowers an established floor', () => {
+			const high = Date.now() + 120_000;
+			raiseAuditFloor(Monotonic.auditStore, high);
+			assert.strictEqual(floorOf(Monotonic), high);
+			raiseAuditFloor(Monotonic.auditStore, high - 60_000);
+			assert.strictEqual(floorOf(Monotonic), high, 'a narrower prune must not undo the floor a wider one established');
+		});
+
+		for (const [label, cutoff] of [
+			['NaN', NaN],
+			['a negative time', -1],
+		]) {
+			it(`throws on ${label} as a cutoff rather than declining it silently`, () => {
+				// Audit keys are raw float64, so NaN and negatives sort ABOVE every real timestamp and the
+				// prune's own range honors them — declining only the floor update would delete everything.
+				const before = floorOf(Monotonic);
+				assert.throws(() => raiseAuditFloor(Monotonic.auditStore, cutoff), /Invalid audit prune bound/);
+				assert.strictEqual(floorOf(Monotonic), before);
+			});
+		}
+
+		it('refuses a deleteHistory whose bound the range would honor but the floor cannot record', async function () {
+			if (Audited.auditStore.reusableIterable) return this.skip(); // LMDB is the engine that removes entries
+			const guarded = tableInOwnDatabase('Guarded');
+			await guarded.put('kept-1', { name: 'one' });
+			await guarded.put('kept-2', { name: 'two' });
+			const before = auditEntries(guarded.auditStore).length;
+			assert.ok(before >= 2, 'precondition: entries that must survive');
+			await assert.rejects(() => guarded.deleteHistory(NaN), /Invalid audit prune bound/);
+			assert.strictEqual(
+				auditEntries(guarded.auditStore).length,
+				before,
+				'a bound that cannot be recorded must delete nothing'
+			);
+		});
+
+		it('refuses a deleteHistory bound that is not a number, even one that coerces to a valid one', async function () {
+			// `boundedAuditPruneEnd` clamps with `cutoff > bound`, and `>` coerces: a numeric STRING, the string
+			// 'Infinity', or a future Date compared true and came back AS the numeric bound — a value
+			// raiseAuditFloor accepts — so an input it used to reject as a type error became a whole-log prune
+			// (harper#2458, kriszyp). Non-numbers must reach raiseAuditFloor untouched.
+			if (Audited.auditStore.reusableIterable) return this.skip(); // LMDB is the engine that removes entries
+			const typed = tableInOwnDatabase('TypedBound');
+			await typed.put('t-1', { name: 'one' });
+			await typed.put('t-2', { name: 'two' });
+			const before = auditEntries(typed.auditStore).length;
+			assert.ok(before >= 2, 'precondition: entries that must survive');
+			const floorBefore = floorOf(typed);
+			for (const bound of ['9999999999999', 'Infinity', new Date(Date.now() + 86_400_000)]) {
+				await assert.rejects(
+					() => typed.deleteHistory(bound),
+					/Invalid audit prune bound/,
+					`${String(bound)} must be refused, not coerced into a bound`
+				);
+			}
+			assert.strictEqual(auditEntries(typed.auditStore).length, before, 'a refused bound must delete nothing');
+			assert.strictEqual(floorOf(typed), floorBefore, 'and must not move the floor');
+		});
+
+		it('takes an Infinity cutoff and reports the floor as unknown', () => {
+			// `deleteHistory(Infinity)` removes ALL of a table's history. Rejecting the cutoff would
+			// remove the entries and leave the previous floor certifying them.
+			const unbounded = tableInOwnDatabase('Unbounded');
+			assert.ok(Number.isFinite(floorOf(unbounded)), 'precondition: a known floor');
+			raiseAuditFloor(unbounded.auditStore, Infinity);
+			assert.strictEqual(floorOf(unbounded), Infinity);
+		});
+
+		it('throws rather than skipping the write when there is no audit store', () => {
+			// Callers order the raise before the prune, so this throw is what stops an unrecorded prune.
+			assert.throws(() => raiseAuditFloor(undefined, Date.now()), /has no audit store/);
+		});
+
+		it('does not report a commit when the floor write fails silently', function () {
+			// The containment around the LMDB put cannot tell a failing write from a replaced one, so the
+			// transaction reads its own write back. Without that, a rejected put was swallowed, the callback
+			// still returned true, and the caller pruned against a floor that was never recorded.
+			if (Audited.auditStore.reusableIterable) return this.skip(); // LMDB write branch
+			const swallowed = tableInOwnDatabase('Swallowed');
+			const before = floorOf(swallowed);
+			const store = swallowed.auditStore;
+			const realPut = store.put.bind(store);
+			store.put = () => Promise.reject(new Error('simulated floor write failure'));
+			try {
+				assert.throws(() => raiseAuditFloor(store, before + 60_000), /did not commit/);
+			} finally {
+				store.put = realPut;
+			}
+			assert.strictEqual(floorOf(swallowed), before, 'and the floor must not have moved');
+		});
+
+		it('does not report a commit when the unknown sentinel itself fails to write', function () {
+			// The read-back compares the value it wrote. On a FLOORLESS store the value is the unknown
+			// sentinel, and `decodeAuditFloor(undefined)` is that same sentinel — so equality alone said
+			// "landed" for a write that never happened, on exactly the store where the marker matters most.
+			// Both other write-failure tests seed a finite floor first, so neither reaches this.
+			if (Audited.auditStore.reusableIterable) return this.skip(); // LMDB write branch
+			const floorless = tableInOwnDatabase('SentinelFails');
+			const store = floorless.auditStore;
+			const floorlessRoot = store.rootStore;
+			if (typeof floorlessRoot.removeSync === 'function') floorlessRoot.removeSync(AUDIT_FLOOR_KEY);
+			return store.remove(AUDIT_FLOOR_KEY).then(() => {
+				assert.strictEqual(store.getBinary(AUDIT_FLOOR_KEY), undefined, 'precondition: no floor record');
+				const realPut = store.put.bind(store);
+				store.put = () => Promise.resolve(true); // accepted, but nothing is stored
+				try {
+					assert.throws(() => raiseAuditFloor(store, Date.now()), /did not commit/);
+				} finally {
+					store.put = realPut;
+				}
+				assert.strictEqual(
+					store.getBinary(AUDIT_FLOOR_KEY),
+					undefined,
+					'and still no record, so the caller must not have pruned'
+				);
+			});
+		});
+
+		it('does not prune when the floor cannot be recorded', () => {
+			let purgeCalls = 0;
+			const failingStore = {
+				auditStore: {
+					rootStore: {
+						transactionSync() {
+							throw new Error('cannot record the floor');
+						},
+					},
+				},
+				purgeLogs() {
+					purgeCalls++;
+					return [];
+				},
+			};
+			assert.throws(() => purgeAgedLogs(failingStore), /cannot record the floor/);
+			assert.strictEqual(purgeCalls, 0, 'the purge must not run once the floor write failed');
+		});
+	});
+
+	it('answers the resume predicate exactly at the floor', () => {
+		const floor = floorOf(Audited);
+		assert.ok(Number.isFinite(floor), 'precondition: a known floor');
+		assert.strictEqual(canResumeFrom(floor - 1, floor), false, 'a cursor below the floor has lost history');
+		assert.strictEqual(canResumeFrom(floor, floor), true, 'a cursor at the floor has processed everything below it');
+		assert.strictEqual(canResumeFrom(floor + 1, floor), true);
+	});
+
+	describe('every prune path advances the floor', () => {
+		it('the retention cleanup loop does, and keeps a usable floor once the log is empty', async function () {
+			if (Audited.auditStore.reusableIterable) return this.skip(); // RocksDB prunes by whole log file, covered below
+			const pruned = tableInOwnDatabase('Pruned');
+			await pruned.put(1, { name: 'one' });
+			await pruned.put(2, { name: 'two' });
+			const written = auditEntries(pruned.auditStore).map((entry) => entry.logKey);
+			assert.ok(written.length >= 2, 'precondition: entries to prune');
+
+			setAuditRetention(0.001, 1);
+			await waitFor(
+				async () => {
+					await pruned.auditStore.scheduleAuditCleanup(1);
+					return auditEntries(pruned.auditStore).length === 0;
+				},
+				{ timeout: 10_000, interval: 0, message: 'audit log was not pruned' }
+			);
+
+			const floor = floorOf(pruned);
+			// The surviving log is empty, so nothing about it distinguishes "pruned everything" from
+			// "never wrote anything" — this is exactly the case a floor derived from the log gets wrong.
+			assert.ok(Number.isFinite(floor), `floor should still be known after a full prune, got ${floor}`);
+			for (const logKey of written) {
+				assert.strictEqual(
+					canResumeFrom(logKey, floor),
+					false,
+					`a cursor at pruned entry ${logKey} must read as stale (floor ${floor})`
+				);
+			}
+		});
+
+		it('deleteHistory does, above entries the surviving log cannot account for', async function () {
+			if (Audited.auditStore.reusableIterable) return this.skip(); // RocksTransactionLogStore.remove() is a no-op
+			setAuditRetention(originalRetention);
+			const auditStore = Audited.auditStore;
+			await Audited.put('sparse-1', { name: 'x1' });
+			await Sibling.put('sparse-a', { name: 'y1' });
+			await Audited.put('sparse-2', { name: 'x2' });
+			await Sibling.put('sparse-b', { name: 'y2' });
+
+			const before = auditEntries(auditStore);
+			const siblingTimes = before.filter((e) => e.tableId === Sibling.tableId).map((e) => e.logKey);
+			const endTime = siblingTimes[siblingTimes.length - 1];
+			const removedTimes = before
+				.filter((e) => e.tableId === Audited.tableId && e.logKey < endTime)
+				.map((e) => e.logKey);
+			assert.ok(removedTimes.length > 0, 'precondition: entries of this table below the cut');
+
+			await Audited.deleteHistory(endTime);
+
+			const floor = floorOf(Audited);
+			const highestRemoved = Math.max(...removedTimes);
+			assert.strictEqual(
+				canResumeFrom(highestRemoved, floor),
+				false,
+				`the floor ${floor} still certifies removed entry ${highestRemoved}`
+			);
+			// And the reason the floor has to be recorded rather than read off the log: this prune takes
+			// one table out of a database-scoped log, so a sibling's entry survives BELOW the newest
+			// entry it removed. "Oldest surviving entry" would have reported a floor under that.
+			const surviving = auditEntries(auditStore);
+			assert.ok(surviving.length > 0, 'precondition: sibling entries survive');
+			assert.ok(
+				surviving[0].logKey < highestRemoved,
+				`expected a surviving entry below the highest removed (${surviving[0].logKey} vs ${highestRemoved})`
+			);
+		});
+
+		it('but a pass with nothing eligible writes no floor at all', async function () {
+			// the Rocks branch purges whole log files, so it has no per-entry eligibility probe to assert on
+			if (Audited.auditStore.reusableIterable) return this.skip();
+			const idle = tableInOwnDatabase('Idle');
+			await idle.put('recent', { name: 'kept' });
+			const before = floorOf(idle);
+			setAuditRetention(originalRetention); // nothing is old enough to prune
+			await idle.auditStore.scheduleAuditCleanup(1);
+			assert.strictEqual(floorOf(idle), before, 'an idle database must not write a floor transaction on every pass');
+		});
+
+		it('deleteHistory(Infinity) leaves the database a usable floor, not the absorbing sentinel', async function () {
+			// Infinity is the unknown sentinel AND absorbing: the lock-free pre-check skips any record no
+			// cutoff exceeds and establishAuditFloor skips any store that has one, so recording it would
+			// retire the floor for this database forever. The floor is database-scoped, so
+			// clearing ONE table's history would take every sibling's consumers down with it, permanently
+			// (#2458). A finite bound above everything in the log is honest about what was removed and
+			// still lets later cursors resume.
+			if (Audited.auditStore.reusableIterable) return this.skip(); // deleteHistory only raises on LMDB
+			const shared = 'auditFloorDB_infinite';
+			const attributes = [{ name: 'id', isPrimaryKey: true }, { name: 'name' }];
+			const wiped = table({ table: 'WipedTable', database: shared, attributes });
+			const spared = table({ table: 'SparedTable', database: shared, attributes });
+			await wiped.put('w-1', { name: 'one' });
+			await spared.put('s-1', { name: 'one' });
+
+			await wiped.deleteHistory(Infinity);
+
+			const floor = floorOf(wiped);
+			assert.ok(Number.isFinite(floor), `the floor must stay finite, got ${floor}`);
+			assert.strictEqual(floorOf(spared), floor, 'precondition: one floor per database');
+			// the sibling was never touched, so a cursor taken after the wipe must still resume
+			await spared.put('s-2', { name: 'two' });
+			const later = auditEntries(spared.auditStore)
+				.map((entry) => entry.logKey)
+				.filter((t) => t >= floor);
+			assert.ok(later.length > 0, 'a sibling write after the wipe must sit at or above the floor');
+			assert.strictEqual(canResumeFrom(later[later.length - 1], floor), true, 'and must read as resumable');
+		});
+
+		it('deleteHistory with a far-future finite bound stays reachable too', async function () {
+			// The same defect as Infinity by degree, and the case Infinity's clamp used to miss: a bare
+			// '9999999999999' or a Date.now()*1000 ms/µs slip is FINITE, so it cleared both the bridge's
+			// finiteness guard and `boundedAuditPruneEnd`'s old `cutoff !== Infinity` early return, and was
+			// recorded verbatim. A floor only ever rises, so every entry written afterwards lands BELOW it
+			// and the accessor is retired for the whole database just as permanently (#2458).
+			if (Audited.auditStore.reusableIterable) return this.skip(); // deleteHistory only raises on LMDB
+			const shared = 'auditFloorDB_farFuture';
+			const attributes = [{ name: 'id', isPrimaryKey: true }, { name: 'name' }];
+			const wiped = table({ table: 'FutureWiped', database: shared, attributes });
+			const spared = table({ table: 'FutureSpared', database: shared, attributes });
+			await wiped.put('w-1', { name: 'one' });
+			await spared.put('s-1', { name: 'one' });
+
+			const absurd = Date.now() * 1000; // a ms value read as µs — about the year 55000
+			await wiped.deleteHistory(absurd);
+
+			const floor = floorOf(wiped);
+			assert.ok(floor < absurd, `the floor must be clamped below the requested bound, got ${floor}`);
+			assert.ok(floor <= Date.now() + 1, `and must not be left sitting in the future, got ${floor}`);
+			// The property the verbatim floor destroyed: a write after the prune is still resumable. The
+			// sibling was never pruned, so this must hold for it regardless of what `wiped` asked for.
+			await spared.put('s-2', { name: 'two' });
+			const later = auditEntries(spared.auditStore)
+				.map((entry) => entry.logKey)
+				.filter((t) => t >= floor);
+			assert.ok(later.length > 0, 'a write after the prune must sit at or above the floor');
+			assert.strictEqual(canResumeFrom(later[later.length - 1], floor), true, 'and must read as resumable');
+		});
+
+		it('deleteHistory with an unbounded endTime leaves no cursor readable as safe', async function () {
+			if (Audited.auditStore.reusableIterable) return this.skip(); // RocksTransactionLogStore.remove() is a no-op
+			const cleared = tableInOwnDatabase('Cleared');
+			await cleared.put('all-1', { name: 'one' });
+			await cleared.put('all-2', { name: 'two' });
+			const written = auditEntries(cleared.auditStore).map((entry) => entry.logKey);
+			assert.ok(written.length >= 2, 'precondition: entries to remove');
+
+			await cleared.deleteHistory(Infinity);
+
+			const floor = floorOf(cleared);
+			for (const logKey of written) {
+				assert.strictEqual(
+					canResumeFrom(logKey, floor),
+					false,
+					`a cursor at removed entry ${logKey} must read as stale (floor ${floor})`
+				);
+			}
+		});
+
+		it('the RocksDB log purge does', async function () {
+			if (!Audited.auditStore.reusableIterable) return this.skip(); // LMDB paths covered above
+			const purgeTable = tableInOwnDatabase('Purged');
+			const auditStore = purgeTable.auditStore;
+			const rootStore = auditStore.rootStore;
+			// RocksDB drops only whole log files that are already flushed and no longer being appended
+			// to, so a purge needs a flushed batch AND a later one to roll the append point off it.
+			for (let i = 0; i < 40; i++) await purgeTable.put(`purge-a-${i}`, { name: 'a'.repeat(200) });
+			rootStore.flushSync();
+			for (let i = 0; i < 40; i++) await purgeTable.put(`purge-b-${i}`, { name: 'b'.repeat(200) });
+			rootStore.flushSync();
+			const written = auditEntries(auditStore).map((entry) => entry.logKey);
+			assert.ok(written.length >= 80, 'precondition: entries the purge is asked to cover');
+
+			const floorBefore = floorOf(purgeTable);
+			setAuditRetention(-60_000); // a cutoff in the future, so every entry written above is eligible
+			const purged = purgeAgedLogs(rootStore);
+			setAuditRetention(originalRetention);
+
+			// Whether the native purge drops a file HERE is not asserted, because it is not Harper's
+			// contract and it is not deterministic across platforms: rocksdb-js rotates logs at ~16MB, so
+			// both batches sit in the one active file, which the Linux binary declines to drop while the
+			// macOS and Windows binaries drop it (measured 2026-09-10 — the assertion this replaces failed
+			// only on Linux CI). What IS Harper's contract, and what this pins, is that the purge path
+			// records a floor covering everything it asked the native purge to remove. The write-ahead
+			// ordering of that record is pinned on a real store by the next test, from inside purgeLogs.
+			assert.ok(Array.isArray(purged), 'purgeAgedLogs returns the purged list, possibly empty');
+			const floor = floorOf(purgeTable);
+			assert.ok(Number.isFinite(floor), `floor should stay known after a purge, got ${floor}`);
+			assert.ok(floor > floorBefore, `the purge path should have advanced the floor (${floorBefore} -> ${floor})`);
+			for (const logKey of written) {
+				assert.strictEqual(
+					canResumeFrom(logKey, floor),
+					false,
+					`the floor ${floor} still certifies entry ${logKey}, which the purge was asked to remove`
+				);
+			}
+		});
+	});
+
+	it('records the floor before the purge on a real store, not only on a stand-in', async function () {
+		// auditPurge.test.js proves the ordering against a plain-object stand-in, which takes the LMDB
+		// branch of updateAuditFloor. This pins it on whichever branch the running engine actually uses,
+		// by observing the floor from inside purgeLogs — the only point where "already recorded?" is a
+		// meaningful question.
+		const ordered = tableInOwnDatabase('Ordered');
+		await ordered.put('ordering-1', { name: 'one' });
+		const rootStore = ordered.auditStore.rootStore;
+		if (typeof rootStore.purgeLogs !== 'function') return this.skip(); // LMDB has no log purge
+		const cutoff = Date.now() + 30_000;
+		let floorDuringPurge;
+		const realPurgeLogs = rootStore.purgeLogs.bind(rootStore);
+		rootStore.purgeLogs = (options) => {
+			floorDuringPurge = floorOf(ordered);
+			return realPurgeLogs(options);
+		};
+		try {
+			setAuditRetention(Date.now() - cutoff); // so purgeAgedLogs' cutoff is `cutoff`
+			purgeAgedLogs(rootStore);
+		} finally {
+			rootStore.purgeLogs = realPurgeLogs;
+			setAuditRetention(originalRetention);
+		}
+		assert.ok(
+			floorDuringPurge >= cutoff,
+			`floor should already be recorded when purgeLogs runs, saw ${floorDuringPurge}`
+		);
+	});
+
+	it('works on a real legacy standalone audit root, which owns its own transaction', function () {
+		// A legacy `auditPath` layout is opened by databases.ts as its own LMDB root, with an encoder that
+		// has no Uint8Array passthrough and no `.rootStore` — so an unwrapped floor write reaches
+		// createAuditEntry and throws `Invalid audit entry type`, failing database startup.
+		const { open } = require('lmdb');
+		const { createAuditEntry, readAuditEntry, establishAuditFloor } = require('#src/resources/auditStore');
+		const legacyPath = path.join(os.tmpdir(), `harper-legacy-audit-${process.pid}-${Date.now()}.mdb`);
+		const legacyEncoder = {
+			encode: (auditRecord) => createAuditEntry(auditRecord),
+			decode: (encoding) => readAuditEntry(encoding),
+		};
+		const legacyRoot = open({ path: legacyPath, encoder: legacyEncoder });
+		try {
+			assert.doesNotThrow(() => establishAuditFloor(legacyRoot), 'a legacy root must open, not throw');
+			const established = getAuditFloor(legacyRoot);
+			assert.ok(Number.isFinite(established), `legacy root should get a floor, got ${established}`);
+			raiseAuditFloor(legacyRoot, established + 5_000);
+			assert.strictEqual(getAuditFloor(legacyRoot), established + 5_000);
+			legacyRoot.close();
+			// Reopen: the whole floor-before-prune ordering rests on the bytes being durable, and every
+			// other assertion in this file reads back through the handle that wrote them.
+			const reopened = open({ path: legacyPath, encoder: legacyEncoder });
+			try {
+				assert.strictEqual(getAuditFloor(reopened), established + 5_000, 'the floor must survive a close and reopen');
+			} finally {
+				reopened.close();
+			}
+		} finally {
+			if (legacyRoot.status !== 'closed') legacyRoot.close();
+		}
+	});
+
+	it('keeps the floor key out of the enumerable audit keys', function () {
+		// openAuditStore's time-reversal check does `time > Date.now()` over getKeys({reverse, limit: 1}).
+		// A symbol reaching that comparison throws, so a database whose audit log holds no entries yet —
+		// only the floor and last-removed markers — would fail to open. The audit key encoder does not
+		// yield symbol keys, which is what keeps that check numeric.
+		if (Audited.auditStore.reusableIterable) return this.skip(); // RocksDB getKeys is unimplemented
+		const fresh = tableInOwnDatabase('KeyOnlyFloor');
+		assert.ok(Number.isFinite(floorOf(fresh)), 'precondition: a floor is recorded');
+		const keys = [];
+		for (const key of fresh.auditStore.getKeys({ reverse: true, limit: 1 })) keys.push(key);
+		assert.deepStrictEqual(keys, [], 'no marker symbol may surface as an enumerable audit key');
+	});
+
+	it('reports the database floor for a table whose own auditing is off', () => {
+		const unaudited = table({
+			table: 'FloorUnaudited',
+			database: 'auditFloorDB',
+			audit: false,
+			attributes: [{ name: 'id', isPrimaryKey: true }],
+		});
+		assert.strictEqual(floorOf(unaudited), floorOf(Audited));
+	});
+});

--- a/unitTests/resources/auditFloor.test.js
+++ b/unitTests/resources/auditFloor.test.js
@@ -51,7 +51,9 @@ function auditEntries(auditStore) {
 /** The epoch `establishAuditFloor` recorded as a guess, or undefined when it recorded none. */
 function bootstrapEpoch(auditStore) {
 	const stored = auditStore.getBinary(AUDIT_FLOOR_BOOTSTRAP_KEY);
-	return stored === undefined ? undefined : new Float64Array(stored.slice().buffer)[0];
+	// copy first: on a pooled Node Buffer `stored.buffer` is the whole pool, so a Float64Array over it
+	// would read pool offset 0, not this record — production copies with FLOOR_BUFFER.set(stored)
+	return stored === undefined ? undefined : new Float64Array(Uint8Array.from(stored).buffer)[0];
 }
 
 /** Clear a record on either engine: on RocksDB the floor lives in the root store, whose log store's own remove() is a no-op. */
@@ -740,7 +742,18 @@ describe('audit staleness floor', () => {
 		raiseAuditFloor(durable.auditStore, raised);
 		assert.strictEqual(floorOf(durable), raised, 'precondition: the raise landed in-process');
 
+		// `closeDatabase` fires `close()` without awaiting it, and on LMDB that close is asynchronous (the
+		// drop path in databases.ts awaits the same call). Reopening the path while the env is still
+		// closing can throw or read pre-flush bytes, so capture the promise closeDatabase discards and
+		// await it. RocksDB's close is synchronous and returns undefined, which awaits as a no-op.
+		const root = durable.auditStore.rootStore;
+		let closing;
+		const realClose = root.close.bind(root);
+		root.close = (...args) => (closing = realClose(...args));
 		assert.ok(closeDatabase('auditFloor_Durable'), 'precondition: the database was open to be closed');
+		if (!durable.auditStore.reusableIterable)
+			assert.ok(closing && typeof closing.then === 'function', 'precondition: the LMDB env close was captured');
+		await closing;
 		const reopened = tableInOwnDatabase('Durable');
 		assert.notStrictEqual(reopened.auditStore, durable.auditStore, 'precondition: a fresh store, not the cached one');
 		assert.strictEqual(

--- a/unitTests/resources/auditFloor.test.js
+++ b/unitTests/resources/auditFloor.test.js
@@ -11,7 +11,7 @@
  */
 const assert = require('node:assert');
 const { setupTestDBPath } = require('../testUtils');
-const { table } = require('#src/resources/databases');
+const { table, closeDatabase } = require('#src/resources/databases');
 const {
 	getAuditFloor,
 	establishAuditFloor,
@@ -719,6 +719,39 @@ describe('audit staleness floor', () => {
 		assert.ok(
 			floorDuringPurge >= cutoff,
 			`floor should already be recorded when purgeLogs runs, saw ${floorDuringPurge}`
+		);
+	});
+
+	it('keeps the floor across a close and reopen of an ordinary database, on this engine', async function () {
+		// Every other assertion in this file reads the floor back through the handle that wrote it. The
+		// guarantee rests on the record being on disk: a floor that did not persist is re-stamped from the
+		// bootstrap epoch on the next open — at or above the newest SURVIVING key — and from then on
+		// certifies history a prune removed before the restart, which is the one failure the floor exists
+		// to prevent. The legacy-root test below covers only the standalone LMDB layout; this is the path
+		// every ordinary database takes, on whichever engine is running. Clean close in one process: a
+		// crash or power-loss window is not exercised here.
+		const durable = tableInOwnDatabase('Durable');
+		await durable.put('d-1', { name: 'one' });
+		const stamped = floorOf(durable);
+		assert.ok(Number.isFinite(stamped), `precondition: a known floor, got ${stamped}`);
+		const provenance = bootstrapEpoch(durable.auditStore);
+		assert.ok(Number.isFinite(provenance), 'precondition: a recorded bootstrap epoch');
+		const raised = stamped + 5_000;
+		raiseAuditFloor(durable.auditStore, raised);
+		assert.strictEqual(floorOf(durable), raised, 'precondition: the raise landed in-process');
+
+		assert.ok(closeDatabase('auditFloor_Durable'), 'precondition: the database was open to be closed');
+		const reopened = tableInOwnDatabase('Durable');
+		assert.notStrictEqual(reopened.auditStore, durable.auditStore, 'precondition: a fresh store, not the cached one');
+		assert.strictEqual(
+			floorOf(reopened),
+			raised,
+			'the floor must come back from disk, not be re-stamped from the bootstrap epoch'
+		);
+		assert.strictEqual(
+			bootstrapEpoch(reopened.auditStore),
+			provenance,
+			'and the provenance record must survive with it, or a later repair has nothing to read'
 		);
 	});
 

--- a/unitTests/resources/auditFloor.test.js
+++ b/unitTests/resources/auditFloor.test.js
@@ -589,6 +589,9 @@ describe('audit staleness floor', () => {
 			assert.ok(Number.isFinite(floor), `the floor must stay finite, got ${floor}`);
 			assert.strictEqual(floorOf(spared), floor, 'precondition: one floor per database');
 			// the sibling was never touched, so a cursor taken after the wipe must still resume
+			// the clamp sits at `newest + 1` when the newest key's fractional millisecond is at or past the
+			// clock, so a write in the same millisecond lands below the floor; let the clock pass it first
+			while (Date.now() <= floor) await new Promise((resolve) => setTimeout(resolve, 1));
 			await spared.put('s-2', { name: 'two' });
 			const later = auditEntries(spared.auditStore)
 				.map((entry) => entry.logKey)
@@ -619,6 +622,9 @@ describe('audit staleness floor', () => {
 			assert.ok(floor <= Date.now() + 1, `and must not be left sitting in the future, got ${floor}`);
 			// The property the verbatim floor destroyed: a write after the prune is still resumable. The
 			// sibling was never pruned, so this must hold for it regardless of what `wiped` asked for.
+			// the clamp sits at `newest + 1` when the newest key's fractional millisecond is at or past the
+			// clock, so a write in the same millisecond lands below the floor; let the clock pass it first
+			while (Date.now() <= floor) await new Promise((resolve) => setTimeout(resolve, 1));
 			await spared.put('s-2', { name: 'two' });
 			const later = auditEntries(spared.auditStore)
 				.map((entry) => entry.logKey)

--- a/unitTests/resources/auditPurge.test.js
+++ b/unitTests/resources/auditPurge.test.js
@@ -8,6 +8,7 @@ const assert = require('node:assert');
 // purge everything older than `Date.now() - auditRetention` and returns the purged list.
 const auditStore = require('#src/resources/auditStore');
 const { purgeAgedLogs, setAuditRetention } = auditStore;
+const { RocksTransactionLogStore } = require('#src/resources/RocksTransactionLogStore');
 
 describe('purgeAgedLogs', () => {
 	let originalRetention;
@@ -20,15 +21,63 @@ describe('purgeAgedLogs', () => {
 		setAuditRetention(originalRetention);
 	});
 
+	// purgeAgedLogs raises the floor before purging (harper#2447); `order` records both steps, because
+	// a crash between them leaves a floor certifying purged history if the write came second.
 	function fakeStore(purgedFiles = ['000001.txnlog', '000002.txnlog']) {
 		const calls = [];
-		return {
+		const order = [];
+		const store = {
 			calls,
+			order,
+			floorWrites: [],
 			purgeLogs(options) {
 				calls.push(options);
+				order.push('purge');
 				return purgedFiles;
 			},
 		};
+		// A REAL RocksTransactionLogStore, because `updateAuditFloor` branches on `instanceof` and
+		// purgeAgedLogs is typed `rootStore: RocksDatabase` — a plain object would silently route this
+		// test through the LMDB branch and leave the one production path that always uses the RocksDB
+		// branch untested.
+		const auditStandIn = new RocksTransactionLogStore({ useLog: () => ({}) });
+		// Holds what it is given, because updateAuditFloor reads its own write back inside the
+		// transaction to catch a put that failed without saying so. Starts at the baseline a database
+		// that has provably pruned nothing carries; an absent floor would instead mean "unknown", which
+		// a prune deliberately leaves alone.
+		let stored = new Uint8Array(Float64Array.of(1).buffer);
+		const txn = {
+			getBinarySync: () => stored,
+			putSync(_key, value) {
+				// the real write wraps the bytes in lmdb's asBinary(), which bypasses both engines' encoders
+				const wrapped = Object.values(value)[0] ?? value;
+				const bytes = Uint8Array.from(Object.values(wrapped));
+				stored = failFloorWrite ? stored : bytes;
+				store.floorWrites.push(new Float64Array(bytes.slice().buffer)[0]);
+			},
+		};
+		let failFloorWrite = false;
+		store.failFloorWrite = () => {
+			failFloorWrite = true;
+		};
+		// A floorless store is the case where the resolver writes the unknown sentinel, and where a
+		// read-back comparing decoded values alone cannot tell that write from no record at all.
+		store.startFloorless = () => {
+			stored = undefined;
+		};
+		auditStandIn.rootStore = {
+			// RocksTransactionLogStore.getBinary delegates here, which is how raiseAuditFloor's lock-free
+			// pre-check reads the floor
+			getBinarySync: () => stored,
+			// returns the callback's value, as both real engines do: updateAuditFloor requires an
+			// explicit `true` because RocksDB swallows an aborted transaction and returns undefined.
+			transactionSync(callback) {
+				order.push('floor');
+				return callback(txn);
+			},
+		};
+		store.auditStore = auditStandIn;
+		return store;
 	}
 
 	it('purges log files older than the configured audit retention window', () => {
@@ -46,6 +95,48 @@ describe('purgeAgedLogs', () => {
 			`cutoff ${cutoff} should be ~Date.now() - 60000 (in [${before - 60_000}, ${after - 60_000}])`
 		);
 		assert.deepEqual(purged, ['000001.txnlog', '000002.txnlog'], 'returns the purged file list');
+	});
+
+	it('records the staleness floor at the same cutoff, before purging anything', () => {
+		setAuditRetention(60_000);
+		const store = fakeStore();
+		const before = Date.now();
+		purgeAgedLogs(store);
+
+		assert.deepStrictEqual(store.order, ['floor', 'purge'], 'the floor must be recorded before the purge runs');
+		assert.strictEqual(store.floorWrites.length, 1, 'exactly one floor write');
+		assert.strictEqual(
+			store.floorWrites[0],
+			store.calls[0].before,
+			'the floor and the purge cutoff must be the same instant'
+		);
+		assert.ok(store.floorWrites[0] >= before - 60_000, 'floor should track the retention window');
+	});
+
+	it('refuses the purge when the RocksDB floor write does not stick', () => {
+		// purgeAgedLogs always drives the RocksDB branch in production, and that branch verifies its own
+		// write. A write that fails without throwing must not read as a commit, or the purge below runs
+		// against a floor that was never recorded.
+		setAuditRetention(60_000);
+		const store = fakeStore();
+		store.failFloorWrite();
+		assert.throws(() => purgeAgedLogs(store), /did not commit/);
+		assert.deepStrictEqual(store.calls, [], 'nothing may be purged once the floor write failed');
+		assert.deepStrictEqual(store.order, ['floor'], 'and the purge must never have been reached');
+	});
+
+	it('refuses the purge when the RocksDB unknown-sentinel write does not stick', () => {
+		// The RocksDB half of the presence check. A floorless store makes the resolver write the unknown
+		// sentinel, and `decodeAuditFloor(undefined)` is that same sentinel — so a read-back comparing
+		// decoded values alone reported a commit for a write that never landed, and purgeAgedLogs (which
+		// always drives this branch in production) would have purged with nothing recorded.
+		setAuditRetention(60_000);
+		const store = fakeStore();
+		store.startFloorless();
+		store.failFloorWrite();
+		assert.throws(() => purgeAgedLogs(store), /did not commit/);
+		assert.deepStrictEqual(store.calls, [], 'nothing may be purged once the sentinel write failed');
+		assert.deepStrictEqual(store.order, ['floor'], 'and the purge must never have been reached');
 	});
 
 	it('tracks the retention window when it changes', () => {

--- a/unitTests/resources/auditPurge.test.js
+++ b/unitTests/resources/auditPurge.test.js
@@ -97,6 +97,22 @@ describe('purgeAgedLogs', () => {
 		assert.deepEqual(purged, ['000001.txnlog', '000002.txnlog'], 'returns the purged file list');
 	});
 
+	it('treats a retention window longer than the epoch as "nothing eligible", not as an error', () => {
+		// `Date.now() - auditRetention` goes negative past ~55.7 years, and for `Infinity` (keep logs
+		// forever). A negative bound is not harmless: raiseAuditFloor rejects it, so every boot purge and
+		// retention pass would warn and the floor would never be raised on that install. Clamped at 0 the
+		// pass is a no-op: nothing is before the epoch, and the existing floor is never lowered to it.
+		for (const retention of [Infinity, 100 * 365.25 * 86_400_000]) {
+			setAuditRetention(retention);
+			const store = fakeStore();
+			const purged = purgeAgedLogs(store);
+			assert.strictEqual(store.calls.length, 1, `${retention}: the purge must still be asked, with a bound`);
+			assert.strictEqual(store.calls[0].before, 0, `${retention}: the bound must clamp to 0, not go negative`);
+			assert.deepStrictEqual(store.floorWrites, [], `${retention}: a floor of 1 already covers 0 — no write`);
+			assert.deepStrictEqual(purged, ['000001.txnlog', '000002.txnlog'], 'and the purge result is returned');
+		}
+	});
+
 	it('records the staleness floor at the same cutoff, before purging anything', () => {
 		setAuditRetention(60_000);
 		const store = fakeStore();

--- a/unitTests/resources/deleteTransactionLogsBeforeRocks.test.js
+++ b/unitTests/resources/deleteTransactionLogsBeforeRocks.test.js
@@ -10,6 +10,9 @@ const assert = require('node:assert');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { getAuditFloor } = require('#src/resources/auditStore');
+// the floor is read off a table's (database-scoped) audit store; there is no Table-level accessor
+const floorOf = (tbl) => getAuditFloor(tbl.auditStore);
 const harperBridge = require('#src/dataLayer/harperBridge/harperBridge').default;
 
 describe('deleteTransactionLogsBefore on RocksDB (harper#2049)', () => {
@@ -89,5 +92,77 @@ describe('deleteTransactionLogsBefore on RocksDB (harper#2049)', () => {
 		assert.ok(results, 'should return results rather than throw');
 		assert.strictEqual(typeof results.entries_deleted, 'number');
 		assert.strictEqual(typeof results.log_files_deleted, 'number');
+	});
+
+	it('rejects a prune bound the audit range would honor as a whole-log delete (harper#2447)', async () => {
+		// Audit keys are raw float64, so NaN and negatives sort above every real timestamp and the prune
+		// range spans the whole log. A non-numeric timestamp reaches that via Number.parseInt.
+		// Stated asymmetry: this file is gated to RocksDB, but the timestamp guard runs before any engine
+		// branch in `deleteTransactionLogsBefore`, so one engine's coverage is the whole of it here.
+		for (const timestamp of [
+			'yesterday',
+			-1,
+			-0,
+			Number.NaN,
+			new Date('nonsense'),
+			undefined,
+			// Number.parseInt took a numeric PREFIX, so this parsed to a year-2286 bound that passed the
+			// guard and purged every log; '12abc' did the same on a smaller scale (#2458).
+			'9999999999999oops',
+			'  12abc',
+			// non-finite bounds purge everything, and Infinity additionally records the unknown sentinel,
+			// which raiseAuditFloor can never lift — so the guard has to be finiteness, not `>= 0`
+			Infinity,
+			-Infinity,
+			// Number('') and Number('   ') are 0, so the strict parse has to reject these explicitly
+			'',
+			'   ',
+		]) {
+			await assert.rejects(
+				harperBridge.deleteTransactionLogsBefore({ database: DB, timestamp }),
+				(error) => {
+					assert.strictEqual(error.statusCode, 400, `${String(timestamp)} should be a client error`);
+					assert.match(error.message, /non-negative epoch time/);
+					return true;
+				},
+				`timestamp ${String(timestamp)} must be refused`
+			);
+		}
+	});
+
+	it('accepts every legitimate timestamp shape', async () => {
+		// '1e3' and a fractional string are legitimate numeric literals that parseInt mangled to 1 and a
+		// truncated integer; Number takes them exactly.
+		for (const timestamp of [Date.now(), String(Date.now()), new Date(), 0, '0', '1e3', '1234.5']) {
+			const results = await harperBridge.deleteTransactionLogsBefore({ database: DB, timestamp });
+			assert.strictEqual(typeof results.log_files_deleted, 'number', `${String(timestamp)} should be accepted`);
+		}
+	});
+
+	it('raises the audit staleness floor, clamped to what the log can reach (harper#2447)', async () => {
+		// `Date.now() + 2000` is the legitimate "purge everything" idiom, so it must be accepted — but
+		// recorded as the bound the prune could actually have covered, not the future instant asked for.
+		const requested = Date.now() + 2000;
+		await harperBridge.deleteTransactionLogsBefore({ database: DB, timestamp: requested });
+		const floor = floorOf(TableA);
+		assert.ok(Number.isFinite(floor) && floor > 0, `a floor must be recorded, got ${floor}`);
+		assert.ok(floor < requested, `the floor must not be recorded above the log's reach, got ${floor}`);
+		assert.strictEqual(floorOf(TableB), floor, 'the floor is database-scoped');
+	});
+
+	it('a far-future prune bound does not pin the whole database floor (harper#2458)', async () => {
+		// Both of these are FINITE, so both cleared the guard above and were recorded verbatim. A floor
+		// only ever rises — `raiseAuditFloor` skips any record no cutoff exceeds and `establishAuditFloor`
+		// skips a store that has one — so a year-2286 or year-55000 floor retires
+		// the floor for every table in this database permanently, including for cursors
+		// saved after the call. Same outcome as the Infinity sentinel, differing only in degree.
+		for (const timestamp of [Date.now() * 1000, '9999999999999']) {
+			const results = await harperBridge.deleteTransactionLogsBefore({ database: DB, timestamp });
+			assert.strictEqual(typeof results.log_files_deleted, 'number', `${timestamp} should be accepted`);
+			const floor = floorOf(TableA);
+			// at or below the present is exactly the property that keeps every later cursor resumable
+			assert.ok(floor <= Date.now() + 1, `${timestamp} left the floor at ${floor}, in the future`);
+			assert.strictEqual(floorOf(TableB), floor, 'and it is the whole database that pays');
+		}
 	});
 });


### PR DESCRIPTION
Records a write-ahead **audit retention floor** for every database — the point at or after which no prune has removed audit history — so that `Table.subscribe` can tell a complete `startTime` catch-up from a silently truncated one (#2448). This PR is the **write side only**: the floor is recorded, verified, and raised first by every path that prunes. Nothing reads it publicly.

**Re-scoped 2026-09-10, per kriszyp's review.** The branch originally shipped `Table.oldestRetainedAuditTime()` as a public accessor with a documented contract. That accessor is removed. Three reasons, all his: it had no caller except #2448; a public single-number floor binds a contract that a per-origin resume vector could not honor; and it created a second resume-validity path where replication already checks *inside* the operation (`shouldForceBaseCopyForRetention`). So the check belongs inside `Table.subscribe` itself — one path, and the only shape where the floor cannot move between being read and being acted on. **Nothing consumes the floor in this PR** — no resume path reads it, and silently truncated catch-up is unchanged until #2448 calls `getAuditFloor(auditStore)` (internal, `resources/auditStore.ts`) from inside `subscribe`. HarperFast/documentation#666 is closed and the section #660 added is being removed; consumer-facing docs land with #2448.

The gap this is infrastructure for is live today: `Table.subscribe`'s `startTime` replay begins wherever the audit log now begins, and MQTT durable sessions hand it a persisted per-topic `startTime` on every resume, so a client offline longer than `logging.auditRetention` loses messages — QoS 1/2 included — with no signal at all.

Making the floor trustworthy was most of the work. All five paths that prune audit history now [raise the floor **before** removing anything](https://github.com/HarperFast/harper/pull/2458/changes?w=1#diff-db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356baR537), monotonically, in [a store transaction whose commit is actually verified](https://github.com/HarperFast/harper/pull/2458/changes?w=1#diff-db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356baR487); only one path did before, and it recorded afterwards, so a crash in between left a floor certifying history that was already gone. The floor lives under a new key whose *presence* is the trust marker: a store without one has retention history that cannot be accounted for, so it gets [a one-time resync epoch](https://github.com/HarperFast/harper/pull/2458/changes?w=1#diff-db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356baR582) rather than a permissive baseline. [Untrustworthy metadata resolves to `Infinity`](https://github.com/HarperFast/harper/pull/2458/changes?w=1#diff-db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356baR649) rather than to a number, so a consumer spelling the check as `cursor < floor` cannot read corrupt bytes as safe.

Two fail-open paths this uncovered are worth naming, because neither depends on the floor existing. A prune bound of `NaN`, a negative, or `-0` was accepted by the range — audit keys are raw float64, so those values set the sign bit or the quiet-NaN pattern and sort *above* every real timestamp, making `getRange({ start: 1, end: NaN })` span the whole log. `delete_transaction_logs_before` reached exactly that through `Number.parseInt` on a non-numeric `timestamp` (and `'9999999999999oops'` parsed to a year-2286 bound that purged everything), so it now [validates at its own boundary and reports a 400](https://github.com/HarperFast/harper/pull/2458/changes?w=1#diff-9e5779d931e27b7a776533f42a89fe7d2c5964dcec7b58aabd68f9caf95c63f9R533), and [the bound guard itself throws](https://github.com/HarperFast/harper/pull/2458/changes?w=1#diff-db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356baR549) rather than declining silently. A *finite* bound above everything reachable — `Infinity`, `Date.now() * 1000`, a bare `'9999999999999'` — is the same defect by degree: recorded verbatim, it pins the whole database's floor in the far future forever, since a floor only rises. `boundedAuditPruneEnd` clamps every operator-supplied bound to just above the newest key in the log, and the prune uses that same clamped value as its range end, so it cannot remove an entry the floor does not cover. And RocksDB's `transactionSync` returns `undefined` on a swallowed abort rather than throwing; [the floor write requires an explicit `true`](https://github.com/HarperFast/harper/pull/2458/changes?w=1#diff-db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356baR487).

The branch originally retired `getLastRemoved`/`updateLastRemoved`, which had no consumers and did not work: both read through the audit store's *value* decoder, so on LMDB the raw eight float bytes decoded as an audit entry and the function returned a stale module global — measured, it stored `1234567.5` and returned `1` — while on RocksDB the same call threw in msgpack decode. **That retirement was reverted when this branch merged #2338**, which hardened the marker's write path and added five tests around it. Both markers are live now and the code says why they are separate keys: `last-removed` records where the LMDB retention loop got to, after the fact, while the floor is written ahead of all five prune paths with its commit verified.

## For the human reviewer

Judgment calls, mirroring the decision slugs in the `Human-Review-Need` footer. Mechanics went through five cross-model rounds (three full, two delta; final adjudicated severity **nit**) and human review; these are the scope and contract choices that remain yours.

1. **Write side first, read side in #2448 — re-scoped.** Originally "ship the public primitive before its consumer," which kriszyp's review overturned: there is no public primitive now. What remains separable is that this PR touches every *prune* path plus bootstrap and the bridge, while #2448 touches `subscribe` — which also serves WebSocket/SSE reconnects and `sourcedFrom` caching-table subscriptions, so its failure mode for a fallen-off cursor is its own design question. Nothing here presumes how #2448 answers it.

2. **One database-scoped floor, not per-table.** The audit store is per-database and entries carry a `tableId`, so an exact per-table floor needs a scan for that table's oldest entry. The cost: `deleteHistory` on one table raises the floor for every sibling, forcing resyncs of history that still exists. Cheap to change now, costly once #2448 depends on the meaning.

3. **`Infinity` is the unknown sentinel** — internal representation now, so no longer a public-type concern. It makes both `cursor >= floor` and `cursor < floor` fail closed, which is why it beat `undefined`/`null`/throw. It is also absorbing (a floor at `Infinity` never comes down), which is why every operator bound is clamped before it can be recorded. **Open (Chris's thread):** with every caller now clamped, nothing can pass `Infinity` to `raiseAuditFloor`, so accepting it only preserves a footgun for a future caller; reversing to a throw is trivial.

4. **Upgrade stamps a resync epoch — decided (Dawson), and its one exception is now named in the contract.** Every existing store lacking the record gets `max(Date.now(), newest retained audit key)` on first open, recorded as a guess under its own key. Never stamping would make every upgraded deployment fail closed forever. **The cost, per kriszyp's review, is stated rather than denied:** the stamp is bounded by what *survives*, so a legacy `deleteHistory` that removed a table's newest entries, followed by a clock rollback, stamps a floor *below* history that is gone, and a cursor in that window is certified over the gap. The guarantee is therefore one-directional for every prune that ran with a floor recorded, and silent about history removed before one existed. Only a database generation closes that (#2451); the recorded epoch is what tells that repair how far the guess reached. On RocksDB `getKeys()` is unimplemented, so the clock-rollback guard reduces to `Date.now()` there.

5. **A floor that cannot be written blocks the prune — routed to #2486.** `raiseAuditFloor` throws, and it is called first precisely so the throw stops the prune. On a full volume the thing that fails *is* the 8-byte floor write, so #1115's boot purge is skipped in exactly the condition it exists for. You cannot record that you pruned without recording — the unknown sentinel is itself a write — so the escapes are reserved headroom, an in-memory poison, or accepting an inaccurate floor. Nothing reads the floor yet, so this is reversible per call site.

6. **`deleteHistory` raises unprobed.** The retention loop probes for an eligible entry before raising; `deleteHistory` raises to its (clamped) bound before knowing whether this table has any entry below it, so a routine per-table trim advances the database floor even when it deletes nothing. Symmetry would mean a `tableId`-filtered scan — the per-table cost decision 2 avoids.

7. **`Table.deleteHistory` now rejects non-number bounds** (`reject-vs-coerce-deletehistory-bounds`). A numeric string, `'Infinity'`, or a `Date` used to coerce through `>` into an accepted bound — the whole-log prune Kris caught — and now throws `Invalid audit prune bound`, matching the bridge's 400. A contract tightening on a public Table static, trivially reversible by coercing through the bridge's validation instead. Nothing that worked before stops working except the coercion that was the bug: a no-arg call was always an empty range (`endTime` defaults to 0), and a `Date` was never a valid range key.

8. **On RocksDB the floor tracks the configured horizon, not surviving reality** (`rocksdb-floor-tracks-configured-horizon`). Every retention pass advances the floor to the horizon whether a log file dropped or not, because whole-file purge granularity cannot say beforehand what will drop and the floor must be written first. Cursors over entries still on disk are told to resync — the safe direction, and the deliberate one; reversible only if the native purge ever reports what it will drop. #2448's consumer must not read "floor advanced" as "history removed".

9. **Power-loss durability of the floor write on RocksDB is trusted, not enforced** (`engine-commit-durability-trusted`). The write-ahead guarantee rests on the floor's `transactionSync` being durable before the same-thread `purgeLogs` unlinks files. It is crash-safe — a process death leaves OS buffers intact for both — but rocksdb-js exposes **no per-commit WAL sync**; the only gate is a full memtable `flushSync`, which its own docs describe as database-wide and stall-prone. So a power cut in that window can persist the unlink and lose the record. One flush per retention pass is cheap in frequency, not in blast radius; this wants a ruling on the engine contract before a sync is added.

10. **The reopen test wraps `root.close`** (`test-monkey-patches-store-close`). `closeDatabase` fire-and-forgets LMDB's asynchronous `close()` while the drop path awaits the same call; the durability test captures the discarded promise rather than changing `closeDatabase`. The helper still fire-and-forgets for any future caller — returning the close promise would fix it at the root, but that is outside this PR's write-side scope.

One deferred limitation stated in the internal contract: **copying a database's state without its history** — `restore_backup` reinstalls the backup's floor, and a RocksDB checkpoint copies the floor but no transaction logs — needs a database-level generation, because the same copy rolls back record versions and per-node replication sequence state too (#2451). The former **check/use race** limitation disappears by construction once #2448 puts the check inside `subscribe` — there is then no separate read to race. In this PR there is no read at all.

## Verification

Storage-layer behavior, reachable from unit tests on both engines.

- `unitTests/resources/auditFloor.test.js` (new): floor establishment and the resync epoch, the exact resume predicate at `F-1`/`F`/`F+1`, six shapes of untrustworthy metadata all resolving to `Infinity`, monotonicity, database scoping and non-leakage, `NaN`/`-0`/non-number bounds refused before anything is deleted — **including numeric strings, `'Infinity'`, and a future `Date`, which `>` would otherwise coerce into an accepted bound** (kriszyp) — `deleteHistory(Infinity)` and far-future finite bounds clamped rather than recorded, bootstrap provenance, a real legacy standalone audit root with close-and-reopen durability, floor-before-purge ordering observed from *inside* `purgeLogs`, and the empty-pass no-write case. Tests read the floor through `getAuditFloor(table.auditStore)`, the call #2448 will make.
- `unitTests/resources/auditPurge.test.js` (extended): `purgeAgedLogs` records the floor at the same cutoff, before `purgeLogs`.
- `unitTests/resources/deleteTransactionLogsBeforeRocks.test.js` (extended): the whole-database purge advances the floor database-scoped and clamped; the bound guard refuses thirteen bad `timestamp` shapes with a 400 while accepting `Date`, numeric strings including `'1e3'` and `'1234.5'`, a number, `0` and `"0"`; a far-future bound does not pin the floor.
- **Every fix has a failing test, verified by ablation** — restoring each pre-fix guard fails its test on both engine branches where the code path exists (the LMDB-only `deleteHistory` path is covered on LMDB, the RocksDB-only whole-database purge on RocksDB).
- `unitTests/resources` at the re-scope commit: **1731 passing** on RocksDB, **1252** on LMDB. The one RocksDB failure is `longLivedTransactions` "names a chain link reachable only through the root", an order-dependent flake of main's own: it fails in the full suite with this branch's test files excluded, and passes in isolation and on re-run.
- Build clean, `npm run lint:required` 0 errors, `prettier --check` clean.
- Merged `origin/main` repeatedly rather than rebased; the `DESIGN.md` cheat-sheet conflicts were resolved as unions and verified row-by-row with an escaped-pipe-aware parser after one resolution silently reverted main's #2434 row.

Docs: HarperFast/documentation#660 documented the now-removed accessor and is being reverted by a follow-up; #666 (corrections to that page) is closed. Consumer-facing docs land with #2448.

**Deferred to its own issue, per the review's disposition:** on RocksDB, `Table.deleteHistory()` still scans the whole audit range and reports a nonzero `entriesDeleted` for no-op removals. Pre-existing on `main`, not this diff — #2566.

**History:** squashed to one commit on current `main` on 2026-09-10 after the re-scope (43 commits over repeated main merges collapsed; tree verified byte-identical to the last tested tip before the force-push). The per-round review record — including the eight rounds on the docs page and the three findings that were the engine's own — is in this PR's threads and comments, not in the commit history.

Complexity: complicated

<sub>Review-Coverage: authored=claude; ran=codex; declined=gemini,cursor-grok,cursor-composer,domain; rounds=18; full=1 @ 167c67f9bfdd</sub>

<sub>Human-Review-Need: 4 @ 167c67f9bfdd</sub>
