### PR TITLE
Register the replication blob-gap escalation config keys

### DIFF
--- a/config-root.schema.json
+++ b/config-root.schema.json
@@ -297,6 +297,16 @@
 					"minimum": 1000,
 					"description": "Time (ms) a replication blob gap may remain connected before reconnecting. Default: blobTimeout"
 				},
+				"blobGapEscalationCycles": {
+					"type": "integer",
+					"minimum": 0,
+					"description": "Reconnect cycles a source blob may keep failing transiently (503) before the receiver skips it and advances its resume cursor. 0 disables this bound. Default: 10"
+				},
+				"blobGapEscalationMs": {
+					"type": "integer",
+					"minimum": 0,
+					"description": "Time (ms) since a source blob first failed transiently (503) before the receiver skips it and advances its resume cursor. 0 disables this bound. Default: 1800000"
+				},
 				"copyCursorFlushBytes": {
 					"type": "number",
 					"minimum": 1,

--- a/unitTests/config/replicationBlobGapEscalationParams.test.js
+++ b/unitTests/config/replicationBlobGapEscalationParams.test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// `env.get` resolves a name only if it is present in CONFIG_PARAM_MAP, which is populated from
+// CONFIG_PARAMS by lowercased name; an unregistered param reads as `undefined` forever and its
+// compiled-in default silently applies (harper-pro#734). harper-pro's blob-gap escalation budget
+// (harper-pro#432) reads these two params, so this guards their registration here.
+
+const assert = require('node:assert/strict');
+const { CONFIG_PARAMS, CONFIG_PARAM_MAP } = require('#src/utility/hdbTerms');
+
+describe('replication blob-gap escalation param registration', () => {
+	it('registers both bounds in CONFIG_PARAMS so env.get can resolve them', () => {
+		assert.strictEqual(CONFIG_PARAMS.REPLICATION_BLOBGAPESCALATIONCYCLES, 'replication_blobGapEscalationCycles');
+		assert.strictEqual(CONFIG_PARAMS.REPLICATION_BLOBGAPESCALATIONMS, 'replication_blobGapEscalationMs');
+	});
+
+	it('reaches both through CONFIG_PARAM_MAP, so set_configuration accepts them', () => {
+		assert.strictEqual(CONFIG_PARAM_MAP['replication_blobgapescalationcycles'], 'replication_blobGapEscalationCycles');
+		assert.strictEqual(CONFIG_PARAM_MAP['replication_blobgapescalationms'], 'replication_blobGapEscalationMs');
+	});
+});

--- a/unitTests/config/replicationBlobGapEscalationParams.test.js
+++ b/unitTests/config/replicationBlobGapEscalationParams.test.js
@@ -1,14 +1,12 @@
 'use strict';
 
-// `env.get` resolves a name only if it is present in CONFIG_PARAM_MAP, which is populated from
-// CONFIG_PARAMS by lowercased name; an unregistered param reads as `undefined` forever and its
-// compiled-in default silently applies (harper-pro#734). harper-pro's blob-gap escalation budget
-// (harper-pro#432) reads these two params, so this guards their registration here.
+// `env.get` resolves only names registered in CONFIG_PARAMS; an unregistered param reads as undefined
+// forever and its compiled-in default silently applies (harper-pro#734).
 
-const assert = require('node:assert/strict');
+const assert = require('node:assert');
 const { CONFIG_PARAMS, CONFIG_PARAM_MAP } = require('#src/utility/hdbTerms');
 
-describe('replication blob-gap escalation param registration', () => {
+describe('replication blob-gap escalation param registration (harper-pro#432)', () => {
 	it('registers both bounds in CONFIG_PARAMS so env.get can resolve them', () => {
 		assert.strictEqual(CONFIG_PARAMS.REPLICATION_BLOBGAPESCALATIONCYCLES, 'replication_blobGapEscalationCycles');
 		assert.strictEqual(CONFIG_PARAMS.REPLICATION_BLOBGAPESCALATIONMS, 'replication_blobGapEscalationMs');

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -228,6 +228,8 @@ describe('Test configValidator module', () => {
 			expect(configValidator(config).error.message).to.include(
 				"'replication.blobGapEscalationMs' must be greater than or equal to 0"
 			);
+			config.replication = { blobGapEscalationMs: 2.5 };
+			expect(configValidator(config).error.message).to.include("'replication.blobGapEscalationMs' must be an integer");
 		});
 
 		it('rejects a URL / port / numeric node.hostname, and accepts a bare host (#2218)', () => {

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -209,6 +209,27 @@ describe('Test configValidator module', () => {
 			expect(configValidator(config).error).to.be.undefined;
 		});
 
+		it('accepts the blob-gap escalation bounds as non-negative integers, 0 meaning disabled', () => {
+			const config = testUtils.deepClone(FAKE_CONFIG);
+			config.replication = { blobGapEscalationCycles: 0, blobGapEscalationMs: 0 };
+			expect(configValidator(config).error).to.be.undefined;
+			config.replication = { blobGapEscalationCycles: 10, blobGapEscalationMs: 1800000 };
+			expect(configValidator(config).error).to.be.undefined;
+
+			config.replication = { blobGapEscalationCycles: -1 };
+			expect(configValidator(config).error.message).to.include(
+				"'replication.blobGapEscalationCycles' must be greater than or equal to 0"
+			);
+			config.replication = { blobGapEscalationCycles: 2.5 };
+			expect(configValidator(config).error.message).to.include(
+				"'replication.blobGapEscalationCycles' must be an integer"
+			);
+			config.replication = { blobGapEscalationMs: -1 };
+			expect(configValidator(config).error.message).to.include(
+				"'replication.blobGapEscalationMs' must be greater than or equal to 0"
+			);
+		});
+
 		it('rejects a URL / port / numeric node.hostname, and accepts a bare host (#2218)', () => {
 			const config = testUtils.deepClone(FAKE_CONFIG);
 			for (const [bad, reason] of [

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -661,6 +661,8 @@ export const CONFIG_PARAMS = {
 	REPLICATION_SHARD: 'replication_shard',
 	REPLICATION_BLOBTIMEOUT: 'replication_blobTimeout',
 	REPLICATION_BLOBGAPRECONNECTMS: 'replication_blobGapReconnectMs',
+	REPLICATION_BLOBGAPESCALATIONCYCLES: 'replication_blobGapEscalationCycles',
+	REPLICATION_BLOBGAPESCALATIONMS: 'replication_blobGapEscalationMs',
 	REPLICATION_COPYCURSORFLUSHBYTES: 'replication_copyCursorFlushBytes',
 	REPLICATION_COPYCURSORFLUSHINTERVALMS: 'replication_copyCursorFlushIntervalMs',
 	REPLICATION_BLOBSENDDRAINTIMEOUT: 'replication_blobSendDrainTimeout',

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -264,6 +264,8 @@ export function configValidator(configJson, skipFsValidation = false) {
 			pingTimeout: number.min(1).optional().empty(null),
 			copyTimeout: number.min(1).optional().empty(null),
 			blobGapReconnectMs: number.min(1000).optional().empty(null),
+			blobGapEscalationCycles: number.integer().min(0).optional().empty(null),
+			blobGapEscalationMs: number.integer().min(0).optional().empty(null),
 			copyCursorFlushBytes: number.min(1).optional().empty(null),
 			copyCursorFlushIntervalMs: number.min(1).optional().empty(null),
 			replayTimeout: number.min(1).optional().empty(null),


### PR DESCRIPTION
Registers `replication.blobGapEscalationCycles` and `replication.blobGapEscalationMs` — the two knobs of harper-pro's new cross-reconnect blob-gap escalation budget (HarperFast/harper-pro#432) — in [`CONFIG_PARAMS`](https://github.com/HarperFast/harper/pull/2461/changes?w=1#diff-85897aa30843afee9a67fc30b41713bbc7f2e3a3e1e9fa1a0437ecac46a698f9R664), [the config schema](https://github.com/HarperFast/harper/pull/2461/changes?w=1#diff-ef8a93bd2922e0b6e460e611904dc32a3004c803c9450c87cd5a0a0144069b68R300), and [the Joi validator](https://github.com/HarperFast/harper/pull/2461/changes?w=1#diff-aeee467d8401b59eaffd099dd61547bbf4a63b0198e2be2dc0fe55d06c284cb0R267), exactly as `blobGapReconnectMs` is registered. `getConfigValue` resolves registered names only, so without this the Pro-side `env.get` reads silently fall back to their defaults. Both are non-negative integers; `0` disables that bound.

## For the human reviewer

1. **`0` means "this bound is disabled", for the duration as well as the cycle count.** The alternative reading of `blobGapEscalationMs: 0` — escalate at once — is what `blobGapEscalationCycles: 1` already expresses, and absent/`null` already means "use the default", so a third sentinel for "disabled" would be a new convention. Reversible only before release (config semantics). Cost of "no": an operator wanting the pre-#432 unbounded hold would have no switch.
2. **No floor above zero on `blobGapEscalationCycles`** (its sibling `blobGapReconnectMs` floors at 1000). `1` makes a single held 503 skip the blob — that is an operator opting to treat 503 as permanent, which the Pro defaults (10 cycles / 30 min) never do on their own. A floor later would reject configs that validated. Cost of "no": one more operator foot-gun guarded only by documentation.
3. **The schema descriptions state Pro-only behavior and defaults**, exactly as `blobGapReconnectMs`'s description does ("… before reconnecting. Default: blobTimeout"). Kept for consistency with the neighboring keys; trivially rewritten if core prefers neutral wording.
4. **The Format Check on this PR is red because of `main`, not this change:** `unitTests/resources/query-array-scoping.test.js` (from #2437, after this branch's base) is unformatted on `origin/main` and this PR does not touch it.

## Verification

Route (a), extended existing unit tests: [`unitTests/validation/configValidator.test.js`](https://github.com/HarperFast/harper/pull/2461/changes?w=1#diff-bfc0bd3b280a1b03fa7b7c6d83f595f3d56383c4e877b739bd149d588acf68a8R212) gains a case accepting `0`/defaults and rejecting negative or fractional values for both keys, and [`unitTests/config/replicationBlobGapEscalationParams.test.js`](https://github.com/HarperFast/harper/pull/2461/changes?w=1#diff-a3aeb96cefe7e3d08054354a68fc763660a3c78a81636334c351b8405727fdc9R10) pins the `CONFIG_PARAMS` entries and their `CONFIG_PARAM_MAP` aliases (the inert-param guard of harper-pro#734); run from the submodule checkout with harper-pro's node_modules (`../node_modules/.bin/mocha unitTests/validation/configValidator.test.js unitTests/config/replicationBlobGapEscalationParams.test.js`): all passing. End to end, harper-pro's new `integrationTests/cluster/blobGapEscalationBudget.test.mjs` sets both keys on the receiver and observed the budget trip on the configured 3rd reconnect cycle; the same run before this registration silently used the 10-cycle default, which is how the gap was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rhy9GSFDiU7ZYjUAMwFgEA

Complexity: easy

<sub>Review-Coverage: authored=claude; ran=codex; blocked=gemini(auth); declined=cursor-grok,cursor-composer,domain; rounds=3 @ ad6483b615c2</sub>

<sub>Human-Review-Need: 3 @ ad6483b615c2</sub>
