### PR TITLE
Format query-array-scoping test so the main Format Check passes again

### DIFF
--- a/unitTests/resources/query-array-scoping.test.js
+++ b/unitTests/resources/query-array-scoping.test.js
@@ -140,10 +140,7 @@ describe('Array-valued property scoping', () => {
 		it('indexed array: same matching records as unindexed', async function () {
 			// unique ids: which leg leads the scan is estimate-dependent, so the harper#2434
 			// duplicate pattern is not stable here
-			assert.deepStrictEqual(
-				await collectUniqueIds(searchRest('sizesIdx=ge=175&sizesIdx=le=180')),
-				[1, 2, 4, 6]
-			);
+			assert.deepStrictEqual(await collectUniqueIds(searchRest('sizesIdx=ge=175&sizesIdx=le=180')), [1, 2, 4, 6]);
 		});
 		it.skip('harper#2434: indexed lead condition must not duplicate records into the result', async function () {
 			assert.deepStrictEqual(await collectIds(searchRest('sizesIdx=ge=175&sizesIdx=le=180')), [1, 2, 4, 6]);
@@ -202,9 +199,7 @@ describe('Array-valued property scoping', () => {
 		});
 		it('programmatic string value against numeric elements: same result', async function () {
 			assert.deepStrictEqual(
-				await collectIds(
-					Widgets.search({ conditions: [{ attribute: 'sizes', comparator: 'contains', value: '17' }] })
-				),
+				await collectIds(Widgets.search({ conditions: [{ attribute: 'sizes', comparator: 'contains', value: '17' }] })),
 				[1, 2, 4]
 			);
 		});


### PR DESCRIPTION
The test file added in "Pin element-scoping semantics of queries over array-valued properties (#2437)" was not run through Prettier, so `npm run format:check` has failed on `main` since eeadbdd8e and every open PR inherits the red Format Check. This is the output of `npx prettier --write unitTests/resources/query-array-scoping.test.js` with no other changes: two `assert.deepStrictEqual` calls collapsed onto fewer lines ([the indexed-array assertion](https://github.com/HarperFast/harper/pull/2464/changes?w=1#diff-bd86af5b66fc6bd6749fdcd0ec5e19784e0813c78bddd877f956c6e55b9a521fR143) and [the string-value assertion](https://github.com/HarperFast/harper/pull/2464/changes?w=1#diff-bd86af5b66fc6bd6749fdcd0ec5e19784e0813c78bddd877f956c6e55b9a521fR201)). Whitespace-stripped, the file is byte-identical to `origin/main`: the query strings (`sizesIdx=ge=175&sizesIdx=le=180`, `{ attribute: 'sizes', comparator: 'contains', value: '17' }`), the collectors (`collectUniqueIds` / `collectIds`, not swapped) and the expected id arrays are all unchanged, so what the suite proves is identical before and after.

## For the human reviewer

One open decision, and it is yours rather than the diff's: **this fix is a standalone follow-up commit** rather than an amend/force-push of the original array-scoping PR (eeadbdd8e). The trade is history legibility against how long `main` carries a red Format Check; it is trivially reversible either way, but only before this lands.

Cross-model pre-push review ran at this head and found nothing: codex (graded) and cursor-composer both reported zero findings, and the Harper domain pass confirmed zero runtime surface. One caveat on coverage — the gemini leg could not run (local CLI not authenticated), so this round is 2 of 4 selected lenses.

Codex noted the branch trails `origin/main` by ten commits and suggested rebasing before landing. Left as-is deliberately: GitHub reports the PR `MERGEABLE`, none of the intervening commits touch this file, and a rebase would force-push a new head whose only effect is to invalidate the review receipt above.

## Verification

Route: the CI gate itself. Locally, `npx prettier --check .` reports "All matched files use Prettier code style!" on this branch, and `npm run format:check` on this PR's Format Check job is the end-to-end confirmation. Independently re-confirmed that `main`'s newest Format Check run still names exactly this one file, so this PR is the whole fix. No behavior change to test.

Complexity: easy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=claude; ran=codex,cursor-composer; adjudicated=domain; blocked=gemini(auth); declined=cursor-grok; rounds=1 @ ad16bbd1ee4a</sub>

<sub>Human-Review-Need: 3 (decisions: formatting-fixup-as-separate-commit) @ ad16bbd1ee4a</sub>
