### PR TITLE
Bump rocksdb-js to 2.8.0 on v5.2 so a commit parked on a never-released write intent stops wedging the worker thread

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
 				"minimist": "1.2.8",
 				"moment": "2.30.1",
 				"mqtt-packet": "~9.0.1",
-				"msgpackr": "2.0.5",
+				"msgpackr": "2.0.6",
 				"needle": "3.5.0",
 				"node-forge": "^1.3.1",
 				"node-stream-zip": "1.16.0",
@@ -2659,15 +2659,6 @@
 			],
 			"engines": {
 				"node": "^22.18.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@harperfast/rocksdb-js/node_modules/msgpackr": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.6.tgz",
-			"integrity": "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw==",
-			"license": "MIT",
-			"optionalDependencies": {
-				"msgpackr-extract": "^3.0.4"
 			}
 		},
 		"node_modules/@harperfast/skills": {
@@ -11556,9 +11547,9 @@
 			"license": "MIT"
 		},
 		"node_modules/msgpackr": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.5.tgz",
-			"integrity": "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.6.tgz",
+			"integrity": "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw==",
 			"license": "MIT",
 			"optionalDependencies": {
 				"msgpackr-extract": "^3.0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@fastify/cors": "^11.2.0",
 				"@fastify/static": "^9.1.3",
 				"@harperfast/extended-iterable": "1.0.3",
-				"@harperfast/rocksdb-js": "2.7.1",
+				"@harperfast/rocksdb-js": "2.8.0",
 				"@harperfast/skills": "^1.10.8",
 				"@turf/area": "6.5.0",
 				"@turf/boolean-contains": "6.5.0",
@@ -2495,13 +2495,13 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-2.7.1.tgz",
-			"integrity": "sha512-Fs+Ki/9ysu4w0oGl4NN+6LWlKlQtUpw0RUZlOewbAXStEzJ4087Dk1vHKM2YqnAqNYoZb0UOz2XeoM8YkelMww==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-2.8.0.tgz",
+			"integrity": "sha512-czswCG+1KCRMYe6XQcsh5u28IQ6EbIx9eXPQd0kmjiLbtoMjiszYE92756bZJSbDykbR2OJLOazMZg7+qfFSJA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@harperfast/extended-iterable": "1.0.3",
-				"msgpackr": "2.0.5",
+				"msgpackr": "2.0.6",
 				"ordered-binary": "1.6.1"
 			},
 			"bin": {
@@ -2511,20 +2511,20 @@
 				"node": "^22.18.0 || >=24.0.0"
 			},
 			"optionalDependencies": {
-				"@harperfast/rocksdb-js-darwin-arm64": "2.7.1",
-				"@harperfast/rocksdb-js-darwin-x64": "2.7.1",
-				"@harperfast/rocksdb-js-linux-arm64-glibc": "2.7.1",
-				"@harperfast/rocksdb-js-linux-arm64-musl": "2.7.1",
-				"@harperfast/rocksdb-js-linux-x64-glibc": "2.7.1",
-				"@harperfast/rocksdb-js-linux-x64-musl": "2.7.1",
-				"@harperfast/rocksdb-js-win32-arm64": "2.7.1",
-				"@harperfast/rocksdb-js-win32-x64": "2.7.1"
+				"@harperfast/rocksdb-js-darwin-arm64": "2.8.0",
+				"@harperfast/rocksdb-js-darwin-x64": "2.8.0",
+				"@harperfast/rocksdb-js-linux-arm64-glibc": "2.8.0",
+				"@harperfast/rocksdb-js-linux-arm64-musl": "2.8.0",
+				"@harperfast/rocksdb-js-linux-x64-glibc": "2.8.0",
+				"@harperfast/rocksdb-js-linux-x64-musl": "2.8.0",
+				"@harperfast/rocksdb-js-win32-arm64": "2.8.0",
+				"@harperfast/rocksdb-js-win32-x64": "2.8.0"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-arm64": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-2.7.1.tgz",
-			"integrity": "sha512-H0aEOziU6WFaVUjoRvsWVUoIEAZ6ylLRYTa4z4R7SRVUt2pzpjiUMW1mHBTmIRAue/Fwsfm8SCM95WQj5goFKA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-2.8.0.tgz",
+			"integrity": "sha512-v7cj3bGpRptZHXSbhVzYJ0k+jyMD0Z0kX0u8YNZH6Xq+ifZ6zBkBbyoSdvQ2waGLJXxBORylUxTgYMvTZWiQBA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2538,9 +2538,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-x64": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-2.7.1.tgz",
-			"integrity": "sha512-YDPVGmfFyg9sCu3C+uulJa68o4B06pJ8MDWSgSqm+5uNXh4QNWuMSE1x2wLZYOt1hxE7xptHXzhMFFuSqIcvtg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-2.8.0.tgz",
+			"integrity": "sha512-9mMPPvRhxjLorE7u1gN3n+InzT4XHXQkHYdNKE6qN4iwZy0vM8iHoQLwIiN9GpzUiueEqBEilAP/9mIOHhMgBw==",
 			"cpu": [
 				"x64"
 			],
@@ -2554,9 +2554,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-glibc": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-2.7.1.tgz",
-			"integrity": "sha512-8LoPDc4muFb4U09VMWC1BJZRA/CxYBer1eIRW6Td6EfB8lOiBgZlpQvmc44GilYgrH4/C1at8lMK+G24U2CDyA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-2.8.0.tgz",
+			"integrity": "sha512-H1nNimVbIB4/6Sxv5DrxmP1asHLbxTCHuZ2ZN/zudqPkp/bTTSs5RsczOH6JeKTEUxUsJDTXM4nGRcn6LwFaOg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2573,9 +2573,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-musl": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-2.7.1.tgz",
-			"integrity": "sha512-vqeH0JM/FUbQfx1Q5n21aBCiLUukN/qMXKa5d3YUQt7hH1fFA4d9wQhnRqwV9VbIjxm6i3drYAy5HaFkU2TV1g==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-2.8.0.tgz",
+			"integrity": "sha512-EqG4lkYptNviIcPPaQjK+X4ufjqzSImIvVxP89GHFHrbOJkGgEwRpiya0gWfGu3vJ1iGL1XL1nsU/kEjeDOugg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2592,9 +2592,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-glibc": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-2.7.1.tgz",
-			"integrity": "sha512-2pbbjq36Ln+ln31a3oDf2ic5IQNvrXNP9ND6LM7lMYUjuG/7tV3tWK79x2AyATym6iq0Kmz5Sp0b8tnUL2nQNg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-2.8.0.tgz",
+			"integrity": "sha512-MZPKZ6gF8kCy/KXTav4tc7T2uq+iOunxDOYq7nifZkCCy+0+C9U7g9CZx0NErORRQRP29x3z0zEKkCQ/go5c6Q==",
 			"cpu": [
 				"x64"
 			],
@@ -2611,9 +2611,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-musl": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-2.7.1.tgz",
-			"integrity": "sha512-hrk3BvNjjrWV0j0XjDZ80r3XIQdLnP2nH/WNy+KFU484XEkdXONmj0zH0hsOJVItTv3JShEECWOk6BXlR3osaw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-2.8.0.tgz",
+			"integrity": "sha512-PnMn1f/UxGOZKxlayR82tzsFCGoaMu0mBGKMmP/r2rbxzX5T89T0c+aVhuhpgNrFlWXTdawlA10Oh/YjfT/2qQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2630,9 +2630,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-arm64": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-2.7.1.tgz",
-			"integrity": "sha512-E4Y725WvIcJjfSidOJt/gee4ogKWaFxj8exX/D6Kw2+v5RxuVjMgyKyOIxXQ+nLd18XGXTKj6HtgYzWOJfbEGg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-2.8.0.tgz",
+			"integrity": "sha512-4khqmGbIebiCwY3FVIgcUXEmMapgWP8f97aNrbThPDCIkuJscB3yoAG4A8OJo+Jln/TdjJZOgy8e2ir9F926dA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2646,9 +2646,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-x64": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-2.7.1.tgz",
-			"integrity": "sha512-7TcSJ3gXgknoccLe+Tc0nqAxOA1kt5FE30GFrrTs7MyZczdO1rioRiccqhgcRA4UvW8Xc29GwJPd9ehmK8yYHg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-2.8.0.tgz",
+			"integrity": "sha512-E5HpBAnRwotITq++534WCinMvYidkkPoaAD5uwBNHiQbNt6YYvNZllJAIh/bukXD+uO6DL6qUMmVkeBh3kWK5A==",
 			"cpu": [
 				"x64"
 			],
@@ -2659,6 +2659,15 @@
 			],
 			"engines": {
 				"node": "^22.18.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@harperfast/rocksdb-js/node_modules/msgpackr": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.6.tgz",
+			"integrity": "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw==",
+			"license": "MIT",
+			"optionalDependencies": {
+				"msgpackr-extract": "^3.0.4"
 			}
 		},
 		"node_modules/@harperfast/skills": {

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
 		"@fastify/cors": "^11.2.0",
 		"@fastify/static": "^9.1.3",
 		"@harperfast/extended-iterable": "1.0.3",
-		"@harperfast/rocksdb-js": "2.7.1",
+		"@harperfast/rocksdb-js": "2.8.0",
 		"@harperfast/skills": "^1.10.8",
 		"@turf/area": "6.5.0",
 		"@turf/boolean-contains": "6.5.0",

--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
 		"minimist": "1.2.8",
 		"moment": "2.30.1",
 		"mqtt-packet": "~9.0.1",
-		"msgpackr": "2.0.5",
+		"msgpackr": "2.0.6",
 		"needle": "3.5.0",
 		"node-forge": "^1.3.1",
 		"node-stream-zip": "1.16.0",


### PR DESCRIPTION
rocksdb-js 2.8.0 bounds the coordinated-retry park (rocksdb-js#744): a commit waiting on a write intent whose holder never releases now wakes after `ROCKSDB_JS_PARK_TIMEOUT_MS` (5000ms default, unparseable/zero/negative values fall back to it, no way to disable) and consumes a retry attempt exactly as a real release would, instead of never settling. That never-settling park is the root cause of #2450 — the commit that stayed outstanding for 12.5 minutes on three worker threads until the process was restarted.

This is a dependency-pin change only; no core code changes. It moves two pins together: [rocksdb-js to 2.8.0](https://github.com/HarperFast/harper/pull/2466/changes?w=1#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R182) and [msgpackr to 2.0.6](https://github.com/HarperFast/harper/pull/2466/changes?w=1#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R226). `build-tools/check-shrinkwrap-pins.mjs` requires the root `msgpackr` pin to equal rocksdb-js's own so the tree carries one msgpackr instance (and so one structure/extension registry), and rocksdb-js 2.8.0 depends on 2.0.6; the docker smoke job caught the mismatch on the first push. The lockfile correspondingly loses the nested `msgpackr` copy under rocksdb-js. 2.0.6 over 2.0.5 is one decode-hardening commit — reject array and map lengths that exceed the remaining source data — and is the pairing `main` already runs. v5.2 already carries the ladder the woken commit lands in: `MAX_RETRIES = 40` with `abortChainAfterRetries()`, `abandonWrites()` on a retained read handle, and per-attempt outstanding-commit tracking. Because `trackOutstandingCommit()` stamps each *attempt* at submission, every attempt now settles inside the park timeout, so a stuck intent holder no longer pushes the oldest outstanding commit past `storage.maxTransactionQueueTime` (45s) and `checkOverloaded()` stops 503-ing every unrelated write on the thread. The thread recovers without a restart, which is the part of #2450 that hurt.

## For the human reviewer

1. **The whole 2.8.0, or a 2.7.2 with only rocksdb-js#744?** 2.7.1 → 2.8.0 is 186 commits of mostly native change: the RocksDB prebuild jump 11.1.2 → 11.8.1, transaction-log recovery and framing rework (rocksdb-js#723, #750, #751), latched background-error observation and recovery (#758), the #741 pending-transaction close-path rework (#780), the verification-table non-unique-version change (#766), and dropped-transaction snapshot release (#768). That is more native surface than a patch line usually takes at once, and 2.8.0 has about a week of soak on `main` only. The minimal alternative is cutting rocksdb-js 2.7.2 = 2.7.1 + #744 and pinning that here instead. Either way the decision is a one-line pin and trivially reversible, but it is the decision this PR is asking for — @kriszyp asked for the 2.8.0 route explicitly.
2. **#2459 is deliberately not backported.** It bounds the retry ladder by queue time and returns a distinct 503 `TRANSACTION_COMMIT_CONFLICT_TIMEOUT`. On 2.7.1 it would be inert for #2450 (a commit parked forever never reaches a retry decision, so the deadline is never evaluated), and on 2.8.0 it only shortens the tail. Without it, a permanently-held intent ends the initiating request after roughly 40 × 5s ≈ 200s with the existing generic 500 "After 40 coordinated retries, unable to commit transaction" rather than a bounded, typed 503. If the reporter needs the bounded error too, #2459 can be backported after it merges on `main` — it does not change the wedge outcome.
3. **No companion harper-pro PR.** harper-pro pins `@harperfast/rocksdb-js` and `msgpackr` in its own `package.json`, but `build-tools/sync-core.sh` copies core's `dependencies`, `devDependencies`, `overrides` and `optionalDependencies` plus core's lockfile into harper-pro wholesale, so both pins arrive there from this PR through the core sync. An earlier hand-written pro PR for the same bump (harper-pro#798) was closed as redundant.
4. **Direction:** this targets `v5.2` directly rather than arriving as a cherry-pick — `main` has been on 2.8.0 since #2065, which bumped it for the verification-table non-unique flag.

## Verification

- `npm run build` — clean.
- `npm run test:unit:dataLayer` — 242 passing, 0 failing.
- Dependency alignment, checked directly against the three predicates `verifyRocksDbDependencyAlignment()` asserts: root pin, rocksdb-js's own pin and the installed version all read `2.0.6` for `msgpackr` and `1.0.3` for `@harperfast/extended-iterable`, and no nested copy of either remains under `node_modules/@harperfast/rocksdb-js/`. The checker itself cannot run locally — it reads `npm-shrinkwrap.packed.json`, which only exists inside the packed docker image the smoke job builds.
- `npm run test:unit:resources` — 1698 passing, 0 failing, re-run after the msgpackr pin moved (same counts). A first run of the same suite had one failure, `Caching > Can load cached indexed data` (asserted 3, got 2); the file passes in isolation and the full-suite re-run is green, so it is a pre-existing ordering flake, not a bump regression.
- `npm run test:unit:main` — **not run locally.** The suite stalled on the storage locks shared with two other local Harper suites running concurrently in sibling worktrees (a known local-only contention on this machine, not a product behavior); it was killed rather than reported. CI runs it on this PR.
- **Not observable end-to-end here:** reproducing the wedge requires deliberately leaking a native write intent that is never released. The park timeout itself is covered inside rocksdb-js (`test/fixtures/fork-park-timeout.mts`, asserting both a lower and an upper bound on elapsed time so the timeout branch is distinguishable from the not-parked fast path), and the retry ladder the woken commit lands in is already covered on this branch.

Refs HarperFast/harper#2450

Complexity: easy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=unknown; ran=none; rounds=1 @ 6ca418d74197</sub>

<sub>Human-Review-Need: 4 @ 6ca418d74197</sub>
