### PR TITLE
Stop discarding log_files_deleted and scanning audit symbol keys

### DIFF
--- a/dataLayer/delete.ts
+++ b/dataLayer/delete.ts
@@ -110,7 +110,12 @@ export async function deleteAuditLogsBefore(deleteObj: any) {
 	harperLogger.info(`Finished deleting audit logs before ${deleteObj.timestamp}`);
 
 	// `deleteTransactionLogsBefore` returns `entries_deleted`; the legacy result exposes it as `transactions_deleted`.
-	return new DeleteAuditLogsBeforeResults(results.start_timestamp, results.end_timestamp, results.entries_deleted);
+	return new DeleteAuditLogsBeforeResults(
+		results.start_timestamp,
+		results.end_timestamp,
+		results.entries_deleted,
+		results.log_files_deleted
+	);
 }
 
 /**

--- a/dataLayer/harperBridge/lmdbBridge/lmdbMethods/DeleteAuditLogsBeforeResults.js
+++ b/dataLayer/harperBridge/lmdbBridge/lmdbMethods/DeleteAuditLogsBeforeResults.js
@@ -8,11 +8,13 @@ class DeleteAuditLogsBeforeResults {
 	 * @param {number} startTimestamp
 	 * @param {number} endTimestamp
 	 * @param {number} transactionsDeleted
+	 * @param {number} logFilesDeleted
 	 */
-	constructor(startTimestamp = undefined, endTimestamp = undefined, transactionsDeleted = 0) {
+	constructor(startTimestamp = undefined, endTimestamp = undefined, transactionsDeleted = 0, logFilesDeleted = 0) {
 		this.start_timestamp = startTimestamp;
 		this.end_timestamp = endTimestamp;
 		this.transactions_deleted = transactionsDeleted;
+		this.log_files_deleted = logFilesDeleted;
 		this.deprecated = 'Please use delete_transaction_logs_before instead';
 	}
 }

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5555,7 +5555,7 @@ export function makeTable(options) {
 			let entriesDeleted = 0;
 			try {
 				for (const auditRecord of auditStore.getRange({
-					start: 0,
+					start: 1, // 0 is encoded as all zeros with audit store's special encoder, and will include symbols (see getHistory)
 					end: endTime,
 				})) {
 					await rest(); // yield to other async operations

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5555,7 +5555,7 @@ export function makeTable(options) {
 			let entriesDeleted = 0;
 			try {
 				for (const auditRecord of auditStore.getRange({
-					start: 1, // 0 is encoded as all zeros with audit store's special encoder, and will include symbols (see getHistory)
+					start: 1, // must not be zero; see getHistory below for why
 					end: endTime,
 				})) {
 					await rest(); // yield to other async operations

--- a/unitTests/dataLayer/delete.test.js
+++ b/unitTests/dataLayer/delete.test.js
@@ -159,6 +159,7 @@ describe('Tests for delete.js', () => {
 			);
 			// the bridge's `entries_deleted` is surfaced as the legacy `transactions_deleted` field
 			expect(result.transactions_deleted).to.equal(3);
+			expect(result.log_files_deleted).to.equal(1);
 		});
 	});
 

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -9,6 +9,7 @@ const {
 	createAuditEntry,
 	transactionKeyEncoder,
 	removeAuditEntry,
+	getLastRemoved,
 } = require('#src/resources/auditStore');
 const { RocksTransactionLogStore } = require('#src/resources/RocksTransactionLogStore');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
@@ -386,6 +387,32 @@ describe('Audit log', () => {
 			AuditedTable.auditStore.remove = originalRemove;
 			await AuditedTable.deleteHistory(cutoff());
 		}
+	});
+	it('deleteHistory does not misdecode the last-removed marker as a corrupt audit entry', async function () {
+		// rocksdb doesn't use deleteHistory (see ResourceBridge.deleteTransactionLogsBefore); this.skip()
+		if (AuditedTable.auditStore.reusableIterable) return this.skip();
+		await AuditedTable.deleteHistory(Date.now() + 60_000); // start from a clean backlog
+		// the last-removed marker is written fire-and-forget when the audit store opens; wait for it
+		// rather than assuming it has already landed by the time this test runs
+		await waitFor(() => getLastRemoved(AuditedTable.auditStore) !== undefined, {
+			timeout: 5000,
+			message: 'expected the audit store to have a last-removed marker',
+		});
+		await AuditedTable.put(900, { name: 'has-history' });
+
+		const originalError = harperLogger.error;
+		const errors = [];
+		harperLogger.error = (...args) => errors.push(args);
+		try {
+			await AuditedTable.deleteHistory(Date.now() + 60_000);
+		} finally {
+			harperLogger.error = originalError;
+		}
+		assert.equal(
+			errors.some((args) => args[0] === 'Reading audit entry error'),
+			false,
+			`deleteHistory must not attempt to decode the last-removed marker as an audit entry: ${JSON.stringify(errors)}`
+		);
 	});
 	it('deleteHistory limits concurrent removals without serializing them', async function () {
 		if (AuditedTable.auditStore.reusableIterable) return this.skip();

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -397,7 +397,6 @@ describe('Audit log', () => {
 			database: 'deleteHistoryMarkerTestDB',
 			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
 		});
-		// rocksdb doesn't use deleteHistory (see ResourceBridge.deleteTransactionLogsBefore); this.skip()
 		if (MarkerTable.auditStore.reusableIterable) return this.skip();
 		// the last-removed marker is written fire-and-forget when the audit store opens; wait for its
 		// key (not its decoded value, which would itself trigger and cache away the bug) to land

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -414,7 +414,7 @@ describe('Audit log', () => {
 		} finally {
 			harperLogger.error = originalError;
 		}
-		assert.equal(
+		assert.strictEqual(
 			errors.some((args) => args[0] === 'Reading audit entry error'),
 			false,
 			`deleteHistory must not attempt to decode the last-removed marker as an audit entry: ${JSON.stringify(errors)}`

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -9,7 +9,6 @@ const {
 	createAuditEntry,
 	transactionKeyEncoder,
 	removeAuditEntry,
-	getLastRemoved,
 } = require('#src/resources/auditStore');
 const { RocksTransactionLogStore } = require('#src/resources/RocksTransactionLogStore');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
@@ -389,22 +388,30 @@ describe('Audit log', () => {
 		}
 	});
 	it('deleteHistory does not misdecode the last-removed marker as a corrupt audit entry', async function () {
-		// rocksdb doesn't use deleteHistory (see ResourceBridge.deleteTransactionLogsBefore); this.skip()
-		if (AuditedTable.auditStore.reusableIterable) return this.skip();
-		await AuditedTable.deleteHistory(Date.now() + 60_000); // start from a clean backlog
-		// the last-removed marker is written fire-and-forget when the audit store opens; wait for it
-		// rather than assuming it has already landed by the time this test runs
-		await waitFor(() => getLastRemoved(AuditedTable.auditStore) !== undefined, {
-			timeout: 5000,
-			message: 'expected the audit store to have a last-removed marker',
+		// A fresh table/audit store, not the shared AuditedTable: lmdb-js caches a key's decoded
+		// value once readAuditEntry() has been run on it (by any earlier test's getRange/get over
+		// the same store), so re-scanning the marker on the shared fixture would silently hit that
+		// cache instead of re-triggering the decode this test exists to catch.
+		const MarkerTable = table({
+			table: 'DeleteHistoryMarkerTable',
+			database: 'deleteHistoryMarkerTestDB',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
 		});
-		await AuditedTable.put(900, { name: 'has-history' });
+		// rocksdb doesn't use deleteHistory (see ResourceBridge.deleteTransactionLogsBefore); this.skip()
+		if (MarkerTable.auditStore.reusableIterable) return this.skip();
+		// the last-removed marker is written fire-and-forget when the audit store opens; wait for its
+		// key (not its decoded value, which would itself trigger and cache away the bug) to land
+		await waitFor(() => [...MarkerTable.auditStore.getRange({ start: 0, end: 1, values: false })].length > 0, {
+			timeout: 5000,
+			message: 'expected the audit store to have a last-removed marker key',
+		});
+		await MarkerTable.put(1, { name: 'has-history' });
 
 		const originalError = harperLogger.error;
 		const errors = [];
 		harperLogger.error = (...args) => errors.push(args);
 		try {
-			await AuditedTable.deleteHistory(Date.now() + 60_000);
+			await MarkerTable.deleteHistory(Date.now() + 60_000);
 		} finally {
 			harperLogger.error = originalError;
 		}


### PR DESCRIPTION
## Summary

Two small, independently-verifiable fixes on the audit-log purge surface:

1. **`delete_audit_logs_before` was discarding `log_files_deleted`.** `ResourceBridge.deleteTransactionLogsBefore` already computes it (`dataLayer/harperBridge/ResourceBridge.ts`), but the deprecated op's result wrapper never passed it through — [`dataLayer/delete.ts`](https://github.com/HarperFast/harper/pull/2472/changes?w=1#diff-f194159e564382732a909f1e7499470cbaed190bcafe3286726ec8df9f957f70R117) now forwards `results.log_files_deleted` into a 4th constructor argument, and [`DeleteAuditLogsBeforeResults.js`](https://github.com/HarperFast/harper/pull/2472/changes?w=1#diff-60ff8d5dae9a104114ee90f3e31d2a8b360b10faecec7e22a0ef81a2f13fcc76R17) now exposes `log_files_deleted`, matching the shape its TS sibling `DeleteTransactionLogsBeforeResults` already has. On RocksDB, file count is the only honest signal of what a purge reclaimed — `entries_deleted` can legitimately be 0 while whole rotated log files were removed — so silently dropping it made a successful purge look like a no-op.

2. **`Table.deleteHistory` scanned audit symbol keys.** It called `auditStore.getRange({ start: 0, end: endTime })`; the sibling generator `getHistory` in the same file uses `start: startTime || 1` with a comment explaining why: 0 is encoded as all zeros by the audit store's special key encoder, so a `start: 0` bound also picks up symbol-keyed entries (e.g. the `Symbol.for('last-removed')` marker, stored as a bare 8-byte float buffer). [`resources/Table.ts`](https://github.com/HarperFast/harper/pull/2472/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R5558) now starts at 1, mirroring `getHistory`. Every `deleteHistory` call was decoding that marker as a corrupt audit entry, throwing a `RangeError` caught by `readAuditEntry`'s outer try/catch, and logging `'Reading audit entry error'` at `harperLogger.error` — a burst of spurious corruption-shaped error logs on every purge that can mask a real corruption signal. Not data loss: the sentinel's `tableId` is `undefined`, so `deleteHistory`'s `tableId` filter always skips it.

## For the human reviewer

- **Design assessment (harper-engineering-guidelines step 6): no triggers, no framing gate.** No new/changed public API surface — (1) adds a field the sibling result class and `ResourceBridge` already carry; (2) is a one-value bound correction matching the sibling method's documented behavior in the same file. No cross-layer/module-boundary question.
- **The acceptance criteria asked for an integration test proving `log_files_deleted` is non-zero for a `delete_audit_logs_before` purge that removes a rotated log file — this is not achievable, by design, and I did not attempt to force it.** `dataLayer/delete.ts`'s `deleteAuditLogsBefore` unconditionally requires `table` (`checkSchemaTableExist`), and `ResourceBridge.deleteTransactionLogsBefore` rejects any table-scoped purge on RocksDB with a 400 (harper#2049 — a shared per-database log has no per-table purge granularity). This pairing is already documented as intentional in [`DESIGN.md`](https://github.com/HarperFast/harper/blob/b96938189689a9593fd1bff770893b930b720558/DESIGN.md#L1137): "the deprecated `delete_audit_logs_before` op _requires_ `table`, so it always errors on RocksDB." So on RocksDB this deprecated op can never reach the `log_files_deleted`-populating branch (which only runs when `table` is omitted), and on LMDB the value is correctly always 0 (LMDB purges don't produce a file count). In other words: there is no storage engine and no valid request shape where this specific op can observe a non-zero value today, and that's pre-existing, documented, unrelated-to-this-fix behavior, not something introduced or fixable here.
  - What I verified instead: [`unitTests/dataLayer/delete.test.js`](https://github.com/HarperFast/harper/pull/2472/changes?w=1#diff-d9fb6637beb212b9b779a85e49200b7fac9131cb0d2c6913cc9fb2347cc61142R162) proves the plumbing — a stubbed bridge result carrying `log_files_deleted: 1` now survives through `DeleteAuditLogsBeforeResults` to the caller (it silently dropped to `undefined` before this fix). The underlying computation itself (`ResourceBridge.deleteTransactionLogsBefore` returning a non-zero `log_files_deleted` for a purge that removes real rotated RocksDB log files) is already proven end-to-end by the existing `delete_transaction_logs_before` integration coverage in `integrationTests/database/qa816-purge-blast-radius.test.ts` (step 3) — both ops delegate to the same bridge method, so that coverage already establishes the value this fix now forwards is correct.
- **Open design notes from the independent review's decision ledger** (none blocking, none disputed — recorded for visibility): (a) this patches `start` at each scan site rather than centralizing the symbol-key guard in `auditStore.getRange`'s own wrapper — three call sites now carry the same magic-constant comment, and `getLastRemoved()`'s `.get()` call is a fourth reader still exposed; a contained refactor later, not blocking here. (b) adding `log_files_deleted` extends a response shape the class itself calls deprecated — additive/safe for clients, reversible only as a breaking change later. (c) the new regression test asserts absence of the error log, not that the purge still deleted the entry — deliberately narrow (this PR's failure mode is log noise, not data loss), and purge-count coverage already exists elsewhere in the same file (e.g. line 341, 489, 370).
- **Fix (2)'s regression test needed a fresh table, not the file's shared `AuditedTable` fixture.** `unitTests/resources/auditLog.test.js` decodes audit entries through lmdb-js, which caches a key's decoded value the first time it's read — reusing the shared fixture would let an earlier test's scan silently pre-warm that cache and mask the bug on a second scan. [The new test](https://github.com/HarperFast/harper/pull/2472/changes?w=1#diff-044077436ab82ecf6c481205bdf0ac84571b38edf4ce663842e72349c3a7b38cR390) creates its own table/database instead. Verified red on the unpatched code (both `Symbol.for('last-removed')` and `Symbol.for('remote-ids')` decode-fail and log `'Reading audit entry error'`) and green after the fix.

## Verification

- `npm run build` — clean.
- `npm run format:write` / `npm run lint:required` — clean, no changes.
- Targeted unit suites, both storage engines where applicable:
  - `unitTests/dataLayer/delete.test.js` — 13 passing.
  - `unitTests/resources/auditLog.test.js` — 37 passing / 7 pending (engine-specific skips), both default (RocksDB) and `HARPER_STORAGE_ENGINE=lmdb`.
  - New `deleteHistory` regression test confirmed red on unpatched `resources/Table.ts`, green after the fix.
- `npm run test:unit:resources` (RocksDB default, then `HARPER_STORAGE_ENGINE=lmdb`) — clean, 1936 and 1592 passing respectively, 0 failures.
- `npm run test:unit:main` — 5286 passing, 1 failing, unrelated to this diff: `unitTests/validation/configValidator.test.js`'s domain-socket-path-length test fails because this worktree's own absolute path is long enough to push a relative `rootPath` over the 107-byte Unix socket limit — pre-existing, environmental, doesn't touch anything this PR changes.
- End-to-end (testing.md route (a), existing integration coverage), run directly rather than the full `test:integration:all` given the size/risk of this change:
  - `integrationTests/database/qa816-purge-blast-radius.test.ts` — 7/7 passing; confirms `log_files_deleted` is computed correctly and non-zero (`log_files_deleted:2`) for a real RocksDB purge that removes rotated log files, via the same `ResourceBridge.deleteTransactionLogsBefore` this fix forwards.
  - `integrationTests/database/audit-retention-lmdb.test.ts` — 4/4 passing.
  - `integrationTests/database/txnlog-purge-stale-read-blast.test.ts` — 14/14 passing on both engines; the LMDB arm exercises `Table.deleteHistory` end-to-end through a real `delete_transaction_logs_before` job with production-scale data (12,000 entries) across two restarts.
- Independent review: `prepush-review.mjs` — 4 rounds (full + 3 trivial deltas after addressing comment nits and the `gemini-code-assist` GitHub bot review below), verdict LGTM every round, `Human-Review-Need: 3`. Codex graded leg produced findings every round; Cursor Composer contributed round 1 (2 suggestions, both adjudicated and dropped with rationale — see decision ledger below); the Gemini *CLI* leg failed on auth (`agy` not logged in) all 4 rounds — degraded but not absent coverage.
  - The one surviving finding (`resources/auditStore.ts:403-408`, `getLastRemoved()` also misdecodes the same marker via `.get()`, silently returning a stale cached value instead of erroring) is scoped **pre-existing** and outside this diff — recorded in `# Findings` below instead of fixed here.
- The GitHub `gemini-code-assist` bot flagged one thread (`unitTests/resources/auditLog.test.js:421`, `assert.equal` → `assert.strictEqual`) — fixed and resolved.

<sub>Review-Coverage: authored=claude; ran=codex; blocked=gemini(auth); declined=cursor-grok,cursor-composer,domain; rounds=4 @ 1521f786a3ae</sub>

<sub>Human-Review-Need: 3 @ 1521f786a3ae</sub>
