### PR TITLE
Prove the record-caching suites reach every HTTP worker instead of assuming it

### DIFF
--- a/integrationTests/database/record-caching-blob.test.ts
+++ b/integrationTests/database/record-caching-blob.test.ts
@@ -31,7 +31,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error no type declarations
 import { createApiClient } from './../apiTests/utils/client.mjs';
-import { WORKER_COUNT, assertMultiWorker, mapBounded } from './recordCachingWorkers.ts';
+import { WORKER_COUNT, assertMultiWorker, mapBounded, NO_MULTI_WORKER_HTTP } from './recordCachingWorkers.ts';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'record-caching-blob');
 const SKIP = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
@@ -140,7 +140,7 @@ async function diskFiles(dir: string): Promise<{ files: number; bytes: number }>
 
 suite(
 	'record-caching Blob-attribute correctness [rocksdb] multi-worker',
-	{ skip: SKIP || process.platform === 'win32' },
+	{ skip: SKIP || NO_MULTI_WORKER_HTTP },
 	(ctx: ContextWithHarper) => {
 		let client: Client;
 		let httpURL: string;

--- a/integrationTests/database/record-caching-cross-worker.test.ts
+++ b/integrationTests/database/record-caching-cross-worker.test.ts
@@ -31,7 +31,8 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error no type declarations
 import { createApiClient } from './../apiTests/utils/client.mjs';
-import { WORKER_COUNT, assertMultiWorker, mapBounded } from './recordCachingWorkers.ts';
+import { WORKER_COUNT, assertMultiWorker, mapBounded, NO_MULTI_WORKER_HTTP } from './recordCachingWorkers.ts';
+import { fetchOnNewConnection } from '../utils/connectionPerRequest.ts';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'record-caching-coherence');
 const SKIP = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
@@ -41,14 +42,12 @@ const CONCURRENCY = 24;
 
 type Rec = { id: string; name: string; counter: number };
 
-// Force a fresh connection per request (no keep-alive) so concurrent requests
-// spray across the SO_REUSEPORT worker pool instead of pinning to one worker.
 function headers(auth: string): Record<string, string> {
-	return { 'Content-Type': 'application/json', 'Authorization': auth, 'Connection': 'close' };
+	return { 'Content-Type': 'application/json', 'Authorization': auth };
 }
 
 async function putRecord(base: string, auth: string, id: string, name: string, counter: number): Promise<void> {
-	const r = await fetch(`${base}/CacheRecord/${encodeURIComponent(id)}`, {
+	const r = await fetchOnNewConnection(`${base}/CacheRecord/${encodeURIComponent(id)}`, {
 		method: 'PUT',
 		headers: headers(auth),
 		body: JSON.stringify({ id, name, counter }),
@@ -60,7 +59,7 @@ async function putRecord(base: string, auth: string, id: string, name: string, c
 }
 
 async function deleteRecord(base: string, auth: string, id: string): Promise<void> {
-	const r = await fetch(`${base}/CacheRecord/${encodeURIComponent(id)}`, {
+	const r = await fetchOnNewConnection(`${base}/CacheRecord/${encodeURIComponent(id)}`, {
 		method: 'DELETE',
 		headers: headers(auth),
 	});
@@ -71,7 +70,7 @@ async function deleteRecord(base: string, auth: string, id: string): Promise<voi
 }
 
 async function getRecord(base: string, auth: string, id: string): Promise<{ status: number; body: Rec | null }> {
-	const r = await fetch(`${base}/CacheRecord/${encodeURIComponent(id)}`, { headers: headers(auth) });
+	const r = await fetchOnNewConnection(`${base}/CacheRecord/${encodeURIComponent(id)}`, { headers: headers(auth) });
 	if (r.status === 404) {
 		await r.text().catch(() => undefined);
 		return { status: 404, body: null };
@@ -84,7 +83,7 @@ async function waitForTable(base: string, auth: string): Promise<void> {
 	const deadline = Date.now() + 60_000;
 	while (Date.now() < deadline) {
 		try {
-			const r = await fetch(`${base}/CacheRecord/probe`, { headers: headers(auth) });
+			const r = await fetchOnNewConnection(`${base}/CacheRecord/probe`, { headers: headers(auth) });
 			if (r.status < 500) {
 				await r.text().catch(() => undefined);
 				return;
@@ -99,7 +98,7 @@ async function waitForTable(base: string, auth: string): Promise<void> {
 
 suite(
 	'record-caching cross-worker coherence [rocksdb] multi-worker',
-	{ skip: SKIP || process.platform === 'win32' },
+	{ skip: SKIP || NO_MULTI_WORKER_HTTP },
 	(ctx: ContextWithHarper) => {
 		let base: string;
 		let auth: string;

--- a/integrationTests/database/record-caching-invalidate.test.ts
+++ b/integrationTests/database/record-caching-invalidate.test.ts
@@ -17,9 +17,12 @@
  *      raw == null -> cache.delete(id) -> undefined), plus a never-written-key absence check.
  *
  * Reads go through primaryStore.getEntry() directly (resources.js) so we observe the cache
- * layer's literal truth per worker, not Table's higher-level read semantics.
+ * layer's literal truth per worker, not Table's higher-level read semantics, and every read phase
+ * runs until EVERY configured worker has answered (utils/connectionPerRequest.ts) rather than
+ * trusting a fixed-width fan-out to have covered them.
  *
- * Skipped on LMDB (PrimaryRocksDatabase is RocksDB-specific).
+ * Skipped on LMDB (PrimaryRocksDatabase is RocksDB-specific) and where Harper cannot spread HTTP
+ * across workers (NO_MULTI_WORKER_HTTP).
  */
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual } from 'node:assert';
@@ -28,7 +31,8 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error no type declarations
 import { createApiClient } from './../apiTests/utils/client.mjs';
-import { WORKER_COUNT, assertMultiWorker } from './recordCachingWorkers.ts';
+import { WORKER_COUNT, assertMultiWorker, NO_MULTI_WORKER_HTTP } from './recordCachingWorkers.ts';
+import { fetchOnNewConnection, observeEveryWorker } from '../utils/connectionPerRequest.ts';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'record-caching-invalidate');
 const SKIP = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
@@ -44,7 +48,7 @@ type GetResult = {
 
 suite(
 	'record-caching value-shape edge: object <-> invalidated-null [rocksdb] multi-worker',
-	{ skip: SKIP || process.platform === 'win32' },
+	{ skip: SKIP || NO_MULTI_WORKER_HTTP },
 	(ctx: ContextWithHarper) => {
 		let client: ReturnType<typeof createApiClient>;
 		let httpURL: string;
@@ -60,7 +64,9 @@ suite(
 			const deadline = Date.now() + 60_000;
 			while (Date.now() < deadline) {
 				try {
-					const probe = await fetch(`${httpURL}/WidgetGet/?id=probe`, { headers: { Authorization: authHeader } });
+					const probe = await fetchOnNewConnection(`${httpURL}/WidgetGet/?id=probe`, {
+						headers: { Authorization: authHeader },
+					});
 					if (probe.status === 200) break;
 				} catch {
 					/* not ready */
@@ -76,7 +82,7 @@ suite(
 		});
 
 		async function putWidget(id: string, name: string, tag: string): Promise<void> {
-			const res = await fetch(`${httpURL}/Widget/${encodeURIComponent(id)}`, {
+			const res = await fetchOnNewConnection(`${httpURL}/Widget/${encodeURIComponent(id)}`, {
 				method: 'PUT',
 				headers: { 'Content-Type': 'application/json', 'Authorization': authHeader },
 				body: JSON.stringify({ id, name, tag }),
@@ -85,7 +91,7 @@ suite(
 		}
 
 		async function putMinimal(id: string): Promise<void> {
-			const res = await fetch(`${httpURL}/Widget/${encodeURIComponent(id)}`, {
+			const res = await fetchOnNewConnection(`${httpURL}/Widget/${encodeURIComponent(id)}`, {
 				method: 'PUT',
 				headers: { 'Content-Type': 'application/json', 'Authorization': authHeader },
 				body: JSON.stringify({ id }),
@@ -94,7 +100,7 @@ suite(
 		}
 
 		async function deleteWidget(id: string): Promise<void> {
-			const res = await fetch(`${httpURL}/Widget/${encodeURIComponent(id)}`, {
+			const res = await fetchOnNewConnection(`${httpURL}/Widget/${encodeURIComponent(id)}`, {
 				method: 'DELETE',
 				headers: { Authorization: authHeader },
 			});
@@ -102,7 +108,7 @@ suite(
 		}
 
 		async function invalidateWidget(id: string): Promise<void> {
-			const res = await fetch(`${httpURL}/Invalidate/`, {
+			const res = await fetchOnNewConnection(`${httpURL}/Invalidate/`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json', 'Authorization': authHeader },
 				body: JSON.stringify({ id }),
@@ -111,7 +117,7 @@ suite(
 		}
 
 		async function getOnce(id: string): Promise<GetResult> {
-			const res = await fetch(`${httpURL}/WidgetGet/?id=${encodeURIComponent(id)}`, {
+			const res = await fetchOnNewConnection(`${httpURL}/WidgetGet/?id=${encodeURIComponent(id)}`, {
 				headers: { Authorization: authHeader },
 			});
 			strictEqual(res.status, 200, `GET ${id} returned ${res.status}`);
@@ -119,9 +125,13 @@ suite(
 			return body;
 		}
 
-		/** Fan out N concurrent point-GETs (maximizes odds of hitting multiple distinct workers). */
-		async function getMulti(id: string, n = 10): Promise<GetResult[]> {
-			return Promise.all(Array.from({ length: n }, () => getOnce(id)));
+		/** Point-GETs until every configured worker has answered, so the assertions below cover all. */
+		function getOnEveryWorker(id: string): Promise<GetResult[]> {
+			return observeEveryWorker(
+				() => getOnce(id),
+				(r) => r.threadId,
+				{ workerCount: WORKER_COUNT }
+			);
 		}
 
 		function assertAllObject(label: string, results: GetResult[], expected: { name: string; tag: string }) {
@@ -173,18 +183,18 @@ suite(
 		test('S1 object -> invalidate(null) -> object transition, cross-worker', async () => {
 			const id = 's1-obj2null';
 			await putWidget(id, 'original', 'x');
-			let results = await getMulti(id, 12);
+			let results = await getOnEveryWorker(id);
 			assertAllObject('S1 warm object', results, { name: 'original', tag: 'x' });
 
 			// Invalidate: real versioned null write. Every worker whose cache is warm with the
 			// stale object must NOT keep serving it.
 			await invalidateWidget(id);
-			results = await getMulti(id, 16);
+			results = await getOnEveryWorker(id);
 			assertAllNull('S1 after invalidate', results);
 
 			// And back to a (different) object once more (round-trip both directions).
 			await putWidget(id, 'restored', 'y');
-			results = await getMulti(id, 12);
+			results = await getOnEveryWorker(id);
 			assertAllObject('S1 after re-create', results, { name: 'restored', tag: 'y' });
 
 			strictEqual(failures.length, 0, `S1 failures:\n${failures.join('\n')}`);
@@ -200,11 +210,11 @@ suite(
 				for (let round = 0; round < ROUNDS; round++) {
 					if (round % 2 === 0) {
 						await putWidget(id, `r${round}`, 'obj');
-						const results = await getMulti(id, 6);
+						const results = await getOnEveryWorker(id);
 						assertAllObject(`S2 round ${round} (object)`, results, { name: `r${round}`, tag: 'obj' });
 					} else {
 						await invalidateWidget(id);
-						const results = await getMulti(id, 6);
+						const results = await getOnEveryWorker(id);
 						assertAllNull(`S2 round ${round} (invalidated)`, results);
 					}
 					if (failures.length > 0) break; // stop early once we have concrete evidence
@@ -217,13 +227,13 @@ suite(
 			// Genuine key absence sanity: a never-written id must read as absent on every worker
 			// (the OTHER getEntry short-circuit: raw == null -> cache.delete(id) -> undefined).
 			const neverWritten = 's3-never-written';
-			let results = await getMulti(neverWritten, 10);
+			let results = await getOnEveryWorker(neverWritten);
 			assertAllAbsent('S3 never-written key', results);
 
 			// Near-empty object: only the primary key attribute set.
 			const idMin = 's3-minimal';
 			await putMinimal(idMin);
-			results = await getMulti(idMin, 8);
+			results = await getOnEveryWorker(idMin);
 			for (const r of results) {
 				if (!r.exists || r.valueType !== 'object') {
 					failures.push(
@@ -242,17 +252,17 @@ suite(
 			// cache-coherence contract.
 			const id = 's3-delete-recreate';
 			await putWidget(id, 'warm', 'before-delete');
-			results = await getMulti(id, 10);
+			results = await getOnEveryWorker(id);
 			assertAllObject('S3 warm object before delete', results, { name: 'warm', tag: 'before-delete' });
 
 			await deleteWidget(id);
-			results = await getMulti(id, 14);
+			results = await getOnEveryWorker(id);
 			assertAllNull('S3 after delete (tombstone, not yet physically reclaimed)', results);
 
 			// Recreate with a DIFFERENT value -- must not resurrect the deleted object nor serve
 			// a stale tombstone/ghost from any worker's cache.
 			await putWidget(id, 'resurrected', 'after-recreate');
-			results = await getMulti(id, 14);
+			results = await getOnEveryWorker(id);
 			assertAllObject('S3 after recreate', results, { name: 'resurrected', tag: 'after-recreate' });
 
 			strictEqual(failures.length, 0, `S3 failures:\n${failures.join('\n')}`);

--- a/integrationTests/database/record-caching-invalidate.test.ts
+++ b/integrationTests/database/record-caching-invalidate.test.ts
@@ -22,7 +22,7 @@
  * trusting a fixed-width fan-out to have covered them.
  *
  * Skipped on LMDB (PrimaryRocksDatabase is RocksDB-specific) and where Harper cannot spread HTTP
- * across workers (NO_MULTI_WORKER_HTTP).
+ * across workers to every one of them (NO_FULL_WORKER_COVERAGE).
  */
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual } from 'node:assert';
@@ -31,7 +31,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error no type declarations
 import { createApiClient } from './../apiTests/utils/client.mjs';
-import { WORKER_COUNT, assertEveryWorkerStarted, NO_MULTI_WORKER_HTTP } from './recordCachingWorkers.ts';
+import { WORKER_COUNT, assertEveryWorkerStarted, NO_FULL_WORKER_COVERAGE } from './recordCachingWorkers.ts';
 import { fetchOnNewConnection, observeEveryWorker } from '../utils/connectionPerRequest.ts';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'record-caching-invalidate');
@@ -48,7 +48,7 @@ type GetResult = {
 
 suite(
 	'record-caching value-shape edge: object <-> invalidated-null [rocksdb] multi-worker',
-	{ skip: SKIP || NO_MULTI_WORKER_HTTP },
+	{ skip: SKIP || NO_FULL_WORKER_COVERAGE },
 	(ctx: ContextWithHarper) => {
 		let client: ReturnType<typeof createApiClient>;
 		let httpURL: string;

--- a/integrationTests/database/record-caching-invalidate.test.ts
+++ b/integrationTests/database/record-caching-invalidate.test.ts
@@ -31,7 +31,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error no type declarations
 import { createApiClient } from './../apiTests/utils/client.mjs';
-import { WORKER_COUNT, assertMultiWorker, NO_MULTI_WORKER_HTTP } from './recordCachingWorkers.ts';
+import { WORKER_COUNT, assertEveryWorkerStarted, NO_MULTI_WORKER_HTTP } from './recordCachingWorkers.ts';
 import { fetchOnNewConnection, observeEveryWorker } from '../utils/connectionPerRequest.ts';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'record-caching-invalidate');
@@ -74,7 +74,7 @@ suite(
 				await sleep(250);
 			}
 
-			await assertMultiWorker(ctx);
+			await assertEveryWorkerStarted(ctx);
 		});
 
 		after(async () => {
@@ -125,7 +125,6 @@ suite(
 			return body;
 		}
 
-		/** Point-GETs until every configured worker has answered, so the assertions below cover all. */
 		function getOnEveryWorker(id: string): Promise<GetResult[]> {
 			return observeEveryWorker(
 				() => getOnce(id),

--- a/integrationTests/database/record-caching-scan-coherence.test.ts
+++ b/integrationTests/database/record-caching-scan-coherence.test.ts
@@ -24,7 +24,8 @@ import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '
 // @ts-expect-error no type declarations
 import { createApiClient } from './../apiTests/utils/client.mjs';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { WORKER_COUNT, assertMultiWorker, mapBounded } from './recordCachingWorkers.ts';
+import { WORKER_COUNT, assertMultiWorker, mapBounded, NO_MULTI_WORKER_HTTP } from './recordCachingWorkers.ts';
+import { fetchOnNewConnection } from '../utils/connectionPerRequest.ts';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'record-caching-coherence');
 const SKIP = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
@@ -38,15 +39,13 @@ interface Rec {
 	counter: number;
 }
 
-// Fresh connection per request so concurrent reads spray across the worker pool
-// (keep-alive would pin a client to a single worker and hide cross-worker divergence).
 function headers(auth: string): Record<string, string> {
-	return { 'Content-Type': 'application/json', 'Authorization': auth, 'Connection': 'close' };
+	return { 'Content-Type': 'application/json', 'Authorization': auth };
 }
 
 suite(
 	'record-caching point-read vs scan coherence [rocksdb] multi-worker',
-	{ skip: SKIP || process.platform === 'win32' },
+	{ skip: SKIP || NO_MULTI_WORKER_HTTP },
 	(ctx: ContextWithHarper) => {
 		let httpURL: string;
 		let authHeader: string;
@@ -63,7 +62,7 @@ suite(
 			let ready = false;
 			while (Date.now() < deadline) {
 				try {
-					const r = await fetch(`${httpURL}/CacheRecord/probe`, { headers: headers(authHeader) });
+					const r = await fetchOnNewConnection(`${httpURL}/CacheRecord/probe`, { headers: headers(authHeader) });
 					if (r.status < 500) {
 						ready = true;
 						break;
@@ -82,7 +81,7 @@ suite(
 		});
 
 		async function putRecord(id: string, name: string, counter: number): Promise<void> {
-			const r = await fetch(`${httpURL}/CacheRecord/${encodeURIComponent(id)}`, {
+			const r = await fetchOnNewConnection(`${httpURL}/CacheRecord/${encodeURIComponent(id)}`, {
 				method: 'PUT',
 				headers: headers(authHeader),
 				body: JSON.stringify({ id, name, counter }),
@@ -93,7 +92,7 @@ suite(
 		}
 
 		async function deleteRecord(id: string): Promise<void> {
-			const r = await fetch(`${httpURL}/CacheRecord/${encodeURIComponent(id)}`, {
+			const r = await fetchOnNewConnection(`${httpURL}/CacheRecord/${encodeURIComponent(id)}`, {
 				method: 'DELETE',
 				headers: headers(authHeader),
 			});
@@ -104,7 +103,9 @@ suite(
 
 		// Point-GET: exercises getEntry (cached path).
 		async function getRecord(id: string): Promise<Rec | null> {
-			const r = await fetch(`${httpURL}/CacheRecord/${encodeURIComponent(id)}`, { headers: headers(authHeader) });
+			const r = await fetchOnNewConnection(`${httpURL}/CacheRecord/${encodeURIComponent(id)}`, {
+				headers: headers(authHeader),
+			});
 			if (r.status === 404) return null;
 			if (r.status !== 200) throw new Error(`GET ${id} returned ${r.status}`);
 			return r.json() as Promise<Rec>;
@@ -112,7 +113,7 @@ suite(
 
 		// Filtered query by indexed `name`: exercises getRange/scan path (uncached, direct store read).
 		async function queryByName(name: string): Promise<Rec[]> {
-			const r = await fetch(`${httpURL}/CacheRecord/?name=${encodeURIComponent(name)}`, {
+			const r = await fetchOnNewConnection(`${httpURL}/CacheRecord/?name=${encodeURIComponent(name)}`, {
 				headers: headers(authHeader),
 			});
 			if (r.status !== 200) throw new Error(`query name=${name} returned ${r.status}`);

--- a/integrationTests/database/record-caching-ttl-eviction.test.ts
+++ b/integrationTests/database/record-caching-ttl-eviction.test.ts
@@ -25,7 +25,8 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error no type declarations
 import { createApiClient } from './../apiTests/utils/client.mjs';
-import { WORKER_COUNT, assertMultiWorker, mapBounded } from './recordCachingWorkers.ts';
+import { WORKER_COUNT, assertMultiWorker, mapBounded, NO_MULTI_WORKER_HTTP } from './recordCachingWorkers.ts';
+import { fetchOnNewConnection } from '../utils/connectionPerRequest.ts';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'record-caching-ttl-eviction');
 const TABLE = 'CacheGhost';
@@ -52,10 +53,8 @@ interface Rec {
 	seq: number;
 }
 
-// Force a fresh connection per request (no keep-alive) so concurrent requests spray across
-// the SO_REUSEPORT worker pool instead of pinning to one worker.
 function headers(auth: string): Record<string, string> {
-	return { 'Content-Type': 'application/json', 'Authorization': auth, 'Connection': 'close' };
+	return { 'Content-Type': 'application/json', 'Authorization': auth };
 }
 
 async function putRecord(
@@ -66,7 +65,7 @@ async function putRecord(
 	bucket: string,
 	seq: number
 ): Promise<number> {
-	const r = await fetch(`${base}/${TABLE}/${encodeURIComponent(id)}`, {
+	const r = await fetchOnNewConnection(`${base}/${TABLE}/${encodeURIComponent(id)}`, {
 		method: 'PUT',
 		headers: headers(auth),
 		body: JSON.stringify({ id, name, bucket, seq }),
@@ -79,7 +78,7 @@ async function putRecord(
 }
 
 async function getRecord(base: string, auth: string, id: string): Promise<{ status: number; body: Rec | null }> {
-	const r = await fetch(`${base}/${TABLE}/${encodeURIComponent(id)}`, { headers: headers(auth) });
+	const r = await fetchOnNewConnection(`${base}/${TABLE}/${encodeURIComponent(id)}`, { headers: headers(auth) });
 	if (r.status === 404) {
 		await r.text().catch(() => undefined);
 		return { status: 404, body: null };
@@ -89,7 +88,9 @@ async function getRecord(base: string, auth: string, id: string): Promise<{ stat
 }
 
 async function scanBucket(base: string, auth: string, bucket: string): Promise<Set<string>> {
-	const r = await fetch(`${base}/${TABLE}/?bucket=${encodeURIComponent(bucket)}`, { headers: headers(auth) });
+	const r = await fetchOnNewConnection(`${base}/${TABLE}/?bucket=${encodeURIComponent(bucket)}`, {
+		headers: headers(auth),
+	});
 	if (r.status !== 200) throw new Error(`scan bucket=${bucket} returned ${r.status}: ${await r.text()}`);
 	const rows = (await r.json()) as Rec[];
 	if (!Array.isArray(rows)) throw new Error(`scan bucket=${bucket} returned non-array body`);
@@ -100,7 +101,7 @@ async function waitForTable(base: string, auth: string): Promise<void> {
 	const deadline = Date.now() + 60_000;
 	while (Date.now() < deadline) {
 		try {
-			const r = await fetch(`${base}/${TABLE}/probe`, { headers: headers(auth) });
+			const r = await fetchOnNewConnection(`${base}/${TABLE}/probe`, { headers: headers(auth) });
 			if (r.status < 500) {
 				await r.text().catch(() => undefined);
 				return;
@@ -115,7 +116,7 @@ async function waitForTable(base: string, auth: string): Promise<void> {
 
 suite(
 	'record-caching TTL-eviction cross-worker ghost [rocksdb] multi-worker',
-	{ skip: SKIP || process.platform === 'win32' },
+	{ skip: SKIP || NO_MULTI_WORKER_HTTP },
 	(ctx: ContextWithHarper) => {
 		let base: string;
 		let auth: string;

--- a/integrationTests/database/record-caching.test.ts
+++ b/integrationTests/database/record-caching.test.ts
@@ -17,7 +17,7 @@ import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '
 // @ts-expect-error no type declarations
 import { createApiClient } from './../apiTests/utils/client.mjs';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { WORKER_COUNT, assertEveryWorkerStarted, NO_MULTI_WORKER_HTTP } from './recordCachingWorkers.ts';
+import { WORKER_COUNT, assertEveryWorkerStarted, NO_FULL_WORKER_COVERAGE } from './recordCachingWorkers.ts';
 import { fetchOnNewConnection, observeEveryWorker } from '../utils/connectionPerRequest.ts';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'record-caching');
@@ -102,7 +102,7 @@ async function waitForTable(httpURL: string, authHeader: string): Promise<void> 
 
 // ── Scenario 1 & 2: 4-worker cache invalidation + load ──────────────────────
 
-suite('record-caching [rocksdb] 4-worker', { skip: SKIP || NO_MULTI_WORKER_HTTP }, (ctx: ContextWithHarper) => {
+suite('record-caching [rocksdb] 4-worker', { skip: SKIP || NO_FULL_WORKER_COVERAGE }, (ctx: ContextWithHarper) => {
 	let httpURL: string;
 	let authHeader: string;
 

--- a/integrationTests/database/record-caching.test.ts
+++ b/integrationTests/database/record-caching.test.ts
@@ -17,7 +17,12 @@ import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '
 // @ts-expect-error no type declarations
 import { createApiClient } from './../apiTests/utils/client.mjs';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { WORKER_COUNT, assertEveryWorkerStarted, NO_FULL_WORKER_COVERAGE } from './recordCachingWorkers.ts';
+import {
+	WORKER_COUNT,
+	assertEveryWorkerStarted,
+	NO_FULL_WORKER_COVERAGE,
+	NO_MULTI_WORKER_HTTP,
+} from './recordCachingWorkers.ts';
 import { fetchOnNewConnection, observeEveryWorker } from '../utils/connectionPerRequest.ts';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'record-caching');
@@ -102,7 +107,7 @@ async function waitForTable(httpURL: string, authHeader: string): Promise<void> 
 
 // ── Scenario 1 & 2: 4-worker cache invalidation + load ──────────────────────
 
-suite('record-caching [rocksdb] 4-worker', { skip: SKIP || NO_FULL_WORKER_COVERAGE }, (ctx: ContextWithHarper) => {
+suite('record-caching [rocksdb] 4-worker', { skip: SKIP || NO_MULTI_WORKER_HTTP }, (ctx: ContextWithHarper) => {
 	let httpURL: string;
 	let authHeader: string;
 
@@ -121,28 +126,33 @@ suite('record-caching [rocksdb] 4-worker', { skip: SKIP || NO_FULL_WORKER_COVERA
 		await teardownHarper(ctx);
 	});
 
-	test('S1 cache invalidation: a PUT must not leave a stale cached value on ANY worker', async () => {
-		const id = 's1-record';
-		await putRecord(httpURL, authHeader, id, 'original', 1);
+	// Only S1 needs every worker; S2 is a load test and keeps running where coverage is unreachable.
+	test(
+		'S1 cache invalidation: a PUT must not leave a stale cached value on ANY worker',
+		{ skip: NO_FULL_WORKER_COVERAGE },
+		async () => {
+			const id = 's1-record';
+			await putRecord(httpURL, authHeader, id, 'original', 1);
 
-		// Warm every worker's cache, so the update below has a stale entry to invalidate everywhere.
-		for (const view of await readCacheOnEveryWorker(httpURL, authHeader, id)) {
-			strictEqual(view.cached?.name, 'original', `worker ${view.threadId} did not warm with the original value`);
+			// Warm every worker's cache, so the update below has a stale entry to invalidate everywhere.
+			for (const view of await readCacheOnEveryWorker(httpURL, authHeader, id)) {
+				strictEqual(view.cached?.name, 'original', `worker ${view.threadId} did not warm with the original value`);
+			}
+
+			await putRecord(httpURL, authHeader, id, 'updated', 2);
+
+			const first = await getRecord(httpURL, authHeader, id);
+			strictEqual(first?.name, 'updated', 'GET after PUT must not return stale cached value');
+			strictEqual(first?.counter, 2, 'counter must reflect the update');
+
+			for (const view of await readCacheOnEveryWorker(httpURL, authHeader, id)) {
+				strictEqual(view.cached?.name, 'updated', `worker ${view.threadId} still caches a stale name`);
+				strictEqual(view.cached?.counter, 2, `worker ${view.threadId} still caches a stale counter`);
+				strictEqual(view.read?.name, 'updated', `worker ${view.threadId} still reads a stale name through Table`);
+				strictEqual(view.read?.counter, 2, `worker ${view.threadId} still reads a stale counter through Table`);
+			}
 		}
-
-		await putRecord(httpURL, authHeader, id, 'updated', 2);
-
-		const first = await getRecord(httpURL, authHeader, id);
-		strictEqual(first?.name, 'updated', 'GET after PUT must not return stale cached value');
-		strictEqual(first?.counter, 2, 'counter must reflect the update');
-
-		for (const view of await readCacheOnEveryWorker(httpURL, authHeader, id)) {
-			strictEqual(view.cached?.name, 'updated', `worker ${view.threadId} still caches a stale name`);
-			strictEqual(view.cached?.counter, 2, `worker ${view.threadId} still caches a stale counter`);
-			strictEqual(view.read?.name, 'updated', `worker ${view.threadId} still reads a stale name through Table`);
-			strictEqual(view.read?.counter, 2, `worker ${view.threadId} still reads a stale counter through Table`);
-		}
-	});
+	);
 
 	test(
 		'S2 write-then-read under load: 50 records × 200 reads all return correct values',

--- a/integrationTests/database/record-caching.test.ts
+++ b/integrationTests/database/record-caching.test.ts
@@ -5,8 +5,8 @@
  *
  * S1 reads through CacheRecordOnWorker (record-caching/resources.js) until every configured worker
  * has answered (utils/connectionPerRequest.ts): each worker holds its own cache, and a plain REST
- * GET on a keep-alive connection cannot say which one served it. S2's 200-wide fan-out already
- * spreads across the pool, so its transport is unchanged.
+ * GET cannot say which one served it. S2 keeps its own 200-wide fan-out, which already spreads
+ * across the pool.
  *
  * Skipped on LMDB (PrimaryRocksDatabase is RocksDB-only).
  */
@@ -17,7 +17,7 @@ import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '
 // @ts-expect-error no type declarations
 import { createApiClient } from './../apiTests/utils/client.mjs';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { WORKER_COUNT, assertMultiWorker, NO_MULTI_WORKER_HTTP } from './recordCachingWorkers.ts';
+import { WORKER_COUNT, assertEveryWorkerStarted, NO_MULTI_WORKER_HTTP } from './recordCachingWorkers.ts';
 import { fetchOnNewConnection, observeEveryWorker } from '../utils/connectionPerRequest.ts';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'record-caching');
@@ -46,7 +46,6 @@ async function readCacheOnWorker(httpURL: string, authHeader: string, id: string
 	return r.json() as Promise<WorkerCacheView>;
 }
 
-/** Reads until all `WORKER_COUNT` workers have answered, so the caller can assert about every one. */
 function readCacheOnEveryWorker(httpURL: string, authHeader: string, id: string): Promise<WorkerCacheView[]> {
 	return observeEveryWorker(
 		() => readCacheOnWorker(httpURL, authHeader, id),
@@ -115,7 +114,7 @@ suite('record-caching [rocksdb] 4-worker', { skip: SKIP || NO_MULTI_WORKER_HTTP 
 		httpURL = ctx.harper.httpURL;
 		authHeader = client.headers.Authorization;
 		await waitForTable(httpURL, authHeader);
-		await assertMultiWorker(ctx);
+		await assertEveryWorkerStarted(ctx);
 	});
 
 	after(async () => {

--- a/integrationTests/database/record-caching.test.ts
+++ b/integrationTests/database/record-caching.test.ts
@@ -126,7 +126,6 @@ suite('record-caching [rocksdb] 4-worker', { skip: SKIP || NO_MULTI_WORKER_HTTP 
 		await teardownHarper(ctx);
 	});
 
-	// Only S1 needs every worker; S2 is a load test and keeps running where coverage is unreachable.
 	test(
 		'S1 cache invalidation: a PUT must not leave a stale cached value on ANY worker',
 		{ skip: NO_FULL_WORKER_COVERAGE },

--- a/integrationTests/database/record-caching.test.ts
+++ b/integrationTests/database/record-caching.test.ts
@@ -2,6 +2,12 @@
  * PrimaryRocksDatabase record-caching integration tests.
  * Exercises cache invalidation correctness, write-then-read under load, and
  * rapid write-read-write cycles at the HTTP/REST layer with multi-worker Harper.
+ *
+ * S1 reads through CacheRecordOnWorker (record-caching/resources.js) until every configured worker
+ * has answered (utils/connectionPerRequest.ts): each worker holds its own cache, and a plain REST
+ * GET on a keep-alive connection cannot say which one served it. S2's 200-wide fan-out already
+ * spreads across the pool, so its transport is unchanged.
+ *
  * Skipped on LMDB (PrimaryRocksDatabase is RocksDB-only).
  */
 import { suite, test, before, after } from 'node:test';
@@ -11,10 +17,45 @@ import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '
 // @ts-expect-error no type declarations
 import { createApiClient } from './../apiTests/utils/client.mjs';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { WORKER_COUNT, assertMultiWorker } from './recordCachingWorkers.ts';
+import { WORKER_COUNT, assertMultiWorker, NO_MULTI_WORKER_HTTP } from './recordCachingWorkers.ts';
+import { fetchOnNewConnection, observeEveryWorker } from '../utils/connectionPerRequest.ts';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'record-caching');
 const SKIP = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
+
+interface Rec {
+	id: string;
+	name: string;
+	counter: number;
+}
+
+interface WorkerCacheView {
+	threadId: number;
+	exists: boolean;
+	/** The per-worker cache entry a point-GET consults. */
+	cached: Rec | null;
+	/** The same id through Table's read semantics on that worker. */
+	read: Rec | null;
+}
+
+async function readCacheOnWorker(httpURL: string, authHeader: string, id: string): Promise<WorkerCacheView> {
+	const r = await fetchOnNewConnection(`${httpURL}/CacheRecordOnWorker/?id=${encodeURIComponent(id)}`, {
+		headers: { Authorization: authHeader },
+	});
+	if (r.status !== 200) throw new Error(`CacheRecordOnWorker ${id} returned ${r.status}`);
+	return r.json() as Promise<WorkerCacheView>;
+}
+
+/** Reads until all `WORKER_COUNT` workers have answered, so the caller can assert about every one. */
+function readCacheOnEveryWorker(httpURL: string, authHeader: string, id: string): Promise<WorkerCacheView[]> {
+	return observeEveryWorker(
+		() => readCacheOnWorker(httpURL, authHeader, id),
+		(view) => view.threadId,
+		{
+			workerCount: WORKER_COUNT,
+		}
+	);
+}
 
 async function putRecord(
 	httpURL: string,
@@ -62,7 +103,7 @@ async function waitForTable(httpURL: string, authHeader: string): Promise<void> 
 
 // ── Scenario 1 & 2: 4-worker cache invalidation + load ──────────────────────
 
-suite('record-caching [rocksdb] 4-worker', { skip: SKIP || process.platform === 'win32' }, (ctx: ContextWithHarper) => {
+suite('record-caching [rocksdb] 4-worker', { skip: SKIP || NO_MULTI_WORKER_HTTP }, (ctx: ContextWithHarper) => {
 	let httpURL: string;
 	let authHeader: string;
 
@@ -81,16 +122,27 @@ suite('record-caching [rocksdb] 4-worker', { skip: SKIP || process.platform === 
 		await teardownHarper(ctx);
 	});
 
-	test('S1 cache invalidation: write→GET(warm)→PUT→GET must return updated value', async () => {
+	test('S1 cache invalidation: a PUT must not leave a stale cached value on ANY worker', async () => {
 		const id = 's1-record';
 		await putRecord(httpURL, authHeader, id, 'original', 1);
-		const first = await getRecord(httpURL, authHeader, id);
-		strictEqual(first?.name, 'original', 'first GET should return original value');
+
+		// Warm every worker's cache, so the update below has a stale entry to invalidate everywhere.
+		for (const view of await readCacheOnEveryWorker(httpURL, authHeader, id)) {
+			strictEqual(view.cached?.name, 'original', `worker ${view.threadId} did not warm with the original value`);
+		}
 
 		await putRecord(httpURL, authHeader, id, 'updated', 2);
-		const second = await getRecord(httpURL, authHeader, id);
-		strictEqual(second?.name, 'updated', 'GET after PUT must not return stale cached value');
-		strictEqual(second?.counter, 2, 'counter must reflect the update');
+
+		const first = await getRecord(httpURL, authHeader, id);
+		strictEqual(first?.name, 'updated', 'GET after PUT must not return stale cached value');
+		strictEqual(first?.counter, 2, 'counter must reflect the update');
+
+		for (const view of await readCacheOnEveryWorker(httpURL, authHeader, id)) {
+			strictEqual(view.cached?.name, 'updated', `worker ${view.threadId} still caches a stale name`);
+			strictEqual(view.cached?.counter, 2, `worker ${view.threadId} still caches a stale counter`);
+			strictEqual(view.read?.name, 'updated', `worker ${view.threadId} still reads a stale name through Table`);
+			strictEqual(view.read?.counter, 2, `worker ${view.threadId} still reads a stale counter through Table`);
+		}
 	});
 
 	test(

--- a/integrationTests/database/record-caching/config.yaml
+++ b/integrationTests/database/record-caching/config.yaml
@@ -1,3 +1,5 @@
 graphqlSchema:
   files: '*.graphql'
+jsResource:
+  files: resources.js
 rest: true

--- a/integrationTests/database/record-caching/resources.js
+++ b/integrationTests/database/record-caching/resources.js
@@ -1,0 +1,24 @@
+// A plain REST GET cannot say WHICH worker answered it, so the 4-worker suite has no way to tell
+// "every worker serves the updated value" from "the one worker my connection was pinned to does".
+// Both layers are returned per worker: `cached` is the per-worker WeakLRUCache entry a point-GET
+// consults (resources/PrimaryRocksDatabase.ts), `read` is the same id through Table's read
+// semantics, so staleness above getEntry is visible too.
+import { threadId } from 'node:worker_threads';
+
+const { CacheRecord } = tables;
+const store = CacheRecord.primaryStore;
+
+export class CacheRecordOnWorker extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const id = query && typeof query.get === 'function' ? query.get('id') : query?.id;
+		const entry = store.getEntry(id);
+		return {
+			threadId,
+			id,
+			exists: entry != null,
+			cached: entry?.value ?? null,
+			read: (await CacheRecord.get(id)) ?? null,
+		};
+	}
+}

--- a/integrationTests/database/recordCachingWorkers.ts
+++ b/integrationTests/database/recordCachingWorkers.ts
@@ -64,3 +64,16 @@ export async function assertMultiWorker(ctx: ContextWithHarper): Promise<void> {
 	const count = await observedWorkerCount(ctx);
 	ok(count >= 2, `expected >= 2 HTTP workers for cross-worker coverage, observed ${count} — suite would be vacuous`);
 }
+
+/**
+ * For suites whose assertions must reach EVERY worker: a partial pool would otherwise surface as
+ * `observeEveryWorker` burning its whole budget and reporting the workers it missed, rather than
+ * the actual cause.
+ */
+export async function assertEveryWorkerStarted(ctx: ContextWithHarper): Promise<void> {
+	const count = await observedWorkerCount(ctx);
+	ok(
+		count >= WORKER_COUNT,
+		`expected ${WORKER_COUNT} HTTP workers, observed ${count} — a worker never started, so full-worker coverage is unreachable`
+	);
+}

--- a/integrationTests/database/recordCachingWorkers.ts
+++ b/integrationTests/database/recordCachingWorkers.ts
@@ -22,6 +22,14 @@ export const WORKER_COUNT = Number.isInteger(parsedWorkerCount) && parsedWorkerC
 export const NO_MULTI_WORKER_HTTP = process.platform === 'win32' || process.platform === 'darwin';
 
 /**
+ * Bun does not spread connections over its HTTP workers the way the Node path does: measured on CI,
+ * 128 fresh connections all landed on one thread while `system_information` reported four. So a
+ * suite that must reach EVERY worker cannot run there, though suites that only tolerate a partial
+ * pool still exercise the cache paths under Bun.
+ */
+export const NO_FULL_WORKER_COVERAGE = NO_MULTI_WORKER_HTTP || process.env.HARPER_RUNTIME === 'bun';
+
+/**
  * Run `fn` over `items` with at most `limit` in flight at once. These suites issue fresh-
  * connection requests (no keep-alive) to spray across the worker pool; firing hundreds at
  * once via an unbounded Promise.all risks ephemeral-port/socket exhaustion on constrained CI

--- a/integrationTests/database/recordCachingWorkers.ts
+++ b/integrationTests/database/recordCachingWorkers.ts
@@ -16,6 +16,12 @@ const parsedWorkerCount = Number(process.env.HARPER_WORKER_COUNT);
 export const WORKER_COUNT = Number.isInteger(parsedWorkerCount) && parsedWorkerCount > 0 ? parsedWorkerCount : 4;
 
 /**
+ * Harper disables reusePort off Linux (`server/http.ts`), so one worker owns the HTTP port there and
+ * no client can reach the others — a cross-worker suite must skip rather than pass single-worker.
+ */
+export const NO_MULTI_WORKER_HTTP = process.platform === 'win32' || process.platform === 'darwin';
+
+/**
  * Run `fn` over `items` with at most `limit` in flight at once. These suites issue fresh-
  * connection requests (no keep-alive) to spray across the worker pool; firing hundreds at
  * once via an unbounded Promise.all risks ephemeral-port/socket exhaustion on constrained CI

--- a/integrationTests/utils/connectionPerRequest.test.ts
+++ b/integrationTests/utils/connectionPerRequest.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Pins the contract of `./connectionPerRequest.ts` against a local `node:http` server: one TCP
+ * connection per call, caller headers preserved and unmutated, and the worker-coverage loop's
+ * concurrency, budget and failure modes. The distinct-connection assertion is what goes red if the
+ * helper ever degrades to a plain `fetch()`.
+ */
+import { suite, test, before, after } from 'node:test';
+import { deepStrictEqual, ok, rejects, strictEqual } from 'node:assert';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { fetchOnNewConnection, observeEveryWorker } from './connectionPerRequest.ts';
+
+interface Echo {
+	connection: number;
+	headers: Record<string, string | string[] | undefined>;
+}
+
+function listen(server: http.Server): Promise<string> {
+	return new Promise((resolve, reject) => {
+		server.once('error', reject);
+		server.listen(0, '127.0.0.1', () => resolve(`http://127.0.0.1:${(server.address() as AddressInfo).port}`));
+	});
+}
+
+function close(server: http.Server): Promise<void> {
+	return new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+}
+
+suite('connection-per-request load helpers', () => {
+	let server: http.Server;
+	let base: string;
+	let connections = 0;
+
+	before(async () => {
+		server = http.createServer((req, res) => {
+			res.setHeader('Content-Type', 'application/json');
+			res.end(
+				JSON.stringify({ connection: (req.socket as { connectionId?: number }).connectionId, headers: req.headers })
+			);
+		});
+		server.on('connection', (socket) => {
+			(socket as { connectionId?: number }).connectionId = ++connections;
+		});
+		base = await listen(server);
+	});
+
+	after(async () => {
+		await close(server);
+	});
+
+	async function echo(response: Response): Promise<Echo> {
+		return (await response.json()) as Echo;
+	}
+
+	test('every call lands on its own connection', async () => {
+		const fresh: number[] = [];
+		for (let i = 0; i < 8; i++) fresh.push((await echo(await fetchOnNewConnection(`${base}/x`))).connection);
+		strictEqual(new Set(fresh).size, 8, `expected 8 distinct connections, saw ${JSON.stringify(fresh)}`);
+	});
+
+	test('plain fetch reuses connections, which is the whole reason this helper exists', async () => {
+		// Its own origin: on Node 24.10-25.6 a single Connection: close request permanently stops
+		// undici reusing connections to that origin, so measuring this against a server the other
+		// tests have already closed connections on would assert the helper into looking redundant.
+		const cleanServer = http.createServer((req, res) =>
+			res.end(JSON.stringify({ connection: (req.socket as { connectionId?: number }).connectionId }))
+		);
+		let opened = 0;
+		cleanServer.on('connection', (socket) => {
+			(socket as { connectionId?: number }).connectionId = ++opened;
+		});
+		const cleanBase = await listen(cleanServer);
+		try {
+			const reused: number[] = [];
+			for (let i = 0; i < 8; i++) reused.push((await echo(await fetch(`${cleanBase}/x`))).connection);
+			ok(
+				new Set(reused).size < 8,
+				`plain fetch is expected to reuse connections — if it stops doing so this helper is obsolete, saw ${JSON.stringify(reused)}`
+			);
+		} finally {
+			await close(cleanServer);
+		}
+	});
+
+	test('caller headers survive in every accepted form', async () => {
+		const asObject = await echo(await fetchOnNewConnection(`${base}/x`, { headers: { Authorization: 'Basic aaa' } }));
+		strictEqual(asObject.headers.authorization, 'Basic aaa');
+		strictEqual(asObject.headers.connection, 'close');
+
+		const asHeaders = await echo(
+			await fetchOnNewConnection(`${base}/x`, { headers: new Headers({ Authorization: 'Basic bbb' }) })
+		);
+		strictEqual(asHeaders.headers.authorization, 'Basic bbb');
+		strictEqual(asHeaders.headers.connection, 'close');
+
+		const asTuples = await echo(await fetchOnNewConnection(`${base}/x`, { headers: [['Authorization', 'Basic ccc']] }));
+		strictEqual(asTuples.headers.authorization, 'Basic ccc');
+		strictEqual(asTuples.headers.connection, 'close');
+	});
+
+	test('a caller-supplied keep-alive is overridden, and caller headers are not mutated', async () => {
+		const callerObject = { Authorization: 'Basic ddd', connection: 'keep-alive' };
+		const fromObject = await echo(await fetchOnNewConnection(`${base}/x`, { headers: callerObject }));
+		strictEqual(fromObject.headers.connection, 'close');
+		deepStrictEqual(callerObject, { Authorization: 'Basic ddd', connection: 'keep-alive' });
+
+		const callerHeaders = new Headers({ Authorization: 'Basic eee' });
+		await fetchOnNewConnection(`${base}/x`, { headers: callerHeaders });
+		strictEqual(callerHeaders.get('connection'), null);
+	});
+
+	test('the request body and method are passed through', async () => {
+		const seen: string[] = [];
+		const bodyServer = http.createServer((req, res) => {
+			let body = '';
+			req.on('data', (chunk) => (body += chunk));
+			req.on('end', () => {
+				seen.push(`${req.method} ${body}`);
+				res.end('{}');
+			});
+		});
+		const url = `${await listen(bodyServer)}/x`;
+		try {
+			await fetchOnNewConnection(url, { method: 'PUT', body: JSON.stringify({ a: 1 }) });
+			deepStrictEqual(seen, ['PUT {"a":1}']);
+		} finally {
+			await close(bodyServer);
+		}
+	});
+
+	test('observeEveryWorker returns every response it gathered while covering all workers', async () => {
+		const sequence = [3, 3, 1, 2, 4, 4, 4, 4];
+		let next = 0;
+		const responses = await observeEveryWorker(
+			async () => ({ worker: sequence[next], seq: next++ }),
+			(r) => r.worker,
+			{ workerCount: 4 }
+		);
+		deepStrictEqual(
+			responses.map((r) => r.seq),
+			[0, 1, 2, 3, 4, 5, 6, 7],
+			'callers assert over the whole result, so nothing observed may be discarded'
+		);
+		deepStrictEqual([...new Set(responses.map((r) => r.worker))].sort(), [1, 2, 3, 4]);
+	});
+
+	test('observeEveryWorker issues each round concurrently, not one request at a time', async () => {
+		let inFlight = 0;
+		let peak = 0;
+		let issued = 0;
+		await observeEveryWorker(
+			async () => {
+				peak = Math.max(peak, ++inFlight);
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				inFlight--;
+				return { worker: ++issued };
+			},
+			(r) => r.worker,
+			{ workerCount: 4 }
+		);
+		strictEqual(peak, 4, 'a serialized loop would widen the window between a write ack and the last read');
+	});
+
+	test('observeEveryWorker fails, naming what it reached, when a worker never answers', async () => {
+		let requests = 0;
+		await rejects(
+			() =>
+				observeEveryWorker(
+					async () => {
+						requests++;
+						return { worker: 1 };
+					},
+					(r) => r.worker,
+					{ workerCount: 3 }
+				),
+			/reached 1 of 3 workers in 96 requests \(saw \[1\]\)/
+		);
+		strictEqual(requests, 96, 'must give up on a request budget, not spin against the instance until a deadline');
+	});
+
+	test('observeEveryWorker gives up on a request that never settles', async () => {
+		await rejects(
+			() =>
+				observeEveryWorker(
+					() => new Promise<{ worker: number }>(() => {}),
+					(r) => r.worker,
+					{
+						workerCount: 2,
+						timeoutMs: 150,
+					}
+				),
+			/did not settle within 1[0-9]{2}ms/
+		);
+	});
+
+	test('observeEveryWorker rejects a response with no worker id rather than looping on it', async () => {
+		await rejects(
+			() =>
+				observeEveryWorker(
+					async () => ({ worker: undefined as unknown as number }),
+					(r) => r.worker,
+					{
+						workerCount: 2,
+					}
+				),
+			/carried no worker id/
+		);
+	});
+});

--- a/integrationTests/utils/connectionPerRequest.test.ts
+++ b/integrationTests/utils/connectionPerRequest.test.ts
@@ -1,8 +1,6 @@
 /**
- * Pins the contract of `./connectionPerRequest.ts` against a local `node:http` server: one TCP
- * connection per call, caller headers preserved and unmutated, and the worker-coverage loop's
- * concurrency, budget and failure modes. The distinct-connection assertion is what goes red if the
- * helper ever degrades to a plain `fetch()`.
+ * Pins `./connectionPerRequest.ts` against a local `node:http` server, Harper-free: the properties
+ * under test are transport-level, so an instance would add nothing.
  */
 import { suite, test, before, after } from 'node:test';
 import { deepStrictEqual, ok, rejects, strictEqual } from 'node:assert';

--- a/integrationTests/utils/connectionPerRequest.test.ts
+++ b/integrationTests/utils/connectionPerRequest.test.ts
@@ -196,7 +196,7 @@ suite('connection-per-request load helpers', () => {
 		const responses = await observeEveryWorker(
 			async () => {
 				const worker = ++issued;
-				if (worker === 2) await new Promise(() => {}); // never settles
+				if (worker === 2) await new Promise(() => {});
 				return { worker };
 			},
 			(r) => r.worker,

--- a/integrationTests/utils/connectionPerRequest.test.ts
+++ b/integrationTests/utils/connectionPerRequest.test.ts
@@ -191,6 +191,41 @@ suite('connection-per-request load helpers', () => {
 		);
 	});
 
+	test('a stalled sibling does not discard a round that completed coverage', async () => {
+		let issued = 0;
+		const responses = await observeEveryWorker(
+			async () => {
+				const worker = ++issued;
+				if (worker === 2) await new Promise(() => {}); // never settles
+				return { worker };
+			},
+			(r) => r.worker,
+			{ workerCount: 3, concurrency: 4, timeoutMs: 150 }
+		);
+		deepStrictEqual(
+			responses.map((r) => r.worker).sort(),
+			[1, 3, 4],
+			'the three workers that answered are the coverage; only the stall is dropped'
+		);
+	});
+
+	test('a failing request still fails the caller even once coverage is complete', async () => {
+		let issued = 0;
+		await rejects(
+			() =>
+				observeEveryWorker(
+					async () => {
+						const worker = ++issued;
+						if (worker === 2) throw new Error('GET returned 500');
+						return { worker };
+					},
+					(r) => r.worker,
+					{ workerCount: 3, concurrency: 4 }
+				),
+			/GET returned 500/
+		);
+	});
+
 	test('observeEveryWorker rejects a response with no worker id rather than looping on it', async () => {
 		await rejects(
 			() =>

--- a/integrationTests/utils/connectionPerRequest.ts
+++ b/integrationTests/utils/connectionPerRequest.ts
@@ -3,9 +3,8 @@
  *
  * Harper's HTTP workers share the port through SO_REUSEPORT (`server/http.ts`), so the kernel picks
  * the serving worker once per TCP connection, and `fetch()` keep-alive therefore pins a serial
- * request stream to one or two workers however many exist. Fresh connections only restore the
- * kernel's choice; `observeEveryWorker` is what makes coverage a fact, because a request that may
- * reach another worker proves nothing about the one it missed.
+ * request stream to one or two workers however many exist. Fresh connections restore the kernel's
+ * choice; `observeEveryWorker` turns that choice into coverage a suite can assert on.
  */
 
 export function fetchOnNewConnection(input: string | URL, init: RequestInit = {}): Promise<Response> {
@@ -15,11 +14,9 @@ export function fetchOnNewConnection(input: string | URL, init: RequestInit = {}
 }
 
 export interface ObserveEveryWorkerOptions {
-	/** Workers the instance was configured with — every one must answer before the caller asserts. */
 	workerCount: number;
-	/** Requests per round, issued together so the post-write observation window stays tight. */
+	/** Issued together, so the window between the caller's write ack and its last read stays tight. */
 	concurrency?: number;
-	/** Request budget before failing; the default sits far above what per-connection routing needs. */
 	maxRequests?: number;
 	timeoutMs?: number;
 }

--- a/integrationTests/utils/connectionPerRequest.ts
+++ b/integrationTests/utils/connectionPerRequest.ts
@@ -40,23 +40,34 @@ export async function observeEveryWorker<T>(
 	const responses: T[] = [];
 	const seen = new Set<number>();
 	const deadline = Date.now() + timeoutMs;
-	while (seen.size < workerCount && responses.length < maxRequests) {
+	let issued = 0;
+	while (seen.size < workerCount && issued < maxRequests) {
 		const remainingMs = deadline - Date.now();
 		if (remainingMs <= 0) break;
-		const round = Math.min(concurrency, maxRequests - responses.length);
-		const gathered = await Promise.all(Array.from({ length: round }, () => settleWithin(request(), remainingMs)));
-		for (const response of gathered) {
-			const workerId = workerIdOf(response);
+		const round = Math.min(concurrency, maxRequests - issued);
+		issued += round;
+		const gathered = await Promise.allSettled(
+			Array.from({ length: round }, () => settleWithin(request(), remainingMs))
+		);
+		for (const result of gathered) {
+			if (result.status !== 'fulfilled') continue;
+			const workerId = workerIdOf(result.value);
 			if (!Number.isInteger(workerId)) {
 				throw new Error(`observeEveryWorker: response carried no worker id (got ${JSON.stringify(workerId)})`);
 			}
 			seen.add(workerId);
-			responses.push(response);
+			responses.push(result.value);
+		}
+		for (const result of gathered) {
+			// A stalled sibling is only noise once its round has completed coverage; anything the
+			// caller's own request threw (a 5xx, a connection error) still fails the suite.
+			if (result.status !== 'rejected') continue;
+			if (!(result.reason instanceof RequestStalled) || seen.size < workerCount) throw result.reason;
 		}
 	}
 	if (seen.size < workerCount) {
 		throw new Error(
-			`observeEveryWorker: reached ${seen.size} of ${workerCount} workers in ${responses.length} requests ` +
+			`observeEveryWorker: reached ${seen.size} of ${workerCount} workers in ${issued} requests ` +
 				`(saw [${[...seen].sort((a, b) => a - b).join(',')}]) — the suite's cross-worker claim cannot be ` +
 				`checked on the workers it never reached`
 		);
@@ -64,11 +75,16 @@ export async function observeEveryWorker<T>(
 	return responses;
 }
 
+class RequestStalled extends Error {}
+
 /** Without this a request that never settles hangs the shard, since the budget only counts requests. */
 function settleWithin<T>(pending: Promise<T>, ms: number): Promise<T> {
 	let timer: ReturnType<typeof setTimeout>;
 	const expiry = new Promise<never>((_, reject) => {
-		timer = setTimeout(() => reject(new Error(`observeEveryWorker: a request did not settle within ${ms}ms`)), ms);
+		timer = setTimeout(
+			() => reject(new RequestStalled(`observeEveryWorker: a request did not settle within ${ms}ms`)),
+			ms
+		);
 		timer.unref?.();
 	});
 	return Promise.race([pending, expiry]).finally(() => clearTimeout(timer));

--- a/integrationTests/utils/connectionPerRequest.ts
+++ b/integrationTests/utils/connectionPerRequest.ts
@@ -1,0 +1,78 @@
+/**
+ * Load helpers for integration specs whose assertions depend on reaching more than one HTTP worker.
+ *
+ * Harper's HTTP workers share the port through SO_REUSEPORT (`server/http.ts`), so the kernel picks
+ * the serving worker once per TCP connection, and `fetch()` keep-alive therefore pins a serial
+ * request stream to one or two workers however many exist. Fresh connections only restore the
+ * kernel's choice; `observeEveryWorker` is what makes coverage a fact, because a request that may
+ * reach another worker proves nothing about the one it missed.
+ */
+
+export function fetchOnNewConnection(input: string | URL, init: RequestInit = {}): Promise<Response> {
+	const headers = new Headers(init.headers);
+	headers.set('Connection', 'close');
+	return fetch(input, { ...init, headers });
+}
+
+export interface ObserveEveryWorkerOptions {
+	/** Workers the instance was configured with — every one must answer before the caller asserts. */
+	workerCount: number;
+	/** Requests per round, issued together so the post-write observation window stays tight. */
+	concurrency?: number;
+	/** Request budget before failing; the default sits far above what per-connection routing needs. */
+	maxRequests?: number;
+	timeoutMs?: number;
+}
+
+/**
+ * Issue `request` in concurrent rounds until every configured worker has answered, returning every
+ * response gathered, or fail naming the workers never reached. `request` must open a fresh
+ * connection (`fetchOnNewConnection`); a keep-alive one would loop against one worker until the
+ * budget ran out.
+ */
+export async function observeEveryWorker<T>(
+	request: () => Promise<T>,
+	workerIdOf: (response: T) => number,
+	{
+		workerCount,
+		concurrency = workerCount,
+		maxRequests = workerCount * 32,
+		timeoutMs = 15_000,
+	}: ObserveEveryWorkerOptions
+): Promise<T[]> {
+	const responses: T[] = [];
+	const seen = new Set<number>();
+	const deadline = Date.now() + timeoutMs;
+	while (seen.size < workerCount && responses.length < maxRequests) {
+		const remainingMs = deadline - Date.now();
+		if (remainingMs <= 0) break;
+		const round = Math.min(concurrency, maxRequests - responses.length);
+		const gathered = await Promise.all(Array.from({ length: round }, () => settleWithin(request(), remainingMs)));
+		for (const response of gathered) {
+			const workerId = workerIdOf(response);
+			if (!Number.isInteger(workerId)) {
+				throw new Error(`observeEveryWorker: response carried no worker id (got ${JSON.stringify(workerId)})`);
+			}
+			seen.add(workerId);
+			responses.push(response);
+		}
+	}
+	if (seen.size < workerCount) {
+		throw new Error(
+			`observeEveryWorker: reached ${seen.size} of ${workerCount} workers in ${responses.length} requests ` +
+				`(saw [${[...seen].sort((a, b) => a - b).join(',')}]) — the suite's cross-worker claim cannot be ` +
+				`checked on the workers it never reached`
+		);
+	}
+	return responses;
+}
+
+/** Without this a request that never settles hangs the shard, since the budget only counts requests. */
+function settleWithin<T>(pending: Promise<T>, ms: number): Promise<T> {
+	let timer: ReturnType<typeof setTimeout>;
+	const expiry = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => reject(new Error(`observeEveryWorker: a request did not settle within ${ms}ms`)), ms);
+		timer.unref?.();
+	});
+	return Promise.race([pending, expiry]).finally(() => clearTimeout(timer));
+}


### PR DESCRIPTION
Node's `fetch()` keeps connections alive, and Harper picks the serving HTTP worker once per TCP connection (`SO_REUSEPORT`, `server/http.ts`). A serial request stream therefore rides two sockets however many workers exist — and does not recover even when the pool already holds sockets on all of them. Two suites that assert cross-worker record-cache invalidation were measurably talking to fewer workers than they claim:

| suite | its claim | workers actually reached, of 4 |
| --- | --- | --- |
| `record-caching.test.ts` S1 | suite named `[rocksdb] 4-worker`; "cache invalidation … must not return stale cached value" | **1** |
| `record-caching-invalidate.test.ts` | "cross-worker"; "cached as an object on **every** worker" | **2** per round in 39 of 40 rounds (union 3) |

Both were green. Neither was green for the reason its name gives. This is a coverage-claim gap, not a product defect — no product code changes here.

## The helper, and why it has two halves

`integrationTests/utils/connectionPerRequest.ts`:

- [`fetchOnNewConnection(input, init)`](https://github.com/HarperFast/harper/pull/2474/changes?w=1#diff-7ac9bf7c989feef2654ac2d35692752965fea909f720e136ad2ecd14235fa74dR10) — one request per TCP connection, so the kernel re-picks the worker. This is the `Connection: close` that eight call sites already open-code, factored out.
- [`observeEveryWorker(request, workerIdOf, { workerCount })`](https://github.com/HarperFast/harper/pull/2474/changes?w=1#diff-7ac9bf7c989feef2654ac2d35692752965fea909f720e136ad2ecd14235fa74dR30) — issues `request` in concurrent rounds until every configured worker has answered, returns **every** response gathered, and otherwise fails naming the workers it never reached. A request that outlives the remaining budget is [dropped once its round completed coverage](https://github.com/HarperFast/harper/pull/2474/changes?w=1#diff-7ac9bf7c989feef2654ac2d35692752965fea909f720e136ad2ecd14235fa74dR49); anything the caller's own request threw (a 5xx, a connection error) fails the suite either way.

The second half exists because of the planning review: fresh connections are a routing *mechanism*, not a coverage *oracle*. They improve the odds of reaching another worker; they never prove which worker was missed, so a defect isolated to one worker still reads green.

## Converted

- **`record-caching.test.ts` S1** [warms every worker's cache, PUTs, then re-reads every worker](https://github.com/HarperFast/harper/pull/2474/changes?w=1#diff-82ecc4b003262816f1e68b917bb8a4320cbc4d3e1c7f5f909268793d0f5f2d22R124) and asserts none serves a stale value. A plain REST GET cannot report which worker served it, so the fixture gains one endpoint (`CacheRecordOnWorker`) returning that worker's `threadId` alongside **both** the raw `primaryStore.getEntry()` cache entry and [the same id read through Table](https://github.com/HarperFast/harper/pull/2474/changes?w=1#diff-bbcea0e44dd7928d4afbdbde2f319f8cd45454dafa0c8fb95bf843056f4b9b03R21), so staleness introduced above the cache layer is visible too. S2's 200-wide fan-out already spreads across the pool and S3 is deliberately single-worker, so their transport is untouched.
- **`record-caching-invalidate.test.ts`** replaces its fixed-width fan-out (`getMulti(id, 6..16)`) with [the coverage loop](https://github.com/HarperFast/harper/pull/2474/changes?w=1#diff-9ec3f77c7f32c0fb71dfc5d03d246e576560de663abdcfc32794ca3819785b8eR128), so `assertAllObject` / `assertAllNull` genuinely assert over every worker.
- **`record-caching-cross-worker`, `-scan-coherence`, `-ttl-eviction`** were already correct and open-coded the header; they now share the helper.
- **[`assertEveryWorkerStarted()`](https://github.com/HarperFast/harper/pull/2474/changes?w=1#diff-819ed7741ea0cb93a86de799394cb9a48488bf4f08d3af1e0608343eaa3019ecR73)** replaces `assertMultiWorker()` in the two converted suites. The old `>= 2` guard let a pool that booted 3 of 4 through, after which `observeEveryWorker` would burn its whole request budget and report the workers it missed rather than the one that never started.
- **[`NO_MULTI_WORKER_HTTP` is hoisted next to `WORKER_COUNT`](https://github.com/HarperFast/harper/pull/2474/changes?w=1#diff-819ed7741ea0cb93a86de799394cb9a48488bf4f08d3af1e0608343eaa3019ecR22)** in `recordCachingWorkers.ts` and applied to all six record-caching suites: Harper disables `reusePort` off Linux, so one worker owns the HTTP port and every one of them was running single-worker under a cross-worker name there. `record-caching.test.ts`'s S3 suite keeps its win32-only skip — it is deliberately single-worker.

## A defect this found in the CI Node matrix

Verifying the helper across the versions CI runs turned up a real, reproducible undici behaviour:

> On **Node 24.10.0 through 25.6.1**, once a single `Connection: close` request has been issued to
> an origin, undici stops reusing connections to that origin **for the rest of the process** — every
> later plain `fetch()` opens a new socket. Node 22.x, 23.x, 24.7.0 and 26.2.0+ all recover.

CI's PR route runs Node 24, so this is live. It made the helper's control assertion ("plain fetch reuses connections") fail on Node 24 while passing on 22 and 26; [the control now measures against its own origin](https://github.com/HarperFast/harper/pull/2474/changes?w=1#diff-d0bfc209447447c1295a668f01688304e7b88347f047686fb857331a05ee689bR59). Two consequences worth knowing beyond this PR: `apiTests/utils/client.mjs` puts `Connection: close` on every operations-API call, so on Node 24/25 any test process using `createApiClient` runs the rest of its HTTP with keep-alive disabled; and any suite that mixes fresh and pooled connections behaves differently on the PR leg than on the 22/26 legs.

## Measurements

On a real 4-worker instance against the `record-caching-invalidate` fixture, whose `WidgetGet` resource returns the serving worker's `threadId` (Node v26.2.0, Linux). Distinct workers reached, of 4:

| load shape against `httpURL` | plain `fetch()` | one connection per request |
| --- | --- | --- |
| 24 serial GETs, cold pool | 2 | 4 |
| 24 serial GETs after a 16-way concurrent warm-up that itself reached all 4 | 2 | — |
| 24 serial GETs with a second request loop in flight | 2 | — |
| concurrent fan-out ×2 / ×3 / ×4 / ×6 / ×12 | 2 / 3 / 2 / 3 / 4 | — |
| `record-caching.test.ts` S1 shape — 8 rounds of serial `PUT` → `GET` | **1** | 3 |
| `record-caching-invalidate.test.ts` S2 shape — 40 rounds of serial write + concurrent 6 reads | union 3; 2 per round in 39/40 | union 4; 3–4 per round in 36/40 |

Two facts follow, and they are what scoped the change: a **serial** stream is pinned, while a **concurrent** fan-out already opens a socket per in-flight request and sprays. So the criterion is "the cross-worker-dependent observation is serial, or narrower than the worker count" — not "the spec calls `fetch()`".

## Audit: `threads.count: 4` specs deliberately NOT converted

Each was checked and left alone rather than changed silently. Where the thread count looks like decoration, the question is raised here rather than answered in the diff.

| spec | why not converted |
| --- | --- |
| `hotConfigAtomicity.test.ts`, `hot-record-read-snapshot.test.ts` (near-duplicates) | T1's invariant (`checksum === flagA + flagB + version`) is record-encoding atomicity, not cross-worker; T2 is explicitly "monotonic version visibility **per reader**"; T3 is a latency distribution that per-request TCP handshakes would change; T4's fan-out is 200-wide and already sprays. **Is `threads.count: 4` earning anything here beyond a 4× boot cost?** |
| `deleteUpdateRace.test.ts`, `delete-update-race-consistency.test.ts` (near-duplicates) | `[threads=4]` "for real multi-worker contention", but the contention is a 2-wide concurrent write pair (already two workers), and the post-race consistency sweep queries the operations API, which is main-thread-only with an exclusive bind (`server/http.ts`). **Would `2` express the same intent?** |
| `eviction-index-orphan-removal-paths.test.ts` | Its heartbeat writer *is* serial and therefore pinned — a genuine gap — but the loop's cadence is tuned against a live TTL sweep window, and a TCP handshake per PUT changes the race it is timing. Worth converting deliberately with the window re-tuned; not as a drive-by. |
| `resources/ttl-rate-limiter-concurrent.test.ts`, `patch-disjoint-field-merge.test.ts`, `concurrentPatchMerge.test.ts` | Load is a 50-wide / N-wide `Promise.all`; already sprays. |
| `ttlResetOnWrite.test.ts` | Deliberately uses `node:http`, documented at its head: per-request timing is the assertion. |
| `blob-eav-type-drift.test.ts`, `blob-reclaim-removal-paths.test.ts`, `audit-blob-reclaim.test.ts`, `bulk-conditional-mutation.test.ts` | Assertions are filesystem / raw-store facts; three drive no `fetch()` load at all. |
| `server/rolling-restart.test.ts` | Already opens fresh connections with `node:http` and `agent: false`. |
| `apiTests/configuration.test.mjs` | Its `count: 4` is a config *value under validation*, not a running worker count. |

## For the human reviewer

- **The planning review returned `Framing-Verdict: better-alternative-exists`, and I adopted it rather than overruling.** My original design was the connection helper alone. The reviewer's point — that generating worker diversity is not the same as proving coverage, and that the `record-caching-invalidate` fixture already returned `threadId` so the oracle was available for free — is correct; `observeEveryWorker`, the new fixture endpoint, the hermetic helper unit test and the off-Linux scoping are the result.
- **The oracle immediately found something on Bun, and it is worth a look beyond this PR.** The first CI run failed the Bun integration shards with `observeEveryWorker: reached 1 of 4 workers in 128 requests` on *both* converted suites: every fresh connection landed on a single thread while `system_information` reported four workers. The uWS shard and all of Node 22/24/26 pass, so this is Bun-specific — Bun does not spread connections over its HTTP workers the way the Node path does, even though `listenOnPortsBun()` passes `reusePort` on Linux (`server/threads/threadServer.js`). **Every `multi-worker` record-caching suite has therefore been running single-worker on the Bun shard all along**; the coverage oracle is what turned that from a green run into a stated fact. [`NO_FULL_WORKER_COVERAGE`](https://github.com/HarperFast/harper/pull/2474/changes?w=1#diff-819ed7741ea0cb93a86de799394cb9a48488bf4f08d3af1e0608343eaa3019ecR30) now gates exactly what cannot run there: `record-caching-invalidate`'s whole suite (every one of its tests needs full coverage) and [`record-caching.test.ts`'s S1 alone](https://github.com/HarperFast/harper/pull/2474/changes?w=1#diff-82ecc4b003262816f1e68b917bb8a4320cbc4d3e1c7f5f909268793d0f5f2d22R131) — S2 is a 50-record × 200-read load test with no coverage requirement, so it keeps running on Bun, as do the four suites that merely tolerate a partial pool. Whether Harper-on-Bun *should* spread HTTP across worker threads is a product question this PR does not touch.
- **A wedged request is bounded by a race, not cancelled.** The graded review asked for an `AbortSignal` threaded through the callback contract. A `Promise.race` against the remaining budget bounds the loop without changing every call site's shape; the abandoned request leaks one socket, on a suite that has already failed and whose Harper instance is torn down in `after()`. Say the word if you want the signal instead.
- **`observeEveryWorker` returns every response, not one per worker.** The review suggested keeping each worker's first response; returning all of them is a superset and keeps the assertions as strong as the fan-out they replaced.
- **Skipping off Linux narrows local coverage.** These suites previously ran on a developer Mac and passed vacuously. That is a real loss of Mac-local signal in exchange for not claiming coverage that cannot exist there; CI is Linux and Windows only, so CI coverage is unchanged.
- **`assertMultiWorker()` is now partially redundant** in the two converted suites — `observeEveryWorker` is strictly stronger. It stays because it fails earlier and more cheaply when the instance simply did not start four workers.
- **Setting the Fetch-spec-forbidden `Connection` header is load-bearing.** If Node ever enforces the forbidden-header list, every one of these suites silently degrades to keep-alive — except that `connectionPerRequest.test.ts` turns that into a red test rather than a false green. The fallback (a dedicated `undici.Agent` per call) is a one-function change.
- **One review finding overruled on CI evidence.** The final review round called the Bun gate ineffective, on the reasoning that the suite's shared `before` hook (`assertEveryWorkerStarted`) would reject Bun before the unskipped S2 could run. It does not: in the Bun shard of the first CI run — same `before` hook, no gate at all — `S2 write-then-read under load: 50 records × 200 reads` **passed in 312 ms** while only S1 failed, so `system_information` does report four threads under Bun and setup completes there. The gate is placed correctly.
- **One review nit knowingly declined.** S2's 40 rounds each run an unbounded coverage loop under a 60 s test timeout, which the reviewer worried could expire before the helper's diagnostic. A round that cannot cover throws immediately, budget exhaustion fails in ~400 ms *with* the diagnostic, and 40 rounds measure at 435 ms total — the bare-timeout path would need repeated stalls, and the first stall already throws at ≤15 s.
- **Open decisions the review flagged, recorded rather than resolved:**
  - Coverage is driven by the `WORKER_COUNT` constant, not the instance's own reported thread count (which `observedWorkerCount()` already fetches). `assertEveryWorkerStarted()` narrows the gap but does not close it.
  - The fixture proves coverage through `store.getEntry()`, which transparently refills an evicted entry — so a trivially-cold read is not distinguishable from a proven invalidation. Exposing a hit/miss signal would close that, at moderate cost in the fixture.
  - `connectionPerRequest.test.ts` asserts third-party keep-alive behaviour as a gating test. If undici's pooling ever changes, integration CI reddens for a non-Harper reason — which is the intended signal (the helper would be obsolete), but it is a real coupling.
  - The helper's unit test lives under `integrationTests/utils/` and consumes an integration shard slot. `unitTests/` runs mocha over `*test.*js` only, so there is no home there for a `.ts` `node:test` file today.
- **One pre-existing nit is filed, not fixed**: `record-caching-invalidate.test.ts`'s suite-scoped `failures` array is never cleared between S1/S2/S3, so a failure in one scenario is re-reported by the next. It predates this diff.
- The pre-push CLI's `no-restart-test` self-check fired on this diff ("adds or changes a recovery/rollback path but no touched test kills and restarts anything"). There is no product code and no recovery path in it; it looks like a keyword false positive.
- **Cross-model coverage was reduced**: the Gemini leg could not authenticate on this machine (`agy` login), so the review ran with Codex + Cursor Composer + the Harper domain adjudicator.

## Verification

- Every touched suite plus the new helper test: **28 tests, 28 pass, 0 fail** (RocksDB, Node 26.2.0). Under `HARPER_STORAGE_ENGINE=lmdb` the six record-caching suites skip as designed (`PrimaryRocksDatabase` is RocksDB-only) and the helper unit test passes.
- Helper unit test green on **Node 22.23.1, 24.19.0 and 26.2.0** — the versions CI's matrix runs. It was red on Node 24 before the control-origin fix described above.
- **Fails on the pinned transport.** Swapping `fetchOnNewConnection` back to plain `fetch()` in the converted `record-caching.test.ts` S1 turns it red: `observeEveryWorker: reached 2 of 4 workers in 128 requests (saw [3,4])`. With the helper it reaches 4 of 4 and passes. That is the check the old S1 could not make.
- Whole-directory run of `integrationTests/database/**/*.test.ts` + `integrationTests/utils/**/*.test.ts` — everything the change can reach, since the helper has no consumers outside it and the new fixture endpoint is private to one spec: **388 tests, 385 pass, 0 fail, 3 skipped**. The full `test:integration:all` gate was not run locally: another agent held this box with a concurrent `test:integration:cluster` + stress run and a second whole-suite run would have contended with it for the loopback pool. CI runs the full matrix.
- **CI**: 37 pass, 1 fail. Every Bun shard now passes, including 3/6 and 6/6 which the gate above fixed, and no `observeEveryWorker` failure appears anywhere in the run. The single red check is `Integration Tests 2/6 (uWS HTTP)` — the `Terminology aliases (database / primary_key)` suite, whose `delete_records_before / csv_file_load / export_local … starts job` cases each time out at 30 s waiting on the job queue. It is unrelated to this diff: shard 2 contains none of the touched files, the same suite failed on a *different* leg (Node 24) in the previous run and passed on this one, and `record-caching TTL-eviction cross-worker ghost` passes inside that very shard. `Unit Test (Node.js v26)` (`Commit-phase pre-commit work is not poisoned by the monitor (#2062)`, an LMDB open-transaction-time timeout) failed on the first run and passes on this one — same story.
- `npm run format:write`, `npm run lint:required` clean. `tsc -p integrationTests/tsconfig.json --noEmit` reports the same 210 pre-existing errors before and after; none are in the touched files. (The root `tsconfig.json` `include` list does not cover `integrationTests/`, so `npm run typecheck` never sees them — noted as a follow-up.)

Refs #410


Complexity: complicated

<sub>Review-Coverage: authored=claude; ran=codex; blocked=gemini(auth); declined=cursor-grok,cursor-composer,domain; rounds=8 @ 81f8d147e3d0</sub>

<sub>Human-Review-Need: 4 @ 81f8d147e3d0</sub>
