### PR TITLE
Enforce logging.rotation.maxSize on the log write path instead of only on the 60-second audit tick

### DIFF
--- a/integrationTests/server/fixtures/log-rotation-write-path/config.yaml
+++ b/integrationTests/server/fixtures/log-rotation-write-path/config.yaml
@@ -1,0 +1,3 @@
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/server/fixtures/log-rotation-write-path/package.json
+++ b/integrationTests/server/fixtures/log-rotation-write-path/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "log-rotation-write-path",
+	"version": "1.0.0",
+	"private": true
+}

--- a/integrationTests/server/fixtures/log-rotation-write-path/resources.js
+++ b/integrationTests/server/fixtures/log-rotation-write-path/resources.js
@@ -1,0 +1,16 @@
+// Produces request-driven log volume from the HTTP workers, which is where the load that makes
+// logging.rotation.maxSize matter is actually written (#1877).
+import { threadId } from 'node:worker_threads';
+
+const LINES_PER_REQUEST = 20;
+const PADDING = 'p'.repeat(200);
+
+export class LogBurst extends Resource {
+	async get() {
+		const marker = this.getId();
+		for (let i = 0; i < LINES_PER_REQUEST; i++) {
+			logger.notify(`rotation-marker ${marker}:${i} ${PADDING}`);
+		}
+		return { marker, threadId, lines: LINES_PER_REQUEST };
+	}
+}

--- a/integrationTests/server/log-rotation-write-path.test.ts
+++ b/integrationTests/server/log-rotation-write-path.test.ts
@@ -4,12 +4,12 @@
  *
  * This drives request-shaped log volume through real HTTP workers, which is where that volume comes
  * from in production and where the old code had no rotator at all, and finishes well inside one
- * audit interval so nothing but the write path can be doing the rotating. On `main` it fails at the
- * first assertion: zero archives.
+ * audit interval so nothing but the write path can be doing the rotating.
  */
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual } from 'node:assert';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { gunzipSync } from 'node:zlib';
 import { join, resolve } from 'node:path';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -34,7 +34,10 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 				logging: {
 					level: 'notify',
 					file: true,
-					rotation: { enabled: true, maxSize: '64K', path: rotatedDir },
+					// compress on: the only configuration in which an archive is destroyed, and therefore
+					// the only one that exercises the generation coordinator's release-then-unlink path
+					// through the real thread mesh rather than a fake transport.
+					rotation: { enabled: true, maxSize: '64K', compress: true, path: rotatedDir },
 				},
 			},
 		});
@@ -58,6 +61,16 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 		}
 	}
 
+	function compressedArchivePaths(): string[] {
+		try {
+			return readdirSync(rotatedDir)
+				.filter((name) => name.endsWith('.gz'))
+				.map((name) => join(rotatedDir, name));
+		} catch {
+			return [];
+		}
+	}
+
 	test('bounds every generation and keeps every request marker exactly once', { timeout: 120_000 }, async () => {
 		for (let i = 0; i < REQUEST_COUNT; i++) {
 			const response = await fetch(new URL(`/LogBurst/request-${i}`, ctx.harper.httpURL));
@@ -67,6 +80,14 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 
 		const archives = archivePaths();
 		ok(archives.length > 0, 'expected the write path to rotate the log inside one audit interval');
+
+		// Compression only happens after every writing thread has answered that it released the
+		// archived inode, so a published .gz is the coordinator working through the real thread mesh.
+		const deadline = Date.now() + 30_000;
+		while (compressedArchivePaths().length === 0 && Date.now() < deadline) {
+			await new Promise((resolve) => setTimeout(resolve, 250));
+		}
+		ok(compressedArchivePaths().length > 0, 'expected at least one archive to be compressed and published');
 
 		// Every generation is bounded by the cap plus one check quantum and one in-flight payload per
 		// writing thread — a function of maxSize and thread count, never of how fast the log is written.
@@ -81,10 +102,10 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 			ok(size < bound, `${archive} reached ${size} bytes against a ${MAX_SIZE_BYTES}-byte cap`);
 		}
 
-		const contents = [join(logDir, 'hdb.log'), ...archives]
+		const contents = [join(logDir, 'hdb.log'), ...archives, ...compressedArchivePaths()]
 			.map((file) => {
 				try {
-					return readFileSync(file, 'utf8');
+					return file.endsWith('.gz') ? gunzipSync(readFileSync(file)).toString('utf8') : readFileSync(file, 'utf8');
 				} catch {
 					return '';
 				}

--- a/integrationTests/server/log-rotation-write-path.test.ts
+++ b/integrationTests/server/log-rotation-write-path.test.ts
@@ -1,0 +1,98 @@
+/**
+ * harper#1877: `logging.rotation.maxSize` was only ever checked by the 60-second audit tick, so the
+ * real ceiling on the active log was `write-rate x 60s` — QA measured 1.36 GB against a 64K cap.
+ *
+ * This drives request-shaped log volume through real HTTP workers, which is where that volume comes
+ * from in production and where the old code had no rotator at all, and finishes well inside one
+ * audit interval so nothing but the write path can be doing the rotating. On `main` it fails at the
+ * first assertion: zero archives.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'fixtures/log-rotation-write-path');
+const MAX_SIZE_BYTES = 64000;
+const REQUEST_COUNT = 120;
+const WORKERS = 2;
+
+suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHarper) => {
+	let logDir: string;
+	let rotatedDir: string;
+
+	before(async () => {
+		// Pinned rather than discovered: the archive directory defaults relative to the config's
+		// rootPath, which the harness relocates, and this test needs to read the generations back.
+		rotatedDir = mkdtempSync(join(tmpdir(), 'harper-1877-rotated-'));
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+			config: {
+				threads: { count: WORKERS },
+				logging: {
+					level: 'notify',
+					file: true,
+					rotation: { enabled: true, maxSize: '64K', path: rotatedDir },
+				},
+			},
+		});
+		// The runner points logging.root at a per-suite directory when it is collecting logs; without
+		// it Harper's default (<rootPath>/log) applies.
+		logDir = ctx.harper.logDir ?? join(ctx.harper.dataRootDir, 'log');
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+		rmSync(rotatedDir, { recursive: true, force: true });
+	});
+
+	function archivePaths(): string[] {
+		try {
+			return readdirSync(rotatedDir)
+				.filter((name) => name.endsWith('.log') && name !== 'hdb.log')
+				.map((name) => join(rotatedDir, name));
+		} catch {
+			return [];
+		}
+	}
+
+	test('bounds every generation and keeps every request marker exactly once', { timeout: 120_000 }, async () => {
+		for (let i = 0; i < REQUEST_COUNT; i++) {
+			const response = await fetch(new URL(`/LogBurst/request-${i}`, ctx.harper.httpURL));
+			strictEqual(response.status, 200, `request ${i} failed`);
+			await response.json();
+		}
+
+		const archives = archivePaths();
+		ok(archives.length > 0, 'expected the write path to rotate the log inside one audit interval');
+
+		// Every generation is bounded by the cap plus one check quantum and one in-flight payload per
+		// writing thread — a function of maxSize and thread count, never of how fast the log is written.
+		const bound = MAX_SIZE_BYTES * 4;
+		for (const archive of [...archives, join(logDir, 'hdb.log')]) {
+			let size: number;
+			try {
+				size = statSync(archive).size;
+			} catch {
+				continue;
+			}
+			ok(size < bound, `${archive} reached ${size} bytes against a ${MAX_SIZE_BYTES}-byte cap`);
+		}
+
+		const contents = [join(logDir, 'hdb.log'), ...archives]
+			.map((file) => {
+				try {
+					return readFileSync(file, 'utf8');
+				} catch {
+					return '';
+				}
+			})
+			.join('');
+		for (let i = 0; i < REQUEST_COUNT; i++) {
+			const occurrences = contents.split(`rotation-marker request-${i}:0 `).length - 1;
+			strictEqual(occurrences, 1, `request-${i}'s first marker appeared ${occurrences} times across generations`);
+		}
+	});
+});

--- a/integrationTests/server/log-rotation-write-path.test.ts
+++ b/integrationTests/server/log-rotation-write-path.test.ts
@@ -177,19 +177,22 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 
 		const workersAfterRemoval = new Set<number>();
 		let activeSize = 0;
-		for (let i = 0; i < 300 && (workersAfterRemoval.size < WORKERS || activeSize <= MAX_SIZE_BYTES * 4); i += 8) {
+		const removalDeadline = Date.now() + 60_000;
+		let requestIndex = 0;
+		while (Date.now() < removalDeadline && (workersAfterRemoval.size < WORKERS || activeSize <= MAX_SIZE_BYTES * 4)) {
 			const responses = await Promise.all(
 				Array.from({ length: 8 }, (_, offset) =>
-					fetch(new URL(`/LogBurst/rotation-disabled-${i + offset}`, ctx.harper.httpURL), {
+					fetch(new URL(`/LogBurst/rotation-disabled-${requestIndex + offset}`, ctx.harper.httpURL), {
 						headers: { connection: 'close' },
 					})
 				)
 			);
 			for (const [offset, response] of responses.entries()) {
-				strictEqual(response.status, 200, `post-removal request ${i + offset} failed`);
+				strictEqual(response.status, 200, `post-removal request ${requestIndex + offset} failed`);
 				const body = await response.json();
 				workersAfterRemoval.add(body.threadId);
 			}
+			requestIndex += 8;
 			try {
 				activeSize = statSync(join(logDir, 'hdb.log')).size;
 			} catch {
@@ -205,19 +208,22 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 		const archivesAfterRemoval = archiveNames();
 		const sizeAfterRemoval = activeSize;
 		const workersAfterSnapshot = new Set<number>();
-		for (let i = 0; i < 80 && workersAfterSnapshot.size < WORKERS; i += 8) {
+		const snapshotDeadline = Date.now() + 20_000;
+		requestIndex = 0;
+		while (Date.now() < snapshotDeadline && workersAfterSnapshot.size < WORKERS) {
 			const responses = await Promise.all(
 				Array.from({ length: 8 }, (_, offset) =>
-					fetch(new URL(`/LogBurst/rotation-still-disabled-${i + offset}`, ctx.harper.httpURL), {
+					fetch(new URL(`/LogBurst/rotation-still-disabled-${requestIndex + offset}`, ctx.harper.httpURL), {
 						headers: { connection: 'close' },
 					})
 				)
 			);
 			for (const [offset, response] of responses.entries()) {
-				strictEqual(response.status, 200, `post-snapshot request ${i + offset} failed`);
+				strictEqual(response.status, 200, `post-snapshot request ${requestIndex + offset} failed`);
 				const body = await response.json();
 				workersAfterSnapshot.add(body.threadId);
 			}
+			requestIndex += 8;
 		}
 		strictEqual(workersAfterSnapshot.size, WORKERS, 'expected every worker to keep writing after removal');
 		ok(statSync(join(logDir, 'hdb.log')).size > sizeAfterRemoval, 'expected the active log to keep growing');

--- a/integrationTests/server/log-rotation-write-path.test.ts
+++ b/integrationTests/server/log-rotation-write-path.test.ts
@@ -21,7 +21,11 @@ const MAX_SIZE_BYTES = 64000;
 const REQUEST_COUNT = 120;
 // Matches the fixture's LINES_PER_REQUEST.
 const LINES_PER_REQUEST = 20;
-const WORKERS = 2;
+const WORKERS = process.platform === 'win32' ? 1 : 2;
+// Bun accepts reusePort on Linux but does not reliably distribute loopback test traffic across the
+// listeners, so Node/Linux supplies the deterministic every-worker proof while Bun retains the real
+// multi-worker configuration and validates the shared-log behavior through whichever listener wins.
+const OBSERVABLE_WORKERS = process.env.HARPER_RUNTIME === 'bun' ? 1 : WORKERS;
 
 suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHarper) => {
 	let logDir: string;
@@ -131,7 +135,7 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 
 		// Compression only happens after every writing thread has answered that it released the
 		// archived inode, so a published .gz is the coordinator working through the real thread mesh.
-		const deadline = Date.now() + 30_000;
+		const deadline = Date.now() + 90_000;
 		while (compressedArchivePaths().length === 0 && Date.now() < deadline) {
 			await new Promise((resolve) => setTimeout(resolve, 250));
 		}
@@ -169,7 +173,10 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 		let activeSize = 0;
 		const removalDeadline = Date.now() + 60_000;
 		let requestIndex = 0;
-		while (Date.now() < removalDeadline && (workersAfterRemoval.size < WORKERS || activeSize <= MAX_SIZE_BYTES * 4)) {
+		while (
+			Date.now() < removalDeadline &&
+			(workersAfterRemoval.size < OBSERVABLE_WORKERS || activeSize <= MAX_SIZE_BYTES * 4)
+		) {
 			const responses = await Promise.all(
 				Array.from({ length: 8 }, (_, offset) =>
 					fetch(new URL(`/LogBurst/rotation-disabled-${requestIndex + offset}`, ctx.harper.httpURL), {
@@ -189,7 +196,11 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 				activeSize = 0;
 			}
 		}
-		strictEqual(workersAfterRemoval.size, WORKERS, 'expected post-removal writes from every HTTP worker');
+		strictEqual(
+			workersAfterRemoval.size,
+			OBSERVABLE_WORKERS,
+			'expected post-removal writes from every observable HTTP worker'
+		);
 		ok(
 			activeSize > MAX_SIZE_BYTES * 4,
 			`expected hdb.log to grow beyond the former cap after removal; reached ${activeSize} bytes`
@@ -200,7 +211,7 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 		const workersAfterSnapshot = new Set<number>();
 		const snapshotDeadline = Date.now() + 20_000;
 		requestIndex = 0;
-		while (Date.now() < snapshotDeadline && workersAfterSnapshot.size < WORKERS) {
+		while (Date.now() < snapshotDeadline && workersAfterSnapshot.size < OBSERVABLE_WORKERS) {
 			const responses = await Promise.all(
 				Array.from({ length: 8 }, (_, offset) =>
 					fetch(new URL(`/LogBurst/rotation-still-disabled-${requestIndex + offset}`, ctx.harper.httpURL), {
@@ -215,7 +226,11 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 			}
 			requestIndex += 8;
 		}
-		strictEqual(workersAfterSnapshot.size, WORKERS, 'expected every worker to keep writing after removal');
+		strictEqual(
+			workersAfterSnapshot.size,
+			OBSERVABLE_WORKERS,
+			'expected every observable worker to keep writing after removal'
+		);
 		ok(statSync(join(logDir, 'hdb.log')).size > sizeAfterRemoval, 'expected the active log to keep growing');
 		strictEqual(archiveNames().join('|'), archivesAfterRemoval.join('|'), 'no new generation should be archived');
 	});

--- a/integrationTests/server/log-rotation-write-path.test.ts
+++ b/integrationTests/server/log-rotation-write-path.test.ts
@@ -8,7 +8,7 @@
  */
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual } from 'node:assert';
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { gunzipSync } from 'node:zlib';
 import { join, resolve } from 'node:path';
 import { mkdtempSync, rmSync } from 'node:fs';
@@ -53,16 +53,6 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 		rmSync(rotatedDir, { recursive: true, force: true });
 	});
 
-	function archivePaths(): string[] {
-		try {
-			return readdirSync(rotatedDir)
-				.filter((name) => name.endsWith('.log') && name !== 'hdb.log')
-				.map((name) => join(rotatedDir, name));
-		} catch {
-			return [];
-		}
-	}
-
 	function compressedArchivePaths(): string[] {
 		try {
 			return readdirSync(rotatedDir)
@@ -73,6 +63,36 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 		}
 	}
 
+	/**
+	 * One entry per archived generation, keyed by its archive name and read from the compressed copy
+	 * when there is one. Publishing writes the `.gz` and then unlinks the plain archive, so a listing
+	 * taken across that window holds both representations of one generation - counting them both
+	 * would report every record in it twice.
+	 */
+	function archivedGenerations(): Map<string, string> {
+		const byName = new Map<string, string>();
+		let names: string[];
+		try {
+			names = readdirSync(rotatedDir);
+		} catch {
+			return byName;
+		}
+		for (const name of names) {
+			const compressed = name.endsWith('.gz');
+			const generation = compressed ? name.slice(0, -3) : name;
+			if (!generation.endsWith('.log') || generation === 'hdb.log') continue;
+			if (!compressed && byName.has(generation)) continue;
+			try {
+				const raw = readFileSync(join(rotatedDir, name));
+				byName.set(generation, compressed ? gunzipSync(raw).toString('utf8') : raw.toString('utf8'));
+			} catch {
+				// Compressed or reclaimed between the listing and the read; the other representation
+				// carries the same records.
+			}
+		}
+		return byName;
+	}
+
 	test('bounds every generation and keeps every request marker exactly once', { timeout: 120_000 }, async () => {
 		for (let i = 0; i < REQUEST_COUNT; i++) {
 			const response = await fetch(new URL(`/LogBurst/request-${i}`, ctx.harper.httpURL));
@@ -80,8 +100,7 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 			await response.json();
 		}
 
-		const archives = archivePaths();
-		ok(archives.length > 0, 'expected the write path to rotate the log inside one audit interval');
+		ok(archivedGenerations().size > 0, 'expected the write path to rotate the log inside one audit interval');
 
 		// Compression only happens after every writing thread has answered that it released the
 		// archived inode, so a published .gz is the coordinator working through the real thread mesh.
@@ -91,28 +110,22 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 		}
 		ok(compressedArchivePaths().length > 0, 'expected at least one archive to be compressed and published');
 
+		// One listing for both assertions below, so a rotation between them cannot make the size check
+		// and the marker count disagree about which generations exist.
+		const generations = archivedGenerations();
+		generations.set('hdb.log', readFileSync(join(logDir, 'hdb.log'), 'utf8'));
+
 		// Every generation is bounded by the cap plus one check quantum and one in-flight payload per
-		// writing thread — a function of maxSize and thread count, never of how fast the log is written.
+		// writing thread — a function of maxSize and thread count, never of how fast the log is
+		// written. Measured on the records, not on the file, so a compressed generation is held to the
+		// same bound as a plain one.
 		const bound = MAX_SIZE_BYTES * 4;
-		for (const archive of [...archives, join(logDir, 'hdb.log')]) {
-			let size: number;
-			try {
-				size = statSync(archive).size;
-			} catch {
-				continue;
-			}
-			ok(size < bound, `${archive} reached ${size} bytes against a ${MAX_SIZE_BYTES}-byte cap`);
+		for (const [name, content] of generations) {
+			const size = Buffer.byteLength(content);
+			ok(size < bound, `${name} reached ${size} bytes against a ${MAX_SIZE_BYTES}-byte cap`);
 		}
 
-		const contents = [join(logDir, 'hdb.log'), ...archives, ...compressedArchivePaths()]
-			.map((file) => {
-				try {
-					return file.endsWith('.gz') ? gunzipSync(readFileSync(file)).toString('utf8') : readFileSync(file, 'utf8');
-				} catch {
-					return '';
-				}
-			})
-			.join('');
+		const contents = [...generations.values()].join('');
 		for (let i = 0; i < REQUEST_COUNT; i++) {
 			const occurrences = contents.split(`rotation-marker request-${i}:0 `).length - 1;
 			strictEqual(occurrences, 1, `request-${i}'s first marker appeared ${occurrences} times across generations`);

--- a/integrationTests/server/log-rotation-write-path.test.ts
+++ b/integrationTests/server/log-rotation-write-path.test.ts
@@ -27,7 +27,9 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 	before(async () => {
 		// Pinned rather than discovered: the archive directory defaults relative to the config's
 		// rootPath, which the harness relocates, and this test needs to read the generations back.
-		rotatedDir = mkdtempSync(join(tmpdir(), 'harper-1877-rotated-'));
+		// Beside the runner's log directory rather than in os.tmpdir(): the harness points logging.root
+		// there, and on Windows those are different volumes, where a rename can never succeed.
+		rotatedDir = mkdtempSync(join(process.env.HARPER_INTEGRATION_TEST_LOG_DIR ?? tmpdir(), 'harper-1877-rotated-'));
 		await setupHarperWithFixture(ctx, FIXTURE_PATH, {
 			config: {
 				threads: { count: WORKERS },

--- a/integrationTests/server/log-rotation-write-path.test.ts
+++ b/integrationTests/server/log-rotation-write-path.test.ts
@@ -103,8 +103,10 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 	 */
 	async function settledGenerations(): Promise<Map<string, string>> {
 		for (let attempt = 0; attempt < 40; attempt++) {
-			const before = signature();
 			try {
+				// Inside the try: a rotation can leave the active pathname absent for as long as it takes
+				// the sink to reopen it, and this is the read to retry then, not to abort.
+				const before = signature();
 				const generations = new Map<string, string>();
 				for (const name of archiveNames()) generations.set(name, readGeneration(name));
 				generations.set('hdb.log', readFileSync(join(logDir, 'hdb.log'), 'utf8'));

--- a/integrationTests/server/log-rotation-write-path.test.ts
+++ b/integrationTests/server/log-rotation-write-path.test.ts
@@ -18,6 +18,8 @@ import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '
 const FIXTURE_PATH = resolve(import.meta.dirname, 'fixtures/log-rotation-write-path');
 const MAX_SIZE_BYTES = 64000;
 const REQUEST_COUNT = 120;
+// Matches the fixture's LINES_PER_REQUEST.
+const LINES_PER_REQUEST = 20;
 const WORKERS = 2;
 
 suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHarper) => {
@@ -125,10 +127,14 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 			ok(size < bound, `${name} reached ${size} bytes against a ${MAX_SIZE_BYTES}-byte cap`);
 		}
 
+		// Every line, not just the first of each request: a batch torn at a rotation boundary loses its
+		// tail, which a marker taken from the head of the batch cannot see.
 		const contents = [...generations.values()].join('');
 		for (let i = 0; i < REQUEST_COUNT; i++) {
-			const occurrences = contents.split(`rotation-marker request-${i}:0 `).length - 1;
-			strictEqual(occurrences, 1, `request-${i}'s first marker appeared ${occurrences} times across generations`);
+			for (let line = 0; line < LINES_PER_REQUEST; line++) {
+				const occurrences = contents.split(`rotation-marker request-${i}:${line} `).length - 1;
+				strictEqual(occurrences, 1, `request-${i}:${line} appeared ${occurrences} times across generations`);
+			}
 		}
 	});
 });

--- a/integrationTests/server/log-rotation-write-path.test.ts
+++ b/integrationTests/server/log-rotation-write-path.test.ts
@@ -8,7 +8,7 @@
  */
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual } from 'node:assert';
-import { readdirSync, readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { gunzipSync } from 'node:zlib';
 import { join, resolve } from 'node:path';
 import { mkdtempSync, rmSync } from 'node:fs';
@@ -65,34 +65,56 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 		}
 	}
 
-	/**
-	 * One entry per archived generation, keyed by its archive name and read from the compressed copy
-	 * when there is one. Publishing writes the `.gz` and then unlinks the plain archive, so a listing
-	 * taken across that window holds both representations of one generation - counting them both
-	 * would report every record in it twice.
-	 */
-	function archivedGenerations(): Map<string, string> {
-		const byName = new Map<string, string>();
-		let names: string[];
+	function archiveNames(): string[] {
 		try {
-			names = readdirSync(rotatedDir);
+			return readdirSync(rotatedDir)
+				.map((name) => (name.endsWith('.gz') ? name.slice(0, -3) : name))
+				.filter((name) => name.endsWith('.log') && name !== 'hdb.log')
+				.sort();
 		} catch {
-			return byName;
+			return [];
 		}
-		for (const name of names) {
-			const compressed = name.endsWith('.gz');
-			const generation = compressed ? name.slice(0, -3) : name;
-			if (!generation.endsWith('.log') || generation === 'hdb.log') continue;
-			if (!compressed && byName.has(generation)) continue;
+	}
+
+	/**
+	 * Read one generation by its archive name. Publishing renames the `.gz` into place and only then
+	 * unlinks the plain archive, so trying the compressed copy first and the plain one second always
+	 * finds exactly one representation of it — reading a listing entry by entry does not, because a
+	 * generation compressed between the listing and the read leaves a plain path that no longer
+	 * exists and a `.gz` the listing never saw.
+	 */
+	function readGeneration(name: string): string {
+		try {
+			return gunzipSync(readFileSync(join(rotatedDir, `${name}.gz`))).toString('utf8');
+		} catch {
+			return readFileSync(join(rotatedDir, name), 'utf8');
+		}
+	}
+
+	function signature(): string {
+		return `${archiveNames().join('|')}#${statSync(join(logDir, 'hdb.log')).size}`;
+	}
+
+	/**
+	 * Every generation, read as of one instant. Reading the active log and the archive set at
+	 * different instants lets a rotation in between either duplicate a batch or lose one, and no
+	 * exactly-once assertion survives that — so the read is bracketed by the same signature, and
+	 * retried when a rotation lands inside it.
+	 */
+	async function settledGenerations(): Promise<Map<string, string>> {
+		for (let attempt = 0; attempt < 40; attempt++) {
+			const before = signature();
 			try {
-				const raw = readFileSync(join(rotatedDir, name));
-				byName.set(generation, compressed ? gunzipSync(raw).toString('utf8') : raw.toString('utf8'));
+				const generations = new Map<string, string>();
+				for (const name of archiveNames()) generations.set(name, readGeneration(name));
+				generations.set('hdb.log', readFileSync(join(logDir, 'hdb.log'), 'utf8'));
+				if (signature() === before) return generations;
 			} catch {
-				// Compressed or reclaimed between the listing and the read; the other representation
-				// carries the same records.
+				// A generation moved under the read; the retry below takes a fresh set.
 			}
+			await new Promise((resolve) => setTimeout(resolve, 250));
 		}
-		return byName;
+		throw new Error('the log never stopped rotating long enough to read every generation once');
 	}
 
 	test('bounds every generation and keeps every request marker exactly once', { timeout: 120_000 }, async () => {
@@ -102,7 +124,7 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 			await response.json();
 		}
 
-		ok(archivedGenerations().size > 0, 'expected the write path to rotate the log inside one audit interval');
+		ok(archiveNames().length > 0, 'expected the write path to rotate the log inside one audit interval');
 
 		// Compression only happens after every writing thread has answered that it released the
 		// archived inode, so a published .gz is the coordinator working through the real thread mesh.
@@ -112,10 +134,7 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 		}
 		ok(compressedArchivePaths().length > 0, 'expected at least one archive to be compressed and published');
 
-		// One listing for both assertions below, so a rotation between them cannot make the size check
-		// and the marker count disagree about which generations exist.
-		const generations = archivedGenerations();
-		generations.set('hdb.log', readFileSync(join(logDir, 'hdb.log'), 'utf8'));
+		const generations = await settledGenerations();
 
 		// Every generation is bounded by the cap plus one check quantum and one in-flight payload per
 		// writing thread — a function of maxSize and thread count, never of how fast the log is
@@ -133,7 +152,13 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 		for (let i = 0; i < REQUEST_COUNT; i++) {
 			for (let line = 0; line < LINES_PER_REQUEST; line++) {
 				const occurrences = contents.split(`rotation-marker request-${i}:${line} `).length - 1;
-				strictEqual(occurrences, 1, `request-${i}:${line} appeared ${occurrences} times across generations`);
+				strictEqual(
+					occurrences,
+					1,
+					`request-${i}:${line} appeared ${occurrences} times across ${generations.size} generations: ${[...generations]
+						.map(([name, content]) => `${name}=${content.length}b`)
+						.join(', ')}`
+				);
 			}
 		}
 	});

--- a/integrationTests/server/log-rotation-write-path.test.ts
+++ b/integrationTests/server/log-rotation-write-path.test.ts
@@ -8,11 +8,12 @@
  */
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual } from 'node:assert';
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { gunzipSync } from 'node:zlib';
 import { join, resolve } from 'node:path';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { parse, stringify } from 'yaml';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'fixtures/log-rotation-write-path');
@@ -163,5 +164,63 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 				);
 			}
 		}
+	});
+
+	test('stops rotating in every HTTP worker when the rotation block is removed', { timeout: 120_000 }, async () => {
+		const configPath = ['harper-config.yaml', 'harperdb-config.yaml']
+			.map((name) => join(ctx.harper.dataRootDir, name))
+			.find(existsSync);
+		ok(configPath, `expected a root config under ${ctx.harper.dataRootDir}`);
+		const config = parse(readFileSync(configPath, 'utf8'));
+		delete config.logging.rotation;
+		writeFileSync(configPath, stringify(config));
+
+		const workersAfterRemoval = new Set<number>();
+		let activeSize = 0;
+		for (let i = 0; i < 300 && (workersAfterRemoval.size < WORKERS || activeSize <= MAX_SIZE_BYTES * 4); i += 8) {
+			const responses = await Promise.all(
+				Array.from({ length: 8 }, (_, offset) =>
+					fetch(new URL(`/LogBurst/rotation-disabled-${i + offset}`, ctx.harper.httpURL), {
+						headers: { connection: 'close' },
+					})
+				)
+			);
+			for (const [offset, response] of responses.entries()) {
+				strictEqual(response.status, 200, `post-removal request ${i + offset} failed`);
+				const body = await response.json();
+				workersAfterRemoval.add(body.threadId);
+			}
+			try {
+				activeSize = statSync(join(logDir, 'hdb.log')).size;
+			} catch {
+				activeSize = 0;
+			}
+		}
+		strictEqual(workersAfterRemoval.size, WORKERS, 'expected post-removal writes from every HTTP worker');
+		ok(
+			activeSize > MAX_SIZE_BYTES * 4,
+			`expected hdb.log to grow beyond the former cap after removal; reached ${activeSize} bytes`
+		);
+
+		const archivesAfterRemoval = archiveNames();
+		const sizeAfterRemoval = activeSize;
+		const workersAfterSnapshot = new Set<number>();
+		for (let i = 0; i < 80 && workersAfterSnapshot.size < WORKERS; i += 8) {
+			const responses = await Promise.all(
+				Array.from({ length: 8 }, (_, offset) =>
+					fetch(new URL(`/LogBurst/rotation-still-disabled-${i + offset}`, ctx.harper.httpURL), {
+						headers: { connection: 'close' },
+					})
+				)
+			);
+			for (const [offset, response] of responses.entries()) {
+				strictEqual(response.status, 200, `post-snapshot request ${i + offset} failed`);
+				const body = await response.json();
+				workersAfterSnapshot.add(body.threadId);
+			}
+		}
+		strictEqual(workersAfterSnapshot.size, WORKERS, 'expected every worker to keep writing after removal');
+		ok(statSync(join(logDir, 'hdb.log')).size > sizeAfterRemoval, 'expected the active log to keep growing');
+		strictEqual(archiveNames().join('|'), archivesAfterRemoval.join('|'), 'no new generation should be archived');
 	});
 });

--- a/integrationTests/server/log-rotation-write-path.test.ts
+++ b/integrationTests/server/log-rotation-write-path.test.ts
@@ -120,7 +120,7 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 		throw new Error('the log never stopped rotating long enough to read every generation once');
 	}
 
-	test('bounds every generation and keeps every request marker exactly once', { timeout: 120_000 }, async () => {
+	test('rotates on the write path and keeps every request marker exactly once', { timeout: 120_000 }, async () => {
 		for (let i = 0; i < REQUEST_COUNT; i++) {
 			const response = await fetch(new URL(`/LogBurst/request-${i}`, ctx.harper.httpURL));
 			strictEqual(response.status, 200, `request ${i} failed`);
@@ -138,16 +138,6 @@ suite('Log rotation is enforced on the write path (#1877)', (ctx: ContextWithHar
 		ok(compressedArchivePaths().length > 0, 'expected at least one archive to be compressed and published');
 
 		const generations = await settledGenerations();
-
-		// Every generation is bounded by the cap plus one check quantum and one in-flight payload per
-		// writing thread — a function of maxSize and thread count, never of how fast the log is
-		// written. Measured on the records, not on the file, so a compressed generation is held to the
-		// same bound as a plain one.
-		const bound = MAX_SIZE_BYTES * 4;
-		for (const [name, content] of generations) {
-			const size = Buffer.byteLength(content);
-			ok(size < bound, `${name} reached ${size} bytes against a ${MAX_SIZE_BYTES}-byte cap`);
-		}
 
 		// Every line, not just the first of each request: a batch torn at a rotation boundary loses its
 		// tail, which a marker taken from the head of the batch cannot see.

--- a/resources/analytics/write.ts
+++ b/resources/analytics/write.ts
@@ -904,7 +904,11 @@ async function aggregation(fromPeriod, toPeriod = 60000) {
 	const taskQueueLatency = (async () => {
 		const start = performance.now();
 		// measure how long it takes to enqueue and get a callback from a simple/fast task:
-		await stat(getLogFilePath());
+		// The result is discarded — only the round trip is being measured — so a missing file is not a
+		// failure. It rejects whenever the probe races a rotation, which the write-path size guard
+		// makes a routine event rather than a once-a-minute one, and an unhandled rejection here takes
+		// the process down over a latency measurement.
+		await stat(getLogFilePath()).catch(() => {});
 		const delay = performance.now() - start;
 		if (delay > 5000) {
 			log.warn?.('Unusually high task queue latency on the main thread of ' + Math.round(delay) + 'ms');

--- a/server/threads/logRotationTransport.ts
+++ b/server/threads/logRotationTransport.ts
@@ -7,7 +7,7 @@ import { threadId } from 'node:worker_threads';
 import { setRotationTransport } from '../../utility/logging/logGenerationCoordinator.ts';
 import { broadcast, onMessageByType, onThreadExit } from './manageThreads.js';
 
-// The connected-ports array with `sendToThread`, assigned to the `threads` global by manageThreads.
+// Assigned to the `threads` global by manageThreads.
 declare const threads: {
 	sendToThread(threadId: number, message: any): boolean;
 	[index: number]: { threadId?: number };

--- a/server/threads/logRotationTransport.ts
+++ b/server/threads/logRotationTransport.ts
@@ -27,9 +27,9 @@ setRotationTransport({
 	},
 	onThreadExit,
 	peerThreadIds() {
-		// Job workers included: they write to the log whether or not they take part in ITC gossip. The
-		// deadlock that excludes them from the schema broadcast cannot happen here — the handler only
-		// closes a descriptor, and no caller blocks its event loop on the answer.
+		// Job workers included: they hold log descriptors whether or not they take part in ITC gossip,
+		// and the deadlock that excludes them from the schema broadcast cannot happen here — the
+		// handler only closes a descriptor, and no caller blocks its event loop on the answer.
 		const ids = new Set<number>();
 		for (let i = 0; i < threads.length; i++) {
 			const peer = threads[i].threadId;

--- a/server/threads/logRotationTransport.ts
+++ b/server/threads/logRotationTransport.ts
@@ -29,7 +29,9 @@ setRotationTransport({
 	peerThreadIds() {
 		// Every connected port, job workers included: an isolate that writes to the log holds a
 		// descriptor on it whether or not it takes part in ITC gossip, and the whole point of the
-		// acknowledgement is to know that no such descriptor survives.
+		// acknowledgement is to know that no such descriptor survives. The deadlock that keeps job
+		// workers out of the schema-gossip broadcast cannot happen here — the handler is a stat and a
+		// close with nothing to wait on, and no caller blocks its event loop on the answer.
 		const ids = new Set<number>();
 		for (let i = 0; i < threads.length; i++) {
 			const peer = threads[i].threadId;

--- a/server/threads/logRotationTransport.ts
+++ b/server/threads/logRotationTransport.ts
@@ -1,0 +1,40 @@
+'use strict';
+
+// Hands the log-rotation coordinator the thread mesh it needs, from this side of the dependency
+// edge: manageThreads already imports harper_logger, so logging can never import manageThreads.
+
+import { threadId } from 'node:worker_threads';
+import { setRotationTransport } from '../../utility/logging/logGenerationCoordinator.ts';
+import { broadcast, onMessageByType, onThreadExit } from './manageThreads.js';
+
+// The connected-ports array with `sendToThread`, assigned to the `threads` global by manageThreads.
+declare const threads: {
+	sendToThread(threadId: number, message: any): boolean;
+	[index: number]: { threadId?: number };
+	length: number;
+};
+
+setRotationTransport({
+	threadId,
+	broadcast(message) {
+		broadcast(message);
+	},
+	sendToThread(target, message) {
+		threads.sendToThread(target, message);
+	},
+	onMessage(type, handler) {
+		onMessageByType(type, handler);
+	},
+	onThreadExit,
+	peerThreadIds() {
+		// Every connected port, job workers included: an isolate that writes to the log holds a
+		// descriptor on it whether or not it takes part in ITC gossip, and the whole point of the
+		// acknowledgement is to know that no such descriptor survives.
+		const ids = new Set<number>();
+		for (let i = 0; i < threads.length; i++) {
+			const peer = threads[i].threadId;
+			if (peer !== undefined && peer !== threadId) ids.add(peer);
+		}
+		return ids;
+	},
+});

--- a/server/threads/logRotationTransport.ts
+++ b/server/threads/logRotationTransport.ts
@@ -27,11 +27,9 @@ setRotationTransport({
 	},
 	onThreadExit,
 	peerThreadIds() {
-		// Every connected port, job workers included: an isolate that writes to the log holds a
-		// descriptor on it whether or not it takes part in ITC gossip, and the whole point of the
-		// acknowledgement is to know that no such descriptor survives. The deadlock that keeps job
-		// workers out of the schema-gossip broadcast cannot happen here — the handler is a stat and a
-		// close with nothing to wait on, and no caller blocks its event loop on the answer.
+		// Job workers included: they write to the log whether or not they take part in ITC gossip. The
+		// deadlock that excludes them from the schema broadcast cannot happen here — the handler only
+		// closes a descriptor, and no caller blocks its event loop on the answer.
 		const ids = new Set<number>();
 		for (let i = 0; i < threads.length; i++) {
 			const peer = threads[i].threadId;

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -1594,6 +1594,6 @@ if (isMainThread) {
 	});
 }
 
-// From here, not from logging, which must never import this module. Last in the file because it
-// calls onThreadExit, whose listener array is declared above it.
+// From here, not from logging, which must never import this module. Last in the file: it calls
+// onThreadExit, declared above.
 require('./logRotationTransport.ts');

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -1594,7 +1594,6 @@ if (isMainThread) {
 	});
 }
 
-// Required from here, not from logging, so the coordinator's listeners are registered in every
-// meshed thread before any port can deliver to them, without logging ever importing this module.
-// Last in the file: it calls back into onThreadExit, whose listener array is declared below.
+// From here, not from logging, which must never import this module. Last in the file because it
+// calls onThreadExit, whose listener array is declared above it.
 require('./logRotationTransport.ts');

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -1594,6 +1594,6 @@ if (isMainThread) {
 	});
 }
 
-// From here, not from logging, which must never import this module. Last in the file: it calls
-// onThreadExit, declared above.
+// Required here, not from logging, which must never import this module; last in the file because it
+// calls onThreadExit.
 require('./logRotationTransport.ts');

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -1593,3 +1593,8 @@ if (isMainThread) {
 		realExit(0);
 	});
 }
+
+// Required from here, not from logging, so the coordinator's listeners are registered in every
+// meshed thread before any port can deliver to them, without logging ever importing this module.
+// Last in the file: it calls back into onThreadExit, whose listener array is declared below.
+require('./logRotationTransport.ts');

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -955,6 +955,14 @@ describe('Test harper_logger module', () => {
 			fs.removeSync(rotationCaseDir);
 		});
 
+		it('keeps a pathless install-time logger from creating an undefined file sink', () => {
+			const pathlessLogger = createLogger({ level: 'info' });
+			assert.doesNotThrow(() => {
+				pathlessLogger.path = undefined;
+			});
+			assert.strictEqual(pathlessLogger.path, undefined);
+		});
+
 		it('inherits the main rotation config (incl. maxSize) and rotates the external log file when no component rotation is configured', async () => {
 			const mainRotation = { enabled: true, maxSize: '1K', auditInterval: 100 };
 			const mainLogPath = path.join(rotationCaseDir, 'hdb.log');

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -934,33 +934,30 @@ describe('Test harper_logger module', () => {
 
 	describe('Test external/component logger rotation inheritance (#1877)', () => {
 		const ROTATION_TEST_DIR = path.join(__dirname, 'rotationInheritanceTest');
-		let loggersToCleanup;
+		let loggersToCleanup, rotationCaseDir;
+		let rotationCase = 0;
 
 		beforeEach(() => {
-			fs.mkdirpSync(ROTATION_TEST_DIR);
+			rotationCaseDir = path.join(ROTATION_TEST_DIR, `case${rotationCase++}`);
+			fs.mkdirpSync(rotationCaseDir);
 			loggersToCleanup = [];
 		});
 
 		afterEach(async () => {
-			// Stop each rotator interval before removing the directory. There's no public handle to
-			// a logger's internal rotator/file-logger entry, but disabling rotation and re-assigning
-			// `.path` (even to its own current value) goes through the same public `.path` setter
-			// production reload uses, which tears down the old rotator interval on a short internal
-			// timer — the same pattern already used to clean up `httpLogger`/`this.externalLogger`
-			// elsewhere in this file. Any still-open file descriptor is closed by the module's own
-			// safety-timeout, unref'd, so it can't hang the test process.
+			// Retract each logger's policy before removing its unique path so no cached sink remains
+			// claimed by a test-only configuration source.
 			for (const logger of loggersToCleanup) {
 				const currentPath = logger.path;
-				logger.rotation = { enabled: false };
-				logger.path = currentPath;
+				updateLogger(logger, { path: currentPath }, undefined, logger);
+				logger.closeLogFile();
 			}
 			await new Promise((resolve) => setTimeout(resolve, 150));
-			fs.removeSync(ROTATION_TEST_DIR);
+			fs.removeSync(rotationCaseDir);
 		});
 
 		it('inherits the main rotation config (incl. maxSize) and rotates the external log file when no component rotation is configured', async () => {
 			const mainRotation = { enabled: true, maxSize: '1K', auditInterval: 100 };
-			const mainLogPath = path.join(ROTATION_TEST_DIR, 'hdb.log');
+			const mainLogPath = path.join(rotationCaseDir, 'hdb.log');
 			const testMainLogger = createLogger({ path: mainLogPath, level: 'info' });
 			loggersToCleanup.push(testMainLogger);
 			// updateLogSettings() always applies the main logging options (incl. rotation) first,
@@ -971,7 +968,7 @@ describe('Test harper_logger module', () => {
 
 			const externalLogger = testMainLogger.forComponent('external');
 			loggersToCleanup.push(externalLogger);
-			const externalLogPath = path.join(ROTATION_TEST_DIR, 'external.log');
+			const externalLogPath = path.join(rotationCaseDir, 'external.log');
 
 			// This is the same call updateLogSettings() makes for `logging.external`: a path of its
 			// own, but no rotation block — it must inherit the main rotation, not lose it.
@@ -981,7 +978,7 @@ describe('Test harper_logger module', () => {
 
 			for (let i = 0; i < 30; i++) externalLogger.info('x'.repeat(80));
 
-			const rotatedDir = path.join(ROTATION_TEST_DIR, 'rotated');
+			const rotatedDir = path.join(rotationCaseDir, 'rotated');
 			await waitFor(() => fs.pathExistsSync(rotatedDir) && fs.readdirSync(rotatedDir).length > 0, {
 				timeout: 5000,
 				message: 'Expected the external log to be rotated using the inherited main maxSize',
@@ -989,16 +986,16 @@ describe('Test harper_logger module', () => {
 		});
 
 		it("does not inherit main's rotation path, so a wholesale-inherited rotation archives beside the component's own log instead of risking a cross-device rename (EXDEV)", () => {
-			const mainArchiveDir = path.join(ROTATION_TEST_DIR, 'mainArchive');
+			const mainArchiveDir = path.join(rotationCaseDir, 'mainArchive');
 			const mainRotation = { enabled: true, maxSize: '1K', path: mainArchiveDir };
-			const mainLogPath = path.join(ROTATION_TEST_DIR, 'hdb.log');
+			const mainLogPath = path.join(rotationCaseDir, 'hdb.log');
 			const testMainLogger = createLogger({ path: mainLogPath, level: 'info' });
 			loggersToCleanup.push(testMainLogger);
 			updateLogger(testMainLogger, { path: mainLogPath, rotation: mainRotation }, undefined, testMainLogger);
 
 			const externalLogger = testMainLogger.forComponent('external');
 			loggersToCleanup.push(externalLogger);
-			updateLogger(externalLogger, { path: path.join(ROTATION_TEST_DIR, 'external.log') }, undefined, testMainLogger);
+			updateLogger(externalLogger, { path: path.join(rotationCaseDir, 'external.log') }, undefined, testMainLogger);
 
 			// maxSize inherits; path does not, so this logger's own rotator defaults beside its file.
 			assert.deepStrictEqual(externalLogger.rotation, { enabled: true, maxSize: '1K' });
@@ -1009,7 +1006,7 @@ describe('Test harper_logger module', () => {
 
 		it('preserves an explicit component rotation override instead of the inherited main config', () => {
 			const mainRotation = { enabled: true, maxSize: '1K' };
-			const mainLogPath = path.join(ROTATION_TEST_DIR, 'hdb.log');
+			const mainLogPath = path.join(rotationCaseDir, 'hdb.log');
 			const testMainLogger = createLogger({ path: mainLogPath, level: 'info' });
 			loggersToCleanup.push(testMainLogger);
 			updateLogger(testMainLogger, { path: mainLogPath, rotation: mainRotation }, undefined, testMainLogger);
@@ -1019,7 +1016,7 @@ describe('Test harper_logger module', () => {
 			const override = { enabled: false };
 			updateLogger(
 				externalLogger,
-				{ path: path.join(ROTATION_TEST_DIR, 'external.log'), rotation: override },
+				{ path: path.join(rotationCaseDir, 'external.log'), rotation: override },
 				undefined,
 				testMainLogger
 			);
@@ -1027,23 +1024,122 @@ describe('Test harper_logger module', () => {
 			assert.deepStrictEqual(externalLogger.rotation, override);
 		});
 
-		it('still allows clearing the main logger rotation itself (no self-referential lock-in)', () => {
-			const mainLogPath = path.join(ROTATION_TEST_DIR, 'hdb.log');
+		it('removes the main sink guard when the main rotation block is removed', async () => {
+			const mainLogPath = path.join(rotationCaseDir, 'hdb.log');
+			const rotatedDir = path.join(rotationCaseDir, 'rotated');
 			const testMainLogger = createLogger({ path: mainLogPath, level: 'info' });
 			loggersToCleanup.push(testMainLogger);
 
 			updateLogger(
 				testMainLogger,
-				{ path: mainLogPath, rotation: { enabled: true, maxSize: '1K' } },
+				{ path: mainLogPath, rotation: { enabled: true, maxSize: '1K', path: rotatedDir } },
 				undefined,
 				testMainLogger
 			);
-			assert.deepStrictEqual(testMainLogger.rotation, { enabled: true, maxSize: '1K' });
+			for (let i = 0; i < 80; i++) testMainLogger.info(`before removal ${i} ${'x'.repeat(80)}`);
+			await waitFor(() => fs.pathExistsSync(rotatedDir) && fs.readdirSync(rotatedDir).length > 0, {
+				timeout: 5000,
+				message: 'Expected the configured write guard to rotate before removal',
+			});
 
 			// A reload with no rotation block at all (logOptions.rotation undefined) must still be
 			// able to clear the main logger's own rotation, not fall back to itself and get stuck.
 			updateLogger(testMainLogger, { path: mainLogPath }, undefined, testMainLogger);
 			assert.strictEqual(testMainLogger.rotation, undefined);
+			const archivesAfterRemoval = fs.readdirSync(rotatedDir).length;
+			for (let i = 0; i < 160; i++) testMainLogger.info(`after removal ${i} ${'y'.repeat(80)}`);
+			testMainLogger.notify('flush after rotation removal');
+			await waitFor(() => fs.statSync(mainLogPath).size > 4000, {
+				timeout: 5000,
+				message: 'Expected the active log to grow beyond the former write-path cap',
+			});
+			assert.strictEqual(fs.readdirSync(rotatedDir).length, archivesAfterRemoval);
+		});
+
+		it('does not let an inherited main policy replace an explicit component policy on the shared sink', async () => {
+			const mainLogPath = path.join(rotationCaseDir, 'hdb.log');
+			const rotatedDir = path.join(rotationCaseDir, 'rotated');
+			const testMainLogger = createLogger({ path: mainLogPath, level: 'info' });
+			loggersToCleanup.push(testMainLogger);
+			updateLogger(
+				testMainLogger,
+				{ path: mainLogPath, rotation: { enabled: true, maxSize: '1K', path: rotatedDir } },
+				undefined,
+				testMainLogger
+			);
+			const explicit = testMainLogger.forComponent('explicit');
+			loggersToCleanup.push(explicit);
+			updateLogger(explicit, { path: mainLogPath, rotation: { enabled: false } }, 'explicit', testMainLogger);
+			const inherited = testMainLogger.forComponent('inherited');
+			loggersToCleanup.push(inherited);
+			updateLogger(inherited, { path: mainLogPath }, 'inherited', testMainLogger);
+
+			for (let i = 0; i < 160; i++) inherited.info(`explicit policy survives ${i} ${'z'.repeat(80)}`);
+			inherited.notify('flush explicit policy test');
+			await waitFor(() => fs.statSync(mainLogPath).size > 4000);
+			assert.ok(!fs.pathExistsSync(rotatedDir) || fs.readdirSync(rotatedDir).length === 0);
+		});
+
+		it('restores the inherited main policy when an explicit component policy is removed', async () => {
+			const mainLogPath = path.join(rotationCaseDir, 'hdb.log');
+			const rotatedDir = path.join(rotationCaseDir, 'rotated');
+			const testMainLogger = createLogger({ path: mainLogPath, level: 'info' });
+			loggersToCleanup.push(testMainLogger);
+			updateLogger(
+				testMainLogger,
+				{ path: mainLogPath, rotation: { enabled: true, maxSize: '1K', path: rotatedDir } },
+				undefined,
+				testMainLogger
+			);
+			const component = testMainLogger.forComponent('component');
+			loggersToCleanup.push(component);
+			updateLogger(component, { path: mainLogPath, rotation: { enabled: false } }, 'component', testMainLogger);
+			updateLogger(component, { path: mainLogPath }, 'component', testMainLogger);
+
+			for (let i = 0; i < 80; i++) component.info(`restored main policy ${i} ${'r'.repeat(80)}`);
+			await waitFor(() => fs.pathExistsSync(rotatedDir) && fs.readdirSync(rotatedDir).length > 0, {
+				timeout: 5000,
+				message: 'Expected inherited main rotation to resume after the override was removed',
+			});
+		});
+
+		it('clears an explicit component policy when no main policy remains', async () => {
+			const mainLogPath = path.join(rotationCaseDir, 'hdb.log');
+			const rotatedDir = path.join(rotationCaseDir, 'rotated');
+			const testMainLogger = createLogger({ path: mainLogPath, level: 'info' });
+			loggersToCleanup.push(testMainLogger);
+			const component = testMainLogger.forComponent('component');
+			loggersToCleanup.push(component);
+			updateLogger(
+				component,
+				{ path: mainLogPath, rotation: { enabled: true, maxSize: '1K', path: rotatedDir } },
+				'component',
+				testMainLogger
+			);
+			for (let i = 0; i < 80; i++) component.info(`before component removal ${i} ${'c'.repeat(80)}`);
+			await waitFor(() => fs.pathExistsSync(rotatedDir) && fs.readdirSync(rotatedDir).length > 0);
+
+			updateLogger(component, { path: mainLogPath }, 'component', testMainLogger);
+			const archivesAfterRemoval = fs.readdirSync(rotatedDir).length;
+			for (let i = 0; i < 160; i++) component.info(`after component removal ${i} ${'d'.repeat(80)}`);
+			component.notify('flush component removal');
+			await waitFor(() => fs.statSync(mainLogPath).size > 4000);
+			assert.strictEqual(fs.readdirSync(rotatedDir).length, archivesAfterRemoval);
+		});
+
+		it('lets a new explicit logger reclaim an identical cached policy before clearing it', async () => {
+			const mainLogPath = path.join(rotationCaseDir, 'hdb.log');
+			const rotatedDir = path.join(rotationCaseDir, 'rotated');
+			const rotation = { enabled: true, maxSize: '1K', path: rotatedDir };
+			const first = createLogger({ path: mainLogPath, level: 'info', rotation });
+			const replacement = createLogger({ path: mainLogPath, level: 'info', rotation: { ...rotation } });
+			loggersToCleanup.push(first, replacement);
+			updateLogger(replacement, { path: mainLogPath }, undefined, replacement);
+
+			for (let i = 0; i < 160; i++) replacement.info(`replacement cleared ${i} ${'s'.repeat(80)}`);
+			replacement.notify('flush replacement clear');
+			await waitFor(() => fs.statSync(mainLogPath).size > 4000);
+			assert.ok(!fs.pathExistsSync(rotatedDir) || fs.readdirSync(rotatedDir).length === 0);
 		});
 	});
 

--- a/unitTests/utility/logging/logGenerationCoordinator.test.js
+++ b/unitTests/utility/logging/logGenerationCoordinator.test.js
@@ -138,6 +138,13 @@ describe('Test log generation coordinator (#1877)', () => {
 		transport.deliverRotation({ logPath, request: 'r3', stale: true });
 		assert.strictEqual(closed, 3, 'expected every descriptor to be released when there is no live log');
 		coordinator.unregisterLogSink(logPath);
+
+		// A filesystem that reports ino 0 cannot prove a descriptor is on the live generation, and
+		// answering "released" without releasing is what lets an archive be destroyed under a peer.
+		coordinator.registerLogSink(logPath, { identity: () => ({ ino: 0, dev: 0 }), close: () => closed++ });
+		transport.deliverRotation({ logPath, request: 'r4', stale: true, keepIno: 0, keepDev: 0 });
+		assert.strictEqual(closed, 4, 'expected an indistinguishable descriptor to be released');
+		coordinator.unregisterLogSink(logPath);
 	});
 
 	it('is not required to wait for a sink registered after the announcement', async () => {

--- a/unitTests/utility/logging/logGenerationCoordinator.test.js
+++ b/unitTests/utility/logging/logGenerationCoordinator.test.js
@@ -158,6 +158,33 @@ describe('Test log generation coordinator (#1877)', () => {
 		coordinator.unregisterLogSink(logPath);
 	});
 
+	it('releases stale descriptors for every log it writes, in one request', () => {
+		// The archive directory holds the archives of every component and external log sharing it, so a
+		// request scoped to one path would leave the others' archives destroyable under a live peer.
+		const transport = fakeTransport();
+		const dir = path.join(TEST_ROOT, `multiSink${caseNumber++}`);
+		fs.mkdirpSync(dir);
+		const closed = [];
+		const held = {};
+		for (const name of ['hdb.log', 'component.log', 'external.log']) {
+			const logPath = path.join(dir, name);
+			fs.writeFileSync(logPath, `${name} contents\n`);
+			held[name] = fs.statSync(logPath);
+			coordinator.registerLogSink(logPath, {
+				// hdb.log is on its live generation; the other two hold an older inode.
+				identity: () => (name === 'hdb.log' ? held[name] : { ino: held[name].ino + 1000, dev: held[name].dev }),
+				close: () => closed.push(name),
+			});
+		}
+
+		transport.deliverRotation({ request: 'multi', stale: true });
+
+		assert.deepStrictEqual(closed.sort(), ['component.log', 'external.log']);
+		for (const name of ['hdb.log', 'component.log', 'external.log']) {
+			coordinator.unregisterLogSink(path.join(dir, name));
+		}
+	});
+
 	it('is not required to wait for a sink registered after the announcement', async () => {
 		const transport = fakeTransport({ peers: [], autoRespond: false });
 		const { generation } = newGeneration();

--- a/unitTests/utility/logging/logGenerationCoordinator.test.js
+++ b/unitTests/utility/logging/logGenerationCoordinator.test.js
@@ -24,7 +24,7 @@ function fakeTransport({ peers = [1, 2], autoRespond = true, quiescenceTimeout =
 		broadcast(message) {
 			transport.broadcasts.push(message);
 			if (!autoRespond) return;
-			for (const peer of peers) transport.respond(peer, message.generation);
+			for (const peer of peers) transport.respond(peer, message.request);
 		},
 		sendToThread() {},
 		onMessage(type, handler) {
@@ -36,10 +36,10 @@ function fakeTransport({ peers = [1, 2], autoRespond = true, quiescenceTimeout =
 		peerThreadIds() {
 			return peers;
 		},
-		respond(threadId, generation) {
+		respond(threadId, request) {
 			handlers.get(coordinator.LOG_GENERATION_CLOSED)({
 				type: coordinator.LOG_GENERATION_CLOSED,
-				generation,
+				request,
 				threadId,
 			});
 		},
@@ -116,14 +116,21 @@ describe('Test log generation coordinator (#1877)', () => {
 		fs.writeFileSync(logPath, 'held\n');
 		const held = fs.statSync(logPath);
 		let closed = 0;
-		coordinator.registerLogSink(logPath, (ino, dev) => {
-			if (ino === held.ino && dev === held.dev) closed++;
+		coordinator.registerLogSink(logPath, {
+			identity: () => ({ ino: held.ino, dev: held.dev }),
+			close: () => closed++,
 		});
-		transport.deliverRotation({ logPath, generation: 'g', ino: held.ino, dev: held.dev, originator: 0 });
+		transport.deliverRotation({ logPath, request: 'g', ino: held.ino, dev: held.dev, originator: 0 });
 		assert.strictEqual(closed, 1, 'expected the sink to be asked to close its descriptor');
 		// A generation this sink never held must not close anything.
-		transport.deliverRotation({ logPath, generation: 'g2', ino: held.ino + 1, dev: held.dev, originator: 0 });
+		transport.deliverRotation({ logPath, request: 'g2', ino: held.ino + 1, dev: held.dev, originator: 0 });
 		assert.strictEqual(closed, 1, 'expected a foreign generation to leave the descriptor alone');
+
+		// The batched form retention uses is the inverse: release everything but the live generation.
+		transport.deliverRotation({ logPath, request: 'r1', keepIno: held.ino, keepDev: held.dev, originator: 0 });
+		assert.strictEqual(closed, 1, 'expected the live generation to be kept');
+		transport.deliverRotation({ logPath, request: 'r2', keepIno: held.ino + 1, keepDev: held.dev, originator: 0 });
+		assert.strictEqual(closed, 2, 'expected a stale descriptor to be released');
 		coordinator.unregisterLogSink(logPath);
 	});
 
@@ -149,6 +156,16 @@ describe('Test log generation coordinator (#1877)', () => {
 		assert.ok(!isArchivePendingQuiescence(generation.archivePath), 'expected the retry to clear the archive');
 		assert.ok(fs.pathExistsSync(`${generation.archivePath}.gz`), 'expected the retry to compress it');
 		assert.ok(!fs.pathExistsSync(generation.archivePath), 'expected the plain archive to be removed');
+	});
+
+	it('lets retention proceed only when every peer has released its stale descriptors', async () => {
+		const stalled = fakeTransport({ autoRespond: false });
+		assert.strictEqual(await coordinator.requestStaleDescriptorRelease('/no/such/log', { ino: 1, dev: 1 }), false);
+		assert.strictEqual(stalled.broadcasts.at(-1).keepIno, 1);
+
+		const answering = fakeTransport();
+		assert.strictEqual(await coordinator.requestStaleDescriptorRelease('/no/such/log', { ino: 1, dev: 1 }), true);
+		assert.strictEqual(answering.broadcasts.at(-1).keepDev, 1);
 	});
 
 	it('leaves the plain archive authoritative when compression fails', async () => {

--- a/unitTests/utility/logging/logGenerationCoordinator.test.js
+++ b/unitTests/utility/logging/logGenerationCoordinator.test.js
@@ -98,12 +98,14 @@ describe('Test log generation coordinator (#1877)', () => {
 		assert.ok((await published).endsWith('.gz'), 'expected worker exit to count as a release');
 	});
 
-	it('does not wait for peers when nothing is being compressed', async () => {
+	it('holds an uncompressed archive back from retention too, not just a compressed one', async () => {
 		fakeTransport({ autoRespond: false });
 		const { generation } = newGeneration();
 		const published = await publishArchivedGeneration(generation, false);
 		assert.strictEqual(published, generation.archivePath);
 		assert.ok(fs.pathExistsSync(generation.archivePath));
+		// Compression is not the only destructive path — retention unlinks archives as well.
+		assert.ok(isArchivePendingQuiescence(generation.archivePath));
 	});
 
 	it('closes a descriptor that still points at the announced generation', () => {

--- a/unitTests/utility/logging/logGenerationCoordinator.test.js
+++ b/unitTests/utility/logging/logGenerationCoordinator.test.js
@@ -130,21 +130,31 @@ describe('Test log generation coordinator (#1877)', () => {
 		transport.deliverRotation({ logPath, request: 'g2', ino: held.ino + 1, dev: held.dev, originator: 0 });
 		assert.strictEqual(closed, 1, 'expected a foreign generation to leave the descriptor alone');
 
-		// The batched form retention uses is the inverse: release everything but the live generation.
-		transport.deliverRotation({ logPath, request: 'r1', stale: true, keepIno: held.ino, keepDev: held.dev });
+		// The batched form retention uses is the inverse, and each sink judges its own path: release
+		// every descriptor that is not on the live generation of the file it is writing.
+		transport.deliverRotation({ request: 'r1', stale: true });
 		assert.strictEqual(closed, 1, 'expected the live generation to be kept');
-		transport.deliverRotation({ logPath, request: 'r2', stale: true, keepIno: held.ino + 1, keepDev: held.dev });
-		assert.strictEqual(closed, 2, 'expected a stale descriptor to be released');
-		// No live generation to name (the active log is gone) means every descriptor is stale.
-		transport.deliverRotation({ logPath, request: 'r3', stale: true });
-		assert.strictEqual(closed, 3, 'expected every descriptor to be released when there is no live log');
+		coordinator.unregisterLogSink(logPath);
+		coordinator.registerLogSink(logPath, {
+			identity: () => ({ ino: held.ino + 1, dev: held.dev }),
+			close: () => closed++,
+		});
+		transport.deliverRotation({ request: 'r2', stale: true });
+		assert.strictEqual(closed, 2, 'expected a descriptor on an older generation to be released');
 		coordinator.unregisterLogSink(logPath);
 
 		// A filesystem that reports ino 0 cannot prove a descriptor is on the live generation, and
 		// answering "released" without releasing is what lets an archive be destroyed under a peer.
 		coordinator.registerLogSink(logPath, { identity: () => ({ ino: 0, dev: 0 }), close: () => closed++ });
-		transport.deliverRotation({ logPath, request: 'r4', stale: true, keepIno: 0, keepDev: 0 });
-		assert.strictEqual(closed, 4, 'expected an indistinguishable descriptor to be released');
+		transport.deliverRotation({ request: 'r3', stale: true });
+		assert.strictEqual(closed, 3, 'expected an indistinguishable descriptor to be released');
+		coordinator.unregisterLogSink(logPath);
+
+		// A log whose file is gone can only be holding an archived inode.
+		fs.removeSync(logPath);
+		coordinator.registerLogSink(logPath, { identity: () => ({ ino: held.ino, dev: held.dev }), close: () => closed++ });
+		transport.deliverRotation({ request: 'r4', stale: true });
+		assert.strictEqual(closed, 4, 'expected a descriptor on a vanished path to be released');
 		coordinator.unregisterLogSink(logPath);
 	});
 
@@ -174,14 +184,13 @@ describe('Test log generation coordinator (#1877)', () => {
 
 	it('lets retention proceed only when every peer has released its stale descriptors', async () => {
 		const stalled = fakeTransport({ autoRespond: false });
-		const unproven = await coordinator.requestStaleDescriptorRelease('/no/such/log', { ino: 1, dev: 1 });
+		const unproven = await coordinator.requestStaleDescriptorRelease();
 		assert.strictEqual(unproven.released, false);
-		assert.strictEqual(stalled.broadcasts.at(-1).keepIno, 1);
+		assert.strictEqual(stalled.broadcasts.at(-1).stale, true);
 
-		const answering = fakeTransport();
-		const proven = await coordinator.requestStaleDescriptorRelease('/no/such/log', { ino: 1, dev: 1 });
+		fakeTransport();
+		const proven = await coordinator.requestStaleDescriptorRelease();
 		assert.strictEqual(proven.released, true);
-		assert.strictEqual(answering.broadcasts.at(-1).keepDev, 1);
 		// A peer's own registered log paths come back with its answer: a component loads in a worker,
 		// so the thread that runs retention only learns about that log this way.
 		assert.ok(proven.liveLogPaths.has('/a/component/own.log'), 'expected a peer-reported live log path');

--- a/unitTests/utility/logging/logGenerationCoordinator.test.js
+++ b/unitTests/utility/logging/logGenerationCoordinator.test.js
@@ -56,6 +56,9 @@ describe('Test log generation coordinator (#1877)', () => {
 
 	before(() => fs.mkdirpSync(TEST_ROOT));
 	after(() => {
+		// The coordinator's transport is module state; a fake left installed would follow every later
+		// suite in the same mocha process.
+		coordinator.setRotationTransport(undefined);
 		try {
 			fs.removeSync(TEST_ROOT);
 		} catch {}

--- a/unitTests/utility/logging/logGenerationCoordinator.test.js
+++ b/unitTests/utility/logging/logGenerationCoordinator.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const assert = require('node:assert');
+const fs = require('fs-extra');
+const path = require('node:path');
+const coordinator = require('#src/utility/logging/logGenerationCoordinator');
+const {
+	isArchivePendingQuiescence,
+	publishArchivedGeneration,
+	retryPendingGenerations,
+	rotateLogFileSync,
+} = require('#src/utility/logging/logRotation');
+
+const TEST_ROOT = path.join(__dirname, 'generationCoordinatorLogs');
+
+// Stands in for the thread mesh manageThreads injects, so the acknowledgement protocol can be driven
+// deterministically instead of by real worker timing.
+function fakeTransport({ peers = [1, 2], autoRespond = true, quiescenceTimeout = 50 } = {}) {
+	const handlers = new Map();
+	const transport = {
+		threadId: 0,
+		quiescenceTimeout,
+		broadcasts: [],
+		broadcast(message) {
+			transport.broadcasts.push(message);
+			if (!autoRespond) return;
+			for (const peer of peers) transport.respond(peer, message.generation);
+		},
+		sendToThread() {},
+		onMessage(type, handler) {
+			handlers.set(type, handler);
+		},
+		onThreadExit(handler) {
+			transport.exitHandler = handler;
+		},
+		peerThreadIds() {
+			return peers;
+		},
+		respond(threadId, generation) {
+			handlers.get(coordinator.LOG_GENERATION_CLOSED)({
+				type: coordinator.LOG_GENERATION_CLOSED,
+				generation,
+				threadId,
+			});
+		},
+		deliverRotation(message) {
+			handlers.get(coordinator.LOG_GENERATION_ROTATED)(message);
+		},
+	};
+	coordinator.setRotationTransport(transport);
+	return transport;
+}
+
+describe('Test log generation coordinator (#1877)', () => {
+	let caseNumber = 0;
+
+	before(() => fs.mkdirpSync(TEST_ROOT));
+	after(() => {
+		try {
+			fs.removeSync(TEST_ROOT);
+		} catch {}
+	});
+
+	function newGeneration(contents = 'archived generation contents\n') {
+		const dir = path.join(TEST_ROOT, `case${caseNumber++}`);
+		const rotatedDir = path.join(dir, 'rotated');
+		fs.mkdirpSync(rotatedDir);
+		const logPath = path.join(dir, 'hdb.log');
+		fs.writeFileSync(logPath, contents);
+		return { generation: rotateLogFileSync(logPath, rotatedDir, () => {}), logPath, rotatedDir };
+	}
+
+	it('publishes the compressed archive once every peer has acknowledged', async () => {
+		fakeTransport();
+		const { generation } = newGeneration();
+		const published = await publishArchivedGeneration(generation, true);
+		assert.ok(published.endsWith('.gz'), `expected a compressed archive, got ${published}`);
+		assert.ok(fs.pathExistsSync(published), 'expected the .gz to exist');
+		assert.ok(!fs.pathExistsSync(generation.archivePath), 'expected the plain archive to be removed');
+		assert.ok(!fs.readdirSync(path.dirname(published)).some((name) => name.endsWith('.tmp')));
+	});
+
+	it('keeps the plain archive when a peer never acknowledges', async () => {
+		fakeTransport({ autoRespond: false });
+		const { generation } = newGeneration();
+		const published = await publishArchivedGeneration(generation, true);
+		assert.strictEqual(published, generation.archivePath, 'expected the plain archive to stay authoritative');
+		assert.ok(fs.pathExistsSync(generation.archivePath), 'expected the plain archive to survive');
+		assert.ok(!fs.pathExistsSync(`${generation.archivePath}.gz`), 'expected no .gz to be published');
+	});
+
+	it('treats a peer that exits as having released the generation', async () => {
+		const transport = fakeTransport({ peers: [1, 2], autoRespond: false });
+		const { generation } = newGeneration();
+		const published = publishArchivedGeneration(generation, true);
+		transport.respond(1, generation.generation);
+		transport.exitHandler(2);
+		assert.ok((await published).endsWith('.gz'), 'expected worker exit to count as a release');
+	});
+
+	it('does not wait for peers when nothing is being compressed', async () => {
+		fakeTransport({ autoRespond: false });
+		const { generation } = newGeneration();
+		const published = await publishArchivedGeneration(generation, false);
+		assert.strictEqual(published, generation.archivePath);
+		assert.ok(fs.pathExistsSync(generation.archivePath));
+	});
+
+	it('closes a descriptor that still points at the announced generation', () => {
+		const transport = fakeTransport();
+		const dir = path.join(TEST_ROOT, `sink${caseNumber++}`);
+		fs.mkdirpSync(dir);
+		const logPath = path.join(dir, 'hdb.log');
+		fs.writeFileSync(logPath, 'held\n');
+		const held = fs.statSync(logPath);
+		let closed = 0;
+		coordinator.registerLogSink(logPath, (ino, dev) => {
+			if (ino === held.ino && dev === held.dev) closed++;
+		});
+		transport.deliverRotation({ logPath, generation: 'g', ino: held.ino, dev: held.dev, originator: 0 });
+		assert.strictEqual(closed, 1, 'expected the sink to be asked to close its descriptor');
+		// A generation this sink never held must not close anything.
+		transport.deliverRotation({ logPath, generation: 'g2', ino: held.ino + 1, dev: held.dev, originator: 0 });
+		assert.strictEqual(closed, 1, 'expected a foreign generation to leave the descriptor alone');
+		coordinator.unregisterLogSink(logPath);
+	});
+
+	it('is not required to wait for a sink registered after the announcement', async () => {
+		const transport = fakeTransport({ peers: [], autoRespond: false });
+		const { generation } = newGeneration();
+		assert.strictEqual(transport.peerThreadIds().length, 0);
+		assert.ok((await publishArchivedGeneration(generation, true)).endsWith('.gz'));
+	});
+
+	it('holds an unproven archive back from retention until a later pass proves it', async () => {
+		fakeTransport({ autoRespond: false });
+		const { generation } = newGeneration();
+		await publishArchivedGeneration(generation, true);
+		assert.ok(
+			isArchivePendingQuiescence(generation.archivePath),
+			'expected retention to be told to leave the unproven archive alone'
+		);
+
+		// A later pass, with the peer answering again, is what clears it.
+		fakeTransport();
+		await retryPendingGenerations();
+		assert.ok(!isArchivePendingQuiescence(generation.archivePath), 'expected the retry to clear the archive');
+		assert.ok(fs.pathExistsSync(`${generation.archivePath}.gz`), 'expected the retry to compress it');
+		assert.ok(!fs.pathExistsSync(generation.archivePath), 'expected the plain archive to be removed');
+	});
+
+	it('leaves the plain archive authoritative when compression fails', async () => {
+		fakeTransport();
+		const { generation } = newGeneration();
+		fs.removeSync(generation.archivePath);
+		await assert.rejects(publishArchivedGeneration(generation, true));
+		assert.ok(!fs.pathExistsSync(`${generation.archivePath}.gz`), 'expected no partial .gz to be published');
+	});
+});

--- a/unitTests/utility/logging/logGenerationCoordinator.test.js
+++ b/unitTests/utility/logging/logGenerationCoordinator.test.js
@@ -127,10 +127,13 @@ describe('Test log generation coordinator (#1877)', () => {
 		assert.strictEqual(closed, 1, 'expected a foreign generation to leave the descriptor alone');
 
 		// The batched form retention uses is the inverse: release everything but the live generation.
-		transport.deliverRotation({ logPath, request: 'r1', keepIno: held.ino, keepDev: held.dev, originator: 0 });
+		transport.deliverRotation({ logPath, request: 'r1', stale: true, keepIno: held.ino, keepDev: held.dev });
 		assert.strictEqual(closed, 1, 'expected the live generation to be kept');
-		transport.deliverRotation({ logPath, request: 'r2', keepIno: held.ino + 1, keepDev: held.dev, originator: 0 });
+		transport.deliverRotation({ logPath, request: 'r2', stale: true, keepIno: held.ino + 1, keepDev: held.dev });
 		assert.strictEqual(closed, 2, 'expected a stale descriptor to be released');
+		// No live generation to name (the active log is gone) means every descriptor is stale.
+		transport.deliverRotation({ logPath, request: 'r3', stale: true });
+		assert.strictEqual(closed, 3, 'expected every descriptor to be released when there is no live log');
 		coordinator.unregisterLogSink(logPath);
 	});
 

--- a/unitTests/utility/logging/logGenerationCoordinator.test.js
+++ b/unitTests/utility/logging/logGenerationCoordinator.test.js
@@ -41,6 +41,7 @@ function fakeTransport({ peers = [1, 2], autoRespond = true, quiescenceTimeout =
 				type: coordinator.LOG_GENERATION_CLOSED,
 				request,
 				threadId,
+				logPaths: ['/a/component/own.log'],
 			});
 		},
 		deliverRotation(message) {
@@ -173,12 +174,17 @@ describe('Test log generation coordinator (#1877)', () => {
 
 	it('lets retention proceed only when every peer has released its stale descriptors', async () => {
 		const stalled = fakeTransport({ autoRespond: false });
-		assert.strictEqual(await coordinator.requestStaleDescriptorRelease('/no/such/log', { ino: 1, dev: 1 }), false);
+		const unproven = await coordinator.requestStaleDescriptorRelease('/no/such/log', { ino: 1, dev: 1 });
+		assert.strictEqual(unproven.released, false);
 		assert.strictEqual(stalled.broadcasts.at(-1).keepIno, 1);
 
 		const answering = fakeTransport();
-		assert.strictEqual(await coordinator.requestStaleDescriptorRelease('/no/such/log', { ino: 1, dev: 1 }), true);
+		const proven = await coordinator.requestStaleDescriptorRelease('/no/such/log', { ino: 1, dev: 1 });
+		assert.strictEqual(proven.released, true);
 		assert.strictEqual(answering.broadcasts.at(-1).keepDev, 1);
+		// A peer's own registered log paths come back with its answer: a component loads in a worker,
+		// so the thread that runs retention only learns about that log this way.
+		assert.ok(proven.liveLogPaths.has('/a/component/own.log'), 'expected a peer-reported live log path');
 	});
 
 	it('leaves the plain archive authoritative when compression fails', async () => {

--- a/unitTests/utility/logging/logGenerationCoordinator.test.js
+++ b/unitTests/utility/logging/logGenerationCoordinator.test.js
@@ -203,6 +203,30 @@ describe('Test log generation coordinator (#1877)', () => {
 		coordinator.unregisterLogSink(logPath);
 	});
 
+	it('closes every sink holding one file, not just the last one registered for it', () => {
+		// harper_logger caches its file loggers by the raw configured path, so two spellings of one
+		// file are two sinks with two descriptors on it. Keying the release map by the resolved path
+		// makes them collide; only closing one leaves an open descriptor outside every release request
+		// while the answer still says "released".
+		const transport = fakeTransport();
+		const dir = path.join(TEST_ROOT, `sameFileTwice${caseNumber++}`);
+		fs.mkdirpSync(dir);
+		const logPath = path.join(dir, 'hdb.log');
+		fs.writeFileSync(logPath, 'contents\n');
+		const held = fs.statSync(logPath);
+		const stale = { ino: held.ino + 1000, dev: held.dev };
+		const closed = [];
+		const first = { identity: () => stale, close: () => closed.push('first') };
+		const second = { identity: () => stale, close: () => closed.push('second') };
+		coordinator.registerLogSink(logPath, first);
+		coordinator.registerLogSink(path.join(dir, '.', 'hdb.log'), second);
+
+		transport.deliverRotation({ request: 'sameFile', stale: true });
+
+		assert.deepStrictEqual(closed.sort(), ['first', 'second']);
+		coordinator.unregisterLogSink(logPath);
+	});
+
 	it('is not required to wait for a sink registered after the announcement', async () => {
 		const transport = fakeTransport({ peers: [], autoRespond: false });
 		const { generation } = newGeneration();

--- a/unitTests/utility/logging/logGenerationCoordinator.test.js
+++ b/unitTests/utility/logging/logGenerationCoordinator.test.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert');
 const fs = require('fs-extra');
 const path = require('node:path');
+const { Worker } = require('node:worker_threads');
 const coordinator = require('#src/utility/logging/logGenerationCoordinator');
 const {
 	isArchivePendingQuiescence,
@@ -91,6 +92,26 @@ describe('Test log generation coordinator (#1877)', () => {
 		assert.strictEqual(published, generation.archivePath, 'expected the plain archive to stay authoritative');
 		assert.ok(fs.pathExistsSync(generation.archivePath), 'expected the plain archive to survive');
 		assert.ok(!fs.pathExistsSync(`${generation.archivePath}.gz`), 'expected no .gz to be published');
+	});
+
+	it('keeps a worker archive plain until its thread transport is installed', async () => {
+		const dir = path.join(TEST_ROOT, `workerWithoutTransport${caseNumber++}`);
+		const logPath = path.join(dir, 'hdb.log');
+		const rotatedDir = path.join(dir, 'rotated');
+		const worker = new Worker(path.join(__dirname, 'rotation-worker-for-tests.js'), {
+			workerData: { withoutTransport: true, logPath, rotatedDir },
+		});
+		const result = await new Promise((resolve, reject) => {
+			worker.once('message', resolve);
+			worker.once('error', reject);
+		});
+		await worker.terminate();
+		assert.ifError(result.error);
+		assert.strictEqual(result.released, false, 'a worker without a mesh cannot prove peer release');
+		assert.strictEqual(result.pending, true, 'the unproven generation must be held back from destruction');
+		assert.strictEqual(result.plainExists, true, 'the plain archive must remain authoritative');
+		assert.strictEqual(result.compressedExists, false, 'no compressed replacement may be published');
+		assert.strictEqual(result.published.endsWith('.log'), true);
 	});
 
 	it('treats a peer that exits as having released the generation', async () => {
@@ -265,6 +286,13 @@ describe('Test log generation coordinator (#1877)', () => {
 		// A peer's own registered log paths come back with its answer: a component loads in a worker,
 		// so the thread that runs retention only learns about that log this way.
 		assert.ok(proven.liveLogPaths.has('/a/component/own.log'), 'expected a peer-reported live log path');
+	});
+
+	it('does not shorten a peer release proof to fit an exhausted audit budget', async () => {
+		const transport = fakeTransport({ autoRespond: false, quiescenceTimeout: 50 });
+		const result = await coordinator.requestStaleDescriptorRelease(Date.now() + 10);
+		assert.strictEqual(result.released, false);
+		assert.strictEqual(transport.broadcasts.length, 0, 'a proof must not start when its full timeout cannot fit');
 	});
 
 	it('leaves the plain archive authoritative when compression fails', async () => {

--- a/unitTests/utility/logging/logGenerationCoordinator.test.js
+++ b/unitTests/utility/logging/logGenerationCoordinator.test.js
@@ -114,6 +114,26 @@ describe('Test log generation coordinator (#1877)', () => {
 		assert.strictEqual(result.published.endsWith('.log'), true);
 	});
 
+	it('keeps a worker archive plain even when its local peer release succeeds', async () => {
+		const dir = path.join(TEST_ROOT, `workerWithTransport${caseNumber++}`);
+		const logPath = path.join(dir, 'hdb.log');
+		const rotatedDir = path.join(dir, 'rotated');
+		const worker = new Worker(path.join(__dirname, 'rotation-worker-for-tests.js'), {
+			workerData: { withTransport: true, logPath, rotatedDir },
+		});
+		const result = await new Promise((resolve, reject) => {
+			worker.once('message', resolve);
+			worker.once('error', reject);
+		});
+		await worker.terminate();
+		assert.ifError(result.error);
+		assert.strictEqual(result.released, true, 'expected the worker-local release proof to succeed');
+		assert.strictEqual(result.pending, false, 'a successful release should need no local retry');
+		assert.strictEqual(result.plainExists, true, 'the main-thread audit must remain the destructive publisher');
+		assert.strictEqual(result.compressedExists, false, 'the worker must not publish a compressed replacement');
+		assert.strictEqual(result.published.endsWith('.log'), true);
+	});
+
 	it('treats a peer that exits as having released the generation', async () => {
 		const transport = fakeTransport({ peers: [1, 2], autoRespond: false });
 		const { generation } = newGeneration();
@@ -150,32 +170,43 @@ describe('Test log generation coordinator (#1877)', () => {
 		// A generation this sink never held must not close anything.
 		transport.deliverRotation({ logPath, request: 'g2', ino: held.ino + 1, dev: held.dev, originator: 0 });
 		assert.strictEqual(closed, 1, 'expected a foreign generation to leave the descriptor alone');
+		coordinator.unregisterLogSink(logPath);
+
+		// The per-generation release needs the same fail-closed treatment as the stale sweep below.
+		coordinator.registerLogSink(logPath, { identity: () => ({ ino: 0, dev: 0 }), close: () => closed++ });
+		transport.deliverRotation({ logPath, request: 'g3', ino: held.ino, dev: held.dev, originator: 0 });
+		assert.strictEqual(closed, 2, 'expected an indistinguishable announced generation to be released');
+		coordinator.unregisterLogSink(logPath);
+		coordinator.registerLogSink(logPath, {
+			identity: () => ({ ino: held.ino, dev: held.dev }),
+			close: () => closed++,
+		});
 
 		// The batched form retention uses is the inverse, and each sink judges its own path: release
 		// every descriptor that is not on the live generation of the file it is writing.
 		transport.deliverRotation({ request: 'r1', stale: true });
-		assert.strictEqual(closed, 1, 'expected the live generation to be kept');
+		assert.strictEqual(closed, 2, 'expected the live generation to be kept');
 		coordinator.unregisterLogSink(logPath);
 		coordinator.registerLogSink(logPath, {
 			identity: () => ({ ino: held.ino + 1, dev: held.dev }),
 			close: () => closed++,
 		});
 		transport.deliverRotation({ request: 'r2', stale: true });
-		assert.strictEqual(closed, 2, 'expected a descriptor on an older generation to be released');
+		assert.strictEqual(closed, 3, 'expected a descriptor on an older generation to be released');
 		coordinator.unregisterLogSink(logPath);
 
 		// A filesystem that reports ino 0 cannot prove a descriptor is on the live generation, and
 		// answering "released" without releasing is what lets an archive be destroyed under a peer.
 		coordinator.registerLogSink(logPath, { identity: () => ({ ino: 0, dev: 0 }), close: () => closed++ });
 		transport.deliverRotation({ request: 'r3', stale: true });
-		assert.strictEqual(closed, 3, 'expected an indistinguishable descriptor to be released');
+		assert.strictEqual(closed, 4, 'expected an indistinguishable descriptor to be released');
 		coordinator.unregisterLogSink(logPath);
 
 		// A log whose file is gone can only be holding an archived inode.
 		fs.removeSync(logPath);
 		coordinator.registerLogSink(logPath, { identity: () => ({ ino: held.ino, dev: held.dev }), close: () => closed++ });
 		transport.deliverRotation({ request: 'r4', stale: true });
-		assert.strictEqual(closed, 4, 'expected a descriptor on a vanished path to be released');
+		assert.strictEqual(closed, 5, 'expected a descriptor on a vanished path to be released');
 		coordinator.unregisterLogSink(logPath);
 	});
 

--- a/unitTests/utility/logging/logGenerationCoordinator.test.js
+++ b/unitTests/utility/logging/logGenerationCoordinator.test.js
@@ -219,7 +219,9 @@ describe('Test log generation coordinator (#1877)', () => {
 		const first = { identity: () => stale, close: () => closed.push('first') };
 		const second = { identity: () => stale, close: () => closed.push('second') };
 		coordinator.registerLogSink(logPath, first);
-		coordinator.registerLogSink(path.join(dir, '.', 'hdb.log'), second);
+		// Built by concatenation, not path.join: join normalizes the dot segment away, and the point
+		// is two different raw strings that resolve to one file.
+		coordinator.registerLogSink(`${dir}${path.sep}.${path.sep}hdb.log`, second);
 
 		transport.deliverRotation({ request: 'sameFile', stale: true });
 

--- a/unitTests/utility/logging/logGenerationCoordinator.test.js
+++ b/unitTests/utility/logging/logGenerationCoordinator.test.js
@@ -295,11 +295,23 @@ describe('Test log generation coordinator (#1877)', () => {
 		assert.strictEqual(transport.broadcasts.length, 0, 'a proof must not start when its full timeout cannot fit');
 	});
 
+	it('bounds generation release requests while a peer is unresponsive', async () => {
+		const transport = fakeTransport({ autoRespond: false, quiescenceTimeout: 25 });
+		const releases = Array.from({ length: 65 }, () => coordinator.requestStaleDescriptorRelease());
+		await new Promise(setImmediate);
+		assert.strictEqual(transport.broadcasts.length, 64, 'overflow must wait for the audit sweep without broadcasting');
+		const results = await Promise.all(releases);
+		assert.ok(results.every(({ released }) => !released));
+	});
+
 	it('leaves the plain archive authoritative when compression fails', async () => {
 		fakeTransport();
 		const { generation } = newGeneration();
 		fs.removeSync(generation.archivePath);
-		await assert.rejects(publishArchivedGeneration(generation, true));
+		let reported;
+		const published = await publishArchivedGeneration(generation, true, (error) => (reported = error));
+		assert.strictEqual(published, generation.archivePath);
+		assert.ok(reported, 'compression failure must be reported without making rotation fail');
 		assert.ok(!fs.pathExistsSync(`${generation.archivePath}.gz`), 'expected no partial .gz to be published');
 	});
 });

--- a/unitTests/utility/logging/logGenerationCoordinator.test.js
+++ b/unitTests/utility/logging/logGenerationCoordinator.test.js
@@ -185,6 +185,24 @@ describe('Test log generation coordinator (#1877)', () => {
 		}
 	});
 
+	it('closes a descriptor whose identity it cannot read rather than answering for it', () => {
+		// openLogFile() leaves the descriptor open when its fstat fails, so a null identity means "open,
+		// generation unknown" — the one state in which answering "released" without releasing lets an
+		// archive be unlinked under this sink.
+		const transport = fakeTransport();
+		const dir = path.join(TEST_ROOT, `unknownIdentity${caseNumber++}`);
+		fs.mkdirpSync(dir);
+		const logPath = path.join(dir, 'hdb.log');
+		fs.writeFileSync(logPath, 'contents\n');
+		let closed = false;
+		coordinator.registerLogSink(logPath, { identity: () => null, close: () => (closed = true) });
+
+		transport.deliverRotation({ request: 'unknown', stale: true });
+
+		assert.ok(closed, 'a sink with an unreadable identity must be closed, not skipped');
+		coordinator.unregisterLogSink(logPath);
+	});
+
 	it('is not required to wait for a sink registered after the announcement', async () => {
 		const transport = fakeTransport({ peers: [], autoRespond: false });
 		const { generation } = newGeneration();

--- a/unitTests/utility/logging/logRotationGuard.test.js
+++ b/unitTests/utility/logging/logRotationGuard.test.js
@@ -129,6 +129,22 @@ describe('Test log rotation on the write path (#1877)', () => {
 		assert.match(contents, /^\S+ \[[^\]]+\] \[notify\]: hdb\.log rotated, old log moved to \S+$/m);
 	});
 
+	it('rotates from inside a buffered flush without duplicating or losing the batch', async () => {
+		const { logger, logPath, rotatedDir } = newCase({ maxSize: '4K' });
+		// The sink starts buffering once it thinks it is spending more than ~2% of the time writing,
+		// which a few very large entries achieve; from then on a flush is a whole batch at once, and
+		// the rotation it triggers writes its notice back through this same sink mid-flush.
+		for (let i = 0; i < 6; i++) logger.error('warming the buffer', 'w'.repeat(200000));
+		for (let i = 0; i < 40; i++) logger.error(`batched-marker-${i}-${'b'.repeat(120)}`);
+		logger.notify('flushing the batch');
+
+		const contents = await waitForContent(logPath, rotatedDir, 'batched-marker-39-');
+		for (let i = 0; i < 40; i++) {
+			const occurrences = contents.split(`batched-marker-${i}-`).length - 1;
+			assert.strictEqual(occurrences, 1, `batched-marker-${i} appeared ${occurrences} times across all generations`);
+		}
+	});
+
 	it('never rotates when rotation is disabled, even with a maxSize set', () => {
 		const { logger, logPath, rotatedDir } = newCase({ enabled: false, maxSize: '1K' });
 		for (let i = 0; i < 200; i++) logger.error(`disabled rotation line ${i} ${'z'.repeat(60)}`);

--- a/unitTests/utility/logging/logRotationGuard.test.js
+++ b/unitTests/utility/logging/logRotationGuard.test.js
@@ -1,0 +1,229 @@
+'use strict';
+
+const assert = require('node:assert');
+const fs = require('fs-extra');
+const path = require('node:path');
+const { Worker } = require('node:worker_threads');
+const hdbLogger = require('#src/utility/logging/harper_logger');
+const { parseMaxSize } = require('#src/utility/logging/logRotation');
+const { pinLogConfig } = require('../../logConfigFixture.js');
+const { waitFor } = require('../../waitFor.js');
+
+// Long enough that the audit tick can never be what rotates: every assertion below is about the
+// write path itself. On origin/main this makes the whole suite fail — nothing else checks the size.
+const NEVER_TICKS = 3600000;
+const TEST_ROOT = path.join(__dirname, 'rotationGuardLogs');
+
+describe('Test log rotation on the write path (#1877)', () => {
+	let restoreLogConfig;
+	let caseNumber = 0;
+
+	before(() => {
+		restoreLogConfig = pinLogConfig({ level: 'error' });
+		fs.mkdirpSync(TEST_ROOT);
+	});
+
+	after(() => {
+		restoreLogConfig?.();
+		try {
+			fs.removeSync(TEST_ROOT);
+		} catch {}
+	});
+
+	// getFileLogger caches by path, and the guard belongs to the first closure built for it, so
+	// every case needs a path of its own.
+	function newCase(rotation) {
+		const dir = path.join(TEST_ROOT, `case${caseNumber++}`);
+		fs.mkdirpSync(dir);
+		const logPath = path.join(dir, 'hdb.log');
+		const rotatedDir = path.join(dir, 'rotated');
+		const logger = hdbLogger.createLogger({
+			stdStreams: false,
+			path: logPath,
+			level: 'error',
+			rotation: { enabled: true, auditInterval: NEVER_TICKS, path: rotatedDir, ...rotation },
+		});
+		return { logger, logPath, rotatedDir };
+	}
+
+	function archives(rotatedDir) {
+		try {
+			return fs.readdirSync(rotatedDir).map((name) => path.join(rotatedDir, name));
+		} catch {
+			return [];
+		}
+	}
+
+	function activeSize(logPath) {
+		try {
+			return fs.statSync(logPath).size;
+		} catch {
+			return 0;
+		}
+	}
+
+	it('bounds the active log while it is being written, without waiting for an audit tick', () => {
+		const { logger, logPath, rotatedDir } = newCase({ maxSize: '4K' });
+		let peak = 0;
+		for (let i = 0; i < 400; i++) {
+			logger.error(`bounded rotation line ${i} ${'x'.repeat(60)}`);
+			peak = Math.max(peak, activeSize(logPath));
+		}
+		assert.ok(archives(rotatedDir).length > 0, 'expected the write path to have rotated the log');
+		// maxBytes + one check quantum + one payload, with room for the rotation notice.
+		assert.ok(peak < 4 * 4000, `active log peaked at ${peak} bytes for a 4K maxSize`);
+	});
+
+	it('rotates a log that is already oversized on the first write, not on a later tick', () => {
+		const dir = path.join(TEST_ROOT, `pre-existing${caseNumber++}`);
+		fs.mkdirpSync(dir);
+		const logPath = path.join(dir, 'hdb.log');
+		const rotatedDir = path.join(dir, 'rotated');
+		fs.writeFileSync(logPath, 'x'.repeat(50000));
+		const logger = hdbLogger.createLogger({
+			stdStreams: false,
+			path: logPath,
+			level: 'error',
+			rotation: { enabled: true, maxSize: '4K', auditInterval: NEVER_TICKS, path: rotatedDir },
+		});
+		logger.error('first write after restart');
+		assert.strictEqual(archives(rotatedDir).length, 1, 'expected exactly one archive after one write');
+		assert.ok(activeSize(logPath) < 4000, 'expected a fresh, small active log');
+	});
+
+	it('keeps every message exactly once across the active log and the archives', () => {
+		const { logger, logPath, rotatedDir } = newCase({ maxSize: '4K' });
+		const total = 300;
+		for (let i = 0; i < total; i++) logger.error(`unique-marker-${i}-${'y'.repeat(40)}`);
+		logger.closeLogFile();
+		const contents = [logPath, ...archives(rotatedDir)]
+			.map((file) => {
+				try {
+					return fs.readFileSync(file, 'utf8');
+				} catch {
+					return '';
+				}
+			})
+			.join('');
+		for (let i = 0; i < total; i++) {
+			const occurrences = contents.split(`unique-marker-${i}-`).length - 1;
+			assert.strictEqual(occurrences, 1, `marker ${i} appeared ${occurrences} times across all generations`);
+		}
+	});
+
+	it('never rotates when rotation is disabled, even with a maxSize set', () => {
+		const { logger, logPath, rotatedDir } = newCase({ enabled: false, maxSize: '1K' });
+		for (let i = 0; i < 200; i++) logger.error(`disabled rotation line ${i} ${'z'.repeat(60)}`);
+		assert.strictEqual(archives(rotatedDir).length, 0, 'expected no archives when rotation is disabled');
+		assert.ok(activeSize(logPath) > 1000, 'expected the log to grow past maxSize when rotation is disabled');
+	});
+
+	it('measures payloads in bytes, so a multi-byte log does not overshoot', () => {
+		const { logger, logPath, rotatedDir } = newCase({ maxSize: '4K' });
+		let peak = 0;
+		for (let i = 0; i < 200; i++) {
+			logger.error(`multibyte ${i} ${'é中🚀'.repeat(20)}`);
+			peak = Math.max(peak, activeSize(logPath));
+		}
+		assert.ok(archives(rotatedDir).length > 0, 'expected rotation for a multi-byte payload');
+		assert.ok(peak < 4 * 4000, `active log peaked at ${peak} bytes for a 4K maxSize`);
+	});
+
+	it('rotates from a worker thread too, keeping every message exactly once across generations', async () => {
+		const { logger, logPath, rotatedDir } = newCase({ maxSize: '4K' });
+		const rotation = { enabled: true, maxSize: '4K', auditInterval: NEVER_TICKS, path: rotatedDir };
+		const worker = new Worker(path.join(__dirname, 'rotation-worker-for-tests.js'), {
+			workerData: { logPath, rotation, lineCount: 200, markerPrefix: 'worker-marker' },
+		});
+		const workerDone = new Promise((resolve, reject) => {
+			worker.once('message', resolve);
+			worker.once('error', reject);
+		});
+		for (let i = 0; i < 200; i++) logger.error(`main-marker-${i}-${'q'.repeat(40)}`);
+		await workerDone;
+		await worker.terminate();
+		logger.closeLogFile();
+
+		assert.ok(archives(rotatedDir).length > 0, 'expected rotation with a worker thread writing');
+		const readAll = () =>
+			[logPath, ...archives(rotatedDir)]
+				.map((file) => {
+					try {
+						return fs.readFileSync(file, 'utf8');
+					} catch {
+						return '';
+					}
+				})
+				.join('');
+		// Both sinks flush on a timer under load, so wait for the last entry rather than racing it.
+		const contents = await waitFor(
+			() => {
+				const all = readAll();
+				return all.includes(`worker-marker-199-`) && all.includes(`main-marker-199-`) ? all : false;
+			},
+			{
+				timeout: 10000,
+				message: 'the last marker from each thread never reached the log',
+			}
+		);
+		for (const prefix of ['main-marker', 'worker-marker']) {
+			for (let i = 0; i < 200; i++) {
+				const occurrences = contents.split(`${prefix}-${i}-`).length - 1;
+				assert.strictEqual(occurrences, 1, `${prefix}-${i} appeared ${occurrences} times across all generations`);
+			}
+		}
+	}).timeout(30000);
+
+	it('resumes writing to the file once a broken rotation target is repaired', async function () {
+		this.timeout(30000);
+		const { logger, logPath, rotatedDir } = newCase({ maxSize: '4K' });
+		logger.error('one line so the rotated directory exists');
+		fs.removeSync(rotatedDir);
+		fs.writeFileSync(rotatedDir, 'not a directory');
+		for (let i = 0; i < 60; i++) logger.error(`broken rotation line ${i} ${'w'.repeat(60)}`);
+		const strandedSize = activeSize(logPath);
+
+		fs.removeSync(rotatedDir);
+		fs.mkdirpSync(rotatedDir);
+		// The retry happens before an append, not after one, so the log has to keep being written to.
+		await waitFor(
+			() => {
+				logger.error(`recovery probe ${'w'.repeat(60)}`);
+				return archives(rotatedDir).length > 0;
+			},
+			{ timeout: 20000, interval: 250, message: 'rotation never recovered after the target was repaired' }
+		);
+		assert.ok(activeSize(logPath) < strandedSize + 4 * 4000, 'expected the log to stay bounded through recovery');
+	});
+
+	it('stops growing the log and reports to stdio when the rotation target cannot be written', () => {
+		const { logger, logPath, rotatedDir } = newCase({ maxSize: '4K' });
+		logger.error('one line so the rotated directory exists');
+		// Replacing the rotated directory with a file makes every rename fail with ENOTDIR, which is
+		// the portable stand-in for the read-only/exhausted rotation target this must survive.
+		fs.removeSync(rotatedDir);
+		fs.writeFileSync(rotatedDir, 'not a directory');
+		for (let i = 0; i < 60; i++) logger.error(`failing rotation line ${i} ${'w'.repeat(60)}`);
+		const size = activeSize(logPath);
+		assert.ok(size < 4 * 4000, `active log grew to ${size} bytes while rotation was failing`);
+	});
+});
+
+describe('Test parseMaxSize (#1877)', () => {
+	it('accepts well-formed sizes', () => {
+		assert.strictEqual(parseMaxSize('64M'), 64000000);
+		assert.strictEqual(parseMaxSize('1K'), 1000);
+		// Forms the old parseInt-based validator accepted and that produce a usable cap keep working.
+		assert.strictEqual(parseMaxSize('1e3K'), 1000000);
+		assert.strictEqual(parseMaxSize('0.1K'), 100);
+		// 3G >> 4 is negative on a 32-bit shift; the quantum arithmetic must stay positive.
+		assert.strictEqual(parseMaxSize('3G'), 3000000000);
+		assert.ok(Math.floor(parseMaxSize('3G') / 16) > 0);
+	});
+
+	it('rejects the values the config validator used to let through', () => {
+		for (const value of ['0K', '-1K', '1xK', '', 'K', '64', '64X', null, undefined, 64]) {
+			assert.strictEqual(parseMaxSize(value), undefined, `expected ${JSON.stringify(value)} to be rejected`);
+		}
+	});
+});

--- a/unitTests/utility/logging/logRotationGuard.test.js
+++ b/unitTests/utility/logging/logRotationGuard.test.js
@@ -6,7 +6,7 @@ const path = require('node:path');
 const { Worker } = require('node:worker_threads');
 const hdbLogger = require('#src/utility/logging/harper_logger');
 const { parseMaxSize } = require('#src/utility/logging/logRotation');
-const { announceGeneration } = require('#src/utility/logging/logGenerationCoordinator');
+const { requestGenerationClose } = require('#src/utility/logging/logGenerationCoordinator');
 const { pinLogConfig } = require('../../logConfigFixture.js');
 const { waitFor } = require('../../waitFor.js');
 
@@ -196,7 +196,7 @@ describe('Test log rotation on the write path (#1877)', () => {
 		assert.ok(activeSize(logPath) < strandedSize + 4 * 4000, 'expected the log to stay bounded through recovery');
 	});
 
-	it('releases a descriptor on an announced generation even with no size guard of its own', () => {
+	it('releases a descriptor on an announced generation even with no size guard of its own', async () => {
 		// A thread rotating only on `interval` builds no size guard, but it still holds a descriptor,
 		// and answering an announcement has to mean released rather than only "handler ran".
 		const dir = path.join(TEST_ROOT, `noGuard${caseNumber++}`);
@@ -214,7 +214,7 @@ describe('Test log rotation on the write path (#1877)', () => {
 		// Another thread rotates: the file moves out from under this descriptor.
 		const archivePath = path.join(dir, 'moved.log');
 		fs.renameSync(logPath, archivePath);
-		announceGeneration({ logPath, generation: 'g', ino: held.ino, dev: held.dev });
+		await requestGenerationClose({ logPath, generation: 'g', ino: held.ino, dev: held.dev });
 
 		logger.error('after the announced rotation');
 		logger.closeLogFile();

--- a/unitTests/utility/logging/logRotationGuard.test.js
+++ b/unitTests/utility/logging/logRotationGuard.test.js
@@ -54,6 +54,28 @@ describe('Test log rotation on the write path (#1877)', () => {
 		}
 	}
 
+	function readGenerations(logPath, rotatedDir) {
+		return [logPath, ...archives(rotatedDir)]
+			.map((file) => {
+				try {
+					return fs.readFileSync(file, 'utf8');
+				} catch {
+					return '';
+				}
+			})
+			.join('');
+	}
+
+	function waitForContent(logPath, rotatedDir, ...expected) {
+		return waitFor(
+			() => {
+				const all = readGenerations(logPath, rotatedDir);
+				return expected.every((marker) => all.includes(marker)) ? all : false;
+			},
+			{ timeout: 10000, message: `the log never contained ${expected.join(', ')}` }
+		);
+	}
+
 	function activeSize(logPath) {
 		try {
 			return fs.statSync(logPath).size;
@@ -91,24 +113,20 @@ describe('Test log rotation on the write path (#1877)', () => {
 		assert.ok(activeSize(logPath) < 4000, 'expected a fresh, small active log');
 	});
 
-	it('keeps every message exactly once across the active log and the archives', () => {
+	it('keeps every message exactly once across the active log and the archives', async () => {
 		const { logger, logPath, rotatedDir } = newCase({ maxSize: '4K' });
 		const total = 300;
 		for (let i = 0; i < total; i++) logger.error(`unique-marker-${i}-${'y'.repeat(40)}`);
 		logger.closeLogFile();
-		const contents = [logPath, ...archives(rotatedDir)]
-			.map((file) => {
-				try {
-					return fs.readFileSync(file, 'utf8');
-				} catch {
-					return '';
-				}
-			})
-			.join('');
+		// The sink buffers under load and flushes on a timer, so wait for the last entry, not for a
+		// fixed moment.
+		const contents = await waitForContent(logPath, rotatedDir, `unique-marker-${total - 1}-`);
 		for (let i = 0; i < total; i++) {
 			const occurrences = contents.split(`unique-marker-${i}-`).length - 1;
 			assert.strictEqual(occurrences, 1, `marker ${i} appeared ${occurrences} times across all generations`);
 		}
+		// The rotation notice keeps the log's own line shape, which readLog parses by level.
+		assert.match(contents, /^\S+ \[[^\]]+\] \[notify\]: hdb\.log rotated, old log moved to \S+$/m);
 	});
 
 	it('never rotates when rotation is disabled, even with a maxSize set', () => {
@@ -145,27 +163,8 @@ describe('Test log rotation on the write path (#1877)', () => {
 		logger.closeLogFile();
 
 		assert.ok(archives(rotatedDir).length > 0, 'expected rotation with a worker thread writing');
-		const readAll = () =>
-			[logPath, ...archives(rotatedDir)]
-				.map((file) => {
-					try {
-						return fs.readFileSync(file, 'utf8');
-					} catch {
-						return '';
-					}
-				})
-				.join('');
 		// Both sinks flush on a timer under load, so wait for the last entry rather than racing it.
-		const contents = await waitFor(
-			() => {
-				const all = readAll();
-				return all.includes(`worker-marker-199-`) && all.includes(`main-marker-199-`) ? all : false;
-			},
-			{
-				timeout: 10000,
-				message: 'the last marker from each thread never reached the log',
-			}
-		);
+		const contents = await waitForContent(logPath, rotatedDir, 'worker-marker-199-', 'main-marker-199-');
 		for (const prefix of ['main-marker', 'worker-marker']) {
 			for (let i = 0; i < 200; i++) {
 				const occurrences = contents.split(`${prefix}-${i}-`).length - 1;

--- a/unitTests/utility/logging/logRotationGuard.test.js
+++ b/unitTests/utility/logging/logRotationGuard.test.js
@@ -131,11 +131,18 @@ describe('Test log rotation on the write path (#1877)', () => {
 
 	it('rotates from inside a buffered flush without duplicating or losing the batch', async () => {
 		const { logger, logPath, rotatedDir } = newCase({ maxSize: '4K' });
-		// The sink starts buffering once it thinks it is spending more than ~2% of the time writing,
-		// which a few very large entries achieve; from then on a flush is a whole batch at once, and
-		// the rotation it triggers writes its notice back through this same sink mid-flush.
-		for (let i = 0; i < 6; i++) logger.error('warming the buffer', 'w'.repeat(200000));
+		// The sink starts buffering once it thinks it is spending more than ~2% of its time writing,
+		// which a handful of multi-megabyte entries achieve on any machine; from then on a flush is a
+		// whole batch at once, and the rotation it triggers writes its notice back through this same
+		// sink while that batch is still in hand.
+		for (let i = 0; i < 6; i++) logger.error('warming the buffer', 'w'.repeat(4000000));
 		for (let i = 0; i < 40; i++) logger.error(`batched-marker-${i}-${'b'.repeat(120)}`);
+		// The precondition, asserted rather than assumed: unbuffered, these would already be on disk,
+		// the batch path would never be exercised, and the assertions below would pass vacuously.
+		assert.ok(
+			!readGenerations(logPath, rotatedDir).includes('batched-marker-39-'),
+			'expected the markers to still be buffered; this test cannot exercise the batch path otherwise'
+		);
 		logger.notify('flushing the batch');
 
 		const contents = await waitForContent(logPath, rotatedDir, 'batched-marker-39-');

--- a/unitTests/utility/logging/logRotationGuard.test.js
+++ b/unitTests/utility/logging/logRotationGuard.test.js
@@ -10,8 +10,7 @@ const { requestGenerationClose } = require('#src/utility/logging/logGenerationCo
 const { pinLogConfig } = require('../../logConfigFixture.js');
 const { waitFor } = require('../../waitFor.js');
 
-// Long enough that the audit tick can never be what rotates: every assertion below is about the
-// write path itself. On origin/main this makes the whole suite fail — nothing else checks the size.
+// Long enough that the audit tick can never fire, so every assertion below is about the write path.
 const NEVER_TICKS = 3600000;
 const TEST_ROOT = path.join(__dirname, 'rotationGuardLogs');
 

--- a/unitTests/utility/logging/logRotationGuard.test.js
+++ b/unitTests/utility/logging/logRotationGuard.test.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 const { Worker } = require('node:worker_threads');
 const hdbLogger = require('#src/utility/logging/harper_logger');
 const { parseMaxSize } = require('#src/utility/logging/logRotation');
+const { announceGeneration } = require('#src/utility/logging/logGenerationCoordinator');
 const { pinLogConfig } = require('../../logConfigFixture.js');
 const { waitFor } = require('../../waitFor.js');
 
@@ -193,6 +194,33 @@ describe('Test log rotation on the write path (#1877)', () => {
 			{ timeout: 20000, interval: 250, message: 'rotation never recovered after the target was repaired' }
 		);
 		assert.ok(activeSize(logPath) < strandedSize + 4 * 4000, 'expected the log to stay bounded through recovery');
+	});
+
+	it('releases a descriptor on an announced generation even with no size guard of its own', () => {
+		// A thread rotating only on `interval` builds no size guard, but it still holds a descriptor,
+		// and answering an announcement has to mean released rather than only "handler ran".
+		const dir = path.join(TEST_ROOT, `noGuard${caseNumber++}`);
+		fs.mkdirpSync(dir);
+		const logPath = path.join(dir, 'hdb.log');
+		const logger = hdbLogger.createLogger({
+			stdStreams: false,
+			path: logPath,
+			level: 'error',
+			rotation: { enabled: true, interval: '1D', auditInterval: NEVER_TICKS },
+		});
+		logger.error('opens the descriptor');
+		const held = fs.statSync(logPath);
+
+		// Another thread rotates: the file moves out from under this descriptor.
+		const archivePath = path.join(dir, 'moved.log');
+		fs.renameSync(logPath, archivePath);
+		announceGeneration({ logPath, generation: 'g', ino: held.ino, dev: held.dev });
+
+		logger.error('after the announced rotation');
+		logger.closeLogFile();
+		assert.ok(fs.pathExistsSync(logPath), 'expected a fresh log file, not an append to the archive');
+		assert.match(fs.readFileSync(logPath, 'utf8'), /after the announced rotation/);
+		assert.doesNotMatch(fs.readFileSync(archivePath, 'utf8'), /after the announced rotation/);
 	});
 
 	it('stops growing the log and reports to stdio when the rotation target cannot be written', () => {

--- a/unitTests/utility/logging/logRotationGuard.test.js
+++ b/unitTests/utility/logging/logRotationGuard.test.js
@@ -300,6 +300,21 @@ describe('Test log rotation on the write path (#1877)', () => {
 		assert.doesNotMatch(fs.readFileSync(archivePath, 'utf8'), /after the announced rotation/);
 	});
 
+	it('recreates a rotation directory that was removed, instead of reading it as a lost race', () => {
+		// rename() reports ENOENT for a missing source and for a missing destination alike. Reading a
+		// missing destination as "another thread already rotated this generation" clears the cap check
+		// on every pass, so the log grows without a bound and without a diagnostic.
+		const { logger, logPath, rotatedDir } = newCase({ maxSize: '4K' });
+		logger.error('one line so the rotated directory exists');
+		fs.removeSync(rotatedDir);
+		for (let i = 0; i < 400; i++) logger.error(`removed target line ${i} ${'z'.repeat(60)}`);
+		const size = activeSize(logPath);
+		assert.ok(size < 4 * 4000, `active log grew to ${size} bytes after its rotation directory was removed`);
+		// Recreated on the failure path, so the retry after the cooldown has somewhere to rename to;
+		// recovery from there is the same path the repaired-target case below covers.
+		assert.ok(fs.pathExistsSync(rotatedDir), 'expected the removed rotation directory to be recreated');
+	});
+
 	it('stops growing the log and reports to stdio when the rotation target cannot be written', () => {
 		const { logger, logPath, rotatedDir } = newCase({ maxSize: '4K' });
 		logger.error('one line so the rotated directory exists');

--- a/unitTests/utility/logging/logRotationGuard.test.js
+++ b/unitTests/utility/logging/logRotationGuard.test.js
@@ -3,7 +3,9 @@
 const assert = require('node:assert');
 const fs = require('fs-extra');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 const { Worker } = require('node:worker_threads');
+const hdbTerms = require('#src/utility/hdbTerms');
 const hdbLogger = require('#src/utility/logging/harper_logger');
 const { parseMaxSize } = require('#src/utility/logging/logRotation');
 const { requestGenerationClose } = require('#src/utility/logging/logGenerationCoordinator');
@@ -13,6 +15,7 @@ const { waitFor } = require('../../waitFor.js');
 // Long enough that the audit tick can never fire, so every assertion below is about the write path.
 const NEVER_TICKS = 3600000;
 const TEST_ROOT = path.join(__dirname, 'rotationGuardLogs');
+const PACKAGE_ROOT = path.resolve(__dirname, '../../..');
 
 describe('Test log rotation on the write path (#1877)', () => {
 	let restoreLogConfig;
@@ -111,6 +114,58 @@ describe('Test log rotation on the write path (#1877)', () => {
 		logger.error('first write after restart');
 		assert.strictEqual(archives(rotatedDir).length, 1, 'expected exactly one archive after one write');
 		assert.ok(activeSize(logPath) < 4000, 'expected a fresh, small active log');
+	});
+
+	it('rotates when the log directory does not exist yet and the archives go elsewhere', () => {
+		// logging.rotation.path resolves against rootPath while logging.root can be moved, so creating
+		// the archive directory does not create the log's own, and the sink only creates that on its
+		// first append.
+		const base = path.join(TEST_ROOT, `freshInstall${caseNumber++}`);
+		const rotatedDir = path.join(base, 'archives');
+		const logPath = path.join(base, 'logs', 'hdb.log');
+		const logger = hdbLogger.createLogger({
+			stdStreams: false,
+			path: logPath,
+			level: 'error',
+			rotation: { enabled: true, maxSize: '4K', auditInterval: NEVER_TICKS, path: rotatedDir },
+		});
+		for (let i = 0; i < 200; i++) logger.error(`fresh install line ${i} ${'y'.repeat(60)}`);
+		assert.ok(archives(rotatedDir).length > 0, 'expected the write path to rotate on a log directory it created');
+	});
+
+	it('reports a rotation target it cannot build without failing the module load', () => {
+		// initLogSettings() installs the guard from harper_logger's own module scope, so a failure is
+		// reported while that module is still evaluating. Only a child process can observe that window:
+		// here the module is long since evaluated.
+		const root = path.join(TEST_ROOT, `moduleLoad${caseNumber++}`);
+		fs.mkdirpSync(path.join(root, 'log'));
+		// A regular file where the archive directory should be: mkdir then fails ENOTDIR on every
+		// platform.
+		fs.writeFileSync(path.join(root, 'blocker'), 'not a directory');
+		fs.writeFileSync(
+			path.join(root, hdbTerms.HARPER_CONFIG_FILE),
+			[
+				`rootPath: ${JSON.stringify(root)}`,
+				'logging:',
+				'  file: true',
+				'  stdStreams: false',
+				'  level: error',
+				`  root: ${JSON.stringify(path.join(root, 'log'))}`,
+				'  rotation:',
+				'    enabled: true',
+				'    maxSize: 4K',
+				`    path: ${JSON.stringify(path.join(root, 'blocker', 'archives'))}`,
+				'',
+			].join('\n')
+		);
+		const child = spawnSync(
+			process.execPath,
+			['-e', "require('#src/utility/logging/harper_logger'); process.stdout.write('loaded'); process.exit(0);"],
+			{ cwd: PACKAGE_ROOT, env: { ...process.env, ROOTPATH: root }, encoding: 'utf8' }
+		);
+		assert.strictEqual(child.status, 0, `logger module load failed: ${child.stderr}`);
+		assert.ok(child.stdout.includes('loaded'), `logger module did not finish loading: ${child.stderr}`);
+		assert.match(child.stderr, /log rotation is disabled for/);
 	});
 
 	it('keeps every message exactly once across the active log and the archives', async () => {

--- a/unitTests/utility/logging/logRotationGuard.test.js
+++ b/unitTests/utility/logging/logRotationGuard.test.js
@@ -320,7 +320,7 @@ describe('Test log rotation on the write path (#1877)', () => {
 		assert.ok(fs.pathExistsSync(rotatedDir), 'expected the removed rotation directory to be recreated');
 	});
 
-	it('keeps records and an in-file diagnostic when the rotation target cannot be written', () => {
+	it('keeps records and an in-file diagnostic when the rotation target cannot be written', async () => {
 		const { logger, logPath, rotatedDir } = newCase({ maxSize: '4K' });
 		logger.error('one line so the rotated directory exists');
 		// Replacing the rotated directory with a file makes every rename fail with ENOTDIR, which is
@@ -328,7 +328,20 @@ describe('Test log rotation on the write path (#1877)', () => {
 		fs.removeSync(rotatedDir);
 		fs.writeFileSync(rotatedDir, 'not a directory');
 		for (let i = 0; i < 60; i++) logger.error(`failing rotation line ${i} ${'w'.repeat(60)}`);
-		const contents = fs.readFileSync(logPath, 'utf8');
+		const contents = await waitFor(
+			() => {
+				// A failed rotation preserves its diagnostic for the next append, so keep exercising that
+				// contract while waiting instead of assuming a timer-only flush can publish the notice.
+				logger.error(`diagnostic probe ${'w'.repeat(60)}`);
+				const all = readGenerations(logPath, rotatedDir);
+				return ['failing rotation line 0 ', 'failing rotation line 59 ', 'Harper log rotation problem'].every(
+					(marker) => all.includes(marker)
+				)
+					? all
+					: false;
+			},
+			{ timeout: 10000, message: 'the failed rotation never preserved its records and diagnostic' }
+		);
 		assert.match(contents, /failing rotation line 0 /);
 		assert.match(contents, /failing rotation line 59 /);
 		assert.match(contents, /Harper log rotation problem/);

--- a/unitTests/utility/logging/logRotationGuard.test.js
+++ b/unitTests/utility/logging/logRotationGuard.test.js
@@ -300,14 +300,20 @@ describe('Test log rotation on the write path (#1877)', () => {
 		assert.doesNotMatch(fs.readFileSync(archivePath, 'utf8'), /after the announced rotation/);
 	});
 
-	it('recreates a removed rotation directory without dropping records during the retry cooldown', () => {
+	it('recreates a removed rotation directory without dropping records during the retry cooldown', async () => {
 		// rename() reports ENOENT for a missing source and for a missing destination alike. Reading a
 		// missing destination as "another thread already rotated this generation" clears recovery.
 		const { logger, logPath, rotatedDir } = newCase({ maxSize: '4K' });
 		logger.error('one line so the rotated directory exists');
 		fs.removeSync(rotatedDir);
 		for (let i = 0; i < 400; i++) logger.error(`removed target line ${i} ${'z'.repeat(60)}`);
-		const contents = fs.readFileSync(logPath, 'utf8');
+		const contents = await waitForContent(
+			logPath,
+			rotatedDir,
+			'removed target line 0 ',
+			'removed target line 399 ',
+			'Harper log rotation problem'
+		);
 		assert.match(contents, /removed target line 0 /);
 		assert.match(contents, /removed target line 399 /);
 		assert.match(contents, /Harper log rotation problem/);

--- a/unitTests/utility/logging/logRotationGuard.test.js
+++ b/unitTests/utility/logging/logRotationGuard.test.js
@@ -300,22 +300,21 @@ describe('Test log rotation on the write path (#1877)', () => {
 		assert.doesNotMatch(fs.readFileSync(archivePath, 'utf8'), /after the announced rotation/);
 	});
 
-	it('recreates a rotation directory that was removed, instead of reading it as a lost race', () => {
+	it('recreates a removed rotation directory without dropping records during the retry cooldown', () => {
 		// rename() reports ENOENT for a missing source and for a missing destination alike. Reading a
-		// missing destination as "another thread already rotated this generation" clears the cap check
-		// on every pass, so the log grows without a bound and without a diagnostic.
+		// missing destination as "another thread already rotated this generation" clears recovery.
 		const { logger, logPath, rotatedDir } = newCase({ maxSize: '4K' });
 		logger.error('one line so the rotated directory exists');
 		fs.removeSync(rotatedDir);
 		for (let i = 0; i < 400; i++) logger.error(`removed target line ${i} ${'z'.repeat(60)}`);
-		const size = activeSize(logPath);
-		assert.ok(size < 4 * 4000, `active log grew to ${size} bytes after its rotation directory was removed`);
-		// Recreated on the failure path, so the retry after the cooldown has somewhere to rename to;
-		// recovery from there is the same path the repaired-target case below covers.
+		const contents = fs.readFileSync(logPath, 'utf8');
+		assert.match(contents, /removed target line 0 /);
+		assert.match(contents, /removed target line 399 /);
+		assert.match(contents, /Harper log rotation problem/);
 		assert.ok(fs.pathExistsSync(rotatedDir), 'expected the removed rotation directory to be recreated');
 	});
 
-	it('stops growing the log and reports to stdio when the rotation target cannot be written', () => {
+	it('keeps records and an in-file diagnostic when the rotation target cannot be written', () => {
 		const { logger, logPath, rotatedDir } = newCase({ maxSize: '4K' });
 		logger.error('one line so the rotated directory exists');
 		// Replacing the rotated directory with a file makes every rename fail with ENOTDIR, which is
@@ -323,8 +322,10 @@ describe('Test log rotation on the write path (#1877)', () => {
 		fs.removeSync(rotatedDir);
 		fs.writeFileSync(rotatedDir, 'not a directory');
 		for (let i = 0; i < 60; i++) logger.error(`failing rotation line ${i} ${'w'.repeat(60)}`);
-		const size = activeSize(logPath);
-		assert.ok(size < 4 * 4000, `active log grew to ${size} bytes while rotation was failing`);
+		const contents = fs.readFileSync(logPath, 'utf8');
+		assert.match(contents, /failing rotation line 0 /);
+		assert.match(contents, /failing rotation line 59 /);
+		assert.match(contents, /Harper log rotation problem/);
 	});
 });
 

--- a/unitTests/utility/logging/logRotator.test.js
+++ b/unitTests/utility/logging/logRotator.test.js
@@ -69,6 +69,41 @@ describe('Test logRotator module', () => {
 		return rotator.getLastRotatedLogPath();
 	}
 
+	it('Finishes an archive another isolate left uncompressed, with no retention configured (#1877)', async () => {
+		// The sweep must not be gated on retention: retention is unset by default, and a worker's
+		// plain archive still has to be compressed however the operator configured `compress`.
+		fs.mkdirpSync(path.join(LOG_DIR_TEST, 'rotated'));
+		// Named as this rotator names archives — the compression sweep only touches files it can tell
+		// apart from the live logs the same directory holds.
+		const stranded = path.join(LOG_DIR_TEST, 'rotated', 'hdb-0a1b2c3d-2020-01-01T00-00-00.000Z-1-0-0.log');
+		fs.writeFileSync(stranded, 'left plain by another isolate\n');
+		await runRotator({ interval: '1D', compress: true, path: path.join(LOG_DIR_TEST, 'rotated') });
+		await waitFor(() => fs.pathExistsSync(`${stranded}.gz`), {
+			timeout: 5000,
+			message: 'Expected the audit tick to compress an archive left plain by another isolate',
+		});
+		expect(fs.pathExistsSync(stranded)).to.be.false;
+	}).timeout(TEST_TIMEOUT);
+
+	it('Never deletes or compresses a live log sharing the rotated directory (#1877)', async () => {
+		// logging.rotation.path defaults to `log`, the same directory logging.root defaults to, so the
+		// rotated directory normally holds the logs being written as well as the archives.
+		const companion = path.join(LOG_DIR_TEST, 'companion.log');
+		fs.writeFileSync(companion, 'a live log written by another logger\n');
+		const companionLogger = hdb_logger.createLogger({ stdStreams: false, path: companion, level: 'error' });
+		companionLogger.error('opens the sink so the path is registered');
+		// Aged past the retention window, and left untouched from here, so retention would delete it if
+		// a live log were ever a candidate. Large maxSize so nothing rotates; retention is the subject.
+		const past = new Date(Date.now() - 7200000);
+		fs.utimesSync(companion, past, past);
+
+		await runRotator({ maxSize: '1G', retention: '1H', compress: true });
+
+		expect(fs.pathExistsSync(companion), 'a live component log must survive retention').to.be.true;
+		expect(fs.pathExistsSync(`${companion}.gz`), 'a live component log must not be compressed').to.be.false;
+		companionLogger.closeLogFile();
+	}).timeout(TEST_TIMEOUT);
+
 	it('Test that log file is rotated if log has exceeded max size', async () => {
 		const rotated_log_path = await runRotator({ maxSize: '1K' });
 		assert(fs.statSync(rotated_log_path).size > 2000, 'Test log file should have contents after it is rotated');

--- a/unitTests/utility/logging/logRotator.test.js
+++ b/unitTests/utility/logging/logRotator.test.js
@@ -82,7 +82,7 @@ describe('Test logRotator module', () => {
 			timeout: 5000,
 			message: 'Expected the audit tick to compress an archive left plain by another isolate',
 		});
-		expect(fs.pathExistsSync(stranded)).to.be.false;
+		assert.strictEqual(fs.pathExistsSync(stranded), false, 'the plain archive must be gone once it is compressed');
 	}).timeout(TEST_TIMEOUT);
 
 	it('Never deletes or compresses a live log sharing the rotated directory (#1877)', async () => {
@@ -99,8 +99,8 @@ describe('Test logRotator module', () => {
 
 		await runRotator({ maxSize: '1G', retention: '1H', compress: true });
 
-		expect(fs.pathExistsSync(companion), 'a live component log must survive retention').to.be.true;
-		expect(fs.pathExistsSync(`${companion}.gz`), 'a live component log must not be compressed').to.be.false;
+		assert.ok(fs.pathExistsSync(companion), 'a live component log must survive retention');
+		assert.strictEqual(fs.pathExistsSync(`${companion}.gz`), false, 'a live component log must not be compressed');
 		companionLogger.closeLogFile();
 	}).timeout(TEST_TIMEOUT);
 

--- a/unitTests/utility/logging/logRotator.test.js
+++ b/unitTests/utility/logging/logRotator.test.js
@@ -85,6 +85,22 @@ describe('Test logRotator module', () => {
 		assert.strictEqual(fs.pathExistsSync(stranded), false, 'the plain archive must be gone once it is compressed');
 	}).timeout(TEST_TIMEOUT);
 
+	it('Clears a plain archive left beside the .gz that already replaced it (#1877)', async () => {
+		// compressOneArchive renames the .gz into place and only then unlinks its source, so a crash in
+		// between leaves both. Every later pass read that as "already compressed" and skipped it, and
+		// with retention unset by default the duplicate survived for the life of the directory.
+		fs.mkdirpSync(path.join(LOG_DIR_TEST, 'rotated'));
+		const orphan = path.join(LOG_DIR_TEST, 'rotated', 'hdb-1a2b3c4d-2020-01-01T00-00-00.000Z-1-0-1.log');
+		fs.writeFileSync(orphan, 'the source the crash never unlinked\n');
+		fs.writeFileSync(`${orphan}.gz`, 'stands in for the published archive\n');
+		await runRotator({ interval: '1D', compress: true, path: path.join(LOG_DIR_TEST, 'rotated') });
+		await waitFor(() => !fs.pathExistsSync(orphan), {
+			timeout: 5000,
+			message: 'Expected the audit tick to clear a plain archive its .gz had already replaced',
+		});
+		assert.ok(fs.pathExistsSync(`${orphan}.gz`), 'the published archive must survive');
+	}).timeout(TEST_TIMEOUT);
+
 	it('Never deletes or compresses a live log sharing the rotated directory (#1877)', async () => {
 		// logging.rotation.path defaults to `log`, the same directory logging.root defaults to, so the
 		// rotated directory normally holds the logs being written as well as the archives.

--- a/unitTests/utility/logging/logRotator.test.js
+++ b/unitTests/utility/logging/logRotator.test.js
@@ -198,6 +198,29 @@ describe('Test logRotator module', () => {
 			.to.be.false;
 	}).timeout(TEST_TIMEOUT);
 
+	it('restarts the interval clock when another writer replaces the active generation', async () => {
+		await callLogger();
+		const rotatedDir = path.join(LOG_DIR_TEST, 'generationClock');
+		const rotator = log_rotator({
+			logger,
+			path: rotatedDir,
+			enabled: true,
+			auditInterval: 50,
+			interval: '0.6s',
+		});
+		await hdb_utils.asyncSetTimeout(400);
+		logger.closeLogFile();
+		fs.renameSync(LOG_FILE_PATH_TEST, path.join(rotatedDir, 'replaced-by-writer.log'));
+		logger.error('fresh generation marker');
+
+		// This models elapsed time to prove the absence of an interval rotation: the old generation
+		// is older than 600ms, while the replacement is not.
+		await hdb_utils.asyncSetTimeout(350);
+		rotator.end();
+		assert.match(fs.readFileSync(LOG_FILE_PATH_TEST, 'utf8'), /fresh generation marker/);
+		assert.strictEqual(rotator.getLastRotatedLogPath(), undefined);
+	}).timeout(TEST_TIMEOUT);
+
 	it('Test log is compressed when rotated', async () => {
 		const rotated_log_path = await runRotator({ maxSize: '1K', compress: true });
 		console.log('rotated log contents', readFileSync(rotated_log_path, 'utf-8'));

--- a/unitTests/utility/logging/logRotator.test.js
+++ b/unitTests/utility/logging/logRotator.test.js
@@ -8,6 +8,7 @@ const hdb_utils = require('#src/utility/common_utils');
 const { readFileSync } = require('fs');
 const hdb_logger = require('#src/utility/logging/harper_logger');
 const { logRotator: log_rotator } = require('#src/utility/logging/logRotator');
+const { compressArchive, compressPendingArchives } = require('#src/utility/logging/logRotation');
 const assert = require('assert');
 const { pinLogConfig } = require('../../logConfigFixture.js');
 const { waitFor } = require('../../waitFor.js');
@@ -85,6 +86,70 @@ describe('Test logRotator module', () => {
 		assert.strictEqual(fs.pathExistsSync(stranded), false, 'the plain archive must be gone once it is compressed');
 	}).timeout(TEST_TIMEOUT);
 
+	it('compresses more than four pending archives in one time-budgeted sweep', async () => {
+		const rotatedDir = path.join(LOG_DIR_TEST, 'sweep');
+		fs.mkdirpSync(rotatedDir);
+		const archives = [];
+		for (let i = 0; i < 8; i++) {
+			const archive = path.join(rotatedDir, `hdb-0a1b2c3d-2020-01-01T00-00-00.00${i}Z-1-0-${i}.log`);
+			fs.writeFileSync(archive, `pending archive ${i}\n`);
+			archives.push(archive);
+		}
+
+		await compressPendingArchives(rotatedDir, fs.readdirSync(rotatedDir), new Set(), {
+			deadline: Date.now() + 5000,
+		});
+
+		for (const archive of archives) {
+			assert.strictEqual(fs.pathExistsSync(archive), false, `${archive} should be replaced`);
+			assert.ok(fs.pathExistsSync(`${archive}.gz`), `${archive}.gz should be published`);
+		}
+	}).timeout(TEST_TIMEOUT);
+
+	it('defers compression when the sweep budget is exhausted and resumes on a later pass', async () => {
+		const rotatedDir = path.join(LOG_DIR_TEST, 'deadline');
+		fs.mkdirpSync(rotatedDir);
+		const archive = path.join(rotatedDir, 'hdb-0a1b2c3d-2020-01-01T00-00-00.000Z-1-0-0.log');
+		fs.writeFileSync(archive, 'deferred archive\n');
+		const files = fs.readdirSync(rotatedDir);
+
+		await compressPendingArchives(rotatedDir, files, new Set(), { deadline: Date.now() });
+		assert.ok(fs.pathExistsSync(archive), 'an expired sweep must not start another gzip');
+		await compressPendingArchives(rotatedDir, files, new Set(), { deadline: Date.now() + 5000 });
+		assert.ok(fs.pathExistsSync(`${archive}.gz`), 'a later pass should finish the deferred archive');
+	}).timeout(TEST_TIMEOUT);
+
+	it('stops sweeping when another compression owns the directory slot', async () => {
+		const rotatedDir = path.join(LOG_DIR_TEST, 'busy');
+		fs.mkdirpSync(rotatedDir);
+		const active = path.join(rotatedDir, 'active.log');
+		const stranded = path.join(rotatedDir, 'hdb-0a1b2c3d-2020-01-01T00-00-00.000Z-1-0-0.log');
+		fs.writeFileSync(active, Buffer.alloc(8 * 1024 * 1024, 'a'));
+		fs.writeFileSync(stranded, 'must wait for the next sweep\n');
+		const inFlight = compressArchive(active);
+
+		await compressPendingArchives(rotatedDir, [path.basename(stranded)], new Set(), {
+			deadline: Date.now() + 5000,
+		});
+		assert.ok(fs.pathExistsSync(stranded), 'a busy directory slot must leave the candidate for a later pass');
+		await inFlight;
+	}).timeout(TEST_TIMEOUT);
+
+	it('reports one compression failure without starving later archives in the snapshot', async () => {
+		const rotatedDir = path.join(LOG_DIR_TEST, 'compressionError');
+		fs.mkdirpSync(rotatedDir);
+		const brokenName = 'hdb-0a1b2c3d-2020-01-01T00-00-00.000Z-1-0-0.log';
+		const healthyName = 'hdb-0a1b2c3d-2020-01-01T00-00-00.001Z-1-0-1.log';
+		fs.mkdirpSync(path.join(rotatedDir, brokenName));
+		fs.writeFileSync(path.join(rotatedDir, healthyName), 'compressible archive\n');
+
+		const failure = await compressPendingArchives(rotatedDir, [brokenName, healthyName], new Set(), {
+			deadline: Date.now() + 5000,
+		});
+		assert.strictEqual(failure.file, brokenName);
+		assert.ok(fs.pathExistsSync(path.join(rotatedDir, `${healthyName}.gz`)));
+	}).timeout(TEST_TIMEOUT);
+
 	it('Clears a plain archive left beside the .gz that already replaced it (#1877)', async () => {
 		// compressOneArchive renames the .gz into place and only then unlinks its source, so a crash in
 		// between leaves both. Every later pass read that as "already compressed" and skipped it, and
@@ -102,8 +167,7 @@ describe('Test logRotator module', () => {
 	}).timeout(TEST_TIMEOUT);
 
 	it('Never deletes or compresses a live log sharing the rotated directory (#1877)', async () => {
-		// logging.rotation.path defaults to `log`, the same directory logging.root defaults to, so the
-		// rotated directory normally holds the logs being written as well as the archives.
+		// An explicitly configured rotation directory can also hold logs that are still being written.
 		const companion = path.join(LOG_DIR_TEST, 'companion.log');
 		fs.writeFileSync(companion, 'a live log written by another logger\n');
 		const companionLogger = hdb_logger.createLogger({ stdStreams: false, path: companion, level: 'error' });
@@ -182,11 +246,14 @@ describe('Test logRotator module', () => {
 		fs.mkdirpSync(retentionDir);
 		const oldLog = path.join(retentionDir, 'HDB-old.log');
 		const newLog = path.join(retentionDir, 'HDB-new.log');
+		const abandonedCompression = path.join(retentionDir, 'HDB-old.log.gz.1-0-0.tmp');
 		fs.writeFileSync(oldLog, 'old rotated log contents');
 		fs.writeFileSync(newLog, 'fresh rotated log contents');
+		fs.writeFileSync(abandonedCompression, 'partial gzip from a crashed process');
 		// Age the old log well beyond the retention window (the fresh log stays comfortably inside it).
 		const past = new Date(Date.now() - 7200000);
 		fs.utimesSync(oldLog, past, past);
+		fs.utimesSync(abandonedCompression, past, past);
 
 		// Large maxSize so the active log is not rotated; retention is what we are exercising.
 		const rotator = log_rotator({
@@ -202,6 +269,26 @@ describe('Test logRotator module', () => {
 
 		expect(fs.pathExistsSync(oldLog), 'Rotated log older than retention should be deleted').to.be.false;
 		expect(fs.pathExistsSync(newLog), 'Rotated log within retention should be kept').to.be.true;
+		expect(fs.pathExistsSync(abandonedCompression), 'An abandoned gzip temp file should be reaped').to.be.false;
+	}).timeout(TEST_TIMEOUT);
+
+	it('starts no destructive sweep work after the rotator is ended', async () => {
+		const rotatedDir = path.join(LOG_DIR_TEST, 'ended');
+		fs.mkdirpSync(rotatedDir);
+		const stranded = path.join(rotatedDir, 'hdb-0a1b2c3d-2020-01-01T00-00-00.000Z-1-0-0.log');
+		fs.writeFileSync(stranded, 'must survive\n');
+		const rotator = log_rotator({
+			logger,
+			path: rotatedDir,
+			enabled: true,
+			auditInterval: 100,
+			interval: '1D',
+			compress: true,
+		});
+		rotator.end();
+		await hdb_utils.asyncSetTimeout(250);
+		assert.ok(fs.pathExistsSync(stranded), 'end() must prevent a later sweep from compressing the archive');
+		assert.strictEqual(fs.pathExistsSync(`${stranded}.gz`), false);
 	}).timeout(TEST_TIMEOUT);
 
 	it('Keeps both archives when two loggers with the same basename rotate into a shared directory at the same instant', async () => {

--- a/unitTests/utility/logging/rotation-worker-for-tests.js
+++ b/unitTests/utility/logging/rotation-worker-for-tests.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// A second isolate writing to the same log file as the main thread, which is how Harper actually
+// produces request logs: every HTTP worker holds its own descriptor on one path.
+
+const { isMainThread, parentPort, workerData } = require('node:worker_threads');
+
+if (!isMainThread && workerData?.logPath) {
+	const hdbLogger = require('#src/utility/logging/harper_logger');
+	const logger = hdbLogger.createLogger({
+		stdStreams: false,
+		path: workerData.logPath,
+		level: 'error',
+		rotation: workerData.rotation,
+	});
+	for (let i = 0; i < workerData.lineCount; i++) logger.error(`${workerData.markerPrefix}-${i}-${'q'.repeat(40)}`);
+	// The sink buffers under load and flushes on a timer; reporting done before that timer fires
+	// would let the main thread read the file while this thread's last entries are still in memory.
+	setTimeout(() => {
+		logger.closeLogFile();
+		parentPort.postMessage({ done: true });
+	}, 200);
+}

--- a/unitTests/utility/logging/rotation-worker-for-tests.js
+++ b/unitTests/utility/logging/rotation-worker-for-tests.js
@@ -5,7 +5,29 @@
 
 const { isMainThread, parentPort, workerData } = require('node:worker_threads');
 
-if (!isMainThread && workerData?.logPath) {
+if (!isMainThread && workerData?.withoutTransport) {
+	(async () => {
+		const fs = require('fs-extra');
+		const { requestStaleDescriptorRelease } = require('#src/utility/logging/logGenerationCoordinator');
+		const {
+			isArchivePendingQuiescence,
+			publishArchivedGeneration,
+			rotateLogFileSync,
+		} = require('#src/utility/logging/logRotation');
+		fs.mkdirpSync(workerData.rotatedDir);
+		fs.writeFileSync(workerData.logPath, 'worker generation with no transport\n');
+		const release = await requestStaleDescriptorRelease();
+		const generation = rotateLogFileSync(workerData.logPath, workerData.rotatedDir, () => {});
+		const published = await publishArchivedGeneration(generation, true);
+		parentPort.postMessage({
+			released: release.released,
+			published,
+			pending: isArchivePendingQuiescence(generation.archivePath),
+			plainExists: fs.pathExistsSync(generation.archivePath),
+			compressedExists: fs.pathExistsSync(`${generation.archivePath}.gz`),
+		});
+	})().catch((error) => parentPort.postMessage({ error: error.stack || error.message }));
+} else if (!isMainThread && workerData?.logPath) {
 	const hdbLogger = require('#src/utility/logging/harper_logger');
 	const logger = hdbLogger.createLogger({
 		stdStreams: false,

--- a/unitTests/utility/logging/rotation-worker-for-tests.js
+++ b/unitTests/utility/logging/rotation-worker-for-tests.js
@@ -3,20 +3,32 @@
 // A second isolate writing to the same log file as the main thread, which is how Harper actually
 // produces request logs: every HTTP worker holds its own descriptor on one path.
 
-const { isMainThread, parentPort, workerData } = require('node:worker_threads');
+const { isMainThread, parentPort, threadId, workerData } = require('node:worker_threads');
 
-if (!isMainThread && workerData?.withoutTransport) {
+if (!isMainThread && (workerData?.withoutTransport || workerData?.withTransport)) {
 	(async () => {
 		const fs = require('fs-extra');
-		const { requestStaleDescriptorRelease } = require('#src/utility/logging/logGenerationCoordinator');
+		const coordinator = require('#src/utility/logging/logGenerationCoordinator');
 		const {
 			isArchivePendingQuiescence,
 			publishArchivedGeneration,
 			rotateLogFileSync,
 		} = require('#src/utility/logging/logRotation');
+		if (workerData.withTransport) {
+			coordinator.setRotationTransport({
+				threadId,
+				broadcast() {},
+				sendToThread() {},
+				onMessage() {},
+				onThreadExit() {},
+				peerThreadIds() {
+					return [];
+				},
+			});
+		}
 		fs.mkdirpSync(workerData.rotatedDir);
-		fs.writeFileSync(workerData.logPath, 'worker generation with no transport\n');
-		const release = await requestStaleDescriptorRelease();
+		fs.writeFileSync(workerData.logPath, 'worker generation\n');
+		const release = await coordinator.requestStaleDescriptorRelease();
 		const generation = rotateLogFileSync(workerData.logPath, workerData.rotatedDir, () => {});
 		const published = await publishArchivedGeneration(generation, true);
 		parentPort.postMessage({

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -503,6 +503,19 @@ describe('Test configValidator module', () => {
 				"Invalid logging.rotation.maxSize value. Value should be a number followed by unit e.g. '10M'"
 			);
 		});
+
+		it('rejects sizes that cannot be a byte limit, and keeps the ones that can (#1877)', () => {
+			const validate_rotation_max_size = config_val.__get__('validateRotationMaxSize');
+			const helpers = { message: () => 'rejected' };
+			// parseInt accepted all of these; on the write path a 0, negative or NaN limit is checked
+			// per flush rather than once a minute, so they are now refused where operators see it.
+			for (const value of ['0K', '-1K', '1xK']) {
+				expect(validate_rotation_max_size(value, helpers), value).to.equal('rejected');
+			}
+			for (const value of ['64M', '3G', '1e3K', '0.1K']) {
+				expect(validate_rotation_max_size(value, helpers), value).to.equal(value);
+			}
+		});
 	});
 
 	describe('Test setDefaultThreads function', () => {

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('node:assert');
 const chai = require('chai');
 const { expect } = chai;
 const sinon = require('sinon');
@@ -505,15 +506,17 @@ describe('Test configValidator module', () => {
 		});
 
 		it('rejects sizes that cannot be a byte limit, and keeps the ones that can (#1877)', () => {
-			const validate_rotation_max_size = config_val.__get__('validateRotationMaxSize');
-			const helpers = { message: () => 'rejected' };
 			// parseInt accepted all of these; on the write path a 0, negative or NaN limit is checked
 			// per flush rather than once a minute, so they are now refused where operators see it.
 			for (const value of ['0K', '-1K', '1xK']) {
-				expect(validate_rotation_max_size(value, helpers), value).to.equal('rejected');
+				const config_obj = testUtils.deepClone(FAKE_CONFIG);
+				config_obj.logging.rotation.maxSize = value;
+				assert.ok(configValidator(config_obj).error, `${value} must be rejected`);
 			}
 			for (const value of ['64M', '3G', '1e3K', '0.1K']) {
-				expect(validate_rotation_max_size(value, helpers), value).to.equal(value);
+				const config_obj = testUtils.deepClone(FAKE_CONFIG);
+				config_obj.logging.rotation.maxSize = value;
+				assert.strictEqual(configValidator(config_obj).error, undefined, `${value} must be accepted`);
 			}
 		});
 	});

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -891,12 +891,15 @@ function getFileLogger(path, rotation, isExternalInstance) {
 	}
 	// this is called on a timer, and will write the log buffer to the file
 	function logQueuedData(entry?: any) {
-		openLogFile(undefined);
 		const payload = logBuffer ? logBuffer.join('') : entry;
 		// A file that just refused a write will refuse the next one too, and every attempt costs a
 		// failed syscall plus a thrown error on whatever path is logging - which, on a full volume,
 		// is the request path at full rate. Go straight to stdio until the cooldown expires.
-		if (logFD && !(retryAppendAfter > performance.now()) && (rotationGuard?.beforeAppend() ?? true)) {
+		// The file is opened after the guard, not before: a guard that recovers by rotating closes this
+		// descriptor, and the write that triggered the recovery belongs in the new generation.
+		const mayAppend = !(retryAppendAfter > performance.now()) && (rotationGuard?.beforeAppend() ?? true);
+		openLogFile(undefined);
+		if (logFD && mayAppend) {
 			let startTime = performance.now();
 			// Encoded once, so the guard's accounting reads a length instead of re-scanning the string.
 			const data = rotationGuard ? Buffer.from(payload) : payload;

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -844,7 +844,9 @@ function getFileLogger(path, rotation, isExternalInstance) {
 				closeLogFile,
 				report: reportRotationProblem,
 				onRotated(archivePath) {
-					logToFile(`log rotated, old log moved to ${archivePath}`);
+					// Same shape as every other line in the file: written straight to the sink, this
+					// bypasses the prefix createLogger's logPrepend adds, and readLog parses by level.
+					logToFile(`[${SERVICE_NAME}/${threadId}] [notify]: hdb.log rotated, old log moved to ${archivePath}`);
 				},
 			});
 		} catch (error) {

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -890,17 +890,14 @@ function getFileLogger(path, rotation, isExternalInstance) {
 	// this is called on a timer, and will write the log buffer to the file
 	function logQueuedData(entry?: any) {
 		const payload = logBuffer ? logBuffer.join('') : entry;
-		// Released before anything can re-enter this sink. The rotation notice is written from inside
-		// the append below, and a re-entrant flush that still saw this batch would either write every
-		// line of it a second time into the new generation, or be swallowed when this call clears the
-		// buffer on its way out.
+		// Released before anything can re-enter: the rotation notice is written from inside the append
+		// below, and a re-entrant flush still holding this batch would write every line of it twice.
 		logBuffer = null;
 		if (payload === undefined) return;
 		// A file that just refused a write will refuse the next one too, and every attempt costs a
 		// failed syscall plus a thrown error on whatever path is logging - which, on a full volume,
 		// is the request path at full rate. Go straight to stdio until the cooldown expires.
-		// The file is opened after the guard, not before: a guard that recovers by rotating closes this
-		// descriptor, and the write that triggered the recovery belongs in the new generation.
+		// Opened after the guard: a guard recovering by rotation closes this descriptor first.
 		const mayAppend = !(retryAppendAfter > performance.now()) && (rotationGuard?.beforeAppend() ?? true);
 		openLogFile(undefined);
 		if (logFD && mayAppend) {
@@ -910,8 +907,7 @@ function getFileLogger(path, rotation, isExternalInstance) {
 				// Both cleared, so a volume that fills again months later reports itself again
 				retryAppendAfter = undefined;
 				loggedAppendError = false;
-				// byteLength, not a Buffer: appendFileSync writes a string through Node's own encoder
-				// without allocating, and rotation is on by default so this runs on every flush.
+				// byteLength, not a Buffer: appendFileSync encodes the string without allocating one.
 				rotationGuard?.recordWrite(Buffer.byteLength(payload));
 			} catch (error) {
 				retryAppendAfter = performance.now() + APPEND_RETRY_COOLDOWN;

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -14,6 +14,7 @@ import { _assignPackageExport } from '../../globals.js';
 import { Console } from 'console';
 import { inspect, types } from 'node:util';
 import { createRotationGuard, INVALID_MAX_SIZE_MSG, parseMaxSize, resolveRotatedLogDir } from './logRotation.ts';
+import { registerLogSink } from './logGenerationCoordinator.ts';
 
 const { isNativeError } = types;
 // store the native write function so we can call it after we write to the log file (and store it on process.stdout
@@ -795,6 +796,10 @@ function getFileLogger(path, rotation, isExternalInstance) {
 		logger.installRotationGuard = installRotationGuard;
 		logger.path = path;
 		fileLoggers.set(path, logger);
+		// Registered by the sink, not by the size guard: a thread that writes this file but has no
+		// guard (no maxSize, or rotation driven only by interval) still holds a descriptor, and an
+		// answer from it has to mean "released" rather than only "handler ran".
+		registerLogSink(path, closeDescriptorOnGeneration);
 	}
 	// An undefined rotation means "this caller has no opinion", not "turn rotation off" — that is
 	// what `enabled: false` says. Several loggers are created for one path during startup and the
@@ -923,6 +928,12 @@ function getFileLogger(path, rotation, isExternalInstance) {
 			logTimeUsage = Math.max(endTime, logTimeUsage) + (endTime - startTime) * 50;
 		} else writeToStdioDirectly(process.stdout, payload);
 		if (logBuffer) logBuffer = null;
+	}
+
+	function closeDescriptorOnGeneration(ino, dev) {
+		// No identity to compare (no descriptor open, or a filesystem that cannot report one) means
+		// closing is the only answer that can still be called a release.
+		if (!logFDIdentity || (logFDIdentity.ino === ino && logFDIdentity.dev === dev)) closeLogFile();
 	}
 
 	function closeLogFile(_unused?: any) {

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -13,6 +13,7 @@ import { PACKAGE_ROOT } from '../../utility/packageUtils.js';
 import { _assignPackageExport } from '../../globals.js';
 import { Console } from 'console';
 import { inspect, types } from 'node:util';
+import { createRotationGuard, INVALID_MAX_SIZE_MSG, parseMaxSize, resolveRotatedLogDir } from './logRotation.ts';
 
 const { isNativeError } = types;
 // store the native write function so we can call it after we write to the log file (and store it on process.stdout
@@ -109,7 +110,16 @@ export function updateLogger(logger: any, logOptions: any, name?: string, mainLo
 	// rotation entirely (#1877). Excluded when `logger` IS mainLoggerRef: the fallback would just
 	// reassign mainLogger.rotation to itself, making it impossible to ever clear main's rotation.
 	const inheritedRotation = logOptions.rotation ?? (logger === mainLoggerRef ? undefined : mainLoggerRef?.rotation);
-	if (inheritedRotation && inheritedRotation === mainLoggerRef?.rotation) {
+	let path = logOptions.path;
+	if (path) {
+		if (!logOptions.root) logOptions.root = pathModule.dirname(path);
+	} else if (logOptions.root) {
+		path = join(logOptions.root, logName);
+	} else {
+		path = mainLoggerRef.path;
+		if (!logOptions.root) logOptions.root = pathModule.dirname(path);
+	}
+	if (inheritedRotation && inheritedRotation === mainLoggerRef?.rotation && path !== mainLoggerRef?.path) {
 		// This logger has no rotation block of its own and is inheriting main's wholesale — but
 		// inheriting `rotation.path` too would point this logger's archives at wherever main
 		// archives to. If this logger's file lives on a different filesystem/volume than that
@@ -120,20 +130,17 @@ export function updateLogger(logger: any, logOptions: any, name?: string, mainLo
 		// goes through `logOptions.rotation` above, not this fallback. Clone rather than mutate:
 		// `inheritedRotation` is the literal object shared by mainLogger.rotation and every other
 		// component that inherited it.
+		//
+		// Only when the paths differ. A logger writing to main's own file shares main's rotation
+		// state — file loggers are cached per path — so stripping there discards the operator's
+		// configured rotation.path for the main log itself, which no EXDEV risk justifies.
 		const { path: _inheritedPath, ...rotationWithoutPath } = inheritedRotation;
 		logger.rotation = rotationWithoutPath;
 	} else {
 		logger.rotation = inheritedRotation;
 	}
-	let path = logOptions.path;
-	if (path) {
-		if (!logOptions.root) logOptions.root = pathModule.dirname(path);
-	} else if (logOptions.root) {
-		path = join(logOptions.root, logName);
-	} else {
-		path = mainLoggerRef.path;
-		if (!logOptions.root) logOptions.root = pathModule.dirname(path);
-	}
+	// After the rotation above: assigning `path` goes through the setter that rebuilds this path's
+	// file logger, and it reads `logger.rotation` as it stands at that moment.
 	if (path) logger.path = path;
 	else console.error('No path for logger', logOptions);
 	logger.level = LOG_LEVEL_HIERARCHY[logOptions.level] ?? mainLoggerRef?.level ?? LOG_LEVEL_HIERARCHY.info;
@@ -764,6 +771,8 @@ export function createLogger(options: any = {} as any) {
 const LOG_TIME_USAGE_THRESHOLD = 100;
 // How long to write straight to stdio after the log file refuses an append.
 const APPEND_RETRY_COOLDOWN = 5000;
+// Ceiling on how often a failing rotation may report itself; the failure repeats every check point.
+const ROTATION_REPORT_INTERVAL = 60000;
 /**
  * Get the file logger for the given path. If it doesn't exist, create it.
  * @param path
@@ -775,14 +784,31 @@ function getFileLogger(path, rotation, isExternalInstance) {
 	let logFD, loggedFDError, loggedAppendError, logTimer, retryAppendAfter;
 	let logBuffer;
 	let logTimeUsage = 0;
+	let rotationGuard,
+		logFDIdentity,
+		nextRotationReport = 0;
 	if (!logger) {
 		logger = logToFile;
 		logger.closeLogFile = closeLogFile;
+		// Only the first call for a path keeps its closure; later calls get the cached logger back and
+		// their own logFD/logBuffer are dead. The guard has to be installed through the live closure.
+		logger.installRotationGuard = installRotationGuard;
 		logger.path = path;
 		fileLoggers.set(path, logger);
 	}
-	if (isMainThread && JSON.stringify(rotation) !== JSON.stringify(logger.rotation)) {
+	// An undefined rotation means "this caller has no opinion", not "turn rotation off" — that is
+	// what `enabled: false` says. Several loggers are created for one path during startup and the
+	// later ones carry no rotation block of their own, so treating undefined as a reconfiguration
+	// tears down the rotation the earlier, configured caller asked for (the same shape of loss #1880
+	// fixed for updateLogger's inheritance).
+	const reconfigured = rotation !== undefined && JSON.stringify(rotation) !== JSON.stringify(logger.rotation);
+	if (reconfigured) {
 		logger.rotation = rotation;
+		// Every writing thread, and synchronously: request logging is produced by the HTTP workers, and
+		// at the rates that make maxSize matter a deferred guard misses megabytes before it exists.
+		logger.installRotationGuard(rotation);
+	}
+	if (isMainThread && reconfigured) {
 		setTimeout(() => {
 			logger.rotator?.end();
 			if (!rotation) return;
@@ -798,6 +824,40 @@ function getFileLogger(path, rotation, isExternalInstance) {
 		}, 100);
 	}
 	return logger;
+	function installRotationGuard(newRotation) {
+		rotationGuard = undefined;
+		if (!newRotation || newRotation.enabled === false) return;
+		const maxBytes = parseMaxSize(newRotation.maxSize);
+		if (!maxBytes) {
+			if (newRotation.maxSize != null) reportRotationProblem(`logging.rotation.maxSize: ${INVALID_MAX_SIZE_MSG}`);
+			return;
+		}
+		try {
+			rotationGuard = createRotationGuard({
+				logPath: path,
+				maxBytes,
+				rotatedLogDir: resolveRotatedLogDir(path, newRotation.path),
+				// From the rotation block rather than environmentManager (which logRotator still reads):
+				// environmentManager imports this module, so it cannot be reached from the write path.
+				compress: newRotation.compress,
+				getLogIdentity: () => logFDIdentity,
+				closeLogFile,
+				report: reportRotationProblem,
+				onRotated(archivePath) {
+					logToFile(`log rotated, old log moved to ${archivePath}`);
+				},
+			});
+		} catch (error) {
+			reportRotationProblem(`log rotation is disabled for ${path}: ${error}`);
+		}
+	}
+	function reportRotationProblem(text) {
+		// Straight to stdio, never back through this sink: the sink is what rotation is failing on.
+		// Rate-limited rather than once-only, so a later, different failure is still reported.
+		if (nextRotationReport > performance.now()) return;
+		nextRotationReport = performance.now() + ROTATION_REPORT_INTERVAL;
+		writeToStdioDirectly(process.stderr, `Harper log rotation problem — ${text}\n`);
+	}
 	function logToFile(log) {
 		let entry = `${new Date().toISOString()} ${log}${log.endsWith('\n') ? '' : '\n'}`;
 		if (logBuffer) {
@@ -829,13 +889,17 @@ function getFileLogger(path, rotation, isExternalInstance) {
 		// A file that just refused a write will refuse the next one too, and every attempt costs a
 		// failed syscall plus a thrown error on whatever path is logging - which, on a full volume,
 		// is the request path at full rate. Go straight to stdio until the cooldown expires.
-		if (logFD && !(retryAppendAfter > performance.now())) {
+		if (logFD && !(retryAppendAfter > performance.now()) && (rotationGuard?.beforeAppend() ?? true)) {
 			let startTime = performance.now();
+			// Encoded once when the size guard is on, so its byte accounting reads a length instead of
+			// re-scanning the string appendFileSync is about to encode anyway.
+			const data = rotationGuard ? Buffer.from(payload) : payload;
 			try {
-				fs.appendFileSync(logFD, payload);
+				fs.appendFileSync(logFD, data);
 				// Both cleared, so a volume that fills again months later reports itself again
 				retryAppendAfter = undefined;
 				loggedAppendError = false;
+				rotationGuard?.recordWrite((data as Buffer).length);
 			} catch (error) {
 				retryAppendAfter = performance.now() + APPEND_RETRY_COOLDOWN;
 				// A log write must never take the process down: on an exhausted volume this throws from
@@ -864,6 +928,7 @@ function getFileLogger(path, rotation, isExternalInstance) {
 			fs.closeSync(logFD);
 		} catch {}
 		logFD = null;
+		logFDIdentity = null;
 		if (isExternalInstance) mainLogFd = null;
 	}
 
@@ -871,6 +936,14 @@ function getFileLogger(path, rotation, isExternalInstance) {
 		if (!logFD) {
 			try {
 				logFD = fs.openSync(path, 'a');
+				// Which generation this descriptor belongs to, recorded once here so the size guard's
+				// checkpoint needs a single pathname stat to tell whether the file has moved under it.
+				try {
+					const opened = fs.fstatSync(logFD);
+					logFDIdentity = { ino: opened.ino, dev: opened.dev };
+				} catch {
+					logFDIdentity = null;
+				}
 				if (isExternalInstance) mainLogFd = logFD;
 			} catch (error) {
 				if (error.code === 'ENOENT' && !isRetry) {

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -898,8 +898,7 @@ function getFileLogger(path, rotation, isExternalInstance) {
 		// is the request path at full rate. Go straight to stdio until the cooldown expires.
 		if (logFD && !(retryAppendAfter > performance.now()) && (rotationGuard?.beforeAppend() ?? true)) {
 			let startTime = performance.now();
-			// Encoded once when the size guard is on, so its byte accounting reads a length instead of
-			// re-scanning the string appendFileSync is about to encode anyway.
+			// Encoded once, so the guard's accounting reads a length instead of re-scanning the string.
 			const data = rotationGuard ? Buffer.from(payload) : payload;
 			try {
 				fs.appendFileSync(logFD, data);

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -799,7 +799,7 @@ function getFileLogger(path, rotation, isExternalInstance) {
 		// Registered by the sink, not by the size guard: a thread that writes this file but has no
 		// guard (no maxSize, or rotation driven only by interval) still holds a descriptor, and an
 		// answer from it has to mean "released" rather than only "handler ran".
-		registerLogSink(path, closeDescriptorOnGeneration);
+		registerLogSink(path, { identity: () => logFDIdentity, close: closeLogFile });
 	}
 	// An undefined rotation means "this caller has no opinion", not "turn rotation off" — that is
 	// what `enabled: false` says. Several loggers are created for one path during startup and the
@@ -928,12 +928,6 @@ function getFileLogger(path, rotation, isExternalInstance) {
 			logTimeUsage = Math.max(endTime, logTimeUsage) + (endTime - startTime) * 50;
 		} else writeToStdioDirectly(process.stdout, payload);
 		if (logBuffer) logBuffer = null;
-	}
-
-	function closeDescriptorOnGeneration(ino, dev) {
-		// No identity to compare (no descriptor open, or a filesystem that cannot report one) means
-		// closing is the only answer that can still be called a release.
-		if (!logFDIdentity || (logFDIdentity.ino === ino && logFDIdentity.dev === dev)) closeLogFile();
 	}
 
 	function closeLogFile(_unused?: any) {

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -801,11 +801,9 @@ function getFileLogger(path, rotation, isExternalInstance) {
 		// answer from it has to mean "released" rather than only "handler ran".
 		registerLogSink(path, { identity: () => logFDIdentity, close: closeLogFile });
 	}
-	// An undefined rotation means "this caller has no opinion", not "turn rotation off" — that is
-	// what `enabled: false` says. Several loggers are created for one path during startup and the
-	// later ones carry no rotation block of their own, so treating undefined as a reconfiguration
-	// tears down the rotation the earlier, configured caller asked for (the same shape of loss #1880
-	// fixed for updateLogger's inheritance).
+	// An undefined rotation means "no opinion", not "off" — that is what `enabled: false` says.
+	// Several loggers are created for one path during startup and the later ones carry no rotation
+	// block, so treating undefined as a reconfiguration tore down the configured caller's rotation.
 	const reconfigured = rotation !== undefined && JSON.stringify(rotation) !== JSON.stringify(logger.rotation);
 	if (reconfigured) {
 		logger.rotation = rotation;
@@ -892,6 +890,12 @@ function getFileLogger(path, rotation, isExternalInstance) {
 	// this is called on a timer, and will write the log buffer to the file
 	function logQueuedData(entry?: any) {
 		const payload = logBuffer ? logBuffer.join('') : entry;
+		// Released before anything can re-enter this sink. The rotation notice is written from inside
+		// the append below, and a re-entrant flush that still saw this batch would either write every
+		// line of it a second time into the new generation, or be swallowed when this call clears the
+		// buffer on its way out.
+		logBuffer = null;
+		if (payload === undefined) return;
 		// A file that just refused a write will refuse the next one too, and every attempt costs a
 		// failed syscall plus a thrown error on whatever path is logging - which, on a full volume,
 		// is the request path at full rate. Go straight to stdio until the cooldown expires.
@@ -901,14 +905,14 @@ function getFileLogger(path, rotation, isExternalInstance) {
 		openLogFile(undefined);
 		if (logFD && mayAppend) {
 			let startTime = performance.now();
-			// Encoded once, so the guard's accounting reads a length instead of re-scanning the string.
-			const data = rotationGuard ? Buffer.from(payload) : payload;
 			try {
-				fs.appendFileSync(logFD, data);
+				fs.appendFileSync(logFD, payload);
 				// Both cleared, so a volume that fills again months later reports itself again
 				retryAppendAfter = undefined;
 				loggedAppendError = false;
-				rotationGuard?.recordWrite((data as Buffer).length);
+				// byteLength, not a Buffer: appendFileSync writes a string through Node's own encoder
+				// without allocating, and rotation is on by default so this runs on every flush.
+				rotationGuard?.recordWrite(Buffer.byteLength(payload));
 			} catch (error) {
 				retryAppendAfter = performance.now() + APPEND_RETRY_COOLDOWN;
 				// A log write must never take the process down: on an exhausted volume this throws from
@@ -921,7 +925,6 @@ function getFileLogger(path, rotation, isExternalInstance) {
 					writeToStdioDirectly(process.stderr, `Harper cannot write to its log file: ${error}\n`);
 				}
 				writeToStdioDirectly(process.stdout, payload);
-				logBuffer = null;
 				return;
 			}
 			let endTime = performance.now();
@@ -929,7 +932,6 @@ function getFileLogger(path, rotation, isExternalInstance) {
 			// will start buffering
 			logTimeUsage = Math.max(endTime, logTimeUsage) + (endTime - startTime) * 50;
 		} else writeToStdioDirectly(process.stdout, payload);
-		if (logBuffer) logBuffer = null;
 	}
 
 	function closeLogFile(_unused?: any) {

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -816,10 +816,13 @@ function getFileLogger(path, rotation, isExternalInstance) {
 	}
 	if (isMainThread && reconfigured) {
 		setTimeout(() => {
-			logger.rotator?.end();
-			if (!rotation) return;
-			const { logRotator } = require('./logRotator');
+			// Everything inside the try: a throw from a timer callback is unhandled, and neither
+			// require('./logRotator') (which reaches environmentManager's synchronous init) nor a
+			// rotator teardown may take the process down over log rotation (#847).
 			try {
+				logger.rotator?.end();
+				if (!rotation) return;
+				const { logRotator } = require('./logRotator');
 				logger.rotator = logRotator({
 					logger,
 					...rotation,

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -59,6 +59,7 @@ const ROTATION_REPORT_INTERVAL = 60000;
 const SET_ROTATION_POLICY = Symbol('setRotationPolicy');
 const GET_ROTATION_POLICY = Symbol('getRotationPolicy');
 const FILE_ROTATION_SOURCE = Symbol('fileRotationSource');
+const SERVICE_NAME = workerData?.name?.replace(/ /g, '-') || 'main';
 
 let logConsole;
 let log_to_file;
@@ -493,9 +494,11 @@ export function initLogSettings(forceInit = false) {
 		if (hdbProperties === undefined || forceInit) {
 			if (forceInit && mainLogger?.[SET_ROTATION_POLICY]) {
 				const currentPath = mainLogger.path;
-				const { ownSource } = mainLogger[GET_ROTATION_POLICY]();
-				mainLogger[SET_ROTATION_POLICY](undefined, ownSource, false);
-				mainLogger.path = currentPath;
+				if (currentPath) {
+					const { ownSource } = mainLogger[GET_ROTATION_POLICY]();
+					mainLogger[SET_ROTATION_POLICY](undefined, ownSource, false);
+					mainLogger.path = currentPath;
+				}
 			}
 			closeLogFile();
 			const bootPropsFilePath = getPropsFilePath();
@@ -670,7 +673,6 @@ export function suppressLogging(callback) {
 	}
 }
 
-const SERVICE_NAME = workerData?.name?.replace(/ /g, '-') || 'main';
 // these are used to store information about the current service and tag so we can prepend them to the log during
 // the writes, without having to pass the information through the Console instance
 let currentLevel = 'info'; // default is info
@@ -776,6 +778,7 @@ export function createLogger(options: any = {} as any) {
 		},
 		set(path) {
 			logFilePath = path;
+			if (!logFilePath) return;
 			logToFile = getFileLogger(logFilePath, logger.rotation, isExternalInstance, rotationPolicy());
 			rotationPolicyApplied();
 			if (isExternalInstance) writeToLogFile = logToFile;
@@ -839,6 +842,7 @@ function getFileLogger(path, rotation, isExternalInstance, rotationPolicy) {
 	let logger = fileLoggers.get(path);
 	let logFD, loggedFDError, loggedAppendError, logTimer, retryAppendAfter;
 	let logBuffer;
+	let rotationProblemNotice;
 	let logTimeUsage = 0;
 	let rotationGuard,
 		logFDIdentity,
@@ -934,7 +938,11 @@ function getFileLogger(path, rotation, isExternalInstance, rotationPolicy) {
 		// Rate-limited rather than once-only, so a later, different failure is still reported.
 		if (nextRotationReport > performance.now()) return;
 		nextRotationReport = performance.now() + ROTATION_REPORT_INTERVAL;
-		writeToStdioDirectly(process.stderr, `Harper log rotation problem — ${text}\n`);
+		const message = `Harper log rotation problem — ${text}`;
+		// Scripted services discard stdio. Preserve the warning in the active file on the next
+		// successful append as well, without recursing through the rotation guard.
+		rotationProblemNotice = `${new Date().toISOString()} [${SERVICE_NAME}/${threadId}] [error]: ${message}\n`;
+		writeToStdioDirectly(process.stderr, `${message}\n`);
 	}
 	function logToFile(log) {
 		let entry = `${new Date().toISOString()} ${log}${log.endsWith('\n') ? '' : '\n'}`;
@@ -976,11 +984,13 @@ function getFileLogger(path, rotation, isExternalInstance, rotationPolicy) {
 		if (logFD && mayAppend) {
 			let startTime = performance.now();
 			try {
-				fs.appendFileSync(logFD, payload);
+				const appendPayload = rotationProblemNotice ? rotationProblemNotice + payload : payload;
+				fs.appendFileSync(logFD, appendPayload);
+				rotationProblemNotice = undefined;
 				// Both cleared, so a volume that fills again months later reports itself again
 				retryAppendAfter = undefined;
 				loggedAppendError = false;
-				rotationGuard?.recordWrite(Buffer.byteLength(payload));
+				rotationGuard?.recordWrite(Buffer.byteLength(appendPayload));
 			} catch (error) {
 				retryAppendAfter = performance.now() + APPEND_RETRY_COOLDOWN;
 				// A log write must never take the process down: on an exhausted volume this throws from

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -49,6 +49,14 @@ const DEFAULT_CONFIG_FILE = join(PACKAGE_ROOT, 'static', hdbTerms.HDB_DEFAULT_CO
 
 const CLOSE_LOG_FD_TIMEOUT = 10000;
 
+// Above the module-scope initLogSettings() call below, which reaches getFileLogger: a const
+// declared after it is still in its temporal dead zone when the file sink first reads one.
+const LOG_TIME_USAGE_THRESHOLD = 100;
+// How long to write straight to stdio after the log file refuses an append.
+const APPEND_RETRY_COOLDOWN = 5000;
+// Ceiling on how often a failing rotation may report itself; the failure repeats every check point.
+const ROTATION_REPORT_INTERVAL = 60000;
+
 let logConsole;
 let log_to_file;
 let logToStdstreams;
@@ -769,11 +777,6 @@ export function createLogger(options: any = {} as any) {
 	}
 	return logger;
 }
-const LOG_TIME_USAGE_THRESHOLD = 100;
-// How long to write straight to stdio after the log file refuses an append.
-const APPEND_RETRY_COOLDOWN = 5000;
-// Ceiling on how often a failing rotation may report itself; the failure repeats every check point.
-const ROTATION_REPORT_INTERVAL = 60000;
 /**
  * Get the file logger for the given path. If it doesn't exist, create it.
  * @param path

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -985,12 +985,13 @@ function getFileLogger(path, rotation, isExternalInstance, rotationPolicy) {
 			let startTime = performance.now();
 			try {
 				const appendPayload = rotationProblemNotice ? rotationProblemNotice + payload : payload;
-				fs.appendFileSync(logFD, appendPayload);
+				const appendBuffer = Buffer.from(appendPayload);
+				fs.appendFileSync(logFD, appendBuffer);
 				rotationProblemNotice = undefined;
 				// Both cleared, so a volume that fills again months later reports itself again
 				retryAppendAfter = undefined;
 				loggedAppendError = false;
-				rotationGuard?.recordWrite(Buffer.byteLength(appendPayload));
+				rotationGuard?.recordWrite(appendBuffer.length);
 			} catch (error) {
 				retryAppendAfter = performance.now() + APPEND_RETRY_COOLDOWN;
 				// A log write must never take the process down: on an exhausted volume this throws from

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -794,8 +794,8 @@ function getFileLogger(path, rotation, isExternalInstance) {
 	if (!logger) {
 		logger = logToFile;
 		logger.closeLogFile = closeLogFile;
-		// Only the first call for a path keeps its closure; later calls get the cached logger back and
-		// their own logFD/logBuffer are dead. The guard has to be installed through the live closure.
+		// The guard has to be installed through the live closure: later calls for this path get the
+		// cached logger back, and their own logFD/logBuffer are dead.
 		logger.installRotationGuard = installRotationGuard;
 		logger.path = path;
 		fileLoggers.set(path, logger);
@@ -894,7 +894,7 @@ function getFileLogger(path, rotation, isExternalInstance) {
 	function logQueuedData(entry?: any) {
 		const payload = logBuffer ? logBuffer.join('') : entry;
 		// Released before anything can re-enter: the rotation notice is written from inside the append
-		// below, and a re-entrant flush still holding this batch would write every line of it twice.
+		// below, and a re-entrant flush still holding this batch would write it twice.
 		logBuffer = null;
 		if (payload === undefined) return;
 		// A file that just refused a write will refuse the next one too, and every attempt costs a
@@ -910,7 +910,6 @@ function getFileLogger(path, rotation, isExternalInstance) {
 				// Both cleared, so a volume that fills again months later reports itself again
 				retryAppendAfter = undefined;
 				loggedAppendError = false;
-				// byteLength, not a Buffer: appendFileSync encodes the string without allocating one.
 				rotationGuard?.recordWrite(Buffer.byteLength(payload));
 			} catch (error) {
 				retryAppendAfter = performance.now() + APPEND_RETRY_COOLDOWN;

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -56,6 +56,9 @@ const LOG_TIME_USAGE_THRESHOLD = 100;
 const APPEND_RETRY_COOLDOWN = 5000;
 // Ceiling on how often a failing rotation may report itself; the failure repeats every check point.
 const ROTATION_REPORT_INTERVAL = 60000;
+const SET_ROTATION_POLICY = Symbol('setRotationPolicy');
+const GET_ROTATION_POLICY = Symbol('getRotationPolicy');
+const FILE_ROTATION_SOURCE = Symbol('fileRotationSource');
 
 let logConsole;
 let log_to_file;
@@ -119,6 +122,10 @@ export function updateLogger(logger: any, logOptions: any, name?: string, mainLo
 	// rotation entirely (#1877). Excluded when `logger` IS mainLoggerRef: the fallback would just
 	// reassign mainLogger.rotation to itself, making it impossible to ever clear main's rotation.
 	const inheritedRotation = logOptions.rotation ?? (logger === mainLoggerRef ? undefined : mainLoggerRef?.rotation);
+	const loggerPolicy = logger[GET_ROTATION_POLICY]?.();
+	const mainPolicy = mainLoggerRef?.[GET_ROTATION_POLICY]?.();
+	const inheritsRotation = logOptions.rotation == null && logger !== mainLoggerRef;
+	const rotationSource = inheritsRotation ? mainPolicy?.source : loggerPolicy?.ownSource;
 	let path = logOptions.path;
 	if (path) {
 		if (!logOptions.root) logOptions.root = pathModule.dirname(path);
@@ -144,9 +151,9 @@ export function updateLogger(logger: any, logOptions: any, name?: string, mainLo
 		// state — file loggers are cached per path — so stripping there discards the operator's
 		// configured rotation.path for the main log itself, which no EXDEV risk justifies.
 		const { path: _inheritedPath, ...rotationWithoutPath } = inheritedRotation;
-		logger.rotation = rotationWithoutPath;
+		setRotationPolicy(rotationWithoutPath);
 	} else {
-		logger.rotation = inheritedRotation;
+		setRotationPolicy(inheritedRotation);
 	}
 	// After the rotation above: assigning `path` goes through the setter that rebuilds this path's
 	// file logger, and it reads `logger.rotation` as it stands at that moment.
@@ -158,6 +165,11 @@ export function updateLogger(logger: any, logOptions: any, name?: string, mainLo
 	// if there is a configured tag or if a component is logging to default/main log path, use the component name as the tag
 	// to differentiate it
 	logger.tag = logOptions.tag ?? ((mainLoggerRef.path === logger.path || externalLogger.path === logger.path) && name);
+
+	function setRotationPolicy(rotation) {
+		if (logger[SET_ROTATION_POLICY]) logger[SET_ROTATION_POLICY](rotation, rotationSource, inheritsRotation);
+		else logger.rotation = rotation;
+	}
 }
 // creates a logger where the methods are only defined if they are within the log level.
 // Using this conditional logger means that every method call must be optional like log.trace?.('message),
@@ -479,6 +491,12 @@ export function logsAtLevel(level: any) {
 export function initLogSettings(forceInit = false) {
 	try {
 		if (hdbProperties === undefined || forceInit) {
+			if (forceInit && mainLogger?.[SET_ROTATION_POLICY]) {
+				const currentPath = mainLogger.path;
+				const { ownSource } = mainLogger[GET_ROTATION_POLICY]();
+				mainLogger[SET_ROTATION_POLICY](undefined, ownSource, false);
+				mainLogger.path = currentPath;
+			}
 			closeLogFile();
 			const bootPropsFilePath = getPropsFilePath();
 			let properties = assignCMDENVVariables(['ROOTPATH']);
@@ -667,7 +685,14 @@ export function createLogger(options: any = {} as any) {
 		isExternalInstance,
 		writeToLog,
 		component,
+		rotationSource,
+		rotationInherited = false,
 	}: any = options;
+	const ownRotationSource = Symbol('rotationPolicySource');
+	let currentRotationSource = rotationSource ?? ownRotationSource;
+	let previousRotationSource;
+	let currentRotationInherited = rotationInherited;
+	let rotationChangeIsAuthoritative = rotation !== undefined;
 	if (!logLevel) logLevel = 'info';
 	let level = typeof logLevel === 'number' ? logLevel : LOG_LEVEL_HIERARCHY[logLevel];
 	let logger;
@@ -711,7 +736,8 @@ export function createLogger(options: any = {} as any) {
 			}
 		} else if (logToStdstreams) process.stderr.write(log);
 	}
-	let logToFile = logFilePath && getFileLogger(logFilePath, rotation, isExternalInstance);
+	let logToFile = logFilePath && getFileLogger(logFilePath, rotation, isExternalInstance, rotationPolicy());
+	rotationPolicyApplied();
 	function logPrepend(write) {
 		return {
 			write(log) {
@@ -734,6 +760,14 @@ export function createLogger(options: any = {} as any) {
 		},
 		level
 	);
+	logger[SET_ROTATION_POLICY] = function (newRotation, source = ownRotationSource, inherited = false) {
+		previousRotationSource = currentRotationSource;
+		currentRotationSource = source ?? ownRotationSource;
+		currentRotationInherited = inherited;
+		rotationChangeIsAuthoritative = true;
+		logger.rotation = newRotation;
+	};
+	logger[GET_ROTATION_POLICY] = () => ({ ownSource: ownRotationSource, source: currentRotationSource });
 	updateConditional(logger);
 	logger.path = logFilePath;
 	Object.defineProperty(logger, 'path', {
@@ -742,7 +776,8 @@ export function createLogger(options: any = {} as any) {
 		},
 		set(path) {
 			logFilePath = path;
-			logToFile = getFileLogger(logFilePath, logger.rotation, isExternalInstance);
+			logToFile = getFileLogger(logFilePath, logger.rotation, isExternalInstance, rotationPolicy());
+			rotationPolicyApplied();
 			if (isExternalInstance) writeToLogFile = logToFile;
 		},
 		enumerable: true,
@@ -755,12 +790,15 @@ export function createLogger(options: any = {} as any) {
 			let componentLogger = components.get(name);
 			if (!componentLogger) {
 				const protoLogger = isExternal ? externalLogger : logger;
+				const protoRotationPolicy = protoLogger[GET_ROTATION_POLICY]?.();
 				componentLogger = createLogger({
 					path: protoLogger.path,
 					level: protoLogger.level,
 					stdStreams: protoLogger.logToStdstreams,
 					isExternalInstance: isExternal || name === 'external',
 					rotation: protoLogger.rotation,
+					rotationSource: protoRotationPolicy?.source,
+					rotationInherited: true,
 					writeToLog,
 					component: true,
 				});
@@ -776,6 +814,20 @@ export function createLogger(options: any = {} as any) {
 		logger.components = components;
 	}
 	return logger;
+
+	function rotationPolicy() {
+		return {
+			source: currentRotationSource,
+			previousSource: previousRotationSource,
+			inherited: currentRotationInherited,
+			authoritative: rotationChangeIsAuthoritative,
+		};
+	}
+
+	function rotationPolicyApplied() {
+		previousRotationSource = currentRotationSource;
+		rotationChangeIsAuthoritative = false;
+	}
 }
 /**
  * Get the file logger for the given path. If it doesn't exist, create it.
@@ -783,7 +835,7 @@ export function createLogger(options: any = {} as any) {
  * @param isExternalInstance
  * @return {any}
  */
-function getFileLogger(path, rotation, isExternalInstance) {
+function getFileLogger(path, rotation, isExternalInstance, rotationPolicy) {
 	let logger = fileLoggers.get(path);
 	let logFD, loggedFDError, loggedAppendError, logTimer, retryAppendAfter;
 	let logBuffer;
@@ -804,15 +856,28 @@ function getFileLogger(path, rotation, isExternalInstance) {
 		// answer from it has to mean "released" rather than only "handler ran".
 		registerLogSink(path, { identity: () => logFDIdentity, close: closeLogFile });
 	}
-	// An undefined rotation means "no opinion", not "off" — that is what `enabled: false` says.
-	// Several loggers are created for one path during startup and the later ones carry no rotation
-	// block, so treating undefined as a reconfiguration tore down the configured caller's rotation.
-	const reconfigured = rotation !== undefined && JSON.stringify(rotation) !== JSON.stringify(logger.rotation);
+	const currentSource = logger[FILE_ROTATION_SOURCE];
+	const sameSource = currentSource === rotationPolicy.source;
+	const replacesPreviousSource = currentSource !== undefined && currentSource === rotationPolicy.previousSource;
+	const canInstall =
+		rotation !== undefined &&
+		(!rotationPolicy.inherited || currentSource === undefined || sameSource || replacesPreviousSource);
+	const canClear = rotation === undefined && rotationPolicy.authoritative && (sameSource || replacesPreviousSource);
+	let reconfigured = false;
+	if (canInstall) {
+		logger[FILE_ROTATION_SOURCE] = rotationPolicy.source;
+		reconfigured = JSON.stringify(rotation) !== JSON.stringify(logger.rotation);
+	}
 	if (reconfigured) {
 		logger.rotation = rotation;
 		// Every writing thread, and synchronously: request logging is produced by the HTTP workers, and
 		// at the rates that make maxSize matter a deferred guard misses megabytes before it exists.
 		logger.installRotationGuard(rotation);
+	} else if (canClear) {
+		logger.rotation = undefined;
+		logger[FILE_ROTATION_SOURCE] = undefined;
+		logger.installRotationGuard(undefined);
+		reconfigured = true;
 	}
 	if (isMainThread && reconfigured) {
 		setTimeout(() => {
@@ -820,7 +885,9 @@ function getFileLogger(path, rotation, isExternalInstance) {
 			// require('./logRotator') (which reaches environmentManager's synchronous init) nor a
 			// rotator teardown may take the process down over log rotation (#847).
 			try {
-				logger.rotator?.end();
+				const previousRotator = logger.rotator;
+				logger.rotator = undefined;
+				previousRotator?.end();
 				if (!rotation) return;
 				const { logRotator } = require('./logRotator');
 				logger.rotator = logRotator({

--- a/utility/logging/logGenerationCoordinator.ts
+++ b/utility/logging/logGenerationCoordinator.ts
@@ -1,15 +1,13 @@
 'use strict';
 
-// Rotation-only coordination between the isolates that write the same log file. Every isolate keeps
-// its own descriptor on the active log (harper_logger's per-thread `fileLoggers`), so a rename by
-// one of them leaves the others appending to the archived inode until their CLOSE_LOG_FD_TIMEOUT
-// fires. Compression then unlinks that inode, and anything written after gzip reached EOF is gone.
-// This module makes the archived generation's quiescence provable instead of timing-dependent: the
-// rotating isolate announces the generation, peers close any descriptor on it and answer, and the
-// plain archive is only ever destroyed once every peer has answered or exited.
+// Every isolate holds its own descriptor on the shared log file, so a rename by one of them leaves
+// the others appending to the archived inode. Destroying that inode — compression's unlink, or
+// retention's — loses whatever they write next, and no size comparison can rule out a write that has
+// not happened yet. This makes the release provable: peers close matching descriptors and answer,
+// and an archive is destroyed only once every peer has answered or exited.
 //
-// Dependency-pure by construction: the thread layer injects its transport (see
-// server/threads/logRotationTransport.ts), because harper_logger must never reach manageThreads.
+// The thread layer injects the transport (server/threads/logRotationTransport.ts); harper_logger
+// must never reach manageThreads.
 
 export const LOG_GENERATION_ROTATED = 'log_generation_rotated';
 export const LOG_GENERATION_CLOSED = 'log_generation_closed';
@@ -54,8 +52,8 @@ export function setRotationTransport(newTransport?: RotationTransport) {
 }
 
 /**
- * Registered by the file sink itself, not by the size guard: a thread that writes this log but has
- * no guard still holds a descriptor, and an answer from it has to mean the descriptor is gone.
+ * Registered by the file sink, not the size guard: a thread with no guard still holds a descriptor,
+ * and its answer has to mean the descriptor is gone.
  */
 export function registerLogSink(logPath: string, sink: { identity(): any; close(): void }) {
 	sinksByPath.set(logPath, sink);

--- a/utility/logging/logGenerationCoordinator.ts
+++ b/utility/logging/logGenerationCoordinator.ts
@@ -1,13 +1,10 @@
 'use strict';
 
-// Every isolate holds its own descriptor on the shared log file, so a rename by one of them leaves
-// the others appending to the archived inode. Destroying that inode — compression's unlink, or
-// retention's — loses whatever they write next, and no size comparison can rule out a write that has
-// not happened yet. This makes the release provable: peers close matching descriptors and answer,
-// and an archive is destroyed only once every peer has answered or exited.
+// Every isolate holds its own descriptor on the shared log file, so a rename leaves the others
+// appending to the archived inode and destroying it loses whatever they write next. No size
+// comparison can rule out a write that has not happened yet; an answer from every peer can.
 //
-// The thread layer injects the transport (server/threads/logRotationTransport.ts); harper_logger
-// must never reach manageThreads.
+// The thread layer injects the transport; harper_logger must never reach manageThreads.
 
 export const LOG_GENERATION_ROTATED = 'log_generation_rotated';
 export const LOG_GENERATION_CLOSED = 'log_generation_closed';
@@ -28,7 +25,10 @@ interface RotationTransport {
 
 let transport: RotationTransport | undefined;
 const sinksByPath = new Map<string, { identity(): any; close(): void }>();
-const pendingByRequest = new Map<string, { expected: Set<number>; settle: (proven: boolean) => void }>();
+const pendingByRequest = new Map<
+	string,
+	{ expected: Set<number>; liveLogPaths: Set<string>; settle: (released: boolean) => void }
+>();
 let requestCounter = 0;
 
 export function setRotationTransport(newTransport?: RotationTransport) {
@@ -40,10 +40,14 @@ export function setRotationTransport(newTransport?: RotationTransport) {
 			type: LOG_GENERATION_CLOSED,
 			request: message.request,
 			threadId: newTransport.threadId,
+			// The paths this isolate writes. Components load in the workers, so a component's own log
+			// is registered only there, and the thread that runs retention would otherwise see a live
+			// file it has never heard of and delete it by age.
+			logPaths: message.stale ? [...sinksByPath.keys()] : undefined,
 		});
 	});
 	newTransport.onMessage(LOG_GENERATION_CLOSED, (message) => {
-		recordPeerResponse(message.request, message.threadId);
+		recordPeerResponse(message.request, message.threadId, message.logPaths);
 	});
 	newTransport.onThreadExit((threadId) => {
 		// An exited thread cannot hold a descriptor, so its exit answers everything it owed.
@@ -63,11 +67,6 @@ export function unregisterLogSink(logPath: string) {
 	sinksByPath.delete(logPath);
 }
 
-/** Whether this path is a log some isolate is writing, rather than something left in the directory. */
-export function isRegisteredLogPath(logPath: string) {
-	return sinksByPath.has(logPath);
-}
-
 export function nextGenerationId() {
 	return `${process.pid}-${transport?.threadId ?? 0}-${requestCounter++}`;
 }
@@ -77,19 +76,20 @@ export function nextGenerationId() {
  * whether they all provably did. `false` means the caller must leave those archives in place — it
  * is never safe to unlink an inode a peer may still be appending to.
  */
-function requestRelease(message: any): Promise<boolean> {
+function requestRelease(message: any): Promise<{ released: boolean; liveLogPaths: Set<string> }> {
 	releaseLocally(message);
+	const liveLogPaths = new Set<string>(sinksByPath.keys());
 	const expected = new Set<number>(transport ? transport.peerThreadIds() : []);
-	if (!transport || expected.size === 0) return Promise.resolve(true);
+	if (!transport || expected.size === 0) return Promise.resolve({ released: true, liveLogPaths });
 	const request = message.request;
 	return new Promise((resolve) => {
 		let timer;
-		const settle = (proven) => {
+		const settle = (released) => {
 			clearTimeout(timer);
 			pendingByRequest.delete(request);
-			resolve(proven);
+			resolve({ released, liveLogPaths });
 		};
-		pendingByRequest.set(request, { expected, settle });
+		pendingByRequest.set(request, { expected, liveLogPaths, settle });
 		timer = setTimeout(() => settle(false), transport.quiescenceTimeout ?? DEFAULT_QUIESCENCE_TIMEOUT);
 		timer.unref?.();
 		transport.broadcast({ ...message, originator: transport.threadId });
@@ -97,14 +97,16 @@ function requestRelease(message: any): Promise<boolean> {
 }
 
 /** One archived generation: release any descriptor still pointing at the inode that was renamed. */
-export function requestGenerationClose(generation: any): Promise<boolean> {
-	return requestRelease({
-		type: LOG_GENERATION_ROTATED,
-		request: generation.generation,
-		logPath: generation.logPath,
-		ino: generation.ino,
-		dev: generation.dev,
-	});
+export async function requestGenerationClose(generation: any): Promise<boolean> {
+	return (
+		await requestRelease({
+			type: LOG_GENERATION_ROTATED,
+			request: generation.generation,
+			logPath: generation.logPath,
+			ino: generation.ino,
+			dev: generation.dev,
+		})
+	).released;
 }
 
 /**
@@ -112,7 +114,10 @@ export function requestGenerationClose(generation: any): Promise<boolean> {
  * process may not have rotated — a worker's unproven archive is invisible to the main thread's own
  * bookkeeping — so it proves the whole set at once rather than asking per archive.
  */
-export function requestStaleDescriptorRelease(logPath: string, active: any): Promise<boolean> {
+export function requestStaleDescriptorRelease(
+	logPath: string,
+	active: any
+): Promise<{ released: boolean; liveLogPaths: Set<string> }> {
 	return requestRelease({
 		type: LOG_GENERATION_ROTATED,
 		request: nextGenerationId(),
@@ -123,9 +128,10 @@ export function requestStaleDescriptorRelease(logPath: string, active: any): Pro
 	});
 }
 
-function recordPeerResponse(request: string, threadId: number) {
+function recordPeerResponse(request: string, threadId: number, logPaths?: string[]) {
 	const pending = pendingByRequest.get(request);
 	if (!pending) return;
+	if (logPaths) for (const logPath of logPaths) pending.liveLogPaths.add(logPath);
 	pending.expected.delete(threadId);
 	if (pending.expected.size === 0) pending.settle(true);
 }
@@ -138,9 +144,8 @@ function releaseLocally(message: any) {
 	// closing is the only answer that can still be called a release. `stale` inverts the test: keep
 	// only the live generation, and when there is no live generation to name, keep nothing.
 	if (message.stale) {
-		// Keep only a descriptor provably on the live generation. `ino === 0` — some Windows
-		// filesystems — cannot prove that, and answering "released" without releasing is what would
-		// let the archive be destroyed under a peer, so an indistinguishable descriptor is closed.
+		// Keep only a descriptor provably on the live generation: `ino === 0` (some Windows filesystems)
+		// proves nothing, and answering "released" without releasing is what destroys an archive.
 		const onLiveGeneration =
 			identity &&
 			identity.ino &&

--- a/utility/logging/logGenerationCoordinator.ts
+++ b/utility/logging/logGenerationCoordinator.ts
@@ -65,6 +65,11 @@ export function unregisterLogSink(logPath: string) {
 	sinksByPath.delete(logPath);
 }
 
+/** Whether this path is a log some isolate is writing, rather than something left in the directory. */
+export function isRegisteredLogPath(logPath: string) {
+	return sinksByPath.has(logPath);
+}
+
 export function nextGenerationId() {
 	return `${process.pid}-${transport?.threadId ?? 0}-${requestCounter++}`;
 }

--- a/utility/logging/logGenerationCoordinator.ts
+++ b/utility/logging/logGenerationCoordinator.ts
@@ -140,7 +140,16 @@ function releaseLocally(message: any) {
 	// closing is the only answer that can still be called a release. `stale` inverts the test: keep
 	// only the live generation, and when there is no live generation to name, keep nothing.
 	if (message.stale) {
-		if (!identity || identity.ino !== message.keepIno || identity.dev !== message.keepDev) sink.close();
+		// Keep only a descriptor provably on the live generation. `ino === 0` — some Windows
+		// filesystems — cannot prove that, and answering "released" without releasing is what would
+		// let the archive be destroyed under a peer, so an indistinguishable descriptor is closed.
+		const onLiveGeneration =
+			identity &&
+			identity.ino &&
+			message.keepIno &&
+			identity.ino === message.keepIno &&
+			identity.dev === message.keepDev;
+		if (!onLiveGeneration) sink.close();
 		return;
 	}
 	if (!identity || (identity.ino === message.ino && identity.dev === message.dev)) sink.close();

--- a/utility/logging/logGenerationCoordinator.ts
+++ b/utility/logging/logGenerationCoordinator.ts
@@ -29,31 +29,35 @@ interface RotationTransport {
 }
 
 let transport: RotationTransport | undefined;
-const sinksByPath = new Map<string, (ino: number, dev: number) => void>();
-const pendingByGeneration = new Map<string, { expected: Set<number>; settle: (proven: boolean) => void }>();
-let generationCounter = 0;
+const sinksByPath = new Map<string, { identity(): any; close(): void }>();
+const pendingByRequest = new Map<string, { expected: Set<number>; settle: (proven: boolean) => void }>();
+let requestCounter = 0;
 
 export function setRotationTransport(newTransport: RotationTransport) {
 	transport = newTransport;
 	newTransport.onMessage(LOG_GENERATION_ROTATED, (message) => {
-		closeLocalDescriptorsOn(message);
+		releaseLocally(message);
 		newTransport.sendToThread(message.originator, {
 			type: LOG_GENERATION_CLOSED,
-			generation: message.generation,
+			request: message.request,
 			threadId: newTransport.threadId,
 		});
 	});
 	newTransport.onMessage(LOG_GENERATION_CLOSED, (message) => {
-		recordPeerResponse(message.generation, message.threadId);
+		recordPeerResponse(message.request, message.threadId);
 	});
 	newTransport.onThreadExit((threadId) => {
-		// An exited thread cannot hold a descriptor, so its exit answers every generation it owed.
-		for (const generation of [...pendingByGeneration.keys()]) recordPeerResponse(generation, threadId);
+		// An exited thread cannot hold a descriptor, so its exit answers everything it owed.
+		for (const request of [...pendingByRequest.keys()]) recordPeerResponse(request, threadId);
 	});
 }
 
-export function registerLogSink(logPath: string, closeIfInodeMatches: (ino: number, dev: number) => void) {
-	sinksByPath.set(logPath, closeIfInodeMatches);
+/**
+ * Registered by the file sink itself, not by the size guard: a thread that writes this log but has
+ * no guard still holds a descriptor, and an answer from it has to mean the descriptor is gone.
+ */
+export function registerLogSink(logPath: string, sink: { identity(): any; close(): void }) {
+	sinksByPath.set(logPath, sink);
 }
 
 export function unregisterLogSink(logPath: string) {
@@ -61,57 +65,99 @@ export function unregisterLogSink(logPath: string) {
 }
 
 export function nextGenerationId() {
-	return `${process.pid}-${transport?.threadId ?? 0}-${generationCounter++}`;
+	return nextRequestId();
+}
+
+function nextRequestId() {
+	return `${process.pid}-${transport?.threadId ?? 0}-${requestCounter++}`;
 }
 
 /**
- * Tell every writer to release an archived generation, without waiting. Worth doing even when the
- * archive will never be destroyed: a peer still holding the moved inode keeps appending to it.
+ * Ask every writer of `logPath` to release the descriptors this request names, and resolve to
+ * whether they all provably did. `false` means the caller must leave those archives in place — it
+ * is never safe to unlink an inode a peer may still be appending to.
  */
+function requestRelease(message: any): Promise<boolean> {
+	releaseLocally(message);
+	const expected = new Set<number>(transport ? transport.peerThreadIds() : []);
+	if (!transport || expected.size === 0) return Promise.resolve(true);
+	const request = message.request;
+	return new Promise((resolve) => {
+		let timer;
+		const settle = (proven) => {
+			clearTimeout(timer);
+			pendingByRequest.delete(request);
+			resolve(proven);
+		};
+		pendingByRequest.set(request, { expected, settle });
+		timer = setTimeout(() => settle(false), transport.quiescenceTimeout ?? DEFAULT_QUIESCENCE_TIMEOUT);
+		timer.unref?.();
+		transport.broadcast({ ...message, originator: transport.threadId });
+	});
+}
+
+/** One archived generation: release any descriptor still pointing at the inode that was renamed. */
+export function requestGenerationClose(generation: any): Promise<boolean> {
+	return requestRelease({
+		type: LOG_GENERATION_ROTATED,
+		request: generation.generation,
+		logPath: generation.logPath,
+		ino: generation.ino,
+		dev: generation.dev,
+	});
+}
+
+/**
+ * Every generation but the live one, in a single round trip. Retention deletes archives this
+ * process may not have rotated — a worker's unproven archive is invisible to the main thread's own
+ * bookkeeping — so it proves the whole set at once rather than asking per archive.
+ */
+export function requestStaleDescriptorRelease(logPath: string, active: any): Promise<boolean> {
+	return requestRelease({
+		type: LOG_GENERATION_ROTATED,
+		request: nextRequestId(),
+		logPath,
+		keepIno: active?.ino,
+		keepDev: active?.dev,
+	});
+}
+
+/** Tell every writer about an archived generation without waiting for the answer. */
 export function announceGeneration(generation: any) {
-	closeLocalDescriptorsOn(generation);
+	releaseLocally({
+		type: LOG_GENERATION_ROTATED,
+		request: generation.generation,
+		logPath: generation.logPath,
+		ino: generation.ino,
+		dev: generation.dev,
+	});
 	transport?.broadcast({
 		type: LOG_GENERATION_ROTATED,
+		request: generation.generation,
 		logPath: generation.logPath,
-		generation: generation.generation,
 		ino: generation.ino,
 		dev: generation.dev,
 		originator: transport.threadId,
 	});
 }
 
-/**
- * Announce an archived generation and resolve to whether every peer has provably released it.
- * `false` means the caller must leave the plain archive in place — it is never safe to unlink an
- * inode a peer may still be appending to.
- */
-export function requestGenerationClose(generation: any): Promise<boolean> {
-	const expected = new Set<number>(transport ? transport.peerThreadIds() : []);
-	if (!transport || expected.size === 0) {
-		announceGeneration(generation);
-		return Promise.resolve(true);
-	}
-	return new Promise((resolve) => {
-		let timer;
-		const settle = (proven) => {
-			clearTimeout(timer);
-			pendingByGeneration.delete(generation.generation);
-			resolve(proven);
-		};
-		pendingByGeneration.set(generation.generation, { expected, settle });
-		timer = setTimeout(() => settle(false), transport.quiescenceTimeout ?? DEFAULT_QUIESCENCE_TIMEOUT);
-		timer.unref?.();
-		announceGeneration(generation);
-	});
-}
-
-function recordPeerResponse(generationId: string, threadId: number) {
-	const pending = pendingByGeneration.get(generationId);
+function recordPeerResponse(request: string, threadId: number) {
+	const pending = pendingByRequest.get(request);
 	if (!pending) return;
 	pending.expected.delete(threadId);
 	if (pending.expected.size === 0) pending.settle(true);
 }
 
-function closeLocalDescriptorsOn(generation: any) {
-	sinksByPath.get(generation.logPath)?.(generation.ino, generation.dev);
+function releaseLocally(message: any) {
+	const sink = sinksByPath.get(message.logPath);
+	if (!sink) return;
+	const identity = sink.identity();
+	if (message.keepIno === undefined) {
+		// No identity to compare (no descriptor open, or a filesystem that cannot report one) means
+		// closing is the only answer that can still be called a release.
+		if (!identity || (identity.ino === message.ino && identity.dev === message.dev)) sink.close();
+		return;
+	}
+	if (identity && identity.ino === message.keepIno && identity.dev === message.keepDev) return;
+	sink.close();
 }

--- a/utility/logging/logGenerationCoordinator.ts
+++ b/utility/logging/logGenerationCoordinator.ts
@@ -1,0 +1,117 @@
+'use strict';
+
+// Rotation-only coordination between the isolates that write the same log file. Every isolate keeps
+// its own descriptor on the active log (harper_logger's per-thread `fileLoggers`), so a rename by
+// one of them leaves the others appending to the archived inode until their CLOSE_LOG_FD_TIMEOUT
+// fires. Compression then unlinks that inode, and anything written after gzip reached EOF is gone.
+// This module makes the archived generation's quiescence provable instead of timing-dependent: the
+// rotating isolate announces the generation, peers close any descriptor on it and answer, and the
+// plain archive is only ever destroyed once every peer has answered or exited.
+//
+// Dependency-pure by construction: the thread layer injects its transport (see
+// server/threads/logRotationTransport.ts), because harper_logger must never reach manageThreads.
+
+export const LOG_GENERATION_ROTATED = 'log_generation_rotated';
+export const LOG_GENERATION_CLOSED = 'log_generation_closed';
+
+// Under manageThreads' 30s ITC default, so an unanswered generation is decided here (retain the
+// plain archive) rather than by a transport backstop that cannot express "unproven".
+const DEFAULT_QUIESCENCE_TIMEOUT = 15000;
+
+interface RotationTransport {
+	broadcast(message: any): void;
+	sendToThread(threadId: number, message: any): void;
+	onMessage(type: string, handler: (message: any) => void): void;
+	onThreadExit(handler: (threadId: number) => void): void;
+	peerThreadIds(): Iterable<number>;
+	threadId: number;
+	quiescenceTimeout?: number;
+}
+
+let transport: RotationTransport | undefined;
+const sinksByPath = new Map<string, (ino: number, dev: number) => void>();
+const pendingByGeneration = new Map<string, { expected: Set<number>; settle: (proven: boolean) => void }>();
+let generationCounter = 0;
+
+export function setRotationTransport(newTransport: RotationTransport) {
+	transport = newTransport;
+	newTransport.onMessage(LOG_GENERATION_ROTATED, (message) => {
+		closeLocalDescriptorsOn(message);
+		newTransport.sendToThread(message.originator, {
+			type: LOG_GENERATION_CLOSED,
+			generation: message.generation,
+			threadId: newTransport.threadId,
+		});
+	});
+	newTransport.onMessage(LOG_GENERATION_CLOSED, (message) => {
+		recordPeerResponse(message.generation, message.threadId);
+	});
+	newTransport.onThreadExit((threadId) => {
+		// An exited thread cannot hold a descriptor, so its exit answers every generation it owed.
+		for (const generation of [...pendingByGeneration.keys()]) recordPeerResponse(generation, threadId);
+	});
+}
+
+export function registerLogSink(logPath: string, closeIfInodeMatches: (ino: number, dev: number) => void) {
+	sinksByPath.set(logPath, closeIfInodeMatches);
+}
+
+export function unregisterLogSink(logPath: string) {
+	sinksByPath.delete(logPath);
+}
+
+export function nextGenerationId() {
+	return `${process.pid}-${transport?.threadId ?? 0}-${generationCounter++}`;
+}
+
+/**
+ * Tell every writer to release an archived generation, without waiting. Worth doing even when the
+ * archive will never be destroyed: a peer still holding the moved inode keeps appending to it.
+ */
+export function announceGeneration(generation: any) {
+	closeLocalDescriptorsOn(generation);
+	transport?.broadcast({
+		type: LOG_GENERATION_ROTATED,
+		logPath: generation.logPath,
+		generation: generation.generation,
+		ino: generation.ino,
+		dev: generation.dev,
+		originator: transport.threadId,
+	});
+}
+
+/**
+ * Announce an archived generation and resolve to whether every peer has provably released it.
+ * `false` means the caller must leave the plain archive in place — it is never safe to unlink an
+ * inode a peer may still be appending to.
+ */
+export function requestGenerationClose(generation: any): Promise<boolean> {
+	const expected = new Set<number>(transport ? transport.peerThreadIds() : []);
+	if (!transport || expected.size === 0) {
+		announceGeneration(generation);
+		return Promise.resolve(true);
+	}
+	return new Promise((resolve) => {
+		let timer;
+		const settle = (proven) => {
+			clearTimeout(timer);
+			pendingByGeneration.delete(generation.generation);
+			resolve(proven);
+		};
+		pendingByGeneration.set(generation.generation, { expected, settle });
+		timer = setTimeout(() => settle(false), transport.quiescenceTimeout ?? DEFAULT_QUIESCENCE_TIMEOUT);
+		timer.unref?.();
+		announceGeneration(generation);
+	});
+}
+
+function recordPeerResponse(generationId: string, threadId: number) {
+	const pending = pendingByGeneration.get(generationId);
+	if (!pending) return;
+	pending.expected.delete(threadId);
+	if (pending.expected.size === 0) pending.settle(true);
+}
+
+function closeLocalDescriptorsOn(generation: any) {
+	sinksByPath.get(generation.logPath)?.(generation.ino, generation.dev);
+}

--- a/utility/logging/logGenerationCoordinator.ts
+++ b/utility/logging/logGenerationCoordinator.ts
@@ -6,6 +6,8 @@
 //
 // The thread layer injects the transport; harper_logger must never reach manageThreads.
 
+import { statSync } from 'node:fs';
+
 export const LOG_GENERATION_ROTATED = 'log_generation_rotated';
 export const LOG_GENERATION_CLOSED = 'log_generation_closed';
 
@@ -110,22 +112,12 @@ export async function requestGenerationClose(generation: any): Promise<boolean> 
 }
 
 /**
- * Every generation but the live one, in a single round trip. Retention deletes archives this
- * process may not have rotated — a worker's unproven archive is invisible to the main thread's own
- * bookkeeping — so it proves the whole set at once rather than asking per archive.
+ * Every generation but the live one, for every log this process writes, in a single round trip.
+ * Not scoped to one path: the archive directory holds the archives of every component and external
+ * log sharing it, and retention destroys those too.
  */
-export function requestStaleDescriptorRelease(
-	logPath: string,
-	active: any
-): Promise<{ released: boolean; liveLogPaths: Set<string> }> {
-	return requestRelease({
-		type: LOG_GENERATION_ROTATED,
-		request: nextGenerationId(),
-		logPath,
-		stale: true,
-		keepIno: active?.ino,
-		keepDev: active?.dev,
-	});
+export function requestStaleDescriptorRelease(): Promise<{ released: boolean; liveLogPaths: Set<string> }> {
+	return requestRelease({ type: LOG_GENERATION_ROTATED, request: nextGenerationId(), stale: true });
 }
 
 function recordPeerResponse(request: string, threadId: number, logPaths?: string[]) {
@@ -137,23 +129,32 @@ function recordPeerResponse(request: string, threadId: number, logPaths?: string
 }
 
 function releaseLocally(message: any) {
+	if (message.stale) return releaseStaleDescriptors();
 	const sink = sinksByPath.get(message.logPath);
 	if (!sink) return;
 	const identity = sink.identity();
 	// No identity to compare (no descriptor open, or a filesystem that cannot report one) means
-	// closing is the only answer that can still be called a release. `stale` inverts the test: keep
-	// only the live generation, and when there is no live generation to name, keep nothing.
-	if (message.stale) {
-		// Keep only a descriptor provably on the live generation: `ino === 0` (some Windows filesystems)
-		// proves nothing, and answering "released" without releasing is what destroys an archive.
-		const onLiveGeneration =
-			identity &&
-			identity.ino &&
-			message.keepIno &&
-			identity.ino === message.keepIno &&
-			identity.dev === message.keepDev;
-		if (!onLiveGeneration) sink.close();
-		return;
-	}
+	// closing is the only answer that can still be called a release.
 	if (!identity || (identity.ino === message.ino && identity.dev === message.dev)) sink.close();
+}
+
+/**
+ * Release every descriptor this isolate holds that is not on the live generation of its own path.
+ * Each sink decides for itself, so nothing has to name the live inode of a log it does not own.
+ */
+function releaseStaleDescriptors() {
+	for (const [logPath, sink] of sinksByPath) {
+		const identity = sink.identity();
+		if (!identity) continue;
+		let live;
+		try {
+			live = statSync(logPath);
+		} catch {
+			sink.close();
+			continue;
+		}
+		// `ino === 0` (some Windows filesystems) proves nothing, and answering "released" without
+		// releasing is what destroys an archive under a peer.
+		if (!identity.ino || !live.ino || identity.ino !== live.ino || identity.dev !== live.dev) sink.close();
+	}
 }

--- a/utility/logging/logGenerationCoordinator.ts
+++ b/utility/logging/logGenerationCoordinator.ts
@@ -33,8 +33,9 @@ const sinksByPath = new Map<string, { identity(): any; close(): void }>();
 const pendingByRequest = new Map<string, { expected: Set<number>; settle: (proven: boolean) => void }>();
 let requestCounter = 0;
 
-export function setRotationTransport(newTransport: RotationTransport) {
+export function setRotationTransport(newTransport?: RotationTransport) {
 	transport = newTransport;
+	if (!newTransport) return;
 	newTransport.onMessage(LOG_GENERATION_ROTATED, (message) => {
 		releaseLocally(message);
 		newTransport.sendToThread(message.originator, {

--- a/utility/logging/logGenerationCoordinator.ts
+++ b/utility/logging/logGenerationCoordinator.ts
@@ -65,10 +65,6 @@ export function unregisterLogSink(logPath: string) {
 }
 
 export function nextGenerationId() {
-	return nextRequestId();
-}
-
-function nextRequestId() {
 	return `${process.pid}-${transport?.threadId ?? 0}-${requestCounter++}`;
 }
 
@@ -115,29 +111,11 @@ export function requestGenerationClose(generation: any): Promise<boolean> {
 export function requestStaleDescriptorRelease(logPath: string, active: any): Promise<boolean> {
 	return requestRelease({
 		type: LOG_GENERATION_ROTATED,
-		request: nextRequestId(),
+		request: nextGenerationId(),
 		logPath,
+		stale: true,
 		keepIno: active?.ino,
 		keepDev: active?.dev,
-	});
-}
-
-/** Tell every writer about an archived generation without waiting for the answer. */
-export function announceGeneration(generation: any) {
-	releaseLocally({
-		type: LOG_GENERATION_ROTATED,
-		request: generation.generation,
-		logPath: generation.logPath,
-		ino: generation.ino,
-		dev: generation.dev,
-	});
-	transport?.broadcast({
-		type: LOG_GENERATION_ROTATED,
-		request: generation.generation,
-		logPath: generation.logPath,
-		ino: generation.ino,
-		dev: generation.dev,
-		originator: transport.threadId,
 	});
 }
 
@@ -152,12 +130,12 @@ function releaseLocally(message: any) {
 	const sink = sinksByPath.get(message.logPath);
 	if (!sink) return;
 	const identity = sink.identity();
-	if (message.keepIno === undefined) {
-		// No identity to compare (no descriptor open, or a filesystem that cannot report one) means
-		// closing is the only answer that can still be called a release.
-		if (!identity || (identity.ino === message.ino && identity.dev === message.dev)) sink.close();
+	// No identity to compare (no descriptor open, or a filesystem that cannot report one) means
+	// closing is the only answer that can still be called a release. `stale` inverts the test: keep
+	// only the live generation, and when there is no live generation to name, keep nothing.
+	if (message.stale) {
+		if (!identity || identity.ino !== message.keepIno || identity.dev !== message.keepDev) sink.close();
 		return;
 	}
-	if (identity && identity.ino === message.keepIno && identity.dev === message.keepDev) return;
-	sink.close();
+	if (!identity || (identity.ino === message.ino && identity.dev === message.dev)) sink.close();
 }

--- a/utility/logging/logGenerationCoordinator.ts
+++ b/utility/logging/logGenerationCoordinator.ts
@@ -145,7 +145,13 @@ function releaseLocally(message: any) {
 function releaseStaleDescriptors() {
 	for (const [logPath, sink] of sinksByPath) {
 		const identity = sink.identity();
-		if (!identity) continue;
+		// No identity is not the same as no descriptor: openLogFile() leaves the descriptor open when
+		// its fstat fails. Skipping the sink and still answering "released" is what lets an archive be
+		// unlinked under it, so close it here as the per-generation path already does.
+		if (!identity) {
+			sink.close();
+			continue;
+		}
 		let live;
 		try {
 			live = statSync(logPath);

--- a/utility/logging/logGenerationCoordinator.ts
+++ b/utility/logging/logGenerationCoordinator.ts
@@ -7,6 +7,8 @@
 // The thread layer injects the transport; harper_logger must never reach manageThreads.
 
 import { statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { isMainThread } from 'node:worker_threads';
 
 export const LOG_GENERATION_ROTATED = 'log_generation_rotated';
 export const LOG_GENERATION_CLOSED = 'log_generation_closed';
@@ -62,11 +64,13 @@ export function setRotationTransport(newTransport?: RotationTransport) {
  * and its answer has to mean the descriptor is gone.
  */
 export function registerLogSink(logPath: string, sink: { identity(): any; close(): void }) {
-	sinksByPath.set(logPath, sink);
+	// Keyed on the resolved path: retention compares resolved paths, so a sink registered under
+	// another spelling of the same file would answer "released" having closed nothing.
+	sinksByPath.set(resolve(logPath), sink);
 }
 
 export function unregisterLogSink(logPath: string) {
-	sinksByPath.delete(logPath);
+	sinksByPath.delete(resolve(logPath));
 }
 
 export function nextGenerationId() {
@@ -81,8 +85,14 @@ export function nextGenerationId() {
 function requestRelease(message: any): Promise<{ released: boolean; liveLogPaths: Set<string> }> {
 	releaseLocally(message);
 	const liveLogPaths = new Set<string>(sinksByPath.keys());
-	const expected = new Set<number>(transport ? transport.peerThreadIds() : []);
-	if (!transport || expected.size === 0) return Promise.resolve({ released: true, liveLogPaths });
+	// No transport in a worker isolate means the mesh cannot be enumerated yet, not that there is
+	// nobody to ask: harper_logger installs the size guard at its own module load and manageThreads
+	// installs the transport at the end of its, so a worker rotating in that window would otherwise
+	// call an empty peer set a proof and unlink the generation its siblings are appending to. On the
+	// main thread the same state means no worker has been spawned, where zero peers is the truth.
+	if (!transport) return Promise.resolve({ released: isMainThread, liveLogPaths });
+	const expected = new Set<number>(transport.peerThreadIds());
+	if (expected.size === 0) return Promise.resolve({ released: true, liveLogPaths });
 	const request = message.request;
 	return new Promise((resolve) => {
 		let timer;
@@ -130,7 +140,7 @@ function recordPeerResponse(request: string, threadId: number, logPaths?: string
 
 function releaseLocally(message: any) {
 	if (message.stale) return releaseStaleDescriptors();
-	const sink = sinksByPath.get(message.logPath);
+	const sink = sinksByPath.get(resolve(message.logPath));
 	if (!sink) return;
 	const identity = sink.identity();
 	// No identity to compare (no descriptor open, or a filesystem that cannot report one) means

--- a/utility/logging/logGenerationCoordinator.ts
+++ b/utility/logging/logGenerationCoordinator.ts
@@ -16,6 +16,9 @@ export const LOG_GENERATION_CLOSED = 'log_generation_closed';
 // Under manageThreads' 30s ITC default, so an unanswered generation is decided here (retain the
 // plain archive) rather than by a transport backstop that cannot express "unproven".
 const DEFAULT_QUIESCENCE_TIMEOUT = 15000;
+// A tiny maxSize can rotate faster than a slow peer answers. Overflow is left as a plain archive
+// for the audit sweep instead of retaining one timer and one mesh request per generation.
+const MAX_PENDING_RELEASE_REQUESTS = 64;
 
 interface RotationTransport {
 	broadcast(message: any): void;
@@ -102,6 +105,7 @@ function requestRelease(message: any, deadline?: number): Promise<{ released: bo
 	if (!transport) return Promise.resolve({ released: isMainThread, liveLogPaths });
 	const expected = new Set<number>(transport.peerThreadIds());
 	if (expected.size === 0) return Promise.resolve({ released: true, liveLogPaths });
+	if (pendingByRequest.size >= MAX_PENDING_RELEASE_REQUESTS) return Promise.resolve({ released: false, liveLogPaths });
 	const quiescenceTimeout = transport.quiescenceTimeout ?? DEFAULT_QUIESCENCE_TIMEOUT;
 	if (deadline !== undefined && Date.now() + quiescenceTimeout > deadline)
 		return Promise.resolve({ released: false, liveLogPaths });

--- a/utility/logging/logGenerationCoordinator.ts
+++ b/utility/logging/logGenerationCoordinator.ts
@@ -165,7 +165,8 @@ function releaseLocally(message: any) {
 		const identity = sink.identity();
 		// No identity to compare (no descriptor open, or a filesystem that cannot report one) means
 		// closing is the only answer that can still be called a release.
-		if (!identity || (identity.ino === message.ino && identity.dev === message.dev)) sink.close();
+		if (!identity || !identity.ino || !message.ino || (identity.ino === message.ino && identity.dev === message.dev))
+			sink.close();
 	}
 }
 

--- a/utility/logging/logGenerationCoordinator.ts
+++ b/utility/logging/logGenerationCoordinator.ts
@@ -28,7 +28,11 @@ interface RotationTransport {
 }
 
 let transport: RotationTransport | undefined;
-const sinksByPath = new Map<string, { identity(): any; close(): void }>();
+type LogSink = { identity(): any; close(): void };
+// A set per path, not one sink: harper_logger caches its file loggers by the raw configured path, so
+// two spellings of one file are two sinks holding two descriptors on it, and a release has to close
+// both. The key is resolved because retention compares resolved paths.
+const sinksByPath = new Map<string, Set<LogSink>>();
 const pendingByRequest = new Map<
 	string,
 	{ expected: Set<number>; liveLogPaths: Set<string>; settle: (released: boolean) => void }
@@ -63,14 +67,19 @@ export function setRotationTransport(newTransport?: RotationTransport) {
  * Registered by the file sink, not the size guard: a thread with no guard still holds a descriptor,
  * and its answer has to mean the descriptor is gone.
  */
-export function registerLogSink(logPath: string, sink: { identity(): any; close(): void }) {
-	// Keyed on the resolved path: retention compares resolved paths, so a sink registered under
-	// another spelling of the same file would answer "released" having closed nothing.
-	sinksByPath.set(resolve(logPath), sink);
+export function registerLogSink(logPath: string, sink: LogSink) {
+	const key = resolve(logPath);
+	const sinks = sinksByPath.get(key) ?? new Set<LogSink>();
+	sinks.add(sink);
+	sinksByPath.set(key, sinks);
 }
 
-export function unregisterLogSink(logPath: string) {
-	sinksByPath.delete(resolve(logPath));
+export function unregisterLogSink(logPath: string, sink?: LogSink) {
+	const key = resolve(logPath);
+	if (!sink) return void sinksByPath.delete(key);
+	const sinks = sinksByPath.get(key);
+	if (!sinks?.delete(sink)) return;
+	if (sinks.size === 0) sinksByPath.delete(key);
 }
 
 export function nextGenerationId() {
@@ -140,12 +149,12 @@ function recordPeerResponse(request: string, threadId: number, logPaths?: string
 
 function releaseLocally(message: any) {
 	if (message.stale) return releaseStaleDescriptors();
-	const sink = sinksByPath.get(resolve(message.logPath));
-	if (!sink) return;
-	const identity = sink.identity();
-	// No identity to compare (no descriptor open, or a filesystem that cannot report one) means
-	// closing is the only answer that can still be called a release.
-	if (!identity || (identity.ino === message.ino && identity.dev === message.dev)) sink.close();
+	for (const sink of sinksByPath.get(resolve(message.logPath)) ?? []) {
+		const identity = sink.identity();
+		// No identity to compare (no descriptor open, or a filesystem that cannot report one) means
+		// closing is the only answer that can still be called a release.
+		if (!identity || (identity.ino === message.ino && identity.dev === message.dev)) sink.close();
+	}
 }
 
 /**
@@ -153,24 +162,22 @@ function releaseLocally(message: any) {
  * Each sink decides for itself, so nothing has to name the live inode of a log it does not own.
  */
 function releaseStaleDescriptors() {
-	for (const [logPath, sink] of sinksByPath) {
-		const identity = sink.identity();
-		// No identity is not the same as no descriptor: openLogFile() leaves the descriptor open when
-		// its fstat fails. Skipping the sink and still answering "released" is what lets an archive be
-		// unlinked under it, so close it here as the per-generation path already does.
-		if (!identity) {
-			sink.close();
-			continue;
-		}
+	for (const [logPath, sinks] of sinksByPath) {
 		let live;
 		try {
 			live = statSync(logPath);
 		} catch {
-			sink.close();
+			for (const sink of sinks) sink.close();
 			continue;
 		}
-		// `ino === 0` (some Windows filesystems) proves nothing, and answering "released" without
-		// releasing is what destroys an archive under a peer.
-		if (!identity.ino || !live.ino || identity.ino !== live.ino || identity.dev !== live.dev) sink.close();
+		for (const sink of sinks) {
+			const identity = sink.identity();
+			// No identity is not the same as no descriptor: openLogFile() leaves the descriptor open when
+			// its fstat fails. Skipping the sink and still answering "released" is what lets an archive be
+			// unlinked under it, so close it here as the per-generation path already does.
+			// `ino === 0` (some Windows filesystems) proves nothing for the same reason.
+			if (!identity || !identity.ino || !live.ino || identity.ino !== live.ino || identity.dev !== live.dev)
+				sink.close();
+		}
 	}
 }

--- a/utility/logging/logGenerationCoordinator.ts
+++ b/utility/logging/logGenerationCoordinator.ts
@@ -2,7 +2,7 @@
 
 // Every isolate holds its own descriptor on the shared log file, so a rename leaves the others
 // appending to the archived inode and destroying it loses whatever they write next. No size
-// comparison can rule out a write that has not happened yet; an answer from every peer can.
+// comparison can rule out a write that has not happened yet; enumerated in-process peers must answer.
 //
 // The thread layer injects the transport; harper_logger must never reach manageThreads.
 
@@ -87,11 +87,11 @@ export function nextGenerationId() {
 }
 
 /**
- * Ask every writer of `logPath` to release the descriptors this request names, and resolve to
- * whether they all provably did. `false` means the caller must leave those archives in place — it
- * is never safe to unlink an inode a peer may still be appending to.
+ * Ask every in-process peer this isolate can enumerate to release the descriptors this request
+ * names. `false` means the caller must leave those archives in place — it is never safe to unlink
+ * an inode a peer may still be appending to.
  */
-function requestRelease(message: any): Promise<{ released: boolean; liveLogPaths: Set<string> }> {
+function requestRelease(message: any, deadline?: number): Promise<{ released: boolean; liveLogPaths: Set<string> }> {
 	releaseLocally(message);
 	const liveLogPaths = new Set<string>(sinksByPath.keys());
 	// No transport in a worker isolate means the mesh cannot be enumerated yet, not that there is
@@ -102,6 +102,9 @@ function requestRelease(message: any): Promise<{ released: boolean; liveLogPaths
 	if (!transport) return Promise.resolve({ released: isMainThread, liveLogPaths });
 	const expected = new Set<number>(transport.peerThreadIds());
 	if (expected.size === 0) return Promise.resolve({ released: true, liveLogPaths });
+	const quiescenceTimeout = transport.quiescenceTimeout ?? DEFAULT_QUIESCENCE_TIMEOUT;
+	if (deadline !== undefined && Date.now() + quiescenceTimeout > deadline)
+		return Promise.resolve({ released: false, liveLogPaths });
 	const request = message.request;
 	return new Promise((resolve) => {
 		let timer;
@@ -111,22 +114,25 @@ function requestRelease(message: any): Promise<{ released: boolean; liveLogPaths
 			resolve({ released, liveLogPaths });
 		};
 		pendingByRequest.set(request, { expected, liveLogPaths, settle });
-		timer = setTimeout(() => settle(false), transport.quiescenceTimeout ?? DEFAULT_QUIESCENCE_TIMEOUT);
+		timer = setTimeout(() => settle(false), quiescenceTimeout);
 		timer.unref?.();
 		transport.broadcast({ ...message, originator: transport.threadId });
 	});
 }
 
 /** One archived generation: release any descriptor still pointing at the inode that was renamed. */
-export async function requestGenerationClose(generation: any): Promise<boolean> {
+export async function requestGenerationClose(generation: any, deadline?: number): Promise<boolean> {
 	return (
-		await requestRelease({
-			type: LOG_GENERATION_ROTATED,
-			request: generation.generation,
-			logPath: generation.logPath,
-			ino: generation.ino,
-			dev: generation.dev,
-		})
+		await requestRelease(
+			{
+				type: LOG_GENERATION_ROTATED,
+				request: generation.generation,
+				logPath: generation.logPath,
+				ino: generation.ino,
+				dev: generation.dev,
+			},
+			deadline
+		)
 	).released;
 }
 
@@ -135,8 +141,10 @@ export async function requestGenerationClose(generation: any): Promise<boolean> 
  * Not scoped to one path: the archive directory holds the archives of every component and external
  * log sharing it, and retention destroys those too.
  */
-export function requestStaleDescriptorRelease(): Promise<{ released: boolean; liveLogPaths: Set<string> }> {
-	return requestRelease({ type: LOG_GENERATION_ROTATED, request: nextGenerationId(), stale: true });
+export function requestStaleDescriptorRelease(
+	deadline?: number
+): Promise<{ released: boolean; liveLogPaths: Set<string> }> {
+	return requestRelease({ type: LOG_GENERATION_ROTATED, request: nextGenerationId(), stale: true }, deadline);
 }
 
 function recordPeerResponse(request: string, threadId: number, logPaths?: string[]) {

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -1,0 +1,274 @@
+'use strict';
+
+// The rotation primitives the log write path needs. Kept free of every Harper import so
+// harper_logger.ts can pull it in eagerly: logRotator.ts reaches server/storageReclamation.ts ->
+// manageThreads.js -> harper_logger.ts, which is why it may only ever be required lazily, and a
+// guard installed on a timer is a guard the first megabytes of a burst are written without.
+
+import {
+	createReadStream,
+	createWriteStream,
+	existsSync,
+	mkdirSync,
+	renameSync,
+	statSync,
+	promises as fsProm,
+} from 'node:fs';
+import { createGzip } from 'node:zlib';
+import { pipeline } from 'node:stream/promises';
+import { basename, dirname, extname, join, resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+import { threadId } from 'node:worker_threads';
+import {
+	announceGeneration,
+	nextGenerationId,
+	registerLogSink,
+	requestGenerationClose,
+} from './logGenerationCoordinator.ts';
+
+// Each writer re-checks the file after this many bytes of its own output. Fixed, not "the remaining
+// budget": a remaining budget assumes one thread's stat accounts for the other threads' future
+// bytes, so T writers each seeing ~maxBytes left can add ~T * maxBytes before any of them looks
+// again. A fixed quantum caps every writer's blind window at quantum + one payload regardless of
+// what the others do, making the bound a function of maxSize and thread count rather than of write
+// rate or scheduler delay.
+const CHECK_QUANTUM_DIVISOR = 16;
+const ROTATION_RETRY_COOLDOWN = 5000;
+const SIZE_UNIT_MULTIPLIERS = { K: 1e3, M: 1e6, G: 1e9 };
+
+export const INVALID_MAX_SIZE_MSG = "'maxSize' must be a positive size with a K, M or G unit (for example '64M')";
+
+/**
+ * Convert a `logging.rotation.maxSize` value to bytes, or undefined if it is not a usable size.
+ * One definition, shared with validation/configValidator.ts: a value this rejects must not reach
+ * the write path, where a zero/negative/NaN limit would trip the size check on every flush.
+ */
+export function parseMaxSize(maxSize: any) {
+	if (typeof maxSize !== 'string') return undefined;
+	const multiplier = SIZE_UNIT_MULTIPLIERS[maxSize.slice(-1)];
+	if (!multiplier) return undefined;
+	const size = maxSize.slice(0, -1);
+	// Number(), not a stricter grammar: every mantissa that produces a usable cap today keeps
+	// working, exponent notation included. What is rejected is only what cannot be a cap at all —
+	// `parseInt` accepted '0K', '-1K' and '1xK', which become a limit of 0, a negative number, and
+	// NaN. Sampled once a minute those merely misbehave; on the write path they are checked per flush.
+	if (size.trim() === '') return undefined;
+	const bytes = Number(size) * multiplier;
+	return Number.isSafeInteger(bytes) && bytes > 0 ? bytes : undefined;
+}
+
+export function resolveRotatedLogDir(logPath: string, configuredPath?: string) {
+	return configuredPath || join(dirname(logPath), 'rotated');
+}
+
+// Monotonically increasing across every rotation in this isolate; combined with the pid and thread
+// id this guarantees two archive names cannot collide even when two threads rotate two different
+// sources within the same millisecond. threadId is load-bearing now that any writing thread can
+// rotate: worker threads share the process's pid, and this counter is per-isolate module state.
+let rotationSequence = 0;
+
+export function archivePathFor(logPath: string, rotatedLogDir: string) {
+	// Name the archive after its source log (hdb, external, a component name, ...), not a fixed
+	// "HDB" literal — external/component loggers inherit rotation from the main logger (#1877) and
+	// default to the same rotated directory. A basename alone is not enough either: two distinct
+	// source paths can share one (`/logs/a/hdb.log`, `/logs/b/hdb.log`), so a hash of the resolved
+	// source path plus the unique suffix give every archive a name rename() can never clobber.
+	const sourceName = basename(logPath, extname(logPath)) || 'HDB';
+	// sha256, not sha1: this only needs a stable identifier, but a FIPS-mode OpenSSL provider
+	// disables sha1 and throws synchronously, which would crash every rotation.
+	const sourceId = createHash('sha256').update(resolve(logPath)).digest('hex').slice(0, 8);
+	const uniqueSuffix = `${process.pid}-${threadId}-${rotationSequence++}`;
+	const timestamp = new Date().toISOString().replaceAll(':', '-');
+	return join(rotatedLogDir, `${sourceName}-${sourceId}-${timestamp}-${uniqueSuffix}.log`);
+}
+
+/**
+ * Move the active log aside and release this isolate's descriptor, with nothing awaited in between:
+ * a rotation that yields to the event loop lets the logging loop that triggered it keep appending,
+ * which is the rate-dependent overshoot this whole change exists to remove.
+ */
+export function rotateLogFileSync(logPath: string, rotatedLogDir: string, closeLogFile: () => void, activeStats?: any) {
+	const active = activeStats ?? statSync(logPath);
+	const archivePath = archivePathFor(logPath, rotatedLogDir);
+	renameSync(logPath, archivePath);
+	closeLogFile();
+	return { logPath, archivePath, ino: active.ino, dev: active.dev, generation: nextGenerationId() };
+}
+
+/**
+ * Publish an archived generation: tell every other writer to release it, then compress it if asked.
+ * The plain archive is only ever unlinked once that release is proven — an unlinked inode a peer is
+ * still appending to loses those records outright, and no size comparison can rule that out.
+ */
+export async function publishArchivedGeneration(generation: any, compress?: boolean) {
+	// Nothing is destroyed without compression, so the release is worth announcing but not worth
+	// waiting on — a wait per rotation would put a live timer behind every rotation on a busy log.
+	if (!compress) {
+		announceGeneration(generation);
+		return generation.archivePath;
+	}
+	if (!(await requestGenerationClose(generation))) {
+		unprovenArchives.set(generation.archivePath, generation);
+		return generation.archivePath;
+	}
+	return compressArchive(generation.archivePath);
+}
+
+// Generations this process archived but could not prove released. Compression is not the only
+// destructive path: retention unlinks archives too, and unlinking an inode a stalled writer still
+// holds loses whatever it writes next just as surely as gzip would.
+const unprovenArchives = new Map<string, any>();
+
+export function isArchivePendingQuiescence(archivePath: string) {
+	return unprovenArchives.has(archivePath);
+}
+
+export async function retryPendingGenerations() {
+	for (const [archivePath, generation] of [...unprovenArchives]) {
+		if (!existsSync(archivePath)) {
+			unprovenArchives.delete(archivePath);
+			continue;
+		}
+		if (!(await requestGenerationClose(generation))) continue;
+		unprovenArchives.delete(archivePath);
+		await compressArchive(archivePath);
+	}
+}
+
+// One compression at a time per rotated directory. A small maxSize on a busy instance rotates
+// hundreds of times a second, and a pipeline per rotation would exhaust descriptors and memory long
+// before retention could run. Nothing is queued in memory: whatever this pass does not reach stays
+// on disk as a plain archive, which is what an uncompressed rotation leaves anyway.
+const compressionByDirectory = new Map<string, Promise<any>>();
+
+export function compressArchive(archivePath: string) {
+	const directory = dirname(archivePath);
+	const previous = compressionByDirectory.get(directory) ?? Promise.resolve();
+	const chain = previous.then(
+		() => compressOneArchive(archivePath),
+		() => compressOneArchive(archivePath)
+	);
+	compressionByDirectory.set(directory, chain);
+	chain
+		.catch(() => {})
+		.then(() => {
+			if (compressionByDirectory.get(directory) === chain) compressionByDirectory.delete(directory);
+		});
+	return chain;
+}
+
+async function compressOneArchive(archivePath: string) {
+	const compressedPath = `${archivePath}.gz`;
+	// Written to a temp file and renamed into place, so a crash mid-gzip can never leave a truncated
+	// `.gz` looking like the authoritative copy of a generation.
+	const temporaryPath = `${compressedPath}.${process.pid}-${threadId}-${rotationSequence++}.tmp`;
+	try {
+		await pipeline(createReadStream(archivePath), createGzip(), createWriteStream(temporaryPath));
+		await fsProm.rename(temporaryPath, compressedPath);
+	} catch (error) {
+		await fsProm.unlink(temporaryPath).catch(() => {});
+		throw error;
+	}
+	await fsProm.unlink(archivePath);
+	return compressedPath;
+}
+
+/**
+ * The write-path size guard. One subtraction and one branch per flush; one pathname stat once per
+ * quantum of this writer's own output.
+ */
+export function createRotationGuard(options: any) {
+	const { logPath, maxBytes, rotatedLogDir, compress, getLogIdentity, closeLogFile, report, onRotated } = options;
+	const checkQuantum = Math.max(1, Math.floor(maxBytes / CHECK_QUANTUM_DIVISOR));
+	mkdirSync(rotatedLogDir, { recursive: true });
+	let bytesUntilCheck = checkQuantum;
+	let retryAfter = 0;
+	let rotationPending = false;
+	let rotating = false;
+	try {
+		// Seeded from the file as it actually is, so an instance restarted onto an already-oversized
+		// log rotates on its first write rather than on the first audit tick a minute later.
+		bytesUntilCheck = Math.min(checkQuantum, Math.max(0, maxBytes - statSync(logPath).size));
+	} catch {
+		// No log file yet; a full quantum is the right first window.
+	}
+	registerLogSink(logPath, closeDescriptorOnGeneration);
+	return { beforeAppend, recordWrite, checkQuantum };
+
+	/**
+	 * Whether the file may be appended to. Once the cap is known to be exceeded and rotation has
+	 * failed, the answer stays no: appending anyway would make the overshoot a function of the write
+	 * rate again, which is the failure this change exists to remove. Recovery is retried here, before
+	 * a write, rather than after one — the sink is on stdio in the meantime, so no append would come.
+	 */
+	function beforeAppend() {
+		if (!rotationPending) return true;
+		if (retryAfter > performance.now()) return false;
+		attemptRotation();
+		return !rotationPending;
+	}
+
+	function recordWrite(byteLength: number) {
+		bytesUntilCheck -= byteLength;
+		if (bytesUntilCheck > 0) return;
+		bytesUntilCheck = checkQuantum;
+		// `rotating` covers the rotation notice, which is written back through this same sink.
+		if (rotating || retryAfter > performance.now()) return;
+		attemptRotation();
+	}
+
+	function attemptRotation() {
+		rotating = true;
+		try {
+			checkAndRotate();
+			rotationPending = false;
+		} catch (error) {
+			rotationPending = true;
+			retryAfter = performance.now() + ROTATION_RETRY_COOLDOWN;
+			closeLogFile();
+			report(`Harper cannot rotate its log file: ${error}`);
+		} finally {
+			rotating = false;
+		}
+	}
+
+	function checkAndRotate() {
+		let active;
+		try {
+			active = statSync(logPath);
+		} catch (error) {
+			if (error.code !== 'ENOENT') throw error;
+			// The generation this descriptor belongs to has already been rotated away by someone else.
+			closeLogFile();
+			return;
+		}
+		// The descriptor's identity is cached when it is opened, so the common checkpoint costs this
+		// one pathname stat rather than a stat plus an fstat.
+		if (!holdsGeneration(active)) {
+			closeLogFile();
+			return;
+		}
+		if (active.size < maxBytes) return;
+		const generation = rotateLogFileSync(logPath, rotatedLogDir, closeLogFile, active);
+		onRotated?.(generation.archivePath);
+		publishArchivedGeneration(generation, compress).catch((error) =>
+			report(`Harper could not compress a rotated log file: ${error}`)
+		);
+	}
+
+	function holdsGeneration(active: any) {
+		const identity = getLogIdentity();
+		if (!identity) return true;
+		// Some Windows filesystems report an unstable or zero ino, where identity cannot distinguish
+		// generations; there this defers to the size check rather than closing a descriptor at random.
+		if (identity.ino === 0 || active.ino === 0) return true;
+		return identity.ino === active.ino && identity.dev === active.dev;
+	}
+
+	function closeDescriptorOnGeneration(ino: number, dev: number) {
+		const identity = getLogIdentity();
+		// No identity to compare (no descriptor, or a filesystem that cannot report one) means closing
+		// is the only answer that can still be called a proof: an open descriptor is what must go.
+		if (!identity || (identity.ino === ino && identity.dev === dev)) closeLogFile();
+	}
+}

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -120,7 +120,9 @@ export async function retryPendingGenerations() {
 		}
 		if (!(await requestGenerationClose(pending.generation))) continue;
 		unprovenArchives.delete(archivePath);
-		if (pending.compress) await compressArchive(archivePath);
+		// One archive that will not compress must not stop the rest of the queue, or the tick that
+		// drives it — retention runs after this and needs the tick to reach it.
+		if (pending.compress) await compressArchive(archivePath).catch(() => {});
 	}
 }
 

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -151,7 +151,7 @@ export async function compressPendingArchives(rotatedLogDir: string, files: stri
 		if (!file.endsWith('.log') || !isArchiveName(file) || files.includes(`${file}.gz`)) continue;
 		if (compressed++ >= MAX_RETRIES_PER_PASS) return;
 		const archivePath = join(rotatedLogDir, file);
-		if (liveLogPaths.has(archivePath) || unprovenArchives.has(archivePath)) continue;
+		if (liveLogPaths.has(resolve(archivePath)) || unprovenArchives.has(archivePath)) continue;
 		await compressArchive(archivePath).catch(() => {});
 	}
 }

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -21,12 +21,9 @@ import { createHash } from 'node:crypto';
 import { threadId } from 'node:worker_threads';
 import { nextGenerationId, requestGenerationClose } from './logGenerationCoordinator.ts';
 
-// Each writer re-checks the file after this many bytes of its own output. Fixed, not "the remaining
-// budget": a remaining budget assumes one thread's stat accounts for the other threads' future
-// bytes, so T writers each seeing ~maxBytes left can add ~T * maxBytes before any of them looks
-// again. A fixed quantum caps every writer's blind window at quantum + the flush that crosses it,
-// independently of scheduler delay. That flush is one batch, and the sink batches under load, so the
-// bound is maxBytes + T * (quantum + batch) rather than a function of elapsed time.
+// Bounds each writer's blind window at one quantum plus the flush that crosses it, so the file is
+// bounded by maxBytes + T * (quantum + batch) rather than by elapsed time. Fixed, not a remaining
+// budget: a budget assumes one thread's stat accounts for the other threads' future bytes.
 const CHECK_QUANTUM_DIVISOR = 16;
 const ROTATION_RETRY_COOLDOWN = 5000;
 const SIZE_UNIT_MULTIPLIERS = { K: 1e3, M: 1e6, G: 1e9 };
@@ -42,8 +39,7 @@ export function parseMaxSize(maxSize: any) {
 	const multiplier = SIZE_UNIT_MULTIPLIERS[maxSize.slice(-1)];
 	if (!multiplier) return undefined;
 	const size = maxSize.slice(0, -1);
-	// Number(), not a stricter grammar, so every mantissa that produces a usable cap today keeps
-	// working — exponent notation included. `parseInt` also accepted '0K', '-1K' and '1xK'.
+	// Number(), not a stricter grammar, so every mantissa that yields a usable cap today keeps working.
 	if (size.trim() === '') return undefined;
 	const bytes = Number(size) * multiplier;
 	return Number.isSafeInteger(bytes) && bytes > 0 ? bytes : undefined;
@@ -57,11 +53,8 @@ export function resolveRotatedLogDir(logPath: string, configuredPath?: string) {
 // counter is per-isolate, so pid+seq alone cannot keep two threads' archives apart.
 let rotationSequence = 0;
 
-// The archive directory defaults to the log's own directory (`logging.rotation.path` defaults to
-// `log`, as does `logging.root`), so it holds live logs — hdb.log, and every component or external
-// log sharing the directory — alongside archives. Anything that compresses or deletes by scanning
-// that directory has to be able to tell the two apart, and the name this module writes is the only
-// thing that distinguishes them.
+// The archive directory defaults to the log's own directory, so it holds live logs alongside
+// archives and anything scanning it to destroy files has to tell the two apart.
 const ARCHIVE_NAME = /-[0-9a-f]{8}-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z-\d+-\d+-\d+\.log(\.gz)?$/;
 
 export function isArchiveName(file: string) {
@@ -109,11 +102,9 @@ export async function publishArchivedGeneration(generation: any, compress?: bool
 	return compress ? compressArchive(generation.archivePath) : generation.archivePath;
 }
 
-// Generations this isolate archived but could not prove released, as a retry queue for compression —
-// not as the safety mechanism. Safety is the release the audit tick proves for the whole directory
-// before anything is deleted, and the archives themselves are found on disk, so a bounded queue that
-// forgets its oldest entries loses nothing. Bounded because write-path rotation happens mostly in
-// the HTTP workers, and only the main thread runs a tick to drain it.
+// A compression retry queue, not the safety mechanism — safety is the release the tick proves before
+// anything is destroyed. Bounded because rotation happens mostly in workers, which run no tick to
+// drain it, and because the archives are found on disk anyway.
 const MAX_UNPROVEN_ARCHIVES = 64;
 const unprovenArchives = new Map<string, any>();
 
@@ -148,26 +139,19 @@ export async function retryPendingGenerations() {
 }
 
 /**
- * Compress archives left plain by any isolate, found on disk rather than in this isolate's memory.
+ * Compress archives left plain by any isolate, from a listing taken before quiescence was proven.
  * Write-path rotations happen mostly in the HTTP workers, whose unproven-archive bookkeeping the
  * main thread cannot see, so without this a worker's archive would silently stay uncompressed for
  * the life of the process however the operator configured `compress`.
- * Only safe to call once quiescence has been proven for the whole directory.
+ * Only safe to call once quiescence has been proven for exactly this listing.
  */
-export async function compressPendingArchives(rotatedLogDir: string) {
-	let files;
-	try {
-		files = await fsProm.readdir(rotatedLogDir);
-	} catch (error) {
-		if (error.code !== 'ENOENT') throw error;
-		return;
-	}
+export async function compressPendingArchives(rotatedLogDir: string, files: string[], liveLogPaths: Set<string>) {
 	let compressed = 0;
 	for (const file of files) {
 		if (!file.endsWith('.log') || !isArchiveName(file) || files.includes(`${file}.gz`)) continue;
 		if (compressed++ >= MAX_RETRIES_PER_PASS) return;
 		const archivePath = join(rotatedLogDir, file);
-		if (unprovenArchives.has(archivePath)) continue;
+		if (liveLogPaths.has(archivePath) || unprovenArchives.has(archivePath)) continue;
 		await compressArchive(archivePath).catch(() => {});
 	}
 }

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -112,17 +112,47 @@ export function isArchivePendingQuiescence(archivePath: string) {
 	return unprovenArchives.has(archivePath);
 }
 
+// Bounded per pass: a peer that never answers must not let the retry queue outlive the audit
+// interval and starve retention, which is the only thing that bounds the rotated directory.
+const MAX_RETRIES_PER_PASS = 4;
+
 export async function retryPendingGenerations() {
+	let attempts = 0;
 	for (const [archivePath, pending] of [...unprovenArchives]) {
+		if (attempts++ >= MAX_RETRIES_PER_PASS) return;
 		if (!existsSync(archivePath)) {
 			unprovenArchives.delete(archivePath);
 			continue;
 		}
 		if (!(await requestGenerationClose(pending.generation))) continue;
 		unprovenArchives.delete(archivePath);
-		// One archive that will not compress must not stop the rest of the queue, or the tick that
-		// drives it — retention runs after this and needs the tick to reach it.
+		// One archive that will not compress must not stop the rest of the queue.
 		if (pending.compress) await compressArchive(archivePath).catch(() => {});
+	}
+}
+
+/**
+ * Compress archives left plain by any isolate, found on disk rather than in this isolate's memory.
+ * Write-path rotations happen mostly in the HTTP workers, whose unproven-archive bookkeeping the
+ * main thread cannot see, so without this a worker's archive would silently stay uncompressed for
+ * the life of the process however the operator configured `compress`.
+ * Only safe to call once quiescence has been proven for the whole directory.
+ */
+export async function compressPendingArchives(rotatedLogDir: string) {
+	let files;
+	try {
+		files = await fsProm.readdir(rotatedLogDir);
+	} catch (error) {
+		if (error.code !== 'ENOENT') throw error;
+		return;
+	}
+	let compressed = 0;
+	for (const file of files) {
+		if (!file.endsWith('.log') || files.includes(`${file}.gz`)) continue;
+		if (compressed++ >= MAX_RETRIES_PER_PASS) return;
+		const archivePath = join(rotatedLogDir, file);
+		if (unprovenArchives.has(archivePath)) continue;
+		await compressArchive(archivePath).catch(() => {});
 	}
 }
 
@@ -172,6 +202,12 @@ export function createRotationGuard(options: any) {
 	const { logPath, maxBytes, rotatedLogDir, compress, getLogIdentity, closeLogFile, report, onRotated } = options;
 	const checkQuantum = Math.max(1, Math.floor(maxBytes / CHECK_QUANTUM_DIVISOR));
 	mkdirSync(rotatedLogDir, { recursive: true });
+	// Rotation is a rename, and a rename across devices can never succeed. Refusing to build the guard
+	// here turns a misconfiguration that would otherwise fail closed on every write — ending file
+	// logging for the life of the process — into one startup error and today's unrotated behavior.
+	if (statSync(rotatedLogDir).dev !== statSync(dirname(logPath)).dev) {
+		throw new Error(`the rotation directory ${rotatedLogDir} is on a different filesystem than ${logPath}`);
+	}
 	let bytesUntilCheck = checkQuantum;
 	let retryAfter = 0;
 	let rotationPending = false;
@@ -181,7 +217,7 @@ export function createRotationGuard(options: any) {
 		// log rotates on its first write rather than on the first audit tick a minute later.
 		bytesUntilCheck = Math.min(checkQuantum, Math.max(0, maxBytes - statSync(logPath).size));
 	} catch {
-		// No log file yet; a full quantum is the right first window.
+		// No log file yet.
 	}
 	return { beforeAppend, recordWrite, checkQuantum };
 
@@ -215,6 +251,14 @@ export function createRotationGuard(options: any) {
 			checkAndRotate();
 			rotationPending = false;
 		} catch (error) {
+			// Losing the race is the normal multi-writer outcome, not a failure: another thread (or the
+			// audit tick) renamed the generation between this thread's stat and its rename. The file is
+			// under the cap now, which is all this check wanted.
+			if (error.code === 'ENOENT') {
+				closeLogFile();
+				rotationPending = false;
+				return;
+			}
 			rotationPending = true;
 			retryAfter = performance.now() + ROTATION_RETRY_COOLDOWN;
 			closeLogFile();

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -19,12 +19,7 @@ import { pipeline } from 'node:stream/promises';
 import { basename, dirname, extname, join, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
 import { threadId } from 'node:worker_threads';
-import {
-	announceGeneration,
-	nextGenerationId,
-	registerLogSink,
-	requestGenerationClose,
-} from './logGenerationCoordinator.ts';
+import { nextGenerationId, requestGenerationClose } from './logGenerationCoordinator.ts';
 
 // Each writer re-checks the file after this many bytes of its own output. Fixed, not "the remaining
 // budget": a remaining budget assumes one thread's stat accounts for the other threads' future
@@ -101,21 +96,15 @@ export function rotateLogFileSync(logPath: string, rotatedLogDir: string, closeL
  * still appending to loses those records outright, and no size comparison can rule that out.
  */
 export async function publishArchivedGeneration(generation: any, compress?: boolean) {
-	// Nothing is destroyed without compression, so the release is worth announcing but not worth
-	// waiting on — a wait per rotation would put a live timer behind every rotation on a busy log.
-	if (!compress) {
-		announceGeneration(generation);
-		return generation.archivePath;
-	}
 	if (!(await requestGenerationClose(generation))) {
-		unprovenArchives.set(generation.archivePath, generation);
+		unprovenArchives.set(generation.archivePath, { generation, compress });
 		return generation.archivePath;
 	}
-	return compressArchive(generation.archivePath);
+	return compress ? compressArchive(generation.archivePath) : generation.archivePath;
 }
 
-// Generations this process archived but could not prove released. Compression is not the only
-// destructive path: retention unlinks archives too, and unlinking an inode a stalled writer still
+// Generations this process archived but could not prove released. Tracked whether or not they are
+// to be compressed: retention unlinks archives too, and unlinking an inode a stalled writer still
 // holds loses whatever it writes next just as surely as gzip would.
 const unprovenArchives = new Map<string, any>();
 
@@ -124,14 +113,14 @@ export function isArchivePendingQuiescence(archivePath: string) {
 }
 
 export async function retryPendingGenerations() {
-	for (const [archivePath, generation] of [...unprovenArchives]) {
+	for (const [archivePath, pending] of [...unprovenArchives]) {
 		if (!existsSync(archivePath)) {
 			unprovenArchives.delete(archivePath);
 			continue;
 		}
-		if (!(await requestGenerationClose(generation))) continue;
+		if (!(await requestGenerationClose(pending.generation))) continue;
 		unprovenArchives.delete(archivePath);
-		await compressArchive(archivePath);
+		if (pending.compress) await compressArchive(archivePath);
 	}
 }
 
@@ -192,7 +181,6 @@ export function createRotationGuard(options: any) {
 	} catch {
 		// No log file yet; a full quantum is the right first window.
 	}
-	registerLogSink(logPath, closeDescriptorOnGeneration);
 	return { beforeAppend, recordWrite, checkQuantum };
 
 	/**
@@ -265,12 +253,5 @@ export function createRotationGuard(options: any) {
 		// generations; there this defers to the size check rather than closing a descriptor at random.
 		if (identity.ino === 0 || active.ino === 0) return true;
 		return identity.ino === active.ino && identity.dev === active.dev;
-	}
-
-	function closeDescriptorOnGeneration(ino: number, dev: number) {
-		const identity = getLogIdentity();
-		// No identity to compare (no descriptor, or a filesystem that cannot report one) means closing
-		// is the only answer that can still be called a proof: an open descriptor is what must go.
-		if (!identity || (identity.ino === ino && identity.dev === dev)) closeLogFile();
 	}
 }

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -202,7 +202,9 @@ export function createRotationGuard(options: any) {
 	 * a write, rather than after one — the sink is on stdio in the meantime, so no append would come.
 	 */
 	function beforeAppend() {
-		if (!rotationPending) return true;
+		// `rotating` first: the rotation notice is written back through this same sink, and it must
+		// not re-enter a rotation that has not finished setting its own state.
+		if (rotating || !rotationPending) return true;
 		if (retryAfter > performance.now()) return false;
 		attemptRotation();
 		return !rotationPending;

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -62,6 +62,17 @@ export function resolveRotatedLogDir(logPath: string, configuredPath?: string) {
 // rotate: worker threads share the process's pid, and this counter is per-isolate module state.
 let rotationSequence = 0;
 
+// The archive directory defaults to the log's own directory (`logging.rotation.path` defaults to
+// `log`, as does `logging.root`), so it holds live logs — hdb.log, and every component or external
+// log sharing the directory — alongside archives. Anything that compresses or deletes by scanning
+// that directory has to be able to tell the two apart, and the name this module writes is the only
+// thing that distinguishes them.
+const ARCHIVE_NAME = /-[0-9a-f]{8}-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z-\d+-\d+-\d+\.log(\.gz)?$/;
+
+export function isArchiveName(file: string) {
+	return ARCHIVE_NAME.test(file);
+}
+
 export function archivePathFor(logPath: string, rotatedLogDir: string) {
 	// Name the archive after its source log (hdb, external, a component name, ...), not a fixed
 	// "HDB" literal — external/component loggers inherit rotation from the main logger (#1877) and
@@ -148,7 +159,7 @@ export async function compressPendingArchives(rotatedLogDir: string) {
 	}
 	let compressed = 0;
 	for (const file of files) {
-		if (!file.endsWith('.log') || files.includes(`${file}.gz`)) continue;
+		if (!file.endsWith('.log') || !isArchiveName(file) || files.includes(`${file}.gz`)) continue;
 		if (compressed++ >= MAX_RETRIES_PER_PASS) return;
 		const archivePath = join(rotatedLogDir, file);
 		if (unprovenArchives.has(archivePath)) continue;

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -24,9 +24,9 @@ import { nextGenerationId, requestGenerationClose } from './logGenerationCoordin
 // Each writer re-checks the file after this many bytes of its own output. Fixed, not "the remaining
 // budget": a remaining budget assumes one thread's stat accounts for the other threads' future
 // bytes, so T writers each seeing ~maxBytes left can add ~T * maxBytes before any of them looks
-// again. A fixed quantum caps every writer's blind window at quantum + one payload regardless of
-// what the others do, making the bound a function of maxSize and thread count rather than of write
-// rate or scheduler delay.
+// again. A fixed quantum caps every writer's blind window at quantum + the flush that crosses it,
+// independently of scheduler delay. That flush is one batch, and the sink batches under load, so the
+// bound is maxBytes + T * (quantum + batch) rather than a function of elapsed time.
 const CHECK_QUANTUM_DIVISOR = 16;
 const ROTATION_RETRY_COOLDOWN = 5000;
 const SIZE_UNIT_MULTIPLIERS = { K: 1e3, M: 1e6, G: 1e9 };
@@ -34,19 +34,16 @@ const SIZE_UNIT_MULTIPLIERS = { K: 1e3, M: 1e6, G: 1e9 };
 export const INVALID_MAX_SIZE_MSG = "'maxSize' must be a positive size with a K, M or G unit (for example '64M')";
 
 /**
- * Convert a `logging.rotation.maxSize` value to bytes, or undefined if it is not a usable size.
- * One definition, shared with validation/configValidator.ts: a value this rejects must not reach
- * the write path, where a zero/negative/NaN limit would trip the size check on every flush.
+ * Convert `logging.rotation.maxSize` to bytes, or undefined if it cannot be a byte limit. One
+ * definition, shared with validation/configValidator.ts.
  */
 export function parseMaxSize(maxSize: any) {
 	if (typeof maxSize !== 'string') return undefined;
 	const multiplier = SIZE_UNIT_MULTIPLIERS[maxSize.slice(-1)];
 	if (!multiplier) return undefined;
 	const size = maxSize.slice(0, -1);
-	// Number(), not a stricter grammar: every mantissa that produces a usable cap today keeps
-	// working, exponent notation included. What is rejected is only what cannot be a cap at all —
-	// `parseInt` accepted '0K', '-1K' and '1xK', which become a limit of 0, a negative number, and
-	// NaN. Sampled once a minute those merely misbehave; on the write path they are checked per flush.
+	// Number(), not a stricter grammar, so every mantissa that produces a usable cap today keeps
+	// working — exponent notation included. `parseInt` also accepted '0K', '-1K' and '1xK'.
 	if (size.trim() === '') return undefined;
 	const bytes = Number(size) * multiplier;
 	return Number.isSafeInteger(bytes) && bytes > 0 ? bytes : undefined;
@@ -56,10 +53,8 @@ export function resolveRotatedLogDir(logPath: string, configuredPath?: string) {
 	return configuredPath || join(dirname(logPath), 'rotated');
 }
 
-// Monotonically increasing across every rotation in this isolate; combined with the pid and thread
-// id this guarantees two archive names cannot collide even when two threads rotate two different
-// sources within the same millisecond. threadId is load-bearing now that any writing thread can
-// rotate: worker threads share the process's pid, and this counter is per-isolate module state.
+// threadId is load-bearing in the suffix below: worker threads share the process pid, and this
+// counter is per-isolate, so pid+seq alone cannot keep two threads' archives apart.
 let rotationSequence = 0;
 
 // The archive directory defaults to the log's own directory (`logging.rotation.path` defaults to
@@ -108,16 +103,26 @@ export function rotateLogFileSync(logPath: string, rotatedLogDir: string, closeL
  */
 export async function publishArchivedGeneration(generation: any, compress?: boolean) {
 	if (!(await requestGenerationClose(generation))) {
-		unprovenArchives.set(generation.archivePath, { generation, compress });
+		rememberUnprovenArchive(generation.archivePath, { generation, compress });
 		return generation.archivePath;
 	}
 	return compress ? compressArchive(generation.archivePath) : generation.archivePath;
 }
 
-// Generations this process archived but could not prove released. Tracked whether or not they are
-// to be compressed: retention unlinks archives too, and unlinking an inode a stalled writer still
-// holds loses whatever it writes next just as surely as gzip would.
+// Generations this isolate archived but could not prove released, as a retry queue for compression —
+// not as the safety mechanism. Safety is the release the audit tick proves for the whole directory
+// before anything is deleted, and the archives themselves are found on disk, so a bounded queue that
+// forgets its oldest entries loses nothing. Bounded because write-path rotation happens mostly in
+// the HTTP workers, and only the main thread runs a tick to drain it.
+const MAX_UNPROVEN_ARCHIVES = 64;
 const unprovenArchives = new Map<string, any>();
+
+function rememberUnprovenArchive(archivePath: string, pending: any) {
+	unprovenArchives.set(archivePath, pending);
+	while (unprovenArchives.size > MAX_UNPROVEN_ARCHIVES) {
+		unprovenArchives.delete(unprovenArchives.keys().next().value);
+	}
+}
 
 export function isArchivePendingQuiescence(archivePath: string) {
 	return unprovenArchives.has(archivePath);

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -156,8 +156,6 @@ export async function retryPendingGenerations() {
  * Only safe to call once quiescence has been proven for exactly this listing.
  */
 export async function compressPendingArchives(rotatedLogDir: string, files: string[], liveLogPaths: Set<string>) {
-	// A Set: the archive rate is write-rate/maxSize, so this listing is unbounded between retention
-	// passes and a per-file includes() over it is quadratic.
 	const present = new Set(files);
 	let compressed = 0;
 	for (const file of files) {
@@ -177,12 +175,10 @@ const compressionByDirectory = new Map<string, Promise<any>>();
 export function compressArchive(archivePath: string) {
 	const directory = dirname(archivePath);
 	// Declined rather than queued: chaining would grow an unbounded list of pending jobs whenever
-	// rotation outruns gzip. The archive stays on disk exactly as an uncompressed rotation leaves it,
-	// and the audit tick's bounded sweep finds it later.
+	// rotation outruns gzip. The archive is left for the tick's bounded sweep, which is where an
+	// uncompressed rotation leaves it anyway. The slot is released by the promise this returns, not by
+	// a detached continuation, because that sweep awaits each call before making the next.
 	if (compressionByDirectory.has(directory)) return Promise.resolve(archivePath);
-	// The slot is released by the promise this returns, not by a detached continuation: the tick's
-	// sweep awaits each call before making the next, and a slot still held at that point would make
-	// it decline every archive after the first.
 	const chain: Promise<any> = compressOneArchive(archivePath).finally(() => {
 		if (compressionByDirectory.get(directory) === chain) compressionByDirectory.delete(directory);
 	});
@@ -273,8 +269,10 @@ export function createRotationGuard(options: any) {
 			// thread (or the audit tick) renamed the generation between this thread's stat and its
 			// rename, so the file is under the cap now, which is all this check wanted. A missing
 			// destination means no rotation can ever succeed, and treating that as a race would clear
-			// the cap check on every pass and let the log grow without a bound or a diagnostic.
-			if (error.code === 'ENOENT' && !existsSync(logPath)) {
+			// the cap check on every pass and let the log grow without a bound or a diagnostic. The
+			// destination is what is asked about: a peer can recreate the source pathname between the
+			// failed rename and this check, which would make the benign case look like the fatal one.
+			if (error.code === 'ENOENT' && existsSync(rotatedLogDir)) {
 				closeLogFile();
 				rotationPending = false;
 				return;

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -102,12 +102,23 @@ export function rotateLogFileSync(logPath: string, rotatedLogDir: string, closeL
  * Publish an archived generation: ask every enumerable in-process peer to release it, then compress
  * it if requested. The plain archive is only unlinked once that release is proven.
  */
-export async function publishArchivedGeneration(generation: any, compress?: boolean) {
+export async function publishArchivedGeneration(
+	generation: any,
+	compress?: boolean,
+	reportCompressionError?: (error: any) => void
+) {
 	if (!(await requestGenerationClose(generation))) {
 		rememberUnprovenArchive(generation.archivePath, { generation, compress });
 		return generation.archivePath;
 	}
-	return compress ? compressArchive(generation.archivePath) : generation.archivePath;
+	if (compress) {
+		try {
+			return await compressArchive(generation.archivePath);
+		} catch (error) {
+			reportCompressionError?.(error);
+		}
+	}
+	return generation.archivePath;
 }
 
 // A compression retry queue, not the safety mechanism — safety is the release the tick proves before
@@ -306,10 +317,12 @@ export function createRotationGuard(options: any) {
 			report(`Harper cannot rotate its log file: ${error}`);
 			// A rotation target removed under a running instance is recoverable; recreate it here rather
 			// than on every rotation, so the common path keeps costing one stat and one rename.
-			try {
-				mkdirSync(rotatedLogDir, { recursive: true });
-			} catch {
-				// Reported above already; the retry will fail the same way and report again.
+			if (error.code === 'ENOENT') {
+				try {
+					mkdirSync(rotatedLogDir, { recursive: true });
+				} catch {
+					// Reported above already; the retry will fail the same way and report again.
+				}
 			}
 		} finally {
 			rotating = false;
@@ -335,9 +348,9 @@ export function createRotationGuard(options: any) {
 		if (active.size < maxBytes) return;
 		const generation = rotateLogFileSync(logPath, rotatedLogDir, closeLogFile, active);
 		onRotated?.(generation.archivePath);
-		publishArchivedGeneration(generation, compress).catch((error) =>
+		publishArchivedGeneration(generation, compress, (error) =>
 			report(`Harper could not compress a rotated log file: ${error}`)
-		);
+		).catch((error) => report(`Harper could not publish a rotated log file: ${error}`));
 	}
 
 	function holdsGeneration(active: any) {

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -18,7 +18,7 @@ import { createGzip } from 'node:zlib';
 import { pipeline } from 'node:stream/promises';
 import { basename, dirname, extname, join, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
-import { threadId } from 'node:worker_threads';
+import { isMainThread, threadId } from 'node:worker_threads';
 import { nextGenerationId, requestGenerationClose } from './logGenerationCoordinator.ts';
 
 // Bounds each writer's blind window at one quantum plus the flush that crosses it, so the file is
@@ -111,7 +111,10 @@ export async function publishArchivedGeneration(
 		rememberUnprovenArchive(generation.archivePath, { generation, compress });
 		return generation.archivePath;
 	}
-	if (compress) {
+	// A worker's peer set is eventually consistent while replacements join. Its release request can
+	// make peers reopen promptly, but only the main thread has an authoritative worker list and may
+	// destroy the plain archive; its audit will obtain a fresh proof for the archived snapshot.
+	if (compress && isMainThread) {
 		try {
 			return await compressArchive(generation.archivePath);
 		} catch (error) {

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -146,9 +146,12 @@ export async function retryPendingGenerations() {
  * Only safe to call once quiescence has been proven for exactly this listing.
  */
 export async function compressPendingArchives(rotatedLogDir: string, files: string[], liveLogPaths: Set<string>) {
+	// A Set: the archive rate is write-rate/maxSize, so this listing is unbounded between retention
+	// passes and a per-file includes() over it is quadratic.
+	const present = new Set(files);
 	let compressed = 0;
 	for (const file of files) {
-		if (!file.endsWith('.log') || !isArchiveName(file) || files.includes(`${file}.gz`)) continue;
+		if (!file.endsWith('.log') || !isArchiveName(file) || present.has(`${file}.gz`)) continue;
 		if (compressed++ >= MAX_RETRIES_PER_PASS) return;
 		const archivePath = join(rotatedLogDir, file);
 		if (liveLogPaths.has(resolve(archivePath)) || unprovenArchives.has(archivePath)) continue;
@@ -201,11 +204,16 @@ async function compressOneArchive(archivePath: string) {
 export function createRotationGuard(options: any) {
 	const { logPath, maxBytes, rotatedLogDir, compress, getLogIdentity, closeLogFile, report, onRotated } = options;
 	const checkQuantum = Math.max(1, Math.floor(maxBytes / CHECK_QUANTUM_DIVISOR));
+	const logDir = dirname(logPath);
 	mkdirSync(rotatedLogDir, { recursive: true });
+	// The sink creates this one lazily, on the first append that gets ENOENT, and rotatedLogDir is not
+	// always under it — so without this the stat below throws ENOENT on a directory that is about to
+	// exist, and rotation stays off for the life of the process.
+	mkdirSync(logDir, { recursive: true });
 	// Rotation is a rename, and a rename across devices can never succeed. Refusing to build the guard
 	// here turns a misconfiguration that would otherwise fail closed on every write — ending file
 	// logging for the life of the process — into one startup error and today's unrotated behavior.
-	if (statSync(rotatedLogDir).dev !== statSync(dirname(logPath)).dev) {
+	if (statSync(rotatedLogDir).dev !== statSync(logDir).dev) {
 		throw new Error(`the rotation directory ${rotatedLogDir} is on a different filesystem than ${logPath}`);
 	}
 	let bytesUntilCheck = checkQuantum;

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -269,18 +269,18 @@ export function createRotationGuard(options: any) {
 	return { beforeAppend, recordWrite, checkQuantum };
 
 	/**
-	 * Whether the file may be appended to. Once the cap is known to be exceeded and rotation has
-	 * failed, the answer stays no: appending anyway would make the overshoot a function of the write
-	 * rate again, which is the failure this change exists to remove. Recovery is retried here, before
-	 * a write, rather than after one — the sink is on stdio in the meantime, so no append would come.
+	 * Try a pending rotation before the next append. A failed rotation leaves the active file
+	 * writable: daemonized services discard stdio, so refusing the append would silently lose logs.
 	 */
 	function beforeAppend() {
 		// `rotating` first: the rotation notice is written back through this same sink, and it must
 		// not re-enter a rotation that has not finished setting its own state.
 		if (rotating || !rotationPending) return true;
-		if (retryAfter > performance.now()) return false;
+		if (retryAfter > performance.now()) return true;
 		attemptRotation();
-		return !rotationPending;
+		// If rotation is still unavailable, preserving records in the writable active log is safer
+		// than silently dropping them (scripted services have no stdio fallback).
+		return true;
 	}
 
 	function recordWrite(byteLength: number) {

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -53,8 +53,7 @@ export function resolveRotatedLogDir(logPath: string, configuredPath?: string) {
 // counter is per-isolate, so pid+seq alone cannot keep two threads' archives apart.
 let rotationSequence = 0;
 
-// The archive directory defaults to the log's own directory, so it holds live logs alongside
-// archives and anything scanning it to destroy files has to tell the two apart.
+// A configured rotation path may also contain live logs, so destructive scans must identify archives.
 const ARCHIVE_NAME = /-[0-9a-f]{8}-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z-\d+-\d+-\d+\.log(\.gz)?$/;
 
 export function isArchiveName(file: string) {
@@ -100,9 +99,8 @@ export function rotateLogFileSync(logPath: string, rotatedLogDir: string, closeL
 }
 
 /**
- * Publish an archived generation: tell every other writer to release it, then compress it if asked.
- * The plain archive is only ever unlinked once that release is proven — an unlinked inode a peer is
- * still appending to loses those records outright, and no size comparison can rule that out.
+ * Publish an archived generation: ask every enumerable in-process peer to release it, then compress
+ * it if requested. The plain archive is only unlinked once that release is proven.
  */
 export async function publishArchivedGeneration(generation: any, compress?: boolean) {
 	if (!(await requestGenerationClose(generation))) {
@@ -129,19 +127,20 @@ export function isArchivePendingQuiescence(archivePath: string) {
 	return unprovenArchives.has(archivePath);
 }
 
-// Bounded per pass: a peer that never answers must not let the retry queue outlive the audit
-// interval and starve retention, which is the only thing that bounds the rotated directory.
+// Bounded per pass: a peer that never answers must not let the retry queue starve the audit work.
 const MAX_RETRIES_PER_PASS = 4;
 
-export async function retryPendingGenerations() {
+export async function retryPendingGenerations(options: any = {}) {
+	const { deadline = Infinity, shouldStop = () => false } = options;
 	let attempts = 0;
 	for (const [archivePath, pending] of [...unprovenArchives]) {
+		if (shouldStop() || Date.now() >= deadline) return;
 		if (attempts++ >= MAX_RETRIES_PER_PASS) return;
 		if (!existsSync(archivePath)) {
 			unprovenArchives.delete(archivePath);
 			continue;
 		}
-		if (!(await requestGenerationClose(pending.generation))) continue;
+		if (!(await requestGenerationClose(pending.generation, deadline))) continue;
 		unprovenArchives.delete(archivePath);
 		// One archive that will not compress must not stop the rest of the queue.
 		if (pending.compress) await compressArchive(archivePath).catch(() => {});
@@ -155,26 +154,36 @@ export async function retryPendingGenerations() {
  * the life of the process however the operator configured `compress`.
  * Only safe to call once quiescence has been proven for exactly this listing.
  */
-export async function compressPendingArchives(rotatedLogDir: string, files: string[], liveLogPaths: Set<string>) {
+export async function compressPendingArchives(
+	rotatedLogDir: string,
+	files: string[],
+	liveLogPaths: Set<string>,
+	options: any = {}
+) {
+	const { deadline = Infinity, shouldStop = () => false } = options;
 	const present = new Set(files);
-	let worked = 0;
+	let firstError;
 	for (const file of files) {
+		if (shouldStop() || Date.now() >= deadline) break;
 		if (!file.endsWith('.log') || !isArchiveName(file)) continue;
 		const archivePath = join(rotatedLogDir, file);
 		if (liveLogPaths.has(resolve(archivePath)) || unprovenArchives.has(archivePath)) continue;
-		// Counted after the skips, not before: the archive directory holds the live logs too, and
-		// spending the pass's budget on files it then skips is what leaves a backlog standing.
-		if (worked++ >= MAX_RETRIES_PER_PASS) return;
-		if (present.has(`${file}.gz`)) {
-			// Both representations of one generation: a crash between the .gz rename and the source
-			// unlink leaves the plain copy behind, and every later pass skipped it as already done, so
-			// it survived until retention aged it out — or forever, retention being unset by default.
-			// The .gz is renamed into place whole, and this pass already proved every peer released it.
-			await fsProm.unlink(archivePath).catch(() => {});
-			continue;
+		try {
+			if (present.has(`${file}.gz`)) {
+				// Both representations of one generation: a crash between the .gz rename and the source
+				// unlink leaves the plain copy behind, and every later pass skipped it as already done, so
+				// it survived until retention aged it out — or forever, retention being unset by default.
+				// The .gz is renamed into place whole, and this pass already proved every peer released it.
+				await fsProm.unlink(archivePath);
+				continue;
+			}
+			const result = await tryCompressArchive(archivePath);
+			if (!result.compressed) break;
+		} catch (error) {
+			if (error.code !== 'ENOENT' && !firstError) firstError = { error, file };
 		}
-		await compressArchive(archivePath).catch(() => {});
 	}
+	return firstError;
 }
 
 // One compression at a time per rotated directory. A small maxSize on a busy instance rotates
@@ -182,18 +191,22 @@ export async function compressPendingArchives(rotatedLogDir: string, files: stri
 // before retention could run.
 const compressionByDirectory = new Map<string, Promise<any>>();
 
-export function compressArchive(archivePath: string) {
+export async function compressArchive(archivePath: string) {
+	return (await tryCompressArchive(archivePath)).path;
+}
+
+async function tryCompressArchive(archivePath: string) {
 	const directory = dirname(archivePath);
 	// Declined rather than queued: chaining would grow an unbounded list of pending jobs whenever
 	// rotation outruns gzip. The archive is left for the tick's bounded sweep, which is where an
 	// uncompressed rotation leaves it anyway. The slot is released by the promise this returns, not by
 	// a detached continuation, because that sweep awaits each call before making the next.
-	if (compressionByDirectory.has(directory)) return Promise.resolve(archivePath);
+	if (compressionByDirectory.has(directory)) return { path: archivePath, compressed: false };
 	const chain: Promise<any> = compressOneArchive(archivePath).finally(() => {
 		if (compressionByDirectory.get(directory) === chain) compressionByDirectory.delete(directory);
 	});
 	compressionByDirectory.set(directory, chain);
-	return chain;
+	return { path: await chain, compressed: true };
 }
 
 async function compressOneArchive(archivePath: string) {

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -86,7 +86,17 @@ export function rotateLogFileSync(logPath: string, rotatedLogDir: string, closeL
 	const archivePath = archivePathFor(logPath, rotatedLogDir);
 	renameSync(logPath, archivePath);
 	closeLogFile();
-	return { logPath, archivePath, ino: active.ino, dev: active.dev, generation: nextGenerationId() };
+	// From the archive, not from the stat above: another isolate can rotate this generation away and
+	// its sink recreate the pathname between the two, and then this rename moves an inode the earlier
+	// stat never saw. Announcing that stat's identity would name a generation nobody holds, so every
+	// peer would answer "released" while still appending to the one about to be destroyed.
+	let { ino, dev } = active;
+	try {
+		({ ino, dev } = statSync(archivePath));
+	} catch {
+		// Already claimed by retention or another pass; the pre-rename identity is the best available.
+	}
+	return { logPath, archivePath, ino, dev, generation: nextGenerationId() };
 }
 
 /**
@@ -161,23 +171,22 @@ export async function compressPendingArchives(rotatedLogDir: string, files: stri
 
 // One compression at a time per rotated directory. A small maxSize on a busy instance rotates
 // hundreds of times a second, and a pipeline per rotation would exhaust descriptors and memory long
-// before retention could run. Nothing is queued in memory: whatever this pass does not reach stays
-// on disk as a plain archive, which is what an uncompressed rotation leaves anyway.
+// before retention could run.
 const compressionByDirectory = new Map<string, Promise<any>>();
 
 export function compressArchive(archivePath: string) {
 	const directory = dirname(archivePath);
-	const previous = compressionByDirectory.get(directory) ?? Promise.resolve();
-	const chain = previous.then(
-		() => compressOneArchive(archivePath),
-		() => compressOneArchive(archivePath)
-	);
+	// Declined rather than queued: chaining would grow an unbounded list of pending jobs whenever
+	// rotation outruns gzip. The archive stays on disk exactly as an uncompressed rotation leaves it,
+	// and the audit tick's bounded sweep finds it later.
+	if (compressionByDirectory.has(directory)) return Promise.resolve(archivePath);
+	// The slot is released by the promise this returns, not by a detached continuation: the tick's
+	// sweep awaits each call before making the next, and a slot still held at that point would make
+	// it decline every archive after the first.
+	const chain: Promise<any> = compressOneArchive(archivePath).finally(() => {
+		if (compressionByDirectory.get(directory) === chain) compressionByDirectory.delete(directory);
+	});
 	compressionByDirectory.set(directory, chain);
-	chain
-		.catch(() => {})
-		.then(() => {
-			if (compressionByDirectory.get(directory) === chain) compressionByDirectory.delete(directory);
-		});
 	return chain;
 }
 
@@ -259,10 +268,13 @@ export function createRotationGuard(options: any) {
 			checkAndRotate();
 			rotationPending = false;
 		} catch (error) {
-			// Losing the race is the normal multi-writer outcome, not a failure: another thread (or the
-			// audit tick) renamed the generation between this thread's stat and its rename. The file is
-			// under the cap now, which is all this check wanted.
-			if (error.code === 'ENOENT') {
+			// rename() reports ENOENT for a missing source AND for a missing destination directory, and
+			// only the first is benign. A missing source is the normal multi-writer outcome: another
+			// thread (or the audit tick) renamed the generation between this thread's stat and its
+			// rename, so the file is under the cap now, which is all this check wanted. A missing
+			// destination means no rotation can ever succeed, and treating that as a race would clear
+			// the cap check on every pass and let the log grow without a bound or a diagnostic.
+			if (error.code === 'ENOENT' && !existsSync(logPath)) {
 				closeLogFile();
 				rotationPending = false;
 				return;
@@ -271,6 +283,13 @@ export function createRotationGuard(options: any) {
 			retryAfter = performance.now() + ROTATION_RETRY_COOLDOWN;
 			closeLogFile();
 			report(`Harper cannot rotate its log file: ${error}`);
+			// A rotation target removed under a running instance is recoverable; recreate it here rather
+			// than on every rotation, so the common path keeps costing one stat and one rename.
+			try {
+				mkdirSync(rotatedLogDir, { recursive: true });
+			} catch {
+				// Reported above already; the retry will fail the same way and report again.
+			}
 		} finally {
 			rotating = false;
 		}

--- a/utility/logging/logRotation.ts
+++ b/utility/logging/logRotation.ts
@@ -157,12 +157,22 @@ export async function retryPendingGenerations() {
  */
 export async function compressPendingArchives(rotatedLogDir: string, files: string[], liveLogPaths: Set<string>) {
 	const present = new Set(files);
-	let compressed = 0;
+	let worked = 0;
 	for (const file of files) {
-		if (!file.endsWith('.log') || !isArchiveName(file) || present.has(`${file}.gz`)) continue;
-		if (compressed++ >= MAX_RETRIES_PER_PASS) return;
+		if (!file.endsWith('.log') || !isArchiveName(file)) continue;
 		const archivePath = join(rotatedLogDir, file);
 		if (liveLogPaths.has(resolve(archivePath)) || unprovenArchives.has(archivePath)) continue;
+		// Counted after the skips, not before: the archive directory holds the live logs too, and
+		// spending the pass's budget on files it then skips is what leaves a backlog standing.
+		if (worked++ >= MAX_RETRIES_PER_PASS) return;
+		if (present.has(`${file}.gz`)) {
+			// Both representations of one generation: a crash between the .gz rename and the source
+			// unlink leaves the plain copy behind, and every later pass skipped it as already done, so
+			// it survived until retention aged it out — or forever, retention being unset by default.
+			// The .gz is renamed into place whole, and this pass already proved every peer released it.
+			await fsProm.unlink(archivePath).catch(() => {});
+			continue;
+		}
 		await compressArchive(archivePath).catch(() => {});
 	}
 }

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -8,7 +8,7 @@ import hdbLogger from './harper_logger.ts';
 import { CONFIG_PARAMS } from '../hdbTerms.ts';
 import { convertToMS } from '../common_utils.ts';
 import { onStorageReclamation } from '../../server/storageReclamation.ts';
-import { requestStaleDescriptorRelease } from './logGenerationCoordinator.ts';
+import { isRegisteredLogPath, requestStaleDescriptorRelease } from './logGenerationCoordinator.ts';
 import {
 	compressPendingArchives,
 	INVALID_MAX_SIZE_MSG,
@@ -127,21 +127,25 @@ function logRotator({
 					}
 				}
 			}
-			if (retention || reclamationPriority) {
-				// Retention deletes archives regardless of which thread rotated them, and a worker's own
-				// unproven-archive bookkeeping is invisible here, so prove the whole set in one round
-				// trip: every peer releases any descriptor that is not on the live generation.
+			// Both the compression sweep and retention touch archives this thread did not rotate, so both
+			// need the same proof: every peer releases any descriptor that is not on the live
+			// generation. One round trip per tick serves both. Not gated on retention being configured —
+			// retention is unset by default, and a worker's uncompressed archive still needs finishing.
+			let released;
+			if (compressArchives || retention || reclamationPriority) {
 				let activeStats;
 				try {
 					activeStats = statSync(logger.path);
 				} catch (err) {
 					if (err.code !== 'ENOENT') throw err;
 				}
-				const released = await requestStaleDescriptorRelease(logger.path, activeStats);
-				// Once the whole directory is proven quiescent, anything still plain there is an archive
-				// some isolate could not finish — including a worker's, which this thread cannot see.
+				released = await requestStaleDescriptorRelease(logger.path, activeStats);
+				// Anything still plain in the directory is an archive some isolate could not finish —
+				// including a worker's, which this thread's own bookkeeping cannot see.
 				if (released && compressArchives) await compressPendingArchives(rotatedLogDir);
+			}
 
+			if (retention || reclamationPriority) {
 				// remove old logs after retention time
 				// adjust retention time if there is a reclamation priority in place
 				const retentionMs = convertToMS(retention ?? '1M') / (1 + reclamationPriority);
@@ -157,6 +161,12 @@ function logRotator({
 				for (const file of files) {
 					try {
 						const archivePath = path.join(rotatedLogDir, file);
+						// The rotated directory defaults to the log directory itself
+						// (`logging.rotation.path` defaults to `log`, as does `logging.root`), so it also
+						// holds the logs currently being written — this one and every component or external
+						// log sharing the directory. Deleting those by age was already possible before this
+						// change; a live log is never a retention candidate.
+						if (archivePath === logger.path || isRegisteredLogPath(archivePath)) continue;
 						// Unlinking an inode a stalled writer still holds loses whatever it writes next
 						// just as surely as compressing over it would, so retention waits for the same proof.
 						if (!released || isArchivePendingQuiescence(archivePath)) continue;

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -119,13 +119,13 @@ function logRotator({
 			}
 
 			if (maxInterval) {
-				// The current generation's own age, so a rotation by any thread — or by a previous run —
-				// resets the clock, not just the ones this tick performed. birthtime is unsupported on
-				// some filesystems, where this falls back to the last rotation this rotator saw.
+				// Whichever origin is older. birthtime is unsupported on some filesystems, where it mirrors
+				// a write-updated ctime and would postpone interval rotation forever; taking the minimum
+				// means this can only ever rotate at least as often as the counter alone did.
 				let generationStartedAt = lastRotationTime;
 				try {
 					const born = statSync(logger.path).birthtimeMs;
-					if (born > 0) generationStartedAt = born;
+					if (born > 0) generationStartedAt = Math.min(generationStartedAt, born);
 				} catch (err) {
 					if (err.code !== 'ENOENT') throw err;
 				}
@@ -154,16 +154,10 @@ function logRotator({
 					if (err.code !== 'ENOENT') hdbLogger.error('Error reading rotated log directory', rotatedLogDir, err);
 					candidates = [];
 				}
-				let activeStats;
-				try {
-					activeStats = statSync(logger.path);
-				} catch (err) {
-					if (err.code !== 'ENOENT') throw err;
-				}
-				const { released, liveLogPaths } = await requestStaleDescriptorRelease(logger.path, activeStats);
-				liveLogPaths.add(logger.path);
+				const { released, liveLogPaths } = await requestStaleDescriptorRelease();
+				const liveLogs = new Set([...liveLogPaths, logger.path].map((p) => path.resolve(p)));
 
-				if (released && compressArchives) await compressPendingArchives(rotatedLogDir, candidates, liveLogPaths);
+				if (released && compressArchives) await compressPendingArchives(rotatedLogDir, candidates, liveLogs);
 
 				if (released && (retention || reclamationPriority)) {
 					// remove old logs after retention time
@@ -177,7 +171,7 @@ function logRotator({
 							// (`logging.rotation.path` defaults to `log`, as does `logging.root`), so it also
 							// holds the logs currently being written — including a component's, which loads in
 							// a worker and is only known here because the peers reported it.
-							if (liveLogPaths.has(archivePath)) continue;
+							if (liveLogs.has(path.resolve(archivePath))) continue;
 							// Unlinking an inode a stalled writer still holds loses whatever it writes next
 							// just as surely as compressing over it would.
 							if (isArchivePendingQuiescence(archivePath)) continue;
@@ -186,7 +180,8 @@ function logRotator({
 								await fsProm.unlink(archivePath);
 							}
 						} catch (err) {
-							hdbLogger.error('Error trying to remove log', file, err);
+							// The compression sweep above unlinks archives from this same listing.
+							if (err.code !== 'ENOENT') hdbLogger.error('Error trying to remove log', file, err);
 						}
 					}
 				}

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -8,7 +8,7 @@ import hdbLogger from './harper_logger.ts';
 import { CONFIG_PARAMS } from '../hdbTerms.ts';
 import { convertToMS } from '../common_utils.ts';
 import { onStorageReclamation } from '../../server/storageReclamation.ts';
-import { isRegisteredLogPath, requestStaleDescriptorRelease } from './logGenerationCoordinator.ts';
+import { requestStaleDescriptorRelease } from './logGenerationCoordinator.ts';
 import {
 	compressPendingArchives,
 	INVALID_MAX_SIZE_MSG,
@@ -65,8 +65,8 @@ function logRotator({
 		hdbLogger.error(`Ignoring logging.rotation.maxSize '${maxSize}': ${INVALID_MAX_SIZE_MSG}`);
 	}
 
-	// The rotation block first, because that is all the write-path guard can read: environmentManager
-	// imports harper_logger, so the sink cannot reach it, and two sources would mean two policies.
+	// The rotation block first, because that is all the write-path guard can read — environmentManager
+	// imports harper_logger — and two sources would mean two destruction policies for one log.
 	const compressArchives = compress ?? envMgr.get(CONFIG_PARAMS.LOGGING_ROTATION_COMPRESS);
 
 	// Convert interval param to ms.
@@ -119,8 +119,17 @@ function logRotator({
 			}
 
 			if (maxInterval) {
-				const minSinceLastRotate = Date.now() - lastRotationTime;
-				if (minSinceLastRotate >= maxInterval) {
+				// The current generation's own age, so a rotation by any thread — or by a previous run —
+				// resets the clock, not just the ones this tick performed. birthtime is unsupported on
+				// some filesystems, where this falls back to the last rotation this rotator saw.
+				let generationStartedAt = lastRotationTime;
+				try {
+					const born = statSync(logger.path).birthtimeMs;
+					if (born > 0) generationStartedAt = born;
+				} catch (err) {
+					if (err.code !== 'ENOENT') throw err;
+				}
+				if (Date.now() - generationStartedAt >= maxInterval) {
 					try {
 						lastRotatedLogPath = await moveLogFile(logger.path, rotatedLogDir, logger, compressArchives);
 						lastRotationTime = Date.now();
@@ -130,55 +139,55 @@ function logRotator({
 					}
 				}
 			}
-			// Both the compression sweep and retention touch archives this thread did not rotate, so both
-			// need the same proof: every peer releases any descriptor that is not on the live
-			// generation. One round trip per tick serves both. Not gated on retention being configured —
-			// retention is unset by default, and a worker's uncompressed archive still needs finishing.
-			let released;
+			// The compression sweep and retention both destroy archives this thread did not rotate, so
+			// both need the same proof: every peer releases any descriptor that is not on the live
+			// generation, and reports the log paths it is writing. One round trip per tick serves both,
+			// and it is not gated on retention being configured — retention is unset by default, and a
+			// worker's uncompressed archive still needs finishing.
 			if (compressArchives || retention || reclamationPriority) {
+				// Enumerated BEFORE the proof, and only these are destroyed: an archive created after the
+				// proof was never covered by it, and a peer blocked mid-rotation may still be writing to it.
+				let candidates;
+				try {
+					candidates = await fsProm.readdir(rotatedLogDir);
+				} catch (err) {
+					if (err.code !== 'ENOENT') hdbLogger.error('Error reading rotated log directory', rotatedLogDir, err);
+					candidates = [];
+				}
 				let activeStats;
 				try {
 					activeStats = statSync(logger.path);
 				} catch (err) {
 					if (err.code !== 'ENOENT') throw err;
 				}
-				released = await requestStaleDescriptorRelease(logger.path, activeStats);
-				// Anything still plain in the directory is an archive some isolate could not finish —
-				// including a worker's, which this thread's own bookkeeping cannot see.
-				if (released && compressArchives) await compressPendingArchives(rotatedLogDir);
-			}
+				const { released, liveLogPaths } = await requestStaleDescriptorRelease(logger.path, activeStats);
+				liveLogPaths.add(logger.path);
 
-			if (retention || reclamationPriority) {
-				// remove old logs after retention time
-				// adjust retention time if there is a reclamation priority in place
-				const retentionMs = convertToMS(retention ?? '1M') / (1 + reclamationPriority);
-				reclamationPriority = 0; // reset it after use
-				let files;
-				try {
-					files = await fsProm.readdir(rotatedLogDir);
-				} catch (err) {
-					// The rotated log dir may not exist yet (nothing rotated so far); nothing to clean up
-					if (err.code !== 'ENOENT') hdbLogger.error('Error reading rotated log directory', rotatedLogDir, err);
-					files = [];
-				}
-				for (const file of files) {
-					try {
-						const archivePath = path.join(rotatedLogDir, file);
-						// The rotated directory defaults to the log directory itself
-						// (`logging.rotation.path` defaults to `log`, as does `logging.root`), so it also
-						// holds the logs currently being written — this one and every component or external
-						// log sharing the directory. Deleting those by age was already possible before this
-						// change; a live log is never a retention candidate.
-						if (archivePath === logger.path || isRegisteredLogPath(archivePath)) continue;
-						// Unlinking an inode a stalled writer still holds loses whatever it writes next
-						// just as surely as compressing over it would, so retention waits for the same proof.
-						if (!released || isArchivePendingQuiescence(archivePath)) continue;
-						const fileStats = await fsProm.stat(archivePath);
-						if (Date.now() - fileStats.mtimeMs > retentionMs) {
-							await fsProm.unlink(archivePath);
+				if (released && compressArchives) await compressPendingArchives(rotatedLogDir, candidates, liveLogPaths);
+
+				if (released && (retention || reclamationPriority)) {
+					// remove old logs after retention time
+					// adjust retention time if there is a reclamation priority in place
+					const retentionMs = convertToMS(retention ?? '1M') / (1 + reclamationPriority);
+					reclamationPriority = 0; // reset it after use
+					for (const file of candidates) {
+						try {
+							const archivePath = path.join(rotatedLogDir, file);
+							// The rotated directory defaults to the log directory itself
+							// (`logging.rotation.path` defaults to `log`, as does `logging.root`), so it also
+							// holds the logs currently being written — including a component's, which loads in
+							// a worker and is only known here because the peers reported it.
+							if (liveLogPaths.has(archivePath)) continue;
+							// Unlinking an inode a stalled writer still holds loses whatever it writes next
+							// just as surely as compressing over it would.
+							if (isArchivePendingQuiescence(archivePath)) continue;
+							const fileStats = await fsProm.stat(archivePath);
+							if (Date.now() - fileStats.mtimeMs > retentionMs) {
+								await fsProm.unlink(archivePath);
+							}
+						} catch (err) {
+							hdbLogger.error('Error trying to remove log', file, err);
 						}
-					} catch (err) {
-						hdbLogger.error('Error trying to remove log', file, err);
 					}
 				}
 			}

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -106,6 +106,10 @@ function logRotator({
 							active
 						);
 						lastRotatedLogPath = await publishArchivedGeneration(generation, compressArchives);
+						// The interval clock counts from the last rotation of any kind. Without this an
+						// instance whose uptime has passed `interval` archives a freshly-created log every
+						// interval on top of the size rotations already doing the work.
+						lastRotationTime = Date.now();
 						hdbLogger.notify(`hdb.log rotated, old log moved to ${lastRotatedLogPath}`);
 					}
 				} catch (err) {

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -8,6 +8,7 @@ import hdbLogger from './harper_logger.ts';
 import { CONFIG_PARAMS } from '../hdbTerms.ts';
 import { convertToMS } from '../common_utils.ts';
 import { onStorageReclamation } from '../../server/storageReclamation.ts';
+import { requestStaleDescriptorRelease } from './logGenerationCoordinator.ts';
 import {
 	INVALID_MAX_SIZE_MSG,
 	isArchivePendingQuiescence,
@@ -127,6 +128,17 @@ function logRotator({
 			await retryPendingGenerations();
 
 			if (retention || reclamationPriority) {
+				// Retention deletes archives regardless of which thread rotated them, and a worker's own
+				// unproven-archive bookkeeping is invisible here, so prove the whole set in one round
+				// trip: every peer releases any descriptor that is not on the live generation.
+				let activeStats;
+				try {
+					activeStats = statSync(logger.path);
+				} catch (err) {
+					if (err.code !== 'ENOENT') throw err;
+				}
+				const released = await requestStaleDescriptorRelease(logger.path, activeStats);
+
 				// remove old logs after retention time
 				// adjust retention time if there is a reclamation priority in place
 				const retentionMs = convertToMS(retention ?? '1M') / (1 + reclamationPriority);
@@ -144,7 +156,7 @@ function logRotator({
 						const archivePath = path.join(rotatedLogDir, file);
 						// Unlinking an inode a stalled writer still holds loses whatever it writes next
 						// just as surely as compressing over it would, so retention waits for the same proof.
-						if (isArchivePendingQuiescence(archivePath)) continue;
+						if (!released || isArchivePendingQuiescence(archivePath)) continue;
 						const fileStats = await fsProm.stat(archivePath);
 						if (Date.now() - fileStats.mtimeMs > retentionMs) {
 							await fsProm.unlink(archivePath);

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -1,18 +1,22 @@
 'use strict';
 
-import { promises as fsProm, createReadStream, createWriteStream, mkdirSync } from 'fs';
-import { createGzip } from 'zlib';
-import { promisify } from 'util';
-import { pipeline } from 'stream';
-const pipe = promisify(pipeline);
+import { mkdirSync, promises as fsProm } from 'fs';
 import * as path from 'path';
-import { createHash } from 'crypto';
 import * as envMgr from '../environment/environmentManager.ts';
 envMgr.initSync();
 import hdbLogger from './harper_logger.ts';
 import { CONFIG_PARAMS } from '../hdbTerms.ts';
 import { convertToMS } from '../common_utils.ts';
 import { onStorageReclamation } from '../../server/storageReclamation.ts';
+import {
+	INVALID_MAX_SIZE_MSG,
+	isArchivePendingQuiescence,
+	parseMaxSize,
+	publishArchivedGeneration,
+	resolveRotatedLogDir,
+	retryPendingGenerations,
+	rotateLogFileSync,
+} from './logRotation.ts';
 
 // Interval in ms to check log file and decide if it should be rotated.
 const LOG_AUDIT_INTERVAL = 60000;
@@ -42,19 +46,12 @@ function logRotator({ logger, maxSize, interval, retention, enabled, path: rotat
 		throw new Error(INT_SIZE_UNDEFINED_MSG);
 	}
 
-	if (!rotatedLogDir) {
-		rotatedLogDir = path.join(path.dirname(logger.path), 'rotated');
-	}
+	rotatedLogDir = resolveRotatedLogDir(logger.path, rotatedLogDir);
 	mkdirSync(rotatedLogDir, { recursive: true });
 
-	// Convert maxSize param to bytes.
-	let maxBytes;
-	if (maxSize) {
-		const unit = maxSize.slice(-1);
-		const size = maxSize.slice(0, -1);
-		if (unit === 'G') maxBytes = size * 1000000000;
-		else if (unit === 'M') maxBytes = size * 1000000;
-		else maxBytes = size * 1000;
+	const maxBytes = parseMaxSize(maxSize);
+	if (maxSize && !maxBytes) {
+		hdbLogger.error(`Ignoring logging.rotation.maxSize '${maxSize}': ${INVALID_MAX_SIZE_MSG}`);
 	}
 
 	// Convert interval param to ms.
@@ -107,6 +104,11 @@ function logRotator({ logger, maxSize, interval, retention, enabled, path: rotat
 					}
 				}
 			}
+			// A generation this process could not prove released is retried here rather than abandoned:
+			// the tick is the only recurring opportunity to compress it, and it must happen before
+			// retention below, which would otherwise be the thing that unlinks it.
+			await retryPendingGenerations();
+
 			if (retention || reclamationPriority) {
 				// remove old logs after retention time
 				// adjust retention time if there is a reclamation priority in place
@@ -122,9 +124,13 @@ function logRotator({ logger, maxSize, interval, retention, enabled, path: rotat
 				}
 				for (const file of files) {
 					try {
-						const fileStats = await fsProm.stat(path.join(rotatedLogDir, file));
+						const archivePath = path.join(rotatedLogDir, file);
+						// Unlinking an inode a stalled writer still holds loses whatever it writes next
+						// just as surely as compressing over it would, so retention waits for the same proof.
+						if (isArchivePendingQuiescence(archivePath)) continue;
+						const fileStats = await fsProm.stat(archivePath);
 						if (Date.now() - fileStats.mtimeMs > retentionMs) {
-							await fsProm.unlink(path.join(rotatedLogDir, file));
+							await fsProm.unlink(archivePath);
 						}
 					} catch (err) {
 						hdbLogger.error('Error trying to remove log', file, err);
@@ -145,46 +151,18 @@ function logRotator({ logger, maxSize, interval, retention, enabled, path: rotat
 	};
 }
 
-// Monotonically increasing across every rotation in this process, regardless of which logger/source
-// triggered it — combined with the pid, this guarantees two archive names can never collide even if
-// two rotations for two different sources race concurrently within the same audit-interval tick.
-let rotationSequence = 0;
-
 async function moveLogFile(logPath: string, rotatedLogPath: string, logger?: any) {
-	const compress = envMgr.get(CONFIG_PARAMS.LOGGING_ROTATION_COMPRESS);
-	// Name the archive after its source log (hdb, external, a component name, ...), not a fixed
-	// "HDB" literal — external/component loggers can now inherit rotation from the main logger
-	// (#1877) and default to the same rotated directory as it, so distinct sources rotating in
-	// the same audit tick must not collide on the same timestamp-only filename. A basename alone
-	// is not enough either: two distinct source paths can share a basename (e.g. `/logs/a/hdb.log`
-	// and `/logs/b/hdb.log`), so a hash of the full resolved source path plus a pid+sequence suffix
-	// give every archive a name POSIX rename() can never clobber, even under a same-millisecond race.
-	const sourceName = path.basename(logPath, path.extname(logPath)) || 'HDB';
-	// sha256, not sha1: this only needs a stable identifier, not cryptographic strength, but a FIPS-mode
-	// OpenSSL provider disables sha1 and throws synchronously, which would crash every rotation tick.
-	const sourceId = createHash('sha256').update(path.resolve(logPath)).digest('hex').slice(0, 8);
-	const uniqueSuffix = `${process.pid}-${rotationSequence++}`;
-	let fullRotateLogPath = path.join(
-		rotatedLogPath,
-		`${sourceName}-${sourceId}-${new Date(Date.now()).toISOString().replaceAll(':', '-')}-${uniqueSuffix}.log`
+	// The rename and the descriptor close must not be separated by an await: the descriptor would
+	// otherwise keep feeding the archived inode while the event loop runs. Closing the rotating
+	// logger's own descriptor (not the module-global one) is what makes the next write reopen a
+	// fresh log file rather than append to the moved — and, when compressing, unlinked — inode.
+	const generation = rotateLogFileSync(logPath, rotatedLogPath, logger?.closeLogFile ?? hdbLogger.closeLogFile);
+	const publishedPath = await publishArchivedGeneration(
+		generation,
+		envMgr.get(CONFIG_PARAMS.LOGGING_ROTATION_COMPRESS)
 	);
-	// Move log file to rotated log path first (if we crash
-	// during compression, we don't want to restart the compression with a new file)
-	await fsProm.rename(logPath, fullRotateLogPath);
-	// Close the rotating logger's own file descriptor now that the file has moved. This must be the
-	// logger's own closeLogFile (which resets its internal logFD), not the module-global one — otherwise
-	// the descriptor stays open on the moved (and, when compressing, subsequently unlinked) inode until the
-	// logger's safety timeout fires, pinning disk space and sending any writes in that window into the
-	// rotated/deleted file. Closing it here makes the next write reopen a fresh log file immediately.
-	(logger?.closeLogFile ?? hdbLogger.closeLogFile)();
-	if (compress) {
-		logPath = fullRotateLogPath;
-		fullRotateLogPath += '.gz';
-		await pipe(createReadStream(logPath), createGzip(), createWriteStream(fullRotateLogPath));
-		await fsProm.unlink(logPath);
-	}
 
 	// This notify log will create a new log file after the previous one has been rotated. It's important to keep this log as notify
-	hdbLogger.notify(`hdb.log rotated, old log moved to ${fullRotateLogPath}`);
-	return fullRotateLogPath;
+	hdbLogger.notify(`hdb.log rotated, old log moved to ${publishedPath}`);
+	return publishedPath;
 }

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -86,8 +86,6 @@ function logRotator({
 		// the logger instead, so one bad tick (e.g. an unexpected fs error) never kills rotation for
 		// the rest of the process's life.
 		try {
-			// A missing/relocated active log file only invalidates the rotation checks below — retention cleanup
-			// must still run. So skip the individual check on ENOENT rather than returning from the whole tick.
 			if (maxBytes) {
 				try {
 					// statSync, and the rename in the same turn: an await here lets a writing thread rotate
@@ -105,7 +103,8 @@ function logRotator({
 						hdbLogger.notify(`hdb.log rotated, old log moved to ${lastRotatedLogPath}`);
 					}
 				} catch (err) {
-					// A missing/relocated active log only invalidates this check — retention must still run
+					// A missing or already-rotated active log only invalidates this check; retention below
+					// must still run, so skip the check rather than leaving the whole tick.
 					if (err.code !== 'ENOENT') throw err;
 				}
 			}

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -10,6 +10,7 @@ import { convertToMS } from '../common_utils.ts';
 import { onStorageReclamation } from '../../server/storageReclamation.ts';
 import { requestStaleDescriptorRelease } from './logGenerationCoordinator.ts';
 import {
+	compressPendingArchives,
 	INVALID_MAX_SIZE_MSG,
 	isArchivePendingQuiescence,
 	parseMaxSize,
@@ -79,7 +80,12 @@ function logRotator({
 	// convert date.now to minutes
 	let lastRotationTime = Date.now();
 	hdbLogger.trace('Log rotate enabled, maxSize:', maxSize, 'interval:', interval);
+	let tickInFlight = false;
 	const setIntervalId = setInterval(async () => {
+		// setInterval does not await the callback, and one pass can now wait on peers; overlapping
+		// passes would work the same archive twice and double-compress it.
+		if (tickInFlight) return;
+		tickInFlight = true;
 		// The tick is async but setInterval doesn't await it, so any error that escapes this callback
 		// becomes an unhandled rejection rather than surfacing anywhere useful — and since it isn't
 		// caught, it also skips the retention cleanup below. Contain everything here and report via
@@ -121,11 +127,6 @@ function logRotator({
 					}
 				}
 			}
-			// A generation this process could not prove released is retried here rather than abandoned:
-			// the tick is the only recurring opportunity to compress it, and it must happen before
-			// retention below, which would otherwise be the thing that unlinks it.
-			await retryPendingGenerations();
-
 			if (retention || reclamationPriority) {
 				// Retention deletes archives regardless of which thread rotated them, and a worker's own
 				// unproven-archive bookkeeping is invisible here, so prove the whole set in one round
@@ -137,6 +138,9 @@ function logRotator({
 					if (err.code !== 'ENOENT') throw err;
 				}
 				const released = await requestStaleDescriptorRelease(logger.path, activeStats);
+				// Once the whole directory is proven quiescent, anything still plain there is an archive
+				// some isolate could not finish — including a worker's, which this thread cannot see.
+				if (released && compressArchives) await compressPendingArchives(rotatedLogDir);
 
 				// remove old logs after retention time
 				// adjust retention time if there is a reclamation priority in place
@@ -165,8 +169,13 @@ function logRotator({
 					}
 				}
 			}
+			// Last: retention is what bounds the rotated directory, so a stranded generation waiting on a
+			// peer must never be ahead of it.
+			await retryPendingGenerations();
 		} catch (err) {
 			hdbLogger.error('Error during log rotation audit tick for', logger.path, err);
+		} finally {
+			tickInFlight = false;
 		}
 	}, auditInterval ?? LOG_AUDIT_INTERVAL).unref();
 	return {

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { mkdirSync, promises as fsProm } from 'fs';
+import { mkdirSync, statSync, promises as fsProm } from 'fs';
 import * as path from 'path';
 import * as envMgr from '../environment/environmentManager.ts';
 envMgr.initSync();
@@ -31,7 +31,16 @@ export { logRotator };
  * If log file is within the values set in config, log file will be renamed/moved and a new empty hdb.log created.
  * @returns LogRotator
  */
-function logRotator({ logger, maxSize, interval, retention, enabled, path: rotatedLogDir, auditInterval }: any) {
+function logRotator({
+	logger,
+	maxSize,
+	interval,
+	retention,
+	enabled,
+	compress,
+	path: rotatedLogDir,
+	auditInterval,
+}: any) {
 	if (enabled === false) return;
 	let reclamationPriority = 0;
 	onStorageReclamation(
@@ -54,6 +63,11 @@ function logRotator({ logger, maxSize, interval, retention, enabled, path: rotat
 		hdbLogger.error(`Ignoring logging.rotation.maxSize '${maxSize}': ${INVALID_MAX_SIZE_MSG}`);
 	}
 
+	// One compress decision for both rotation paths. The write-path guard can only read the rotation
+	// block (environmentManager imports harper_logger, so it is unreachable from the sink), so a tick
+	// that consulted only the env would apply a different destruction policy to the same log.
+	const compressArchives = compress ?? envMgr.get(CONFIG_PARAMS.LOGGING_ROTATION_COMPRESS);
+
 	// Convert interval param to ms.
 	let maxInterval;
 	if (interval) {
@@ -74,21 +88,24 @@ function logRotator({ logger, maxSize, interval, retention, enabled, path: rotat
 			// A missing/relocated active log file only invalidates the rotation checks below — retention cleanup
 			// must still run. So skip the individual check on ENOENT rather than returning from the whole tick.
 			if (maxBytes) {
-				let fileStats;
 				try {
-					fileStats = await fsProm.stat(logger.path);
-				} catch (err) {
-					// If the log file doesn't exist, skip the size-based rotation check
-					if (err.code !== 'ENOENT') throw err;
-				}
-
-				if (fileStats && fileStats.size >= maxBytes) {
-					try {
-						lastRotatedLogPath = await moveLogFile(logger.path, rotatedLogDir, logger);
-					} catch (err) {
-						// If the log file doesn't exist, skip rotation
-						if (err.code !== 'ENOENT') throw err;
+					// statSync, and the rename in the same turn: an await here lets a writing thread rotate
+					// the generation this tick measured and start a fresh one, which the tick would then
+					// archive near-empty.
+					const active = statSync(logger.path);
+					if (active.size >= maxBytes) {
+						const generation = rotateLogFileSync(
+							logger.path,
+							rotatedLogDir,
+							logger?.closeLogFile ?? hdbLogger.closeLogFile,
+							active
+						);
+						lastRotatedLogPath = await publishArchivedGeneration(generation, compressArchives);
+						hdbLogger.notify(`hdb.log rotated, old log moved to ${lastRotatedLogPath}`);
 					}
+				} catch (err) {
+					// A missing/relocated active log only invalidates this check — retention must still run
+					if (err.code !== 'ENOENT') throw err;
 				}
 			}
 
@@ -96,7 +113,7 @@ function logRotator({ logger, maxSize, interval, retention, enabled, path: rotat
 				const minSinceLastRotate = Date.now() - lastRotationTime;
 				if (minSinceLastRotate >= maxInterval) {
 					try {
-						lastRotatedLogPath = await moveLogFile(logger.path, rotatedLogDir, logger);
+						lastRotatedLogPath = await moveLogFile(logger.path, rotatedLogDir, logger, compressArchives);
 						lastRotationTime = Date.now();
 					} catch (err) {
 						// If the log file doesn't exist, skip rotation
@@ -151,7 +168,7 @@ function logRotator({ logger, maxSize, interval, retention, enabled, path: rotat
 	};
 }
 
-async function moveLogFile(logPath: string, rotatedLogPath: string, logger?: any) {
+async function moveLogFile(logPath: string, rotatedLogPath: string, logger?: any, compress?: boolean) {
 	// The rename and the descriptor close must not be separated by an await: the descriptor would
 	// otherwise keep feeding the archived inode while the event loop runs. Closing the rotating
 	// logger's own descriptor (not the module-global one) is what makes the next write reopen a
@@ -159,7 +176,7 @@ async function moveLogFile(logPath: string, rotatedLogPath: string, logger?: any
 	const generation = rotateLogFileSync(logPath, rotatedLogPath, logger?.closeLogFile ?? hdbLogger.closeLogFile);
 	const publishedPath = await publishArchivedGeneration(
 		generation,
-		envMgr.get(CONFIG_PARAMS.LOGGING_ROTATION_COMPRESS)
+		compress ?? envMgr.get(CONFIG_PARAMS.LOGGING_ROTATION_COMPRESS)
 	);
 
 	// This notify log will create a new log file after the previous one has been rotated. It's important to keep this log as notify

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -65,9 +65,8 @@ function logRotator({
 		hdbLogger.error(`Ignoring logging.rotation.maxSize '${maxSize}': ${INVALID_MAX_SIZE_MSG}`);
 	}
 
-	// One compress decision for both rotation paths. The write-path guard can only read the rotation
-	// block (environmentManager imports harper_logger, so it is unreachable from the sink), so a tick
-	// that consulted only the env would apply a different destruction policy to the same log.
+	// The rotation block first, because that is all the write-path guard can read: environmentManager
+	// imports harper_logger, so the sink cannot reach it, and two sources would mean two policies.
 	const compressArchives = compress ?? envMgr.get(CONFIG_PARAMS.LOGGING_ROTATION_COMPRESS);
 
 	// Convert interval param to ms.

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -114,18 +114,11 @@ function logRotator({
 					// archive near-empty.
 					const active = statSync(logger.path);
 					if (active.size >= maxBytes) {
-						const generation = rotateLogFileSync(
-							logger.path,
-							rotatedLogDir,
-							logger?.closeLogFile ?? hdbLogger.closeLogFile,
-							active
-						);
-						lastRotatedLogPath = await publishArchivedGeneration(generation, compressArchives);
+						lastRotatedLogPath = await moveLogFile(logger.path, rotatedLogDir, logger, compressArchives, active);
 						// The interval clock counts from the last rotation of any kind. Without this an
 						// instance whose uptime has passed `interval` archives a freshly-created log every
 						// interval on top of the size rotations already doing the work.
 						lastRotationTime = Date.now();
-						hdbLogger.notify(`hdb.log rotated, old log moved to ${lastRotatedLogPath}`);
 					}
 				} catch (err) {
 					// A missing or already-rotated active log only invalidates this check; retention below
@@ -236,12 +229,25 @@ function logRotator({
 	};
 }
 
-async function moveLogFile(logPath: string, rotatedLogPath: string, logger?: any, compress?: boolean) {
+async function moveLogFile(
+	logPath: string,
+	rotatedLogPath: string,
+	logger?: any,
+	compress?: boolean,
+	activeStats?: any
+) {
 	// The rename and the descriptor close must not be separated by an await: the descriptor would
 	// otherwise keep feeding the archived inode while the event loop runs. Closing the rotating
 	// logger's own descriptor (not the module-global one) is what makes the next write reopen a
 	// fresh log file rather than append to the moved — and, when compressing, unlinked — inode.
-	const generation = rotateLogFileSync(logPath, rotatedLogPath, logger?.closeLogFile ?? hdbLogger.closeLogFile);
+	// `activeStats` is the caller's own stat of the live generation, when it has one: the size check
+	// must rename the generation it measured, and a second stat here could pick up a newer one.
+	const generation = rotateLogFileSync(
+		logPath,
+		rotatedLogPath,
+		logger?.closeLogFile ?? hdbLogger.closeLogFile,
+		activeStats
+	);
 	const publishedPath = await publishArchivedGeneration(
 		generation,
 		compress ?? envMgr.get(CONFIG_PARAMS.LOGGING_ROTATION_COMPRESS)

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { mkdirSync, statSync, promises as fsProm } from 'fs';
+import { existsSync, mkdirSync, statSync, promises as fsProm } from 'fs';
 import * as path from 'path';
 import * as envMgr from '../environment/environmentManager.ts';
 envMgr.initSync();
@@ -80,6 +80,22 @@ function logRotator({
 	let lastRotationTime = Date.now();
 	hdbLogger.trace('Log rotate enabled, maxSize:', maxSize, 'interval:', interval);
 	let tickInFlight = false;
+	let releaseProofStalled = false;
+	/**
+	 * rename() reports ENOENT for a missing destination directory as well as a missing source, and
+	 * only the second is the benign lost race. The directory is created once at rotator start, so a
+	 * rotation target removed under a running instance otherwise stops rotation permanently and
+	 * silently — and with `interval` and no `maxSize` there is no write-path guard to recreate it.
+	 */
+	function recoverRotationTarget(err: any) {
+		if (err.code !== 'ENOENT' || existsSync(rotatedLogDir)) return;
+		try {
+			mkdirSync(rotatedLogDir, { recursive: true });
+			hdbLogger.warn(`The log rotation directory ${rotatedLogDir} was missing and has been recreated`);
+		} catch (mkdirErr) {
+			hdbLogger.error('Could not recreate the log rotation directory', rotatedLogDir, mkdirErr);
+		}
+	}
 	const setIntervalId = setInterval(async () => {
 		// setInterval does not await the callback, and one pass can now wait on peers; overlapping
 		// passes would work the same archive twice and double-compress it.
@@ -114,6 +130,7 @@ function logRotator({
 				} catch (err) {
 					// A missing or already-rotated active log only invalidates this check; retention below
 					// must still run, so skip the check rather than leaving the whole tick.
+					recoverRotationTarget(err);
 					if (err.code !== 'ENOENT') throw err;
 				}
 			}
@@ -135,6 +152,7 @@ function logRotator({
 						lastRotationTime = Date.now();
 					} catch (err) {
 						// If the log file doesn't exist, skip rotation
+						recoverRotationTarget(err);
 						if (err.code !== 'ENOENT') throw err;
 					}
 				}
@@ -155,6 +173,19 @@ function logRotator({
 					candidates = [];
 				}
 				const { released, liveLogPaths } = await requestStaleDescriptorRelease();
+				// A peer whose event loop is blocked never answers, and the whole pass then destroys
+				// nothing — correct, but it is also the only thing bounding the rotated directory, so an
+				// operator who configured retention has to be able to see that it has stopped. Latched
+				// rather than repeated, so a permanently stalled peer reports once per stall.
+				if (!released && !releaseProofStalled) {
+					releaseProofStalled = true;
+					hdbLogger.warn(
+						`Log rotation could not prove every thread released its archived log descriptors; compression and retention are paused for ${rotatedLogDir}`
+					);
+				} else if (released && releaseProofStalled) {
+					releaseProofStalled = false;
+					hdbLogger.notify(`Log rotation descriptor release recovered; retention resumed for ${rotatedLogDir}`);
+				}
 				const liveLogs = new Set([...liveLogPaths, logger.path].map((p) => path.resolve(p)));
 
 				if (released && compressArchives) await compressPendingArchives(rotatedLogDir, candidates, liveLogs);

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -80,7 +80,10 @@ function logRotator({
 	let lastRotationTime = Date.now();
 	hdbLogger.trace('Log rotate enabled, maxSize:', maxSize, 'interval:', interval);
 	let tickInFlight = false;
+	let ended = false;
 	let releaseProofStalled = false;
+	const auditIntervalMs = auditInterval ?? LOG_AUDIT_INTERVAL;
+	const compressionBudgetMs = Math.max(1, Math.floor(auditIntervalMs / 4));
 	/**
 	 * rename() reports ENOENT for a missing destination directory as well as a missing source, and
 	 * only the second is the benign lost race. The directory is created once at rotator start, so a
@@ -99,8 +102,9 @@ function logRotator({
 	const setIntervalId = setInterval(async () => {
 		// setInterval does not await the callback, and one pass can now wait on peers; overlapping
 		// passes would work the same archive twice and double-compress it.
-		if (tickInFlight) return;
+		if (tickInFlight || ended) return;
 		tickInFlight = true;
+		const tickDeadline = Date.now() + auditIntervalMs;
 		// The tick is async but setInterval doesn't await it, so any error that escapes this callback
 		// becomes an unhandled rejection rather than surfacing anywhere useful — and since it isn't
 		// caught, it also skips the retention cleanup below. Contain everything here and report via
@@ -165,7 +169,7 @@ function logRotator({
 					if (err.code !== 'ENOENT') hdbLogger.error('Error reading rotated log directory', rotatedLogDir, err);
 					candidates = [];
 				}
-				const { released, liveLogPaths } = await requestStaleDescriptorRelease();
+				const { released, liveLogPaths } = await requestStaleDescriptorRelease(tickDeadline);
 				// A peer whose event loop is blocked never answers, and the whole pass then destroys
 				// nothing — correct, but it is also the only thing bounding the rotated directory, so an
 				// operator who configured retention has to be able to see that it has stopped. Latched
@@ -181,20 +185,19 @@ function logRotator({
 				}
 				const liveLogs = new Set([...liveLogPaths, logger.path].map((p) => path.resolve(p)));
 
-				if (released && compressArchives) await compressPendingArchives(rotatedLogDir, candidates, liveLogs);
-
 				if (released && (retention || reclamationPriority)) {
 					// remove old logs after retention time
 					// adjust retention time if there is a reclamation priority in place
 					const retentionMs = convertToMS(retention ?? '1M') / (1 + reclamationPriority);
-					reclamationPriority = 0; // reset it after use
+					let retentionCompleted = true;
 					for (const file of candidates) {
+						if (ended || Date.now() >= tickDeadline) {
+							retentionCompleted = false;
+							break;
+						}
 						try {
 							const archivePath = path.join(rotatedLogDir, file);
-							// The rotated directory defaults to the log directory itself
-							// (`logging.rotation.path` defaults to `log`, as does `logging.root`), so it also
-							// holds the logs currently being written — including a component's, which loads in
-							// a worker and is only known here because the peers reported it.
+							// An explicitly configured rotation path may contain live component logs too.
 							if (liveLogs.has(path.resolve(archivePath))) continue;
 							// Unlinking an inode a stalled writer still holds loses whatever it writes next
 							// just as surely as compressing over it would.
@@ -204,23 +207,35 @@ function logRotator({
 								await fsProm.unlink(archivePath);
 							}
 						} catch (err) {
-							// The compression sweep above unlinks archives from this same listing.
 							if (err.code !== 'ENOENT') hdbLogger.error('Error trying to remove log', file, err);
 						}
 					}
+					if (retentionCompleted) reclamationPriority = 0;
+				}
+
+				if (released && compressArchives && !ended) {
+					const compressionFailure = await compressPendingArchives(rotatedLogDir, candidates, liveLogs, {
+						deadline: Math.min(tickDeadline, Date.now() + compressionBudgetMs),
+						shouldStop: () => ended,
+					});
+					if (compressionFailure)
+						hdbLogger.error('Error compressing rotated log', compressionFailure.file, compressionFailure.error);
 				}
 			}
-			// Last: retention is what bounds the rotated directory, so a stranded generation waiting on a
-			// peer must never be ahead of it.
-			await retryPendingGenerations();
 		} catch (err) {
 			hdbLogger.error('Error during log rotation audit tick for', logger.path, err);
 		} finally {
+			try {
+				await retryPendingGenerations({ deadline: tickDeadline, shouldStop: () => ended });
+			} catch (err) {
+				hdbLogger.error('Error retrying pending log generations for', logger.path, err);
+			}
 			tickInFlight = false;
 		}
-	}, auditInterval ?? LOG_AUDIT_INTERVAL).unref();
+	}, auditIntervalMs).unref();
 	return {
 		end() {
+			ended = true;
 			clearInterval(setIntervalId);
 		},
 		getLastRotatedLogPath() {

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -77,13 +77,19 @@ function logRotator({
 	}
 
 	let lastRotatedLogPath;
-	// convert date.now to minutes
 	let lastRotationTime = Date.now();
+	let observedGeneration;
+	try {
+		const active = statSync(logger.path);
+		observedGeneration = generationIdentity(active);
+		if (active.birthtimeMs > 0) lastRotationTime = Math.min(lastRotationTime, active.birthtimeMs);
+	} catch {}
 	hdbLogger.trace('Log rotate enabled, maxSize:', maxSize, 'interval:', interval);
 	let tickInFlight = false;
 	let ended = false;
 	let releaseProofStalled = false;
 	let nextReleaseProofReport = 0;
+	let retentionCursor = 0;
 	const auditIntervalMs = auditInterval ?? LOG_AUDIT_INTERVAL;
 	const compressionBudgetMs = Math.max(1, Math.floor(auditIntervalMs / 4));
 	/**
@@ -135,17 +141,16 @@ function logRotator({
 			}
 
 			if (maxInterval) {
-				// Whichever origin is older. birthtime is unsupported on some filesystems, where it mirrors
-				// a write-updated ctime and would postpone interval rotation forever; taking the minimum
-				// means this can only ever rotate at least as often as the counter alone did.
-				let generationStartedAt = lastRotationTime;
 				try {
-					const born = statSync(logger.path).birthtimeMs;
-					if (born > 0) generationStartedAt = Math.min(generationStartedAt, born);
+					const activeGeneration = generationIdentity(statSync(logger.path));
+					if (activeGeneration && activeGeneration !== observedGeneration) {
+						observedGeneration = activeGeneration;
+						lastRotationTime = Date.now();
+					}
 				} catch (err) {
 					if (err.code !== 'ENOENT') throw err;
 				}
-				if (Date.now() - generationStartedAt >= maxInterval) {
+				if (Date.now() - lastRotationTime >= maxInterval) {
 					try {
 						lastRotatedLogPath = await moveLogFile(logger.path, rotatedLogDir, logger, compressArchives);
 						lastRotationTime = Date.now();
@@ -194,11 +199,13 @@ function logRotator({
 					// adjust retention time if there is a reclamation priority in place
 					const retentionMs = convertToMS(retention ?? '1M') / (1 + reclamationPriority);
 					let retentionCompleted = true;
-					for (const file of candidates) {
+					let examined = 0;
+					for (; examined < candidates.length; examined++) {
 						if (ended || Date.now() >= tickDeadline) {
 							retentionCompleted = false;
 							break;
 						}
+						const file = candidates[(retentionCursor + examined) % candidates.length];
 						try {
 							const archivePath = path.join(rotatedLogDir, file);
 							// An explicitly configured rotation path may contain live component logs too.
@@ -214,7 +221,12 @@ function logRotator({
 							if (err.code !== 'ENOENT') hdbLogger.error('Error trying to remove log', file, err);
 						}
 					}
-					if (retentionCompleted) reclamationPriority = 0;
+					if (retentionCompleted) {
+						retentionCursor = 0;
+						reclamationPriority = 0;
+					} else if (candidates.length) {
+						retentionCursor = (retentionCursor + examined) % candidates.length;
+					}
 				}
 
 				if (released && compressArchives && !ended) {
@@ -246,6 +258,10 @@ function logRotator({
 			return lastRotatedLogPath;
 		},
 	};
+
+	function generationIdentity(stats: any) {
+		return stats.ino ? `${stats.dev}:${stats.ino}` : undefined;
+	}
 }
 
 async function moveLogFile(

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -22,6 +22,7 @@ import {
 
 // Interval in ms to check log file and decide if it should be rotated.
 const LOG_AUDIT_INTERVAL = 60000;
+const RELEASE_PROOF_REPORT_INTERVAL = 5 * 60 * 1000;
 const INT_SIZE_UNDEFINED_MSG =
 	"'interval' and 'maxSize' are both undefined, to enable logging rotation at least one of these values must be defined in harperdb-config.yaml";
 
@@ -82,6 +83,7 @@ function logRotator({
 	let tickInFlight = false;
 	let ended = false;
 	let releaseProofStalled = false;
+	let nextReleaseProofReport = 0;
 	const auditIntervalMs = auditInterval ?? LOG_AUDIT_INTERVAL;
 	const compressionBudgetMs = Math.max(1, Math.floor(auditIntervalMs / 4));
 	/**
@@ -172,15 +174,17 @@ function logRotator({
 				const { released, liveLogPaths } = await requestStaleDescriptorRelease(tickDeadline);
 				// A peer whose event loop is blocked never answers, and the whole pass then destroys
 				// nothing — correct, but it is also the only thing bounding the rotated directory, so an
-				// operator who configured retention has to be able to see that it has stopped. Latched
-				// rather than repeated, so a permanently stalled peer reports once per stall.
-				if (!released && !releaseProofStalled) {
+				// operator who configured retention has to be able to see that it has stopped. Repeat at
+				// a low rate so a permanent stall does not disappear after one warning.
+				if (!released && Date.now() >= nextReleaseProofReport) {
+					nextReleaseProofReport = Date.now() + RELEASE_PROOF_REPORT_INTERVAL;
 					releaseProofStalled = true;
 					hdbLogger.warn(
 						`Log rotation could not prove every thread released its archived log descriptors; compression and retention are paused for ${rotatedLogDir}`
 					);
 				} else if (released && releaseProofStalled) {
 					releaseProofStalled = false;
+					nextReleaseProofReport = 0;
 					hdbLogger.notify(`Log rotation descriptor release recovered; retention resumed for ${rotatedLogDir}`);
 				}
 				const liveLogs = new Set([...liveLogPaths, logger.path].map((p) => path.resolve(p)));
@@ -265,7 +269,8 @@ async function moveLogFile(
 	);
 	const publishedPath = await publishArchivedGeneration(
 		generation,
-		compress ?? envMgr.get(CONFIG_PARAMS.LOGGING_ROTATION_COMPRESS)
+		compress ?? envMgr.get(CONFIG_PARAMS.LOGGING_ROTATION_COMPRESS),
+		(error) => hdbLogger.error('Error compressing rotated log', generation.archivePath, error)
 	);
 
 	// This notify log will create a new log file after the previous one has been rotated. It's important to keep this log as notify

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -11,6 +11,7 @@ import * as hdbUtils from '../utility/common_utils.ts';
 import * as hdbTerms from '../utility/hdbTerms.ts';
 import { getDomainSocketPathMaxBytes } from '../utility/domainSocket.ts';
 import { bareHostViolation } from '../utility/nodeIdentity.ts';
+import { parseMaxSize } from '../utility/logging/logRotation.ts';
 import * as validator from './validationWrapper.ts';
 
 const DEFAULT_LOG_FOLDER = 'log';
@@ -19,7 +20,7 @@ const INVALID_SIZE_UNIT_MSG = 'Invalid logging.rotation.maxSize unit. Available 
 const INVALID_INTERVAL_UNIT_MSG =
 	'Invalid logging.rotation.interval unit. Available units are D (days), H (hours), M (months) or m (minutes)';
 const INVALID_MAX_SIZE_VALUE_MSG =
-	"Invalid logging.rotation.maxSize value. Value should be a number followed by unit e.g. '10M'";
+	"Invalid logging.rotation.maxSize value. Value should be a positive number followed by unit e.g. '10M'";
 const INVALID_INTERVAL_VALUE_MSG =
 	"Invalid logging.rotation.interval value. Value should be a number followed by unit e.g. '10D'";
 const INVALID_RETENTION_UNIT_MSG =
@@ -501,8 +502,9 @@ function validateRotationMaxSize(value, helpers) {
 		return helpers.message(INVALID_SIZE_UNIT_MSG);
 	}
 
-	const size = value.slice(0, -1);
-	if (isNaN(parseInt(size))) {
+	// The same parser the write-path size check uses, so a value accepted here can never become a
+	// zero, negative or NaN byte limit downstream. `parseInt` alone accepted '0K', '-1K' and '1xK'.
+	if (!parseMaxSize(value)) {
 		return helpers.message(INVALID_MAX_SIZE_VALUE_MSG);
 	}
 


### PR DESCRIPTION
`logging.rotation.maxSize` is now enforced by every file-writing isolate, so a busy HTTP worker no longer grows the active log until the main thread's 60-second audit tick. The sink counts the bytes it actually appends and invokes the [write-path rotation guard](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-cde66fc5c81773a66e7af2e438e0730dbc3f44a99cc2835b26726729048b2c11R275) at a fixed `maxSize / 16` checkpoint; an already-oversized file rotates on the next append. The final hot path [encodes each batch once](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-22ec5442298b8e9a003e550f7164aa5bbce8d0395aaef06720baeafd92308baaR972), uses that buffer for the append, and records its exact byte length.

Rotation is split into a synchronous rename/descriptor release and an asynchronous publish step. Before compression or retention can unlink an archive, the [generation coordinator](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-c4e280f5946af493a4ee91dfca05681b61528bca5821e213bc83be4ce2da6f18R128) asks every enumerable in-process peer to close a descriptor still pointing at that inode. An unproven generation remains plain and is retried. Workers that have not received the thread transport cannot claim an empty peer set as proof, pending release requests are bounded, and [only the main thread may destructively publish an archive](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-cde66fc5c81773a66e7af2e438e0730dbc3f44a99cc2835b26726729048b2c11R114) because its worker roster is authoritative.

The follow-up fixes in this pass close the review findings on the existing PR:

- Runtime removal of `logging.rotation` now retracts the guard owned by that configuration source, while explicit component policies keep precedence over inherited main policies. Re-adding either source reclaims the cached sink safely through the [policy-source arbitration](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-22ec5442298b8e9a003e550f7164aa5bbce8d0395aaef06720baeafd92308baaR863).
- Compression catch-up and retention use a deadline rather than a four-file ceiling. One compression failure no longer starves later archives, a busy compression leaves work for the next tick, and the retention cursor resumes fairly when a pass exhausts its budget.
- A failed archive rename no longer diverts all future file logs to daemon stdio. Appends continue to the active file, the cap may temporarily be exceeded, and a parseable in-file diagnostic is prepended on the next successful append.
- Interval rotation notices when another isolate replaced the active generation and restarts its clock, preventing a freshly-created log from being rotated immediately by a stale timer.
- The end-to-end test now asserts [every request marker exactly once](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-b2fb589e3adc69b737bf57e661612c5da54a45e2c7a5e763de1f42227a1a574dR123) across active and compressed generations and separately proves that removing the rotation policy reaches both HTTP workers.

## For the human reviewer

Please focus on the lifecycle and failure-policy choices below.

- The release proof covers peers enumerable through this process's worker mesh; it does not cover another OS process writing the same path. A worker can still briefly miss a newly admitted peer, but its local proof now only prompts descriptor release and leaves the archive plain; the main-thread audit obtains a fresh proof from its authoritative roster before compression or retention. A separate OS process remains outside that roster, so default `compress: false` with no retention is non-destructive while configured compression/retention still carries that cross-process limitation.
- A blocked worker deliberately pauses both compression and retention because destroying an inode it may still hold can lose buffered records. The audit emits a warning every five minutes while stalled and a recovery notice afterward. This preserves logs but can let the archive directory grow despite configured retention.
- Compression publishes via temp-file rename but does not `fsync` the gzip before replacing the authoritative name. A process crash leaves the plain archive intact; an abrupt host/storage failure can theoretically leave a present but non-durable gzip that a later sweep trusts. Crash-left `.tmp` files can also persist indefinitely when retention is unset.
- Invalid values such as `0K`, `-1K`, and `1xK` are now rejected by config validation instead of booting with broken historical behavior. That is intentional strictness, but it can make an upgrade fail fast on an existing typo.
- An explicit component rotation policy for the same file retains the historical last-explicit-owner precedence over inherited main policy. Removing the explicit policy restores main inheritance; removing both clears the guard.
- Retention and its release gate have extensive unit coverage but no full-server deletion assertion. The HTTP integration test covers real two-worker rotation, gzip publication, exactly-once markers, and runtime policy removal. Its fallback archive directory is under the OS temp root; the focused run was same-device, while a runner mounting `/tmp` separately from Harper's data root would exercise the EXDEV refusal instead.
- Two consecutive Gemini passes disagreed about append encoding: the first called the prior string write plus `Buffer.byteLength` a major double-scan and requested one buffer; the final pass requested reverting because of buffer allocation. The buffer is retained because `appendFileSync` must encode the string anyway, while this form reuses that encoding for exact accounting. Claude independently traced this path and found it sound.

The framing gate cleared before implementation: `Framing-Verdict: chosen-approach-sound (22fe112820ec)`. The final exact-head review covered the complete diff with Gemini at `4c0ef25b3bf0`; the Claude grader failed at startup and the domain adjudicator timed out, so neither is claimed as final-head coverage. Gemini's repeated buffer-allocation concern was adjudicated against the write path: retaining the buffer avoids separately scanning with `Buffer.byteLength` and then encoding the same string again inside `appendFileSync`. Its additional memory-stress-test request and aggregated comment-cleanup nit identified no failing behavior in this CI repair.

## Changes

- The analytics task-queue probe in [resources/analytics/write.ts](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-f1e47c8ff8e65d10e6aa737a8eb28cf19219efe000ea2890bedc6b013cb955c4R907) now treats a log-path `ENOENT` race as a completed latency round trip instead of an unhandled rejection when another isolate rotates the file.
- [server/threads/logRotationTransport.ts](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-a0f78930589f1806895163c65f9006df1c5c37caf037b6c50a59e4f30fc28a90R1) adapts the existing thread mesh to the generation coordinator without reversing the logging-to-thread dependency, and [server/threads/manageThreads.js](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-02c28577c2ca63129ed10809ce3db1469c70bef080e04fd273f8cbd510b6521bR1596) installs that adapter only after its thread-exit hooks exist.
- The audit rotator in [utility/logging/logRotator.ts](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-ef748258d2f3272624c4f884139aa041682e9d9eead288206ccd0cdddf578c78R11) now shares the synchronous generation primitives, gates destructive compression/retention on peer release, bounds sweep work by time, resumes retention fairly, and contains tick failures without overlapping passes.
- [validation/configValidator.ts](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-aeee467d8401b59eaffd099dd61547bbf4a63b0198e2be2dc0fe55d06c284cb0R505) uses the runtime's `parseMaxSize` implementation, so accepted configuration cannot become a zero, negative, or `NaN` write-path limit.

## Verification

- `npm run build` at `4c0ef25b3bf0` — passed.
- `npx mocha "unitTests/utility/logging/**/*.test.js"` at `4c0ef25b3bf0` — 190 passing, 14 pending. The added [main-thread publication](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-0740149e0ea8986d460a5dbd25572519433e5c551d0b73d715299ebf656600e8R117), [zero-inode release](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-c4e280f5946af493a4ee91dfca05681b61528bca5821e213bc83be4ce2da6f18R168), [buffered-diagnostic wait](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-5305ab395a92c37278874d49421e9e2258d790ac64f5ab0f7f416a91fa52bda1R323), and [worker fixture transport](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-24dfab84ec07cbd39ba2e3a0d2f1be39b43c1d543b8305b50499b9ef33043818R6) cases all passed.
- `npm run test:integration -- integrationTests/server/log-rotation-write-path.test.ts` at `4c0ef25b3bf0` — 2 passing. The test uses the [platform-observable worker count](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-b2fb589e3adc69b737bf57e661612c5da54a45e2c7a5e763de1f42227a1a574dR24) while retaining two-worker Node/Linux coverage.
- The integration fixture's [component mapping](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-16e74f28ddb987dde0c1b9a07644b2a67e4d545f5f900934bf722f0c32eaa073R1), [private package metadata](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-aad2f218f92a410501eb0873feac43988b0a7cee0dc29e082b5a149d8f7c21a9R1), and [request-driven worker logger](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-c3022fe86a83a21fe667f17103b8a01e9b5ac78f6b7c27cbacc09ad25e5e6f0aR1) drive the real HTTP-worker write path rather than a direct logging helper.
- The earlier same-commit focused Bun run recorded 2 passing. A fresh rerun on this worker could not start because `bun` is unavailable (`spawn bun ENOENT`); pushed-head Bun CI is the authoritative rerun.
- [unitTests/utility/logging/harper_logger.test.js](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-8c33beb56189cc9ff99eae34414ae37a65c1e99da970ef11cd57d30bd24e88e9R937) covers pathless setup and every inherited/explicit rotation-policy ownership transition on isolated paths; [unitTests/utility/logging/logRotator.test.js](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-d4bc187e1a3bd090f79ae354250749642065ca254d7fbb544d2b86a610ac7db9R73) covers compression catch-up, duplicate cleanup, live-log protection, interval resets, failure continuation, and shutdown.
- [unitTests/validation/configValidator.test.js](https://github.com/HarperFast/harper/pull/2475/changes?w=1#diff-bfc0bd3b280a1b03fa7b7c6d83f595f3d56383c4e877b739bd149d588acf68a8R507) covers rejected unusable size values and preserves accepted decimal/exponent forms.
- `npm run test:unit:resources` — 1,943 passing, 28 pending.
- `npm run test:unit:main` — 5,319 passing, 196 pending, 12 unrelated/environment failures: the existing Git credentials assertion, ten component-loader cases blocked by this deep worktree resolving dependencies outside its containment rule, and the domain-socket path-length assertion.
- Prettier and oxlint passed on all six files changed by `4c0ef25b3bf0`; `git diff --check origin/main...HEAD` also passed. Full lint still reports 13 pre-existing warnings outside this diff.
- `npm run test:unit:windows` could not start locally because the gate hard-codes a worktree-local `node_modules/mocha/bin/mocha.js`; this checkout uses the parent install. The focused cross-platform worker coverage passed locally.
- The full integration sweep encountered unrelated harness/service failures (including Ollama import/service setup and pre-existing fixtures); the focused logging integration passed independently.

Refs #1877

Complexity: complicated

Comment generated by Codex (GPT-5)

<sub>Review-Coverage: authored=codex; ran=gemini; blocked=claude(exit-1),domain(timeout); declined=cursor-grok,cursor-composer; rounds=8 @ 4c0ef25b3bf0</sub>

<sub>Human-Review-Need: 3 @ 4c0ef25b3bf0</sub>
