### PR TITLE
Size tables for query planning with the O(1) RocksDB key estimate instead of a full key-space scan (backport #2163 to v5.1)

### DIFF
--- a/resources/search.ts
+++ b/resources/search.ts
@@ -1008,7 +1008,7 @@ export function estimateCondition(table) {
 					for (const subCondition of condition.conditions) {
 						estimateConditionForTable(subCondition);
 						estimatedCount = isFinite(estimatedCount)
-							? (estimatedCount * subCondition.estimated_count) / estimatedEntryCount(table.primaryStore)
+							? (estimatedCount * subCondition.estimated_count) / (estimatedEntryCount(table.primaryStore) || 1)
 							: subCondition.estimated_count;
 					}
 				}
@@ -1051,8 +1051,10 @@ export function estimateCondition(table) {
 				const attribute_name = condition[0] ?? condition.attribute;
 				const index = table.indices[attribute_name];
 				if (condition.value === null && searchType === 'ne') {
-					condition.estimated_count =
-						estimatedEntryCount(table.primaryStore) - (index ? index.getValuesCount(null) : 0);
+					condition.estimated_count = Math.max(
+						estimatedEntryCount(table.primaryStore) - (index ? index.getValuesCount(null) : 0),
+						0
+					);
 				} else condition.estimated_count = Infinity;
 			} else if (searchType === 'in') {
 				const attribute_name = condition[0] ?? condition.attribute;
@@ -1496,16 +1498,18 @@ export function flattenKey(key) {
 	return key;
 }
 
-function estimatedEntryCount(store) {
+export function estimatedEntryCount(store) {
 	const now = Date.now();
 	if ((store.estimatedEntryCountExpires || 0) < now) {
-		// use getStats for LMDB because it is fast path, otherwise RocksDB can handle fast path on its own
-		store.estimatedEntryCount = store instanceof RocksDatabase ? store.getKeysCount() : store.getStats().entryCount;
+		// getStats is the LMDB fast path; for RocksDB, estimate-num-keys is O(1) where an exact
+		// getKeysCount() would iterate the entire store
+		store.estimatedEntryCount =
+			store instanceof RocksDatabase ? store.getEstimatedKeyCount() : store.getStats().entryCount;
 		store.estimatedEntryCountExpires = now + 10000;
 	}
 	return store.estimatedEntryCount;
 }
 
 export function intersectionEstimate(store, left, right) {
-	return (left * right) / estimatedEntryCount(store);
+	return (left * right) / Math.max(estimatedEntryCount(store), 1);
 }

--- a/unitTests/resources/estimatedEntryCount.test.js
+++ b/unitTests/resources/estimatedEntryCount.test.js
@@ -1,0 +1,96 @@
+require('../testUtils');
+const assert = require('node:assert');
+const { RocksDatabase } = require('@harperfast/rocksdb-js');
+const { estimateCondition, estimatedEntryCount, intersectionEstimate } = require('#src/resources/search');
+
+describe('estimatedEntryCount', () => {
+	const { setupTestDBPath } = require('../testUtils');
+	const { table } = require('#src/resources/databases');
+	const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+	const N = 2000;
+	let T;
+
+	before(async function () {
+		this.timeout(120000);
+		setupTestDBPath();
+		setMainIsWorker(true);
+		T = table({
+			table: 'EntryCountTest',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }],
+		});
+		const written = [];
+		for (let i = 0; i < N; i++) {
+			written.push(T.put({ id: i }));
+		}
+		await Promise.all(written);
+		if (typeof T.primaryStore.flush === 'function') await T.primaryStore.flush();
+	});
+
+	it('reads the O(1) key-count estimate rather than iterating the store', function () {
+		const store = T.primaryStore;
+		// gate on the engine, not on the method: under RocksDB a renamed or dropped
+		// getEstimatedKeyCount must fail this guard rather than silently skip it
+		if (!(store instanceof RocksDatabase)) return this.skip();
+		store.estimatedEntryCountExpires = 0;
+		const getKeysCount = store.getKeysCount;
+		store.getKeysCount = () => assert.fail('estimatedEntryCount must not iterate the whole key space');
+		let estimate;
+		try {
+			estimate = estimatedEntryCount(store);
+		} finally {
+			store.getKeysCount = getKeysCount;
+		}
+		assert.ok(estimate >= N / 2 && estimate <= N * 2, `estimate ${estimate} is not in range for ${N} rows`);
+	});
+
+	it('memoizes the estimate for 10 seconds', () => {
+		const store = T.primaryStore;
+		store.estimatedEntryCountExpires = 0;
+		const first = estimatedEntryCount(store);
+		const { getEstimatedKeyCount, getStats } = store;
+		const reprobed = () => assert.fail('memoized estimate must not re-probe the store');
+		store.getEstimatedKeyCount = reprobed;
+		store.getStats = reprobed;
+		try {
+			assert.strictEqual(estimatedEntryCount(store), first);
+		} finally {
+			store.getEstimatedKeyCount = getEstimatedKeyCount;
+			store.getStats = getStats;
+		}
+	});
+});
+
+describe('a store estimating zero entries', () => {
+	// estimate-num-keys reports this for a populated table whose tombstones reach its non-deletions
+	const churned = { getStats: () => ({ entryCount: 0 }) };
+
+	it('is reported as zero rather than floored, so callers see the real count', () => {
+		assert.strictEqual(estimatedEntryCount(churned), 0);
+	});
+
+	it('keeps intersectionEstimate finite', () => {
+		churned.estimatedEntryCountExpires = 0;
+		assert.strictEqual(intersectionEstimate(churned, 5, 7), 35);
+	});
+
+	it('keeps a `ne null` estimate non-negative, so an estimated total is never below zero', () => {
+		churned.estimatedEntryCountExpires = 0;
+		const table = {
+			primaryKey: 'id',
+			primaryStore: churned,
+			indices: { attr: { getValuesCount: () => 500 } },
+			attributes: [],
+		};
+		const estimated = estimateCondition(table)({ attribute: 'attr', comparator: 'ne', value: null });
+		assert.strictEqual(estimated, 0);
+	});
+
+	it("keeps an AND group's estimate finite, so the adaptive index guard still applies", () => {
+		churned.estimatedEntryCountExpires = 0;
+		const table = { primaryKey: 'id', primaryStore: churned, indices: {}, attributes: [] };
+		const condition = { operator: 'and', conditions: [{ estimated_count: 10 }, { estimated_count: 20 }] };
+		const estimated = estimateCondition(table)(condition);
+		assert.strictEqual(estimated, 200);
+	});
+});


### PR DESCRIPTION
`estimatedEntryCount()` sized every table for query planning by calling `RocksDatabase.getKeysCount()` — a synchronous native iteration of the entire key space. On a 28.6M-row analytics table that is ~11s of blocked main thread per call, and its 10-second memo never took effect there: `now` is sampled *before* the call, so `now + 10000` is already in the past by the time it returns. The planner reaches it once per additional condition, so an N-condition query paid N−1 full scans — a 10-condition operation measured ~100s of main-thread stall with the Operations API unresponsive throughout, while the data plane kept answering in 1–3ms.

It now [reads the `rocksdb.estimate-num-keys` property](https://github.com/HarperFast/harper/pull/2477/changes?w=1#diff-e321acd3b1cfdafa43c8a2aec7d9b2d318880adfe8510b34571460057cc4f003R1507), which is O(1) and returned the identical count (28,668,898) on the affected table.

This is the `estimatedEntryCount` portion of #2163, which merged to `main` on 2026-08-31; the helper and `intersectionEstimate` are taken byte-identical from it. **No dependency bump is needed** — `getEstimatedKeyCount()` has been present since rocksdb-js 2.4.x, so v5.1's `~2.4.1` pin already carries it. The statistical range-estimate portion of #2163, which does require rocksdb-js 2.8.0, is deliberately excluded.

### The two guards, which are the addition beyond #2163

`estimate-num-keys` reports **0 for a populated table** once its accumulated tombstones reach its non-deletions. The exact count it replaces could not do that — a 0 there meant a genuinely empty store. Measured on rocksdb-js 2.4.1: a store holding 200 live records reports an estimate of 0 after 5000 tombstones for never-written keys, while `getKeysCount()` still returns 200.

Zero is still the *truthful* count, so the count is left alone and the two arithmetic sites that cannot take it are guarded instead:

| site | with a 0 estimate | guard | what it fixes |
|---|---|---|---|
| [AND-group branch divides by it](https://github.com/HarperFast/harper/pull/2477/changes?w=1#diff-e321acd3b1cfdafa43c8a2aec7d9b2d318880adfe8510b34571460057cc4f003R1011) | `Infinity` | `\|\| 1`, the idiom already on the sibling relationship divisor two branches below | plan selection |
| [`ne null` branch subtracts the index null count from it](https://github.com/HarperFast/harper/pull/2477/changes?w=1#diff-e321acd3b1cfdafa43c8a2aec7d9b2d318880adfe8510b34571460057cc4f003R1055) | negative (e.g. `-500`) | `Math.max(…, 0)` | a negative cardinality handed to a caller |

The divisor is the one that changes planning. The adaptive filter/index switch derives `thresholdRemainingMisses` as `estimated_count >> 4`, and `Infinity >> 4` is `0` rather than `NaN`, so the `isNaN` check passes it through and the first non-matching record flips the request onto `searchByIndex` plus a full `Set` build for the next 10 seconds — the inverse of the plan this change exists to protect. Guarded, [the same group estimates 200](https://github.com/HarperFast/harper/pull/2477/changes?w=1#diff-42c5c966b17439f7abe8eb2dd167749c3598f8352b947dc499101dce3486e089R89) and the threshold is a usable 12.

The subtraction does **not** change planning: `-32` and `0` both trip the switch on the first miss. It is guarded because a negative cardinality is not a value to hand to a caller — on `main`, `Table.ts` reports `estimated_count` verbatim as an estimated pagination total, so an empty page could answer `Content-Range: */-500`. The clamp is [at 0, not 1](https://github.com/HarperFast/harper/pull/2477/changes?w=1#diff-e321acd3b1cfdafa43c8a2aec7d9b2d318880adfe8510b34571460057cc4f003R1055): a table whose rows are all null has a true `ne null` count of zero, and flooring at 1 would trade a negative total for a phantom row. The same two guards go to `main` separately, since #2163 left them there.

For the record, my first justification for this second guard was that it protected the adaptive switch. That was wrong — review caught it — and the guard is kept on the narrower, real ground above.

## For the human reviewer

1. **Estimate accuracy, in both directions — the decision worth your attention.** `estimate-num-keys` counts entries across memtable and SSTs without reconciling overwrites, so it reads high on rewrite-heavy stores and collapses toward 0 once tombstones reach non-deletions. This repo already measured it: `DESIGN.md` records **37,775 against an exact 4,001** on a real HNSW index store, and concludes it "reads exact on a fresh store with simple puts, so it validates clean in isolation and only misleads on a real index" — which is why HNSW node counting uses a monotonic id counter instead. That matters here because the relationship estimate calls this helper on `table.indices[…]`, which is a `RocksIndexStore extends RocksDatabase`. The consequence is mis-sized range heuristics and condition ordering that can put a wide range ahead of a narrow indexed `equals`: plan *quality*, not correctness, and never wrong rows. It is #2163's trade, already merged on `main`, and this PR carries it unchanged rather than re-litigating it — but if you want the backport scoped to the primary store only, this is the place to say so. Reverting is one line and reinstates the ~11s-per-condition scan.
2. **The four multiplier call sites are deliberately left unguarded.** A 0 estimate makes `starts_with`/`between`/sort/open-range estimate 1 — finite and positive, so the `>> 4` guard still functions; only the divisor and the subtraction produce values it cannot handle. Guarding them would need a *representative* count, not a floor, which is the hard problem above.
3. **Guard at the arithmetic, not in the helper.** The first draft floored inside `estimatedEntryCount`. That is wrong on `main`, where `Table.ts` returns the value verbatim as the estimated pagination total for a condition-free query — an empty table would have answered `Content-Range: */1` with zero rows, and the clamp below it only ever raises a total. v5.1 has no such consumer, but the branches should not disagree about what the accessor means. [A unit test pins the count as 0](https://github.com/HarperFast/harper/pull/2477/changes?w=1#diff-42c5c966b17439f7abe8eb2dd167749c3598f8352b947dc499101dce3486e089R68).
4. **Two different idioms for the same invariant** (`|| 1` on the divisor, `Math.max(…, 0)` on the subtraction) reads inconsistent. It is deliberate: `|| 1` cannot catch a negative, and the two sites want different floors — 1 for a divisor, 0 for a cardinality.
5. **Residual, deliberately not fixed here.** `estimated_count >> 4` is not a safe way to derive a threshold from an unbounded estimate. It wraps negative above 2³¹ (`1e12 >> 4 === -45461248`), and its `isNaN` guard is dead code either way — `NaN >> 4` is `0`, so the check can never fire and a non-numeric estimate silently becomes threshold 0. Every pathology in this PR passes through that one expression. Review also surfaced a separate pre-existing defect in the same accumulator, which this PR does not touch: a zero-match condition followed by a full-scan comparator makes it `NaN` (`0 * Infinity`), and `isFinite(NaN)` being false then discards every estimate accumulated before it. The `|| 1` divisor is not involved — it is `NaN` for any divisor. Fixing that, or clamping an intersection to `min(|A|,|B|)` as set semantics require, is a planner-wide behavior change and wants its own PR on `main`.
6. **The `ne null` subtraction now mixes precisions.** Its subtrahend, `getValuesCount(null)`, is an exact index range count, while the minuend is now approximate — before this change both came from the same exact count. On a table after a bulk delete/reinsert cycle the estimate can fall below the live null count, so `ne null` clamps to 0 and the planner ranks it as the *most* selective condition. Worth knowing, though it is not made worse by the clamp: a negative sorted even more selective than 0. Same root as item 1.

## Verification

### Unit tests

`unitTests/resources/estimatedEntryCount.test.js` — 6 tests. All 6 pass under RocksDB; under `HARPER_STORAGE_ENGINE=lmdb` 5 pass and the RocksDB-specific one is pending. That test [gates on `store instanceof RocksDatabase`](https://github.com/HarperFast/harper/pull/2477/changes?w=1#diff-42c5c966b17439f7abe8eb2dd167749c3598f8352b947dc499101dce3486e089R34) rather than on `typeof store.getEstimatedKeyCount`, so a renamed or dropped binding method fails the guard loudly instead of silently skipping the one test that covers it. It asserts the returned estimate against an `[N/2, 2N]` band rather than comparing two live probes, so a background compaction between them cannot redden CI.

### Fails on base

Re-verified at the final head with `rm -rf dist` before each build, because `tsc` incremental will otherwise report a pass against stale output. The base is `origin/v5.1` **with only the `export` keyword added**, so the export is not what fails and behavior is the only variable:

| assertion | on base |
|---|---|
| does not iterate the key space | `estimatedEntryCount must not iterate the whole key space` |
| `intersectionEstimate` stays finite | `Infinity !== 35` |
| `ne null` estimate stays non-negative | `-500 !== 0` |
| AND-group estimate stays finite | `Infinity !== 200` |

4 of 6 fail on base. The other two pass there and should: the memo test is a regression guard, and the "count is reported as 0" test guards against the *wrong* fix rather than proving this one.

### Dependency claim

A review leg raised this as a blocker on the grounds that it could not be checked offline, so to be explicit about what was actually run: `@harperfast/rocksdb-js@2.4.1` was installed from the registry into a scratch project and exercised, not inferred from the version range or from typings. `RocksDatabase.prototype.getEstimatedKeyCount` is a function; its body (`getDBIntProperty('rocksdb.estimate-num-keys') ?? 0`) is identical to 2.8.0's; a live store of 5,000 records returned `{estimated: 5000, exact: 5000}`; and the tombstone case that motivates the guards was measured on that same 2.4.1 build — 200 live rows plus 5,000 tombstones for never-written keys gives `{estimated: 0, exact: 200}`. CI settles it independently, since it installs under the branch's own range and the new test calls the method directly.

That probe also rules out a `BigInt` return (which would throw inside `Math.max`): its result was serialized with `JSON.stringify`, which throws on a `BigInt` and did not.

### Suites

`test:unit:resources` — 1001 passing, 3 failing, all in `sourceApplyConflictRetry.test.js`. Those 3 reproduce identically on unmodified `origin/v5.1`: their premises assume the branch's pinned `~2.4.1` and this worktree resolves 2.8.0 through a shared `node_modules`. `test:unit:main` — 2987 passing, 18 failing, all in `globalIsolation.test.js` and `resolvePreload.test.js`, which reproduce on the pristine `main` checkout too (macOS resolves the temp dir through `/private/var`). CI is the authoritative run for both.

### Not covered

The tests prove no `Infinity` or negative escapes into a plan estimate. They do not prove the resulting plan is the *better* one on a churned table, and — per the `DESIGN.md` note above — the 2,000-row fixture is a fresh store with simple puts, which is precisely the profile the estimate reads accurately on. Neither the rewrite-inflated nor the tombstone-collapsed real-store case is covered; both need an end-to-end query against a churned table and are additive to this change.

Complexity: medium

<sub>Review-Coverage: authored=claude; ran=gemini,codex; adjudicated=domain; declined=cursor-grok,cursor-composer; rounds=7 @ 52e8c09c8fb0</sub>

<sub>Human-Review-Need: 4 (decisions: zero-floor-placement, estimate-vs-exact-for-ne-null, export-helper-for-testing, engine-gated-skip) @ 52e8c09c8fb0</sub>
