### PR TITLE
Guard the condition estimates that a zero RocksDB entry-count estimate turns into Infinity or a negative

### DIFF
--- a/resources/search.ts
+++ b/resources/search.ts
@@ -1216,7 +1216,7 @@ export function estimateCondition(table) {
 					for (const subCondition of condition.conditions) {
 						estimateConditionForTable(subCondition);
 						estimatedCount = isFinite(estimatedCount)
-							? (estimatedCount * subCondition.estimated_count) / estimatedEntryCount(table.primaryStore)
+							? (estimatedCount * subCondition.estimated_count) / (estimatedEntryCount(table.primaryStore) || 1)
 							: subCondition.estimated_count;
 					}
 				}
@@ -1266,8 +1266,10 @@ export function estimateCondition(table) {
 				const attribute_name = condition[0] ?? condition.attribute;
 				const index = table.indices[attribute_name];
 				if (condition.value === null && searchType === 'ne') {
-					condition.estimated_count =
-						estimatedEntryCount(table.primaryStore) - (index ? index.getValuesCount(null) : 0);
+					condition.estimated_count = Math.max(
+						estimatedEntryCount(table.primaryStore) - (index ? index.getValuesCount(null) : 0),
+						0
+					);
 				} else condition.estimated_count = Infinity;
 			} else if (searchType === 'in') {
 				const attribute_name = condition[0] ?? condition.attribute;

--- a/unitTests/resources/estimatedEntryCount.test.js
+++ b/unitTests/resources/estimatedEntryCount.test.js
@@ -1,0 +1,96 @@
+require('../testUtils');
+const assert = require('node:assert');
+const { RocksDatabase } = require('@harperfast/rocksdb-js');
+const { estimateCondition, estimatedEntryCount, intersectionEstimate } = require('#src/resources/search');
+
+describe('estimatedEntryCount', () => {
+	const { setupTestDBPath } = require('../testUtils');
+	const { table } = require('#src/resources/databases');
+	const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+	const N = 2000;
+	let T;
+
+	before(async function () {
+		this.timeout(120000);
+		setupTestDBPath();
+		setMainIsWorker(true);
+		T = table({
+			table: 'EntryCountTest',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }],
+		});
+		const written = [];
+		for (let i = 0; i < N; i++) {
+			written.push(T.put({ id: i }));
+		}
+		await Promise.all(written);
+		if (typeof T.primaryStore.flush === 'function') await T.primaryStore.flush();
+	});
+
+	it('reads the O(1) key-count estimate rather than iterating the store', function () {
+		const store = T.primaryStore;
+		// gate on the engine, not on the method: under RocksDB a renamed or dropped
+		// getEstimatedKeyCount must fail this guard rather than silently skip it
+		if (!(store instanceof RocksDatabase)) return this.skip();
+		store.estimatedEntryCountExpires = 0;
+		const getKeysCount = store.getKeysCount;
+		store.getKeysCount = () => assert.fail('estimatedEntryCount must not iterate the whole key space');
+		let estimate;
+		try {
+			estimate = estimatedEntryCount(store);
+		} finally {
+			store.getKeysCount = getKeysCount;
+		}
+		assert.ok(estimate >= N / 2 && estimate <= N * 2, `estimate ${estimate} is not in range for ${N} rows`);
+	});
+
+	it('memoizes the estimate for 10 seconds', () => {
+		const store = T.primaryStore;
+		store.estimatedEntryCountExpires = 0;
+		const first = estimatedEntryCount(store);
+		const { getEstimatedKeyCount, getStats } = store;
+		const reprobed = () => assert.fail('memoized estimate must not re-probe the store');
+		store.getEstimatedKeyCount = reprobed;
+		store.getStats = reprobed;
+		try {
+			assert.strictEqual(estimatedEntryCount(store), first);
+		} finally {
+			store.getEstimatedKeyCount = getEstimatedKeyCount;
+			store.getStats = getStats;
+		}
+	});
+});
+
+describe('a store estimating zero entries', () => {
+	// estimate-num-keys reports this for a populated table whose tombstones reach its non-deletions
+	const churned = { getStats: () => ({ entryCount: 0 }) };
+
+	it('is reported as zero rather than floored, so callers see the real count', () => {
+		assert.strictEqual(estimatedEntryCount(churned), 0);
+	});
+
+	it('keeps intersectionEstimate finite', () => {
+		churned.estimatedEntryCountExpires = 0;
+		assert.strictEqual(intersectionEstimate(churned, 5, 7), 35);
+	});
+
+	it('keeps a `ne null` estimate non-negative, so an estimated total is never below zero', () => {
+		churned.estimatedEntryCountExpires = 0;
+		const table = {
+			primaryKey: 'id',
+			primaryStore: churned,
+			indices: { attr: { getValuesCount: () => 500 } },
+			attributes: [],
+		};
+		const estimated = estimateCondition(table)({ attribute: 'attr', comparator: 'ne', value: null });
+		assert.strictEqual(estimated, 0);
+	});
+
+	it("keeps an AND group's estimate finite, so the adaptive index guard still applies", () => {
+		churned.estimatedEntryCountExpires = 0;
+		const table = { primaryKey: 'id', primaryStore: churned, indices: {}, attributes: [] };
+		const condition = { operator: 'and', conditions: [{ estimated_count: 10 }, { estimated_count: 20 }] };
+		const estimated = estimateCondition(table)(condition);
+		assert.strictEqual(estimated, 200);
+	});
+});


### PR DESCRIPTION
#2163 switched RocksDB plan sizing from an exact `getKeysCount()` full-key-space scan to the O(1) `rocksdb.estimate-num-keys` read. That property reports **0 for a populated table** once its accumulated tombstones reach its non-deletions, which the exact count could not do — a 0 there meant a genuinely empty store. Measured on the shipped binding: a store holding 200 live records reports an estimate of 0 after 5000 tombstones for keys that were never written, while `getKeysCount()` still returns 200.

Two arithmetic sites in `estimateConditionForTable` cannot take a 0 there:

| site | with a 0 estimate | guard | what it fixes |
|---|---|---|---|
| [the AND-group branch divides by it](https://github.com/HarperFast/harper/pull/2479/changes?w=1#diff-e321acd3b1cfdafa43c8a2aec7d9b2d318880adfe8510b34571460057cc4f003R1219) | `estimated_count === Infinity` | `\|\| 1`, the idiom already on the sibling relationship divisor two branches below | plan selection |
| [the `ne null` branch subtracts the index null count from it](https://github.com/HarperFast/harper/pull/2479/changes?w=1#diff-e321acd3b1cfdafa43c8a2aec7d9b2d318880adfe8510b34571460057cc4f003R1270) | negative (e.g. `-500`) | `Math.max(…, 0)` | a negative public estimated total |

**The divisor breaks planning.** The adaptive filter/index switch derives `thresholdRemainingMisses` as `estimated_count >> 4`, and `Infinity >> 4` is `0` rather than `NaN`, so the `isNaN` check passes it through, `canUseIndex` stays true with a threshold the loop can never respect, and the first non-matching record flips the request onto `searchByIndex` plus a full `Set` build, memoized for the next 10 seconds — the inverse of the plan #2163 exists to protect, on exactly the eviction- and replication-heavy tables that accumulate tombstones. Guarded, [the same group estimates 200](https://github.com/HarperFast/harper/pull/2479/changes?w=1#diff-42c5c966b17439f7abe8eb2dd167749c3598f8352b947dc499101dce3486e089R89) and the threshold is a usable 12.

**The subtraction does not.** `-32` and `0` both trip the switch on the first miss, so clamping it changes no plan. It matters because `Table.ts` reports `estimated_count` verbatim as the estimated pagination total, so an empty page could answer `Content-Range: */-500` — the clamp below that call only ever raises a total, never lowers it. [`Math.max(…, 0)` rather than 1](https://github.com/HarperFast/harper/pull/2479/changes?w=1#diff-e321acd3b1cfdafa43c8a2aec7d9b2d318880adfe8510b34571460057cc4f003R1270), because a table whose rows are all null has a true `ne null` count of zero and flooring at 1 would trade a negative total for a phantom row.

`estimatedEntryCount` itself keeps returning 0 for the same reason: it is not planner-private, so flooring it in the helper would make an empty table report a record count of 1 — [pinned by a test](https://github.com/HarperFast/harper/pull/2479/changes?w=1#diff-42c5c966b17439f7abe8eb2dd167749c3598f8352b947dc499101dce3486e089R68).

The same two guards ship to v5.1 and v5.2 alongside the backport of #2163's `estimatedEntryCount` portion, so those branches do not inherit this.

## For the human reviewer

1. **Estimate accuracy is the standing trade, not this PR's.** `estimate-num-keys` counts entries without reconciling overwrites, so it reads high on rewrite-heavy stores and collapses to 0 under tombstones. `DESIGN.md` records **37,775 against an exact 4,001** on a real HNSW index store, and notes it "validates clean in isolation and only misleads on a real index" — which is why HNSW node counting uses a monotonic id counter. This PR does not change that; it only removes the two values the `>> 4` guard provably cannot handle. The four *multiplier* call sites stay unguarded on purpose: a 0 estimate makes them 1, which is finite and positive, so the guard still functions — they degrade ordering, which is #2163's trade.
2. **Guard placement — arithmetic vs helper.** The first draft floored inside `estimatedEntryCount`, which is the tidier-looking fix and covers all ten call sites at once. It is wrong for the reason above: the accessor has two contracts, a planner input and a user-visible cardinality, and only the former needs a positive value. If you'd rather see a separate planner-only accessor wrapping the raw one, that is a reasonable alternative and a bigger diff.
3. **Two idioms for one invariant.** `|| 1` on the divisor, `Math.max(…, 0)` on the subtraction. Deliberate: `|| 1` cannot catch a negative, and the sites want different floors — 1 for a divisor, 0 for a cardinality.
4. **What this does not fix.** `estimated_count >> 4` is not a safe way to derive a threshold from an unbounded estimate. It wraps negative above 2³¹ (`1e12 >> 4 === -45461248`), and its `isNaN` guard is dead code regardless — `NaN >> 4` is `0`, so the check can never fire. Every pathology this PR removes passes through that one expression, which is the real thing to fix. Review also surfaced a separate pre-existing defect in the same accumulator, which this PR does not touch: a zero-match condition followed by a full-scan comparator makes it `NaN` (`0 * Infinity`), and `isFinite(NaN)` being false then discards every estimate accumulated before it. The `|| 1` divisor is not involved — it is `NaN` for any divisor. And the underlying estimate is inaccurate in both directions — inflated under overwrite churn, collapsed under tombstones — so condition ordering can still put a wide range ahead of a narrow indexed `equals`. Those are plan-quality problems, not correctness ones, and each wants its own change; this PR only removes the values the guard provably cannot handle.

## Verification

`unitTests/resources/estimatedEntryCount.test.js` — 6 tests, all passing under RocksDB; 5 passing and 1 pending under `HARPER_STORAGE_ENGINE=lmdb`. The RocksDB-specific test [gates on `store instanceof RocksDatabase`](https://github.com/HarperFast/harper/pull/2479/changes?w=1#diff-42c5c966b17439f7abe8eb2dd167749c3598f8352b947dc499101dce3486e089R34) rather than on `typeof store.getEstimatedKeyCount`, so a renamed or dropped binding method fails the guard loudly instead of silently skipping the one test that covers it.

Fails on base against `origin/main`, with `rm -rf dist` before each build because `tsc` incremental will otherwise report a pass against stale output: `Infinity !== 200` for the AND-group estimate and `-500 !== 0` for the `ne null` estimate — the two values this PR removes. The other four pass on base and should: `main` already has the O(1) swap and the `intersectionEstimate` clamp, and the "count is reported as 0" test guards against the *wrong* fix rather than proving this one.

The tombstone premise was measured, not argued: on the shipped binding, 200 live rows plus 5000 tombstones for never-written keys gives `{estimated: 0, exact: 200}`.

`test:unit:resources` — 2003 passing, 0 failing. `test:unit:main` did not complete in this worktree: it wedges in the `before all` hook of a git-tag test (`resolves a local tag to its commit SHA`), which needs tag/remote state the worktree does not have, and never reaches a summary. Not related to this diff — the same suite runs to completion in a v5.1 worktree — but stating it rather than reporting a pass I did not observe. CI is the authoritative run.

Not covered: the tests prove no `Infinity` or negative escapes into a plan estimate. They do not prove the resulting plan is the better one on a churned table, and the 2,000-row fixture is a fresh store with simple puts — precisely the profile `DESIGN.md` says the estimate reads accurately on. Neither the rewrite-inflated nor the tombstone-collapsed real-store case is covered; both need an end-to-end query against a churned table and are additive.

Complexity: medium

<sub>Review-Coverage: authored=claude; ran=gemini,codex; adjudicated=domain; declined=cursor-grok,cursor-composer; rounds=3 @ 64b408a8ecc5</sub>

<sub>Human-Review-Need: 3 (decisions: ne-null-clamp-to-zero, divisor-floor-vs-product-cap, guard-at-call-sites-vs-in-the-helper, stub-store-test-scope) @ 64b408a8ecc5</sub>
