### PR TITLE
test(mqtt): promote QA-649 MQTT connect wedge regression anchor

### DIFF
--- a/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
+++ b/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
@@ -1,0 +1,455 @@
+/**
+ * Promoted from qa-explorer (QA-649 / P-425): pins that an MQTT connect attempt, on any
+ * transport, never wedges (neither completes nor errors) across an `http_workers` restart —
+ * the MQTT-side companion to the REST-side restart contract in
+ * deploy-restart-topic-availability.test.ts.
+ *
+ * QA-649 — does an MQTT connect wedge (neither complete nor error) across an HTTP-worker
+ * restart, as seen in a prior cluster experiment where `mqtt.connect()` over the WebSocket
+ * `/mqtt` endpoint, fired right after `restart_service {service:'http_workers'}`, sat forever
+ * (600s+) with no `connectTimeout` firing and no further connection attempts in the log?
+ *
+ * Background established by QA-642 (integrationTests/qa-scratch/qa642-restart-contract.test.ts):
+ * `restart_service`'s initial HTTP 200 is launch-only (job CREATED/IN_PROGRESS), not "restart
+ * complete" — but `get_job` reaching COMPLETE DOES correlate with the HTTP worker threadIds
+ * having actually, fully rotated. So `get_job` COMPLETE is the correct completion signal to poll
+ * for; the outer 200 is not. This test reuses that idiom (poll get_job, never the fire-and-forget
+ * `restartHttpWorkers()` shared helper, which discards the job id and would race the very window
+ * under test).
+ *
+ * Method: fire MQTT connect attempts on a fixed cadence (WS /mqtt every 50ms; raw TCP :1883 every
+ * 100ms; TLS :8883 every 200ms — coarser cadences on the contrast surfaces purely to bound total
+ * concurrent client count, not because they matter less) spanning [1s warm-up] -> [restart_service
+ * trigger] -> [get_job poll to COMPLETE] -> [2s tail]. Every attempt is bounded: mqtt.js
+ * `connectTimeout` + our own wall-clock cap (WALL_CLOCK_MS) via a manual timer, so a real wedge is
+ * *measured* (kind: 'wedged') rather than hanging the test. Every attempt is fully accounted for:
+ * exactly one of completed / refused / wedged.
+ *
+ * Oracle, both sides:
+ *   - client side: did 'connect' fire (completed), 'error'/'close' fire pre-connack (refused), or
+ *     neither within the bounded window (wedged)?
+ *   - server side: {dataRootDir}/log/hdb.log at logging.level 'trace' — server/mqtt.ts logs
+ *     `Received WebSocket connection for MQTT from` / `Received TCP connection for MQTT from` /
+ *     `Received SSL connection for MQTT from` at the moment the TRANSPORT (WS upgrade / raw
+ *     socket) is accepted, BEFORE the MQTT CONNECT packet is even parsed. If the count of these
+ *     "accepted" log lines during the restart window exceeds the count of client-side 'completed'
+ *     outcomes for the same surface/window, that is server-side proof some connections were
+ *     accepted at the transport level but never finished the MQTT handshake — the wedge shape
+ *     described in the scenario, not a client-side illusion (a past QA finding was retracted for
+ *     exactly this kind of one-sided evidence).
+ *
+ * Stage-2 gate: 2/2 cold runs green against Harper SHA 1e1edc666.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { resolve, join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { randomUUID } from 'node:crypto';
+
+import mqtt, { type IClientOptions, type MqttClient } from 'mqtt';
+
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'qa649-mqtt-restart-wedge');
+const WORKERS = 4; // need >1 for a real "rotate them all" restart, matching QA-642's rationale
+
+// mqtt.js's WebSocket transport doesn't complete CONNACK on Bun, and `restart_service` crashes
+// the instance on Windows (harper#549) — the same skips the sibling MQTT and restart suites carry.
+const skipSuite = process.env.HARPER_RUNTIME === 'bun' || process.platform === 'win32';
+
+// Per-attempt bounds. WALL_CLOCK_MS is the hard measurement cap: an attempt that hits this without
+// 'connect'/'error'/'close' is classified 'wedged'. mqtt.js's own connectTimeout is set shorter so
+// mqtt.js's internal watchdog gets a chance to fire first if it's going to — if it DOESN'T fire and
+// we still hit WALL_CLOCK_MS, that's itself an interesting sub-finding (mqtt.js's own timeout is
+// wedged too, matching the "no connectTimeout fired" detail from the prior cluster report).
+const MQTT_JS_CONNECT_TIMEOUT_MS = 6000;
+const WALL_CLOCK_MS = 10_000;
+const LATE_GRACE_MS = 5000; // extra observation window on a capped subset of wedged clients, to see if they self-heal
+const LATE_WATCH_CAP = 6; // per surface
+
+const WARMUP_MS = 1000;
+const TAIL_MS = 2000;
+
+interface AttemptResult {
+	surface: 'ws' | 'tcp' | 'tls';
+	seq: number;
+	launchedAt: number;
+	kind: 'completed' | 'refused' | 'wedged';
+	detail: string;
+	tEnd: number;
+	client: MqttClient;
+}
+
+function authOpts(ctx: ContextWithHarper, clientId: string): IClientOptions {
+	return {
+		protocolVersion: 5,
+		reconnectPeriod: 0,
+		connectTimeout: MQTT_JS_CONNECT_TIMEOUT_MS,
+		clean: true,
+		username: ctx.harper.admin.username,
+		password: ctx.harper.admin.password,
+		clientId,
+		rejectUnauthorized: false, // only meaningful for the TLS (mqtts) surface; harmless elsewhere
+	};
+}
+
+/** One bounded connect attempt. NEVER rejects/throws; always resolves within WALL_CLOCK_MS. */
+function attemptConnect(
+	url: string,
+	opts: IClientOptions
+): Promise<Omit<AttemptResult, 'surface' | 'seq' | 'launchedAt'>> {
+	const launchedAt = Date.now();
+	return new Promise((resolveOuter) => {
+		let classified = false;
+		let client: MqttClient;
+		try {
+			client = mqtt.connect(url, opts);
+		} catch (err: any) {
+			resolveOuter({
+				kind: 'refused',
+				detail: `sync throw: ${err?.message}`,
+				tEnd: Date.now(),
+				client: undefined as any,
+			});
+			return;
+		}
+		const finish = (kind: AttemptResult['kind'], detail: string) => {
+			if (classified) return;
+			classified = true;
+			clearTimeout(wedgeTimer);
+			resolveOuter({ kind, detail, tEnd: Date.now(), client });
+		};
+		client.once('connect', () => finish('completed', 'connack received'));
+		client.once('error', (err: any) => finish('refused', String(err?.code ?? err?.message ?? err)));
+		client.once('close', () => finish('refused', 'socket closed before connect/error'));
+		const wedgeTimer = setTimeout(() => {
+			finish(
+				'wedged',
+				`neither connect/error/close within ${WALL_CLOCK_MS}ms (mqtt.js connectTimeout=${MQTT_JS_CONNECT_TIMEOUT_MS}ms did not fire either)`
+			);
+		}, WALL_CLOCK_MS);
+		void launchedAt;
+	});
+}
+
+function endQuiet(client: MqttClient | undefined): Promise<void> {
+	return new Promise((resolveEnd) => {
+		if (!client) return resolveEnd();
+		try {
+			client.end(true, {}, () => resolveEnd());
+		} catch {
+			resolveEnd();
+		}
+	});
+}
+
+suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSuite }, (ctx: ContextWithHarper) => {
+	let procOutput = '';
+
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+			config: {
+				threads: { count: WORKERS },
+				logging: { root: 'log', level: 'trace', console: true },
+			},
+			env: {},
+		});
+
+		procOutput += ctx.harper.startupOutput?.stdout ?? '';
+		procOutput += ctx.harper.startupOutput?.stderr ?? '';
+		const proc = ctx.harper.process;
+		proc?.stdout?.on('data', (d: Buffer) => (procOutput += d.toString()));
+		proc?.stderr?.on('data', (d: Buffer) => (procOutput += d.toString()));
+
+		// Poll the probe route directly for non-404 — deliberately NOT restartHttpWorkers() (fire-
+		// and-forget; would race the readiness wait against the same class of bug under test).
+		const deadline = Date.now() + 120_000;
+		while (Date.now() < deadline) {
+			try {
+				const res = await fetch(`${ctx.harper.httpURL}/Probe/`, {
+					headers: {
+						Authorization: `Basic ${Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64')}`,
+					},
+					signal: AbortSignal.timeout(2000),
+				});
+				if (res.status !== 404) break;
+			} catch {
+				/* not ready yet */
+			}
+			await sleep(150);
+		}
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	function authHeader() {
+		return `Basic ${Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64')}`;
+	}
+
+	async function opsCall(body: unknown, timeoutMs = 5000) {
+		try {
+			const res = await fetch(ctx.harper.operationsAPIURL, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', 'Authorization': authHeader(), 'Connection': 'close' },
+				body: JSON.stringify(body),
+				signal: AbortSignal.timeout(timeoutMs),
+			});
+			const text = await res.text();
+			let json: any;
+			try {
+				json = JSON.parse(text);
+			} catch {
+				json = text;
+			}
+			return { status: res.status, body: json };
+		} catch (err: any) {
+			return { status: -1, body: undefined, errCode: String(err?.cause?.code ?? err?.code ?? err?.message) };
+		}
+	}
+
+	function readServerLog(): string {
+		let text = procOutput;
+		const p = join(ctx.harper.dataRootDir, 'log', 'hdb.log');
+		if (existsSync(p)) {
+			try {
+				text += readFileSync(p, 'utf8');
+			} catch {
+				/* ignore */
+			}
+		}
+		const logDir = (ctx.harper as any).logDir as string | undefined;
+		if (logDir) {
+			for (const name of ['hdb.log', 'stdout.log', 'stderr.log']) {
+				const p2 = join(logDir, name);
+				if (existsSync(p2)) {
+					try {
+						text += readFileSync(p2, 'utf8');
+					} catch {
+						/* ignore */
+					}
+				}
+			}
+		}
+		return text;
+	}
+
+	function countMatches(text: string, re: RegExp): number {
+		return (text.match(re) || []).length;
+	}
+
+	test(
+		'MQTT connect storm (WS /mqtt, raw TCP :1883, TLS :8883) across restart_service http_workers',
+		{ timeout: 240_000 },
+		async () => {
+			const wsBase = ctx.harper.httpURL.replace(/^http/, 'ws');
+			const surfaces: Array<{ surface: 'ws' | 'tcp' | 'tls'; url: string; intervalMs: number }> = [
+				{ surface: 'ws', url: `${wsBase}/mqtt`, intervalMs: 50 },
+				{ surface: 'tcp', url: `mqtt://${ctx.harper.hostname}:1883`, intervalMs: 100 },
+				{ surface: 'tls', url: `mqtts://${ctx.harper.hostname}:8883`, intervalMs: 200 },
+			];
+
+			// --- Baseline usability probe per surface (bounded; skip a surface if unusable rather
+			// than treat harness/environment limitations as a Harper defect). ---
+			const usable = new Map<string, boolean>();
+			const skipReason = new Map<string, string>();
+			for (const s of surfaces) {
+				const r = await attemptConnect(s.url, authOpts(ctx, `qa649-probe-${s.surface}`));
+				usable.set(s.surface, r.kind === 'completed');
+				if (r.kind !== 'completed') skipReason.set(s.surface, `${r.kind}: ${r.detail}`);
+				await endQuiet(r.client);
+			}
+			for (const s of surfaces) {
+				console.log(
+					`[QA-649] baseline probe ${s.surface} (${s.url}): usable=${usable.get(s.surface)} ${skipReason.get(s.surface) ?? ''}`
+				);
+			}
+			ok(
+				usable.get('ws'),
+				`WS /mqtt surface must be usable at baseline for this experiment to be meaningful: ${skipReason.get('ws')}`
+			);
+
+			// --- Storm driver: fire connects on a fixed cadence per surface until stormOver ---
+			const results: AttemptResult[] = [];
+			const lateSelfHeals: Array<{ surface: string; seq: number; wedgedAt: number; lateConnectAt: number }> = [];
+			const lateWatchCount: Record<string, number> = { ws: 0, tcp: 0, tls: 0 };
+			let stormOver = false;
+
+			async function runStorm(surface: 'ws' | 'tcp' | 'tls', url: string, intervalMs: number) {
+				let seq = 0;
+				const pending: Array<Promise<void>> = [];
+				while (!stormOver) {
+					const mySeq = seq++;
+					const launchedAt = Date.now();
+					const clientId = `qa649-${surface}-${mySeq}-${randomUUID().slice(0, 6)}`;
+					const p = attemptConnect(url, authOpts(ctx, clientId)).then((r) => {
+						const rec: AttemptResult = { surface, seq: mySeq, launchedAt, ...r };
+						results.push(rec);
+						if (r.kind === 'completed') {
+							void endQuiet(r.client);
+						} else if (r.kind === 'wedged' && lateWatchCount[surface] < LATE_WATCH_CAP) {
+							lateWatchCount[surface]++;
+							const onLateConnect = () => {
+								lateSelfHeals.push({ surface, seq: mySeq, wedgedAt: r.tEnd, lateConnectAt: Date.now() });
+							};
+							r.client.once('connect', onLateConnect);
+							setTimeout(() => {
+								r.client.removeListener('connect', onLateConnect);
+								void endQuiet(r.client);
+							}, LATE_GRACE_MS);
+						} else {
+							void endQuiet(r.client);
+						}
+					});
+					pending.push(p);
+					await sleep(intervalMs);
+				}
+				await Promise.all(pending);
+			}
+
+			const stormPromises: Array<Promise<void>> = [];
+			for (const s of surfaces) {
+				if (usable.get(s.surface)) stormPromises.push(runStorm(s.surface, s.url, s.intervalMs));
+				else console.log(`[QA-649] skipping storm for surface '${s.surface}': ${skipReason.get(s.surface)}`);
+			}
+
+			// --- Warm-up: confirm live traffic before touching anything ---
+			await sleep(WARMUP_MS);
+			ok(results.length > 0, 'connect storm produced no attempts during warm-up -- harness problem');
+
+			// --- Trigger restart_service http_workers, capture job_id ---
+			const tBeforeRestart = Date.now();
+			const restartResp = await opsCall({ operation: 'restart_service', service: 'http_workers' }, 30_000);
+			const tAfterRestartResp = Date.now();
+			strictEqual(
+				restartResp.status,
+				200,
+				`restart_service should ack 200: ${restartResp.status} ${JSON.stringify(restartResp.body)}`
+			);
+			const jobId = (restartResp.body as any)?.job_id;
+			ok(jobId, `restart_service response carried no job_id: ${JSON.stringify(restartResp.body)}`);
+			console.log(`[QA-649] restart_service acked 200 in ${tAfterRestartResp - tBeforeRestart}ms, job_id=${jobId}`);
+
+			// --- Poll get_job to a terminal state (the real completion signal per QA-642) ---
+			let tJobComplete: number | undefined;
+			let finalJob: any;
+			{
+				const deadline = Date.now() + 60_000;
+				while (Date.now() < deadline) {
+					const r = await opsCall({ operation: 'get_job', id: jobId }, 3000);
+					const job = Array.isArray(r.body) ? r.body[0] : undefined;
+					if (job?.status === 'COMPLETE' || job?.status === 'ERROR') {
+						tJobComplete = Date.now();
+						finalJob = job;
+						break;
+					}
+					await sleep(20);
+				}
+			}
+			ok(tJobComplete, `get_job(${jobId}) never reached a terminal status within 60s`);
+			strictEqual(finalJob.status, 'COMPLETE', `restart job ended in ${finalJob.status}: ${JSON.stringify(finalJob)}`);
+			console.log(`[QA-649] get_job(${jobId}) COMPLETE at t+${tJobComplete! - tBeforeRestart}ms`);
+
+			// --- Tail: keep storming a bit past COMPLETE, to see whether the window truly closes ---
+			await sleep(TAIL_MS);
+			stormOver = true;
+			await Promise.all(stormPromises);
+
+			// Give any attempts launched right at the tail edge (up to WALL_CLOCK_MS + LATE_GRACE_MS
+			// to fully classify/self-heal-observe) time to finish before we analyze.
+			await sleep(WALL_CLOCK_MS + LATE_GRACE_MS + 500);
+
+			// ================= ANALYSIS =================
+			const serverLog = readServerLog();
+
+			function analyzeSurface(surface: 'ws' | 'tcp' | 'tls') {
+				const rs = results.filter((r) => r.surface === surface);
+				if (rs.length === 0) return null;
+				const completed = rs.filter((r) => r.kind === 'completed');
+				const refused = rs.filter((r) => r.kind === 'refused');
+				const wedged = rs.filter((r) => r.kind === 'wedged');
+				const preRestart = rs.filter((r) => r.launchedAt < tBeforeRestart);
+				const inWindow = rs.filter((r) => r.launchedAt >= tBeforeRestart && r.launchedAt < tJobComplete!);
+				const postComplete = rs.filter((r) => r.launchedAt >= tJobComplete!);
+				const wedgedInWindow = inWindow.filter((r) => r.kind === 'wedged');
+				const wedgedPostComplete = postComplete.filter((r) => r.kind === 'wedged');
+				const windowStart = wedged.length ? Math.min(...wedged.map((r) => r.launchedAt)) - tBeforeRestart : null;
+				const windowEnd = wedged.length ? Math.max(...wedged.map((r) => r.launchedAt)) - tBeforeRestart : null;
+
+				console.log(
+					`\n[QA-649][${surface}] total=${rs.length} completed=${completed.length} refused=${refused.length} wedged=${wedged.length}\n` +
+						`  pre-restart: ${preRestart.length} attempts, ${preRestart.filter((r) => r.kind === 'completed').length} completed\n` +
+						`  during-window [restart-trigger, job-COMPLETE): ${inWindow.length} attempts, wedged=${wedgedInWindow.length}, refused=${inWindow.filter((r) => r.kind === 'refused').length}, completed=${inWindow.filter((r) => r.kind === 'completed').length}\n` +
+						`  post-COMPLETE: ${postComplete.length} attempts, wedged=${wedgedPostComplete.length}, refused=${postComplete.filter((r) => r.kind === 'refused').length}, completed=${postComplete.filter((r) => r.kind === 'completed').length}\n` +
+						`  wedge window (relative to restart trigger, by launch time): ${windowStart}ms .. ${windowEnd}ms`
+				);
+
+				return {
+					rs,
+					completed,
+					refused,
+					wedged,
+					preRestart,
+					inWindow,
+					postComplete,
+					wedgedInWindow,
+					wedgedPostComplete,
+				};
+			}
+
+			const wsA = analyzeSurface('ws');
+			const tcpA = usable.get('tcp') ? analyzeSurface('tcp') : null;
+			const tlsA = usable.get('tls') ? analyzeSurface('tls') : null;
+
+			// Server-side cross-check: count of transport-accepted lines vs client-completed count.
+			const wsAcceptedLines = countMatches(serverLog, /Received WebSocket connection for MQTT from/g);
+			const tcpAcceptedLines = countMatches(serverLog, /Received TCP connection for MQTT from/g);
+			const sslAcceptedLines = countMatches(serverLog, /Received SSL connection for MQTT from/g);
+			const closedLines = countMatches(serverLog, /MQTT connection was closed/g);
+			console.log(
+				`\n[QA-649] SERVER LOG cross-check: WS-accepted-lines=${wsAcceptedLines} (vs ${wsA!.completed.length} client-completed), ` +
+					`TCP-accepted-lines=${tcpAcceptedLines}, SSL-accepted-lines=${sslAcceptedLines}, "MQTT connection was closed"-lines=${closedLines}`
+			);
+			ok(
+				wsAcceptedLines > 0,
+				'server log never recorded a single "Received WebSocket connection for MQTT from" line -- logging/harness problem, cannot evaluate the transport-accepted-but-never-completed hypothesis'
+			);
+
+			console.log(
+				`\n[QA-649] SELF-HEAL: ${lateSelfHeals.length} of the ${Object.values(lateWatchCount).reduce((a, b) => a + b, 0)} tracked wedged client(s) ` +
+					`fired a late 'connect' within the ${LATE_GRACE_MS}ms post-classification grace window. ` +
+					`${lateSelfHeals.length ? JSON.stringify(lateSelfHeals) : '(none observed within our bounded observation window -- this does NOT prove they never connect, only that they did not within our grace period)'}`
+			);
+
+			// ================= VERDICT =================
+			// Pre-restart traffic must actually have been live (sanity, not the hypothesis under test).
+			ok(
+				wsA!.preRestart.some((r) => r.kind === 'completed'),
+				'no successful WS connects observed before the restart -- stream was not live, test invalid'
+			);
+
+			// Q3: does polling get_job to COMPLETE close the window entirely? Evidence: any wedged
+			// WS attempt LAUNCHED AT/AFTER tJobComplete would mean the window survives past the
+			// documented completion signal.
+			console.log(
+				`\n[QA-649] Q3 (does get_job COMPLETE close the window?): ${wsA!.wedgedPostComplete.length} wedged WS attempt(s) launched at/after get_job COMPLETE ` +
+					(wsA!.wedgedPostComplete.length === 0
+						? '-- window appears CLOSED by the time get_job reports COMPLETE.'
+						: '-- DEFECT-ADJACENT: the window OUTLIVES the documented completion signal.')
+			);
+
+			// Primary hypothesis: a WS /mqtt connect must never wedge (neither complete nor cleanly
+			// refuse) within our bounded observation window. Contrast surfaces are informational.
+			ok(
+				wsA!.wedged.length === 0,
+				`WEDGE DEFECT: ${wsA!.wedged.length} of ${wsA!.rs.length} WS /mqtt connect attempt(s) neither completed nor errored within ${WALL_CLOCK_MS}ms ` +
+					`(mqtt.js connectTimeout=${MQTT_JS_CONNECT_TIMEOUT_MS}ms also did not fire) -- samples: ${JSON.stringify(wsA!.wedged.slice(0, 5).map((r) => ({ seq: r.seq, launchRelMs: r.launchedAt - tBeforeRestart, detail: r.detail })))}`
+			);
+
+			if (tcpA) console.log(`[QA-649] contrast: raw TCP :1883 wedged=${tcpA.wedged.length}/${tcpA.rs.length}`);
+			if (tlsA) console.log(`[QA-649] contrast: TLS :8883 wedged=${tlsA.wedged.length}/${tlsA.rs.length}`);
+		}
+	);
+});

--- a/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
+++ b/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
@@ -264,17 +264,16 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 	// child process's captured stdout is not a substitute: it does not carry the per-thread trace
 	// lines this oracle counts.
 	function readServerLog(): string {
-		const candidates = [join(ctx.harper.dataRootDir, 'log', 'hdb.log')];
-		if (ctx.harper.logDir) candidates.unshift(join(ctx.harper.logDir, 'hdb.log'));
-		for (const candidate of candidates) {
-			try {
-				const text = readFileSync(candidate, 'utf8');
-				if (text) return text;
-			} catch {
-				/* try the next candidate */
-			}
+		// Exclusive, not preferred: logging.root points at exactly one of these, so falling through
+		// on an empty read would confuse "not flushed yet" with "wrong file".
+		const path = ctx.harper.logDir
+			? join(ctx.harper.logDir, 'hdb.log')
+			: join(ctx.harper.dataRootDir, 'log', 'hdb.log');
+		try {
+			return readFileSync(path, 'utf8');
+		} catch {
+			return '';
 		}
-		return '';
 	}
 
 	/** Waits minWaitMs, then polls until the accept counts THIS ORACLE READS stop changing for one
@@ -432,6 +431,10 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 
 			let tBeforeRestart = 0;
 			let tJobComplete: number | undefined;
+			// When the pool was PROVEN rotated, which can be later than tJobComplete. Recovery is
+			// keyed to this: an outgoing worker serving one connect after COMPLETE would otherwise
+			// satisfy "the surface came back" while every replacement listener refuses the tail.
+			let tRotated: number | undefined;
 			let finalJob: any;
 			try {
 				await sleep(WARMUP_MS);
@@ -452,7 +455,7 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				strictEqual(
 					restartResp.status,
 					200,
-					`restart_service should ack 200: ${restartResp.status} ${JSON.stringify(restartResp.body)}`
+					`restart_service should ack 200: ${restartResp.status} ${JSON.stringify(restartResp.body)} ${restartResp.errCode ?? ''}`
 				);
 				const jobId = (restartResp.body as any)?.job_id;
 				ok(jobId, `restart_service response carried no job_id: ${JSON.stringify(restartResp.body)}`);
@@ -504,8 +507,10 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 					if (Date.now() >= rotationDeadline) break;
 					await sleep(100);
 				}
+				tRotated = Date.now();
 				console.log(
-					`[QA-649] http worker threadIds ${JSON.stringify(workersBefore)} -> ${JSON.stringify(workersAfter)}`
+					`[QA-649] http worker threadIds ${JSON.stringify(workersBefore)} -> ${JSON.stringify(workersAfter)} ` +
+						`(proven rotated at t+${tRotated - tBeforeRestart}ms)`
 				);
 				strictEqual(
 					survivors.length,
@@ -528,7 +533,7 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				// the surface genuinely never came back. ---
 				await sleep(TAIL_MS);
 				const recoveredAfterRestart = (surface: string) =>
-					results.some((r) => r.surface === surface && r.kind === 'completed' && r.launchedAt >= tJobComplete!);
+					results.some((r) => r.surface === surface && r.kind === 'completed' && r.launchedAt >= tRotated!);
 				const tailDeadline = Date.now() + POST_RESTART_RECOVERY_MS;
 				while (Date.now() < tailDeadline && !surfaces.every((s) => recoveredAfterRestart(s.surface))) {
 					await sleep(100);
@@ -567,6 +572,7 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				const preRestart = rs.filter((r) => r.launchedAt < tBeforeRestart);
 				const inWindow = rs.filter((r) => r.launchedAt >= tBeforeRestart && r.launchedAt < tJobComplete!);
 				const postComplete = rs.filter((r) => r.launchedAt >= tJobComplete!);
+				const postRotation = rs.filter((r) => r.launchedAt >= tRotated!);
 				const wedgedInWindow = inWindow.filter((r) => r.kind === 'wedged');
 				const wedgedPostComplete = postComplete.filter((r) => r.kind === 'wedged');
 				const windowStart = wedged.length ? Math.min(...wedged.map((r) => r.launchedAt)) - tBeforeRestart : null;
@@ -588,6 +594,7 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 					preRestart,
 					inWindow,
 					postComplete,
+					postRotation,
 					wedgedInWindow,
 					wedgedPostComplete,
 				};
@@ -674,13 +681,10 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 			// one real post-restart completion per usable surface.
 			function assertUsableAfterRestart(surface: string, a: NonNullable<ReturnType<typeof analyzeSurface>>) {
 				ok(
-					a.postComplete.some((r) => r.kind === 'completed'),
-					`MQTT (${surface}) never completed a single connect after get_job COMPLETE -- listener may not have survived the restart`
+					a.postRotation.some((r) => r.kind === 'completed'),
+					`MQTT (${surface}) never completed a single connect after the pool was PROVEN rotated -- the replacement listener may not have come back (${a.postRotation.length} attempt(s) tried)`
 				);
 			}
-			assertUsableAfterRestart('WS', wsA!);
-			assertUsableAfterRestart('TCP', tcpA!);
-			assertUsableAfterRestart('TLS', tlsA!);
 
 			// Primary hypothesis: an MQTT connect on any usable transport must never wedge (neither
 			// complete nor cleanly refuse) within our bounded observation window.
@@ -694,6 +698,14 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 			assertNoWedge('WS', wsA!);
 			assertNoWedge('TCP', tcpA!);
 			assertNoWedge('TLS', tlsA!);
+
+			// After assertNoWedge, deliberately: a post-restart listener that WEDGES also completes
+			// nothing, so running this first would swallow the specific WEDGE DEFECT diagnostic and
+			// its samples behind a generic "never came back". Same ordering rule as the accept
+			// oracle below.
+			assertUsableAfterRestart('WS', wsA!);
+			assertUsableAfterRestart('TCP', tcpA!);
+			assertUsableAfterRestart('TLS', tlsA!);
 
 			// Two-sided oracle, enforced last: `assertNoWedge` above already independently pins
 			// the client-observed wedge count to zero with the most specific diagnostic, so a real

--- a/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
+++ b/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
@@ -322,6 +322,11 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 							void endQuiet(r.client);
 						}
 					});
+					// attemptConnect never rejects, and this handler never throws -- but `p` sits
+					// unawaited in `pending` for the rest of the storm, so any future violation of
+					// that contract would otherwise crash the whole process on the next tick as an
+					// unhandled rejection instead of failing just this test.
+					p.catch(() => {});
 					pending.push(p);
 					await sleep(intervalMs);
 				}
@@ -355,8 +360,10 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 
 				// --- Poll get_job to a terminal state (the real completion signal per QA-642) ---
 				const deadline = Date.now() + 60_000;
+				let lastPoll: { status: number; body: any; errCode?: string } | undefined;
 				while (Date.now() < deadline) {
 					const r = await opsCall({ operation: 'get_job', id: jobId }, 3000);
+					lastPoll = r;
 					const job = Array.isArray(r.body) ? r.body[0] : undefined;
 					if (job?.status === 'COMPLETE' || job?.status === 'ERROR') {
 						tJobComplete = Date.now();
@@ -365,7 +372,10 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 					}
 					await sleep(20);
 				}
-				ok(tJobComplete, `get_job(${jobId}) never reached a terminal status within 60s`);
+				ok(
+					tJobComplete,
+					`get_job(${jobId}) never reached a terminal status within 60s -- last poll: ${JSON.stringify(lastPoll)}`
+				);
 				strictEqual(
 					finalJob.status,
 					'COMPLETE',

--- a/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
+++ b/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
@@ -74,6 +74,8 @@ const LATE_WATCH_CAP = 6; // per surface
 
 const WARMUP_MS = 1000;
 const TAIL_MS = 2000;
+// Ceiling on the post-COMPLETE condition-wait for every surface to serve a fresh connect again.
+const POST_RESTART_RECOVERY_MS = 30_000;
 
 interface AttemptResult {
 	surface: 'ws' | 'tcp' | 'tls';
@@ -226,19 +228,36 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 		}
 	}
 
-	// setupHarperWithFixture always runs under harper-integration-test-run, which sets
-	// HARPER_INTEGRATION_TEST_LOG_DIR itself when the caller hasn't -- so logDir (and the
-	// config.logging.root it forces, overriding whatever `logging.root` this suite passes in) is
-	// always populated, not only when a caller opts in. That makes it the one reliable source:
-	// dataRootDir/log/hdb.log never gets created (root is redirected to logDir), and the child
-	// process's captured stdout does not carry the per-thread trace lines this oracle needs.
+	/** HTTP worker thread ids as the operations API reports them (the repo idiom for observing a
+	 * rotation -- server/rolling-restart.test.ts uses the same `threads` attribute). Job threads
+	 * are excluded: `restart_service` itself runs in one, and they never rotate with the pool. */
+	async function httpWorkerThreadIds(): Promise<number[]> {
+		const r = await opsCall({ operation: 'system_information', attributes: ['threads'] });
+		const threads = (r.body as any)?.threads;
+		if (!Array.isArray(threads)) return [];
+		return threads.filter((w: any) => w?.name !== 'job' && typeof w?.threadId === 'number').map((w: any) => w.threadId);
+	}
+
+	// Where `logging.root` actually points depends on how the file was launched, so try both in
+	// priority order rather than assume one. Under harper-integration-test-run (every documented
+	// command) the runner sets HARPER_INTEGRATION_TEST_LOG_DIR itself when the caller hasn't, and
+	// the harness then overrides logging.root with its per-suite logDir -- so only the first
+	// candidate exists. Under a bare `node --test` nothing sets it and only the second does.
+	// Neighbouring suites read the same union (database/blob-restart-ttl-unlink.test.ts). The
+	// child process's captured stdout is not a substitute: it does not carry the per-thread trace
+	// lines this oracle counts.
 	function readServerLog(): string {
-		if (!ctx.harper.logDir) return '';
-		try {
-			return readFileSync(join(ctx.harper.logDir, 'hdb.log'), 'utf8');
-		} catch {
-			return '';
+		const candidates = [join(ctx.harper.dataRootDir, 'log', 'hdb.log')];
+		if (ctx.harper.logDir) candidates.unshift(join(ctx.harper.logDir, 'hdb.log'));
+		for (const candidate of candidates) {
+			try {
+				const text = readFileSync(candidate, 'utf8');
+				if (text) return text;
+			} catch {
+				/* try the next candidate */
+			}
 		}
+		return '';
 	}
 
 	/** Waits minWaitMs, then polls until the log stops growing for one quiet interval (bounded) --
@@ -263,7 +282,7 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 	test(
 		'MQTT connect storm (WS /mqtt, raw TCP :1883, TLS :8883) across restart_service http_workers',
 		{ timeout: 240_000 },
-		async () => {
+		async (t) => {
 			const wsBase = ctx.harper.httpURL.replace(/^http/, 'ws');
 			const surfaces: Array<{ surface: 'ws' | 'tcp' | 'tls'; url: string; intervalMs: number }> = [
 				{ surface: 'ws', url: `${wsBase}/mqtt`, intervalMs: 50 },
@@ -271,30 +290,54 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				{ surface: 'tls', url: `mqtts://${ctx.harper.hostname}:8883`, intervalMs: 200 },
 			];
 
-			// --- Baseline usability probe per surface (bounded; skip a surface if unusable rather
-			// than treat harness/environment limitations as a Harper defect). ---
+			// --- Baseline usability probe per surface. Every surface is REQUIRED. Treating an
+			// unusable surface as "skip it" would make the anchor silently self-narrowing: the
+			// regression class this file falsifies includes "the TCP/TLS listener stops coming
+			// back", and that regression presents at the probe -- as a skip, not a failure. Only
+			// whole-runtime limitations get to skip, and those are `skipSuite` above. Retried to a
+			// deadline so a listener that is merely slow to bind is waited out instead. ---
+			const PROBE_DEADLINE_MS = 30_000;
+			const probeAttempts: Record<string, number> = { ws: 0, tcp: 0, tls: 0 };
 			const usable = new Map<string, boolean>();
-			const skipReason = new Map<string, string>();
+			const probeFailure = new Map<string, string>();
 			for (const s of surfaces) {
-				const r = await attemptConnect(s.url, authOpts(ctx, `qa649-probe-${s.surface}`));
-				usable.set(s.surface, r.kind === 'completed');
-				if (r.kind !== 'completed') skipReason.set(s.surface, `${r.kind}: ${r.detail}`);
-				await endQuiet(r.client);
+				const deadline = Date.now() + PROBE_DEADLINE_MS;
+				do {
+					const n = ++probeAttempts[s.surface];
+					const r = await attemptConnect(s.url, authOpts(ctx, `qa649-probe-${s.surface}-${n}`));
+					usable.set(s.surface, r.kind === 'completed');
+					if (r.kind !== 'completed') probeFailure.set(s.surface, `${r.kind}: ${r.detail}`);
+					await endQuiet(r.client);
+					if (usable.get(s.surface)) break;
+					await sleep(500);
+				} while (Date.now() < deadline);
 			}
 			for (const s of surfaces) {
 				console.log(
-					`[QA-649] baseline probe ${s.surface} (${s.url}): usable=${usable.get(s.surface)} ${skipReason.get(s.surface) ?? ''}`
+					`[QA-649] baseline probe ${s.surface} (${s.url}): usable=${usable.get(s.surface)} ` +
+						`attempts=${probeAttempts[s.surface]} ${probeFailure.get(s.surface) ?? ''}`
 				);
 			}
-			ok(
-				usable.get('ws'),
-				`WS /mqtt surface must be usable at baseline for this experiment to be meaningful: ${skipReason.get('ws')}`
-			);
+			for (const s of surfaces) {
+				ok(
+					usable.get(s.surface),
+					`${s.surface} surface (${s.url}) never became usable within ${PROBE_DEADLINE_MS}ms over ${probeAttempts[s.surface]} attempt(s) -- last: ${probeFailure.get(s.surface)}`
+				);
+			}
 
 			const results: AttemptResult[] = [];
 			const lateSelfHeals: Array<{ surface: string; seq: number; wedgedAt: number; lateConnectAt: number }> = [];
 			const lateWatchCount: Record<string, number> = { ws: 0, tcp: 0, tls: 0 };
 			let stormOver = false;
+			// Every await in the body below is deadline-bounded, so the `finally` that sets
+			// stormOver is always reached and the storms do terminate on their own. What they do
+			// NOT do is stop *promptly*: node:test cannot interrupt a running async function, so
+			// after a runner timeout it proceeds to `after`/teardownHarper while this body keeps
+			// firing connects for up to another WALL_CLOCK_MS at 50/100/200ms. t.signal aborts on
+			// timeout as well as on normal completion, which cuts that overlap.
+			t.signal.addEventListener('abort', () => {
+				stormOver = true;
+			});
 
 			async function runStorm(surface: 'ws' | 'tcp' | 'tls', url: string, intervalMs: number) {
 				let seq = 0;
@@ -333,11 +376,7 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				await Promise.all(pending);
 			}
 
-			const stormPromises: Array<Promise<void>> = [];
-			for (const s of surfaces) {
-				if (usable.get(s.surface)) stormPromises.push(runStorm(s.surface, s.url, s.intervalMs));
-				else console.log(`[QA-649] skipping storm for surface '${s.surface}': ${skipReason.get(s.surface)}`);
-			}
+			const stormPromises = surfaces.map((s) => runStorm(s.surface, s.url, s.intervalMs));
 
 			let tBeforeRestart = 0;
 			let tJobComplete: number | undefined;
@@ -345,6 +384,15 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 			try {
 				await sleep(WARMUP_MS);
 				ok(results.length > 0, 'connect storm produced no attempts during warm-up -- harness problem');
+
+				// Rotation proof, half 1. `threads.count` not applying would leave a single worker,
+				// making "rotate them all" degenerate while every assertion below still passes --
+				// the same vacuity guard integrationTests/server/rolling-restart.test.ts makes.
+				const workersBefore = await httpWorkerThreadIds();
+				ok(
+					workersBefore.length >= 2,
+					`expected >= 2 HTTP worker threads before the restart (threads.count=${WORKERS}), observed ${workersBefore.length} [${workersBefore}] -- a single-worker rotation is vacuous`
+				);
 
 				tBeforeRestart = Date.now();
 				const restartResp = await opsCall({ operation: 'restart_service', service: 'http_workers' }, 30_000);
@@ -383,8 +431,43 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				);
 				console.log(`[QA-649] get_job(${jobId}) COMPLETE at t+${tJobComplete! - tBeforeRestart}ms`);
 
-				// --- Tail: keep storming a bit past COMPLETE, to see whether the window truly closes ---
+				// Rotation proof, half 2. get_job COMPLETE is a *documented* completion signal, not
+				// evidence that anything moved: a restart_service that regressed to a no-op would
+				// still report COMPLETE, and then every assertion below passes on a window that was
+				// never opened -- pre-restart connects complete, in-window connects complete,
+				// wedged=0. Worker identity is the evidence. QA-642 established that COMPLETE
+				// correlates with the pool having FULLY rotated, so a survivor is a real finding
+				// about that signal, not a tolerance to widen.
+				const workersAfter = await httpWorkerThreadIds();
+				console.log(
+					`[QA-649] http worker threadIds ${JSON.stringify(workersBefore)} -> ${JSON.stringify(workersAfter)}`
+				);
+				ok(
+					workersAfter.length >= 2,
+					`expected >= 2 HTTP worker threads after the restart, observed ${workersAfter.length} [${workersAfter}]`
+				);
+				const survivors = workersAfter.filter((id) => workersBefore.includes(id));
+				strictEqual(
+					survivors.length,
+					0,
+					`restart_service http_workers reported COMPLETE but thread(s) [${survivors}] of [${workersBefore}] never rotated -- the restart window this test measures was not fully opened`
+				);
+
+				// --- Tail: keep storming past COMPLETE, to see whether the window truly closes.
+				// TAIL_MS is a floor (so the post-COMPLETE sample is never degenerate), then a
+				// condition-wait for each surface to actually complete a fresh connect. A fixed
+				// sleep followed by asserting the side effect is the `await delay(N);
+				// assert(sideEffectHappened)` shape AGENTS.md names as flake class #1138: a
+				// listener that re-registers a second later than the tail would red the run.
+				// assertUsableAfterRestart below still asserts it -- reaching this deadline means
+				// the surface genuinely never came back. ---
 				await sleep(TAIL_MS);
+				const recoveredAfterRestart = (surface: string) =>
+					results.some((r) => r.surface === surface && r.kind === 'completed' && r.launchedAt >= tJobComplete!);
+				const tailDeadline = Date.now() + POST_RESTART_RECOVERY_MS;
+				while (Date.now() < tailDeadline && !surfaces.every((s) => recoveredAfterRestart(s.surface))) {
+					await sleep(100);
+				}
 			} finally {
 				// Stop the storm loops no matter what -- if an assertion above throws (e.g. a
 				// regressed restart_service), leaving them running would fire qa649-* connects
@@ -439,8 +522,9 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 			}
 
 			const wsA = analyzeSurface('ws');
-			const tcpA = usable.get('tcp') ? analyzeSurface('tcp') : null;
-			const tlsA = usable.get('tls') ? analyzeSurface('tls') : null;
+			const tcpA = analyzeSurface('tcp');
+			const tlsA = analyzeSurface('tls');
+			ok(wsA && tcpA && tlsA, 'a required surface produced no attempts at all -- harness problem, not an MQTT result');
 
 			// Server-side cross-check: count of transport-accepted lines vs client-completed count.
 			const wsAcceptedLines = countMatches(serverLog, /Received WebSocket connection for MQTT from/g);
@@ -469,13 +553,20 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				'no successful WS connects observed before the restart -- stream was not live, test invalid'
 			);
 
-			// Precondition proof: attempts must actually have landed strictly inside the restart
-			// window, not just before/after it -- otherwise a degenerate window (e.g. get_job
-			// completing on its very first poll) would make the wedge check below vacuous.
-			ok(
-				wsA!.inWindow.length > 0,
-				`no WS connect attempts landed inside the restart window [trigger, COMPLETE) -- window was ${tJobComplete! - tBeforeRestart}ms, nothing to test`
-			);
+			// Precondition proof, per surface: attempts must actually have landed strictly inside
+			// the restart window, not just before/after it -- otherwise a degenerate window (e.g.
+			// get_job completing on its very first poll, or a cadence too coarse to fit inside it)
+			// would make that surface's wedge check below vacuous while it still reported green.
+			for (const [surface, a] of [
+				['WS', wsA!],
+				['TCP', tcpA!],
+				['TLS', tlsA!],
+			] as const) {
+				ok(
+					a.inWindow.length > 0,
+					`no ${surface} connect attempts landed inside the restart window [trigger, COMPLETE) -- window was ${tJobComplete! - tBeforeRestart}ms, nothing to test on this surface`
+				);
+			}
 
 			// Q3: does polling get_job to COMPLETE close the window entirely? Evidence: any wedged
 			// WS attempt LAUNCHED AT/AFTER tJobComplete would mean the window survives past the
@@ -498,8 +589,8 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				);
 			}
 			assertUsableAfterRestart('WS', wsA!);
-			if (tcpA) assertUsableAfterRestart('TCP', tcpA);
-			if (tlsA) assertUsableAfterRestart('TLS', tlsA);
+			assertUsableAfterRestart('TCP', tcpA!);
+			assertUsableAfterRestart('TLS', tlsA!);
 
 			// Primary hypothesis: an MQTT connect on any usable transport must never wedge (neither
 			// complete nor cleanly refuse) within our bounded observation window.
@@ -511,33 +602,46 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				);
 			}
 			assertNoWedge('WS', wsA!);
-			if (tcpA) assertNoWedge('TCP', tcpA);
-			if (tlsA) assertNoWedge('TLS', tlsA);
+			assertNoWedge('TCP', tcpA!);
+			assertNoWedge('TLS', tlsA!);
 
 			// Two-sided oracle, enforced last: `assertNoWedge` above already independently pins
 			// the client-observed wedge count to zero with the most specific diagnostic, so a real
 			// wedge fails there first rather than surfacing here as a less informative accept
-			// mismatch. This instead catches accepts the client never accounted for at all -- the
-			// server must never have accepted more transports than the client accounted for as
-			// completed OR cleanly refused. +1 per surface allows for the baseline usability probe
-			// above, which triggers an "accepted" log line but is deliberately excluded from
-			// `results`. `refused` counts here deliberately: the server logs "accepted" the instant
-			// the transport upgrade lands, several ms before CONNACK, so a worker torn down inside
-			// that gap during the rolling restart produces a legitimate accepted-then-reset the
-			// client correctly classifies `refused`, not a wedge.
+			// mismatch.
+			//
+			// The bound is closed at BOTH ends, because each end fails a different way:
+			//   upper -- the server accepted a transport the client never accounted for at all.
+			//     `refused` counts as accounted-for deliberately: the server logs "accepted" the
+			//     instant the transport upgrade lands, several ms before CONNACK, so a worker torn
+			//     down inside that gap during the rolling restart is a legitimate
+			//     accepted-then-reset the client correctly classifies `refused`, not a wedge.
+			//   lower -- the trace is not actually being read. Every completed connect necessarily
+			//     crossed the accept-log site, so `acceptedLines` below the completed count means
+			//     the server half of the oracle is silently disabled (a wording change in
+			//     server/mqtt.ts, a truncated log) and the upper bound alone would still pass, at
+			//     its most permissive, on zero evidence.
+			// Both ends allow for the baseline probe attempts, which trigger accept lines but are
+			// deliberately excluded from `results`: every attempt may have been accepted (upper),
+			// and exactly one of them completed (lower).
 			function assertServerAccepts(
 				surface: string,
 				acceptedLines: number,
+				probes: number,
 				a: NonNullable<ReturnType<typeof analyzeSurface>>
 			) {
 				ok(
-					acceptedLines <= a.completed.length + a.refused.length + 1,
-					`SERVER-SIDE ACCEPT MISMATCH (${surface}): server log recorded ${acceptedLines} accepted transports vs only ${a.completed.length + a.refused.length} client-accounted-for (completed+refused) attempts`
+					acceptedLines >= a.completed.length + 1,
+					`SERVER-SIDE TRACE MISSING (${surface}): only ${acceptedLines} accepted-transport log line(s) for ${a.completed.length} client-completed connect(s) + 1 completed baseline probe. Every completed connect crosses the accept-log site, so this oracle is not reading it -- the server/mqtt.ts log wording changed, or the log was truncated mid-run`
+				);
+				ok(
+					acceptedLines <= a.completed.length + a.refused.length + probes,
+					`SERVER-SIDE ACCEPT MISMATCH (${surface}): server log recorded ${acceptedLines} accepted transports vs at most ${a.completed.length + a.refused.length + probes} client-accounted-for (completed ${a.completed.length} + refused ${a.refused.length} + ${probes} baseline probe attempt(s))`
 				);
 			}
-			assertServerAccepts('WS', wsAcceptedLines, wsA!);
-			if (tcpA) assertServerAccepts('TCP', tcpAcceptedLines, tcpA);
-			if (tlsA) assertServerAccepts('TLS', sslAcceptedLines, tlsA);
+			assertServerAccepts('WS', wsAcceptedLines, probeAttempts.ws, wsA!);
+			assertServerAccepts('TCP', tcpAcceptedLines, probeAttempts.tcp, tcpA!);
+			assertServerAccepts('TLS', sslAcceptedLines, probeAttempts.tls, tlsA!);
 		}
 	);
 });

--- a/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
+++ b/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
@@ -28,22 +28,23 @@
  * Oracle, both sides:
  *   - client side: did 'connect' fire (completed), 'error'/'close' fire pre-connack (refused), or
  *     neither within the bounded window (wedged)?
- *   - server side: {dataRootDir}/log/hdb.log at logging.level 'trace' — server/mqtt.ts logs
+ *   - server side: hdb.log at logging.level 'trace' in the harness's per-suite log directory
+ *     (`ctx.harper.logDir`, always populated -- the test runner sets
+ *     HARPER_INTEGRATION_TEST_LOG_DIR itself when the caller hasn't) — server/mqtt.ts logs
  *     `Received WebSocket connection for MQTT from` / `Received TCP connection for MQTT from` /
  *     `Received SSL connection for MQTT from` at the moment the TRANSPORT (WS upgrade / raw
- *     socket) is accepted, BEFORE the MQTT CONNECT packet is even parsed. If the count of these
- *     "accepted" log lines during the restart window exceeds the count of client-side 'completed'
- *     outcomes for the same surface/window, that is server-side proof some connections were
- *     accepted at the transport level but never finished the MQTT handshake — the wedge shape
- *     described in the scenario, not a client-side illusion (a past QA finding was retracted for
- *     exactly this kind of one-sided evidence).
- *
- * Stage-2 gate: 2/2 cold runs green against Harper SHA 1e1edc666.
+ *     socket) is accepted, BEFORE the MQTT CONNECT packet is even parsed. If the whole-run count
+ *     of these "accepted" log lines exceeds the whole-run count of client-side 'completed'
+ *     outcomes for the same surface (beyond the +1 the baseline usability probe below
+ *     deliberately contributes and excludes from `completed`), that is server-side proof some
+ *     connection was accepted at the transport level but never finished the MQTT handshake — the
+ *     wedge shape described in the scenario, not a client-side illusion (a past QA finding was
+ *     retracted for exactly this kind of one-sided evidence). This is asserted, not just logged.
  */
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual } from 'node:assert';
 import { resolve, join } from 'node:path';
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { randomUUID } from 'node:crypto';
 
@@ -99,7 +100,6 @@ function attemptConnect(
 	url: string,
 	opts: IClientOptions
 ): Promise<Omit<AttemptResult, 'surface' | 'seq' | 'launchedAt'>> {
-	const launchedAt = Date.now();
 	return new Promise((resolveOuter) => {
 		let classified = false;
 		let client: MqttClient;
@@ -121,7 +121,10 @@ function attemptConnect(
 			resolveOuter({ kind, detail, tEnd: Date.now(), client });
 		};
 		client.once('connect', () => finish('completed', 'connack received'));
-		client.once('error', (err: any) => finish('refused', String(err?.code ?? err?.message ?? err)));
+		// .on, not .once: classified guards finish() to a single effect, but the listener must
+		// stay attached -- a client force-closed post-classification can emit a second 'error',
+		// and an unhandled second EventEmitter 'error' throws and kills the whole test process.
+		client.on('error', (err: any) => finish('refused', String(err?.code ?? err?.message ?? err)));
 		client.once('close', () => finish('refused', 'socket closed before connect/error'));
 		const wedgeTimer = setTimeout(() => {
 			finish(
@@ -129,7 +132,6 @@ function attemptConnect(
 				`neither connect/error/close within ${WALL_CLOCK_MS}ms (mqtt.js connectTimeout=${MQTT_JS_CONNECT_TIMEOUT_MS}ms did not fire either)`
 			);
 		}, WALL_CLOCK_MS);
-		void launchedAt;
 	});
 }
 
@@ -145,26 +147,19 @@ function endQuiet(client: MqttClient | undefined): Promise<void> {
 }
 
 suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSuite }, (ctx: ContextWithHarper) => {
-	let procOutput = '';
-
 	before(async () => {
 		await setupHarperWithFixture(ctx, FIXTURE_PATH, {
 			config: {
 				threads: { count: WORKERS },
-				logging: { root: 'log', level: 'trace', console: true },
+				logging: { level: 'trace' },
 			},
 			env: {},
 		});
 
-		procOutput += ctx.harper.startupOutput?.stdout ?? '';
-		procOutput += ctx.harper.startupOutput?.stderr ?? '';
-		const proc = ctx.harper.process;
-		proc?.stdout?.on('data', (d: Buffer) => (procOutput += d.toString()));
-		proc?.stderr?.on('data', (d: Buffer) => (procOutput += d.toString()));
-
 		// Poll the probe route directly for non-404 — deliberately NOT restartHttpWorkers() (fire-
 		// and-forget; would race the readiness wait against the same class of bug under test).
 		const deadline = Date.now() + 120_000;
+		let ready = false;
 		while (Date.now() < deadline) {
 			try {
 				const res = await fetch(`${ctx.harper.httpURL}/Probe/`, {
@@ -173,12 +168,16 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 					},
 					signal: AbortSignal.timeout(2000),
 				});
-				if (res.status !== 404) break;
+				if (res.status !== 404) {
+					ready = true;
+					break;
+				}
 			} catch {
 				/* not ready yet */
 			}
 			await sleep(150);
 		}
+		ok(ready, 'Probe route never left 404 within 120s -- fixture did not mount, not an MQTT problem');
 	});
 
 	after(async () => {
@@ -210,30 +209,19 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 		}
 	}
 
+	// setupHarperWithFixture always runs under harper-integration-test-run, which sets
+	// HARPER_INTEGRATION_TEST_LOG_DIR itself when the caller hasn't -- so logDir (and the
+	// config.logging.root it forces, overriding whatever `logging.root` this suite passes in) is
+	// always populated, not only when a caller opts in. That makes it the one reliable source:
+	// dataRootDir/log/hdb.log never gets created (root is redirected to logDir), and the child
+	// process's captured stdout does not carry the per-thread trace lines this oracle needs.
 	function readServerLog(): string {
-		let text = procOutput;
-		const p = join(ctx.harper.dataRootDir, 'log', 'hdb.log');
-		if (existsSync(p)) {
-			try {
-				text += readFileSync(p, 'utf8');
-			} catch {
-				/* ignore */
-			}
+		if (!ctx.harper.logDir) return '';
+		try {
+			return readFileSync(join(ctx.harper.logDir, 'hdb.log'), 'utf8');
+		} catch {
+			return '';
 		}
-		const logDir = (ctx.harper as any).logDir as string | undefined;
-		if (logDir) {
-			for (const name of ['hdb.log', 'stdout.log', 'stderr.log']) {
-				const p2 = join(logDir, name);
-				if (existsSync(p2)) {
-					try {
-						text += readFileSync(p2, 'utf8');
-					} catch {
-						/* ignore */
-					}
-				}
-			}
-		}
-		return text;
 	}
 
 	function countMatches(text: string, re: RegExp): number {
@@ -271,7 +259,6 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				`WS /mqtt surface must be usable at baseline for this experiment to be meaningful: ${skipReason.get('ws')}`
 			);
 
-			// --- Storm driver: fire connects on a fixed cadence per surface until stormOver ---
 			const results: AttemptResult[] = [];
 			const lateSelfHeals: Array<{ surface: string; seq: number; wedgedAt: number; lateConnectAt: number }> = [];
 			const lateWatchCount: Record<string, number> = { ws: 0, tcp: 0, tls: 0 };
@@ -315,27 +302,27 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				else console.log(`[QA-649] skipping storm for surface '${s.surface}': ${skipReason.get(s.surface)}`);
 			}
 
-			// --- Warm-up: confirm live traffic before touching anything ---
-			await sleep(WARMUP_MS);
-			ok(results.length > 0, 'connect storm produced no attempts during warm-up -- harness problem');
-
-			// --- Trigger restart_service http_workers, capture job_id ---
-			const tBeforeRestart = Date.now();
-			const restartResp = await opsCall({ operation: 'restart_service', service: 'http_workers' }, 30_000);
-			const tAfterRestartResp = Date.now();
-			strictEqual(
-				restartResp.status,
-				200,
-				`restart_service should ack 200: ${restartResp.status} ${JSON.stringify(restartResp.body)}`
-			);
-			const jobId = (restartResp.body as any)?.job_id;
-			ok(jobId, `restart_service response carried no job_id: ${JSON.stringify(restartResp.body)}`);
-			console.log(`[QA-649] restart_service acked 200 in ${tAfterRestartResp - tBeforeRestart}ms, job_id=${jobId}`);
-
-			// --- Poll get_job to a terminal state (the real completion signal per QA-642) ---
+			let tBeforeRestart = 0;
 			let tJobComplete: number | undefined;
 			let finalJob: any;
-			{
+			try {
+				// --- Warm-up: confirm live traffic before touching anything ---
+				await sleep(WARMUP_MS);
+				ok(results.length > 0, 'connect storm produced no attempts during warm-up -- harness problem');
+
+				tBeforeRestart = Date.now();
+				const restartResp = await opsCall({ operation: 'restart_service', service: 'http_workers' }, 30_000);
+				const tAfterRestartResp = Date.now();
+				strictEqual(
+					restartResp.status,
+					200,
+					`restart_service should ack 200: ${restartResp.status} ${JSON.stringify(restartResp.body)}`
+				);
+				const jobId = (restartResp.body as any)?.job_id;
+				ok(jobId, `restart_service response carried no job_id: ${JSON.stringify(restartResp.body)}`);
+				console.log(`[QA-649] restart_service acked 200 in ${tAfterRestartResp - tBeforeRestart}ms, job_id=${jobId}`);
+
+				// --- Poll get_job to a terminal state (the real completion signal per QA-642) ---
 				const deadline = Date.now() + 60_000;
 				while (Date.now() < deadline) {
 					const r = await opsCall({ operation: 'get_job', id: jobId }, 3000);
@@ -347,19 +334,29 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 					}
 					await sleep(20);
 				}
+				ok(tJobComplete, `get_job(${jobId}) never reached a terminal status within 60s`);
+				strictEqual(
+					finalJob.status,
+					'COMPLETE',
+					`restart job ended in ${finalJob.status}: ${JSON.stringify(finalJob)}`
+				);
+				console.log(`[QA-649] get_job(${jobId}) COMPLETE at t+${tJobComplete! - tBeforeRestart}ms`);
+
+				// --- Tail: keep storming a bit past COMPLETE, to see whether the window truly closes ---
+				await sleep(TAIL_MS);
+			} finally {
+				// Stop the storm loops no matter what -- if an assertion above throws (e.g. a
+				// regressed restart_service), leaving them running would fire qa649-* connects
+				// every 50/100/200ms past teardownHarper and hang the whole integration shard
+				// instead of just failing this test.
+				stormOver = true;
+				await Promise.all(stormPromises).catch(() => {});
 			}
-			ok(tJobComplete, `get_job(${jobId}) never reached a terminal status within 60s`);
-			strictEqual(finalJob.status, 'COMPLETE', `restart job ended in ${finalJob.status}: ${JSON.stringify(finalJob)}`);
-			console.log(`[QA-649] get_job(${jobId}) COMPLETE at t+${tJobComplete! - tBeforeRestart}ms`);
 
-			// --- Tail: keep storming a bit past COMPLETE, to see whether the window truly closes ---
-			await sleep(TAIL_MS);
-			stormOver = true;
-			await Promise.all(stormPromises);
-
-			// Give any attempts launched right at the tail edge (up to WALL_CLOCK_MS + LATE_GRACE_MS
-			// to fully classify/self-heal-observe) time to finish before we analyze.
-			await sleep(WALL_CLOCK_MS + LATE_GRACE_MS + 500);
+			// Promise.all(stormPromises) above already waited for every launched attempt to be
+			// CLASSIFIED (up to WALL_CLOCK_MS after launch); only the LATE_GRACE_MS late-connect
+			// watch that starts once a 'wedged' result lands is still outstanding.
+			await sleep(LATE_GRACE_MS + 500);
 
 			// ================= ANALYSIS =================
 			const serverLog = readServerLog();
@@ -417,6 +414,29 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				'server log never recorded a single "Received WebSocket connection for MQTT from" line -- logging/harness problem, cannot evaluate the transport-accepted-but-never-completed hypothesis'
 			);
 
+			// Two-sided oracle, enforced: the server must never have accepted more transports than
+			// the client saw complete. +1 per surface allows for the baseline usability probe fired
+			// above, which triggers an "accepted" log line but is deliberately excluded from
+			// `results`/`completed` (Stage-2 gate measured this delta at exactly 1, both cold runs).
+			// A larger delta is server-side proof of a transport accepted but never handshaken --
+			// the wedge shape this spec exists to catch, not a client-side illusion (F-164's mistake).
+			ok(
+				wsAcceptedLines <= wsA!.completed.length + 1,
+				`SERVER-SIDE WEDGE PROOF (WS): server log recorded ${wsAcceptedLines} accepted transports vs only ${wsA!.completed.length} client-side completions`
+			);
+			if (tcpA) {
+				ok(
+					tcpAcceptedLines <= tcpA.completed.length + 1,
+					`SERVER-SIDE WEDGE PROOF (TCP): server log recorded ${tcpAcceptedLines} accepted transports vs only ${tcpA.completed.length} client-side completions`
+				);
+			}
+			if (tlsA) {
+				ok(
+					sslAcceptedLines <= tlsA.completed.length + 1,
+					`SERVER-SIDE WEDGE PROOF (TLS): server log recorded ${sslAcceptedLines} accepted transports vs only ${tlsA.completed.length} client-side completions`
+				);
+			}
+
 			console.log(
 				`\n[QA-649] SELF-HEAL: ${lateSelfHeals.length} of the ${Object.values(lateWatchCount).reduce((a, b) => a + b, 0)} tracked wedged client(s) ` +
 					`fired a late 'connect' within the ${LATE_GRACE_MS}ms post-classification grace window. ` +
@@ -430,6 +450,14 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				'no successful WS connects observed before the restart -- stream was not live, test invalid'
 			);
 
+			// Precondition proof: attempts must actually have landed strictly inside the restart
+			// window, not just before/after it -- otherwise a degenerate window (e.g. get_job
+			// completing on its very first poll) would make the wedge check below vacuous.
+			ok(
+				wsA!.inWindow.length > 0,
+				`no WS connect attempts landed inside the restart window [trigger, COMPLETE) -- window was ${tJobComplete! - tBeforeRestart}ms, nothing to test`
+			);
+
 			// Q3: does polling get_job to COMPLETE close the window entirely? Evidence: any wedged
 			// WS attempt LAUNCHED AT/AFTER tJobComplete would mean the window survives past the
 			// documented completion signal.
@@ -440,16 +468,18 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 						: '-- DEFECT-ADJACENT: the window OUTLIVES the documented completion signal.')
 			);
 
-			// Primary hypothesis: a WS /mqtt connect must never wedge (neither complete nor cleanly
-			// refuse) within our bounded observation window. Contrast surfaces are informational.
-			ok(
-				wsA!.wedged.length === 0,
-				`WEDGE DEFECT: ${wsA!.wedged.length} of ${wsA!.rs.length} WS /mqtt connect attempt(s) neither completed nor errored within ${WALL_CLOCK_MS}ms ` +
-					`(mqtt.js connectTimeout=${MQTT_JS_CONNECT_TIMEOUT_MS}ms also did not fire) -- samples: ${JSON.stringify(wsA!.wedged.slice(0, 5).map((r) => ({ seq: r.seq, launchRelMs: r.launchedAt - tBeforeRestart, detail: r.detail })))}`
-			);
-
-			if (tcpA) console.log(`[QA-649] contrast: raw TCP :1883 wedged=${tcpA.wedged.length}/${tcpA.rs.length}`);
-			if (tlsA) console.log(`[QA-649] contrast: TLS :8883 wedged=${tlsA.wedged.length}/${tlsA.rs.length}`);
+			// Primary hypothesis: an MQTT connect on any usable transport must never wedge (neither
+			// complete nor cleanly refuse) within our bounded observation window.
+			function assertNoWedge(surface: string, a: NonNullable<ReturnType<typeof analyzeSurface>>) {
+				ok(
+					a.wedged.length === 0,
+					`WEDGE DEFECT (${surface}): ${a.wedged.length} of ${a.rs.length} connect attempt(s) neither completed nor errored within ${WALL_CLOCK_MS}ms ` +
+						`(mqtt.js connectTimeout=${MQTT_JS_CONNECT_TIMEOUT_MS}ms also did not fire) -- samples: ${JSON.stringify(a.wedged.slice(0, 5).map((r) => ({ seq: r.seq, launchRelMs: r.launchedAt - tBeforeRestart, detail: r.detail })))}`
+				);
+			}
+			assertNoWedge('WS', wsA!);
+			if (tcpA) assertNoWedge('TCP', tcpA);
+			if (tlsA) assertNoWedge('TLS', tlsA);
 		}
 	);
 });

--- a/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
+++ b/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
@@ -34,12 +34,15 @@
  *     `Received WebSocket connection for MQTT from` / `Received TCP connection for MQTT from` /
  *     `Received SSL connection for MQTT from` at the moment the TRANSPORT (WS upgrade / raw
  *     socket) is accepted, BEFORE the MQTT CONNECT packet is even parsed. If the whole-run count
- *     of these "accepted" log lines exceeds the whole-run count of client-side 'completed'
- *     outcomes for the same surface (beyond the +1 the baseline usability probe below
- *     deliberately contributes and excludes from `completed`), that is server-side proof some
- *     connection was accepted at the transport level but never finished the MQTT handshake — the
- *     wedge shape described in the scenario, not a client-side illusion (a past QA finding was
- *     retracted for exactly this kind of one-sided evidence). This is asserted, not just logged.
+ *     of these "accepted" log lines exceeds the whole-run count of client-accounted-for
+ *     (completed + refused) outcomes for the same surface (beyond the +1 the baseline usability
+ *     probe below deliberately contributes and excludes), that is server-side proof of an accept
+ *     the client never accounted for at all — evidence independent of, and complementary to, the
+ *     client-side wedge count `assertNoWedge` pins to zero (a past QA finding was retracted for
+ *     exactly this kind of one-sided evidence). `refused` counts on the client side because the
+ *     server logs "accepted" several ms before CONNACK — a worker torn down inside that gap
+ *     during the rolling restart is a legitimate accept-then-reset, not a wedge. This is asserted,
+ *     not just logged.
  */
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual } from 'node:assert';
@@ -224,6 +227,21 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 		}
 	}
 
+	/** Waits minWaitMs, then polls until the log stops growing for one quiet interval (bounded) --
+	 * a condition-wait on the file transport actually flushing, not a fixed guess at how long. */
+	async function readServerLogStable(minWaitMs: number, quietMs = 250, maxExtraMs = 3000): Promise<string> {
+		await sleep(minWaitMs);
+		let text = readServerLog();
+		const deadline = Date.now() + maxExtraMs;
+		while (Date.now() < deadline) {
+			await sleep(quietMs);
+			const next = readServerLog();
+			if (next.length === text.length) return next;
+			text = next;
+		}
+		return text;
+	}
+
 	function countMatches(text: string, re: RegExp): number {
 		return (text.match(re) || []).length;
 	}
@@ -306,7 +324,6 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 			let tJobComplete: number | undefined;
 			let finalJob: any;
 			try {
-				// --- Warm-up: confirm live traffic before touching anything ---
 				await sleep(WARMUP_MS);
 				ok(results.length > 0, 'connect storm produced no attempts during warm-up -- harness problem');
 
@@ -355,11 +372,12 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 
 			// Promise.all(stormPromises) above already waited for every launched attempt to be
 			// CLASSIFIED (up to WALL_CLOCK_MS after launch); only the LATE_GRACE_MS late-connect
-			// watch that starts once a 'wedged' result lands is still outstanding.
-			await sleep(LATE_GRACE_MS + 500);
+			// watch that starts once a 'wedged' result lands is still outstanding. Then poll the
+			// log file until it stops growing, rather than guess a fixed extra wait for the file
+			// transport to flush.
+			const serverLog = await readServerLogStable(LATE_GRACE_MS + 500);
 
 			// ================= ANALYSIS =================
-			const serverLog = readServerLog();
 
 			function analyzeSurface(surface: 'ws' | 'tcp' | 'tls') {
 				const rs = results.filter((r) => r.surface === surface);
@@ -415,27 +433,28 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 			);
 
 			// Two-sided oracle, enforced: the server must never have accepted more transports than
-			// the client saw complete. +1 per surface allows for the baseline usability probe fired
-			// above, which triggers an "accepted" log line but is deliberately excluded from
-			// `results`/`completed` (Stage-2 gate measured this delta at exactly 1, both cold runs).
-			// A larger delta is server-side proof of a transport accepted but never handshaken --
-			// the wedge shape this spec exists to catch, not a client-side illusion (F-164's mistake).
-			ok(
-				wsAcceptedLines <= wsA!.completed.length + 1,
-				`SERVER-SIDE WEDGE PROOF (WS): server log recorded ${wsAcceptedLines} accepted transports vs only ${wsA!.completed.length} client-side completions`
-			);
-			if (tcpA) {
+			// the client accounted for as completed OR cleanly refused. +1 per surface allows for
+			// the baseline usability probe fired above, which triggers an "accepted" log line but
+			// is deliberately excluded from `results`. `refused` counts here deliberately: the
+			// server logs "accepted" the instant the transport upgrade lands, several ms before
+			// CONNACK, so a worker torn down inside that gap during the rolling restart produces a
+			// legitimate accepted-then-reset that the client correctly classifies `refused`, not a
+			// wedge -- comparing only against `completed` would fail that benign interleaving.
+			// `assertNoWedge` above already independently pins the client-observed wedge count to
+			// zero; this oracle instead catches accepts the client never accounted for at all.
+			function assertServerAccepts(
+				surface: string,
+				acceptedLines: number,
+				a: NonNullable<ReturnType<typeof analyzeSurface>>
+			) {
 				ok(
-					tcpAcceptedLines <= tcpA.completed.length + 1,
-					`SERVER-SIDE WEDGE PROOF (TCP): server log recorded ${tcpAcceptedLines} accepted transports vs only ${tcpA.completed.length} client-side completions`
+					acceptedLines <= a.completed.length + a.refused.length + 1,
+					`SERVER-SIDE ACCEPT MISMATCH (${surface}): server log recorded ${acceptedLines} accepted transports vs only ${a.completed.length + a.refused.length} client-accounted-for (completed+refused) attempts`
 				);
 			}
-			if (tlsA) {
-				ok(
-					sslAcceptedLines <= tlsA.completed.length + 1,
-					`SERVER-SIDE WEDGE PROOF (TLS): server log recorded ${sslAcceptedLines} accepted transports vs only ${tlsA.completed.length} client-side completions`
-				);
-			}
+			assertServerAccepts('WS', wsAcceptedLines, wsA!);
+			if (tcpA) assertServerAccepts('TCP', tcpAcceptedLines, tcpA);
+			if (tlsA) assertServerAccepts('TLS', sslAcceptedLines, tlsA);
 
 			console.log(
 				`\n[QA-649] SELF-HEAL: ${lateSelfHeals.length} of the ${Object.values(lateWatchCount).reduce((a, b) => a + b, 0)} tracked wedged client(s) ` +
@@ -467,6 +486,20 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 						? '-- window appears CLOSED by the time get_job reports COMPLETE.'
 						: '-- DEFECT-ADJACENT: the window OUTLIVES the documented completion signal.')
 			);
+
+			// A zero client-side wedge count is not by itself proof MQTT survived the restart -- a
+			// listener that never re-registers after the rotation would refuse every post-restart
+			// attempt (ECONNRESET, classified 'refused') and still show wedged=0. Require at least
+			// one real post-restart completion per usable surface.
+			function assertUsableAfterRestart(surface: string, a: NonNullable<ReturnType<typeof analyzeSurface>>) {
+				ok(
+					a.postComplete.some((r) => r.kind === 'completed'),
+					`MQTT (${surface}) never completed a single connect after get_job COMPLETE -- listener may not have survived the restart`
+				);
+			}
+			assertUsableAfterRestart('WS', wsA!);
+			if (tcpA) assertUsableAfterRestart('TCP', tcpA);
+			if (tlsA) assertUsableAfterRestart('TLS', tlsA);
 
 			// Primary hypothesis: an MQTT connect on any usable transport must never wedge (neither
 			// complete nor cleanly refuse) within our bounded observation window.

--- a/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
+++ b/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
@@ -432,30 +432,6 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				'server log never recorded a single "Received WebSocket connection for MQTT from" line -- logging/harness problem, cannot evaluate the transport-accepted-but-never-completed hypothesis'
 			);
 
-			// Two-sided oracle, enforced: the server must never have accepted more transports than
-			// the client accounted for as completed OR cleanly refused. +1 per surface allows for
-			// the baseline usability probe fired above, which triggers an "accepted" log line but
-			// is deliberately excluded from `results`. `refused` counts here deliberately: the
-			// server logs "accepted" the instant the transport upgrade lands, several ms before
-			// CONNACK, so a worker torn down inside that gap during the rolling restart produces a
-			// legitimate accepted-then-reset that the client correctly classifies `refused`, not a
-			// wedge -- comparing only against `completed` would fail that benign interleaving.
-			// `assertNoWedge` above already independently pins the client-observed wedge count to
-			// zero; this oracle instead catches accepts the client never accounted for at all.
-			function assertServerAccepts(
-				surface: string,
-				acceptedLines: number,
-				a: NonNullable<ReturnType<typeof analyzeSurface>>
-			) {
-				ok(
-					acceptedLines <= a.completed.length + a.refused.length + 1,
-					`SERVER-SIDE ACCEPT MISMATCH (${surface}): server log recorded ${acceptedLines} accepted transports vs only ${a.completed.length + a.refused.length} client-accounted-for (completed+refused) attempts`
-				);
-			}
-			assertServerAccepts('WS', wsAcceptedLines, wsA!);
-			if (tcpA) assertServerAccepts('TCP', tcpAcceptedLines, tcpA);
-			if (tlsA) assertServerAccepts('TLS', sslAcceptedLines, tlsA);
-
 			console.log(
 				`\n[QA-649] SELF-HEAL: ${lateSelfHeals.length} of the ${Object.values(lateWatchCount).reduce((a, b) => a + b, 0)} tracked wedged client(s) ` +
 					`fired a late 'connect' within the ${LATE_GRACE_MS}ms post-classification grace window. ` +
@@ -513,6 +489,31 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 			assertNoWedge('WS', wsA!);
 			if (tcpA) assertNoWedge('TCP', tcpA);
 			if (tlsA) assertNoWedge('TLS', tlsA);
+
+			// Two-sided oracle, enforced last: `assertNoWedge` above already independently pins
+			// the client-observed wedge count to zero with the most specific diagnostic, so a real
+			// wedge fails there first rather than surfacing here as a less informative accept
+			// mismatch. This instead catches accepts the client never accounted for at all -- the
+			// server must never have accepted more transports than the client accounted for as
+			// completed OR cleanly refused. +1 per surface allows for the baseline usability probe
+			// above, which triggers an "accepted" log line but is deliberately excluded from
+			// `results`. `refused` counts here deliberately: the server logs "accepted" the instant
+			// the transport upgrade lands, several ms before CONNACK, so a worker torn down inside
+			// that gap during the rolling restart produces a legitimate accepted-then-reset the
+			// client correctly classifies `refused`, not a wedge.
+			function assertServerAccepts(
+				surface: string,
+				acceptedLines: number,
+				a: NonNullable<ReturnType<typeof analyzeSurface>>
+			) {
+				ok(
+					acceptedLines <= a.completed.length + a.refused.length + 1,
+					`SERVER-SIDE ACCEPT MISMATCH (${surface}): server log recorded ${acceptedLines} accepted transports vs only ${a.completed.length + a.refused.length} client-accounted-for (completed+refused) attempts`
+				);
+			}
+			assertServerAccepts('WS', wsAcceptedLines, wsA!);
+			if (tcpA) assertServerAccepts('TCP', tcpAcceptedLines, tcpA);
+			if (tlsA) assertServerAccepts('TLS', sslAcceptedLines, tlsA);
 		}
 	);
 });

--- a/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
+++ b/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
@@ -138,13 +138,27 @@ function attemptConnect(
 	});
 }
 
-function endQuiet(client: MqttClient | undefined): Promise<void> {
+/** Bounded: a client on a genuinely wedged socket may never invoke end()'s own callback, which
+ * would otherwise hang every caller (including the whole suite, via the baseline probe) on
+ * exactly the defect class this file exists to catch instead of reporting it. */
+function endQuiet(client: MqttClient | undefined, timeoutMs = 2000): Promise<void> {
 	return new Promise((resolveEnd) => {
 		if (!client) return resolveEnd();
-		try {
-			client.end(true, {}, () => resolveEnd());
-		} catch {
+		let done = false;
+		const finish = () => {
+			if (done) return;
+			done = true;
 			resolveEnd();
+		};
+		const timer = setTimeout(finish, timeoutMs);
+		try {
+			client.end(true, {}, () => {
+				clearTimeout(timer);
+				finish();
+			});
+		} catch {
+			clearTimeout(timer);
+			finish();
 		}
 	});
 }
@@ -303,7 +317,7 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 							setTimeout(() => {
 								r.client.removeListener('connect', onLateConnect);
 								void endQuiet(r.client);
-							}, LATE_GRACE_MS);
+							}, LATE_GRACE_MS).unref();
 						} else {
 							void endQuiet(r.client);
 						}

--- a/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
+++ b/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
@@ -72,6 +72,15 @@ const WALL_CLOCK_MS = 10_000;
 const LATE_GRACE_MS = 5000; // extra observation window on a capped subset of wedged clients, to see if they self-heal
 const LATE_WATCH_CAP = 6; // per surface
 
+// server/mqtt.ts logs these the moment the TRANSPORT is accepted, before the MQTT CONNECT packet
+// is parsed. Shared by the settle-wait and by the assertions, so the condition we wait on is
+// exactly the quantity we then assert on.
+const ACCEPT_PATTERNS: Record<'ws' | 'tcp' | 'tls', RegExp> = {
+	ws: /Received WebSocket connection for MQTT from/g,
+	tcp: /Received TCP connection for MQTT from/g,
+	tls: /Received SSL connection for MQTT from/g,
+};
+
 const WARMUP_MS = 1000;
 const TAIL_MS = 2000;
 // Ceiling on the post-COMPLETE condition-wait for every surface to serve a fresh connect again.
@@ -172,7 +181,9 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 		await setupHarperWithFixture(ctx, FIXTURE_PATH, {
 			config: {
 				threads: { count: WORKERS },
-				logging: { level: 'trace' },
+				// Rotation is on by default at maxSize 64M; a trace-level storm can cross it and
+				// take the accept lines this suite's oracle counts with it.
+				logging: { level: 'trace', rotation: { enabled: false } },
 			},
 			env: {},
 		});
@@ -186,6 +197,7 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				const res = await fetch(`${ctx.harper.httpURL}/Probe/`, {
 					headers: {
 						Authorization: `Basic ${Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64')}`,
+						Connection: 'close',
 					},
 					signal: AbortSignal.timeout(2000),
 				});
@@ -265,23 +277,36 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 		return '';
 	}
 
-	/** Waits minWaitMs, then polls until the log stops growing for one quiet interval (bounded) --
-	 * a condition-wait on the file transport actually flushing, not a fixed guess at how long. */
+	/** Waits minWaitMs, then polls until the accept counts THIS ORACLE READS stop changing for one
+	 * quiet interval (bounded). Whole-file length was the wrong condition in both directions:
+	 * unrelated trace chatter keeps hdb.log growing regardless, and neither growth nor stillness
+	 * says anything about whether the accept lines specifically are all on disk. */
 	async function readServerLogStable(minWaitMs: number, quietMs = 250, maxExtraMs = 10_000): Promise<string> {
 		await sleep(minWaitMs);
 		let text = readServerLog();
+		let counts = JSON.stringify(acceptCounts(text));
 		const deadline = Date.now() + maxExtraMs;
 		while (Date.now() < deadline) {
 			await sleep(quietMs);
 			const next = readServerLog();
-			if (next.length === text.length) return next;
+			const nextCounts = JSON.stringify(acceptCounts(next));
 			text = next;
+			if (nextCounts === counts) return next;
+			counts = nextCounts;
 		}
 		return text;
 	}
 
 	function countMatches(text: string, re: RegExp): number {
 		return (text.match(re) || []).length;
+	}
+
+	function acceptCounts(text: string): Record<'ws' | 'tcp' | 'tls', number> {
+		return {
+			ws: countMatches(text, ACCEPT_PATTERNS.ws),
+			tcp: countMatches(text, ACCEPT_PATTERNS.tcp),
+			tls: countMatches(text, ACCEPT_PATTERNS.tls),
+		};
 	}
 
 	test(
@@ -301,7 +326,7 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 			// back", and that regression presents at the probe -- as a skip, not a failure. Only
 			// whole-runtime limitations get to skip, and those are `skipSuite` above. Retried to a
 			// deadline so a listener that is merely slow to bind is waited out instead. ---
-			const PROBE_DEADLINE_MS = 30_000;
+			const PROBE_DEADLINE_MS = 15_000;
 			const probeAttempts: Record<string, number> = { ws: 0, tcp: 0, tls: 0 };
 			const usable = new Map<string, boolean>();
 			const probeFailure = new Map<string, string>();
@@ -445,7 +470,7 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 						finalJob = job;
 						break;
 					}
-					await sleep(20);
+					await sleep(100);
 				}
 				ok(
 					tJobComplete,
@@ -574,16 +599,14 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 			ok(wsA && tcpA && tlsA, 'a required surface produced no attempts at all -- harness problem, not an MQTT result');
 
 			// Server-side cross-check: count of transport-accepted lines vs client-completed count.
-			const wsAcceptedLines = countMatches(serverLog, /Received WebSocket connection for MQTT from/g);
-			const tcpAcceptedLines = countMatches(serverLog, /Received TCP connection for MQTT from/g);
-			const sslAcceptedLines = countMatches(serverLog, /Received SSL connection for MQTT from/g);
+			const accepted = acceptCounts(serverLog);
 			const closedLines = countMatches(serverLog, /MQTT connection was closed/g);
 			console.log(
-				`\n[QA-649] SERVER LOG cross-check: WS-accepted-lines=${wsAcceptedLines} (vs ${wsA!.completed.length} client-completed), ` +
-					`TCP-accepted-lines=${tcpAcceptedLines}, SSL-accepted-lines=${sslAcceptedLines}, "MQTT connection was closed"-lines=${closedLines}`
+				`\n[QA-649] SERVER LOG cross-check: WS-accepted-lines=${accepted.ws} (vs ${wsA!.completed.length} client-completed), ` +
+					`TCP-accepted-lines=${accepted.tcp}, SSL-accepted-lines=${accepted.tls}, "MQTT connection was closed"-lines=${closedLines}`
 			);
 			ok(
-				wsAcceptedLines > 0,
+				accepted.ws > 0,
 				'server log never recorded a single "Received WebSocket connection for MQTT from" line -- logging/harness problem, cannot evaluate the transport-accepted-but-never-completed hypothesis'
 			);
 
@@ -599,6 +622,26 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				wsA!.preRestart.some((r) => r.kind === 'completed'),
 				'no successful WS connects observed before the restart -- stream was not live, test invalid'
 			);
+
+			// The `refused` bucket absorbs the most likely regression shape: a listener that accepts
+			// the transport and never sends CONNACK is closed by mqtt.js's own connectTimeout,
+			// arrives here as `refused`, and every other oracle treats refused as accounted-for
+			// (the accept bound counts it; assertUsableAfterRestart is satisfied by any one later
+			// success). Bounding it BEFORE the restart is what keeps the bucket carrying signal --
+			// an in-window refusal is legitimate (a worker torn down between accept and CONNACK),
+			// a baseline one never is.
+			for (const [surface, a] of [
+				['WS', wsA!],
+				['TCP', tcpA!],
+				['TLS', tlsA!],
+			] as const) {
+				const baselineRefusals = a.preRestart.filter((r) => r.kind === 'refused');
+				strictEqual(
+					baselineRefusals.length,
+					0,
+					`${surface} refused ${baselineRefusals.length} of ${a.preRestart.length} connect(s) BEFORE the restart was triggered -- the transport was not healthy at baseline: ${JSON.stringify(baselineRefusals.slice(0, 5).map((r) => ({ seq: r.seq, detail: r.detail })))}`
+				);
+			}
 
 			// Precondition proof, per surface: attempts must actually have landed strictly inside
 			// the restart window, not just before/after it -- otherwise a degenerate window (e.g.
@@ -686,9 +729,9 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 					`SERVER-SIDE ACCEPT MISMATCH (${surface}): server log recorded ${acceptedLines} accepted transports vs at most ${a.completed.length + a.refused.length + probes} client-accounted-for (completed ${a.completed.length} + refused ${a.refused.length} + ${probes} baseline probe attempt(s))`
 				);
 			}
-			assertServerAccepts('WS', wsAcceptedLines, probeAttempts.ws, wsA!);
-			assertServerAccepts('TCP', tcpAcceptedLines, probeAttempts.tcp, tcpA!);
-			assertServerAccepts('TLS', sslAcceptedLines, probeAttempts.tls, tlsA!);
+			assertServerAccepts('WS', accepted.ws, probeAttempts.ws, wsA!);
+			assertServerAccepts('TCP', accepted.tcp, probeAttempts.tcp, tcpA!);
+			assertServerAccepts('TLS', accepted.tls, probeAttempts.tls, tlsA!);
 		}
 	);
 });

--- a/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
+++ b/integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts
@@ -76,6 +76,8 @@ const WARMUP_MS = 1000;
 const TAIL_MS = 2000;
 // Ceiling on the post-COMPLETE condition-wait for every surface to serve a fresh connect again.
 const POST_RESTART_RECOVERY_MS = 30_000;
+// Ceiling on re-sampling worker identity for the rotation proof after get_job reports COMPLETE.
+const ROTATION_PROOF_MS = 15_000;
 
 interface AttemptResult {
 	surface: 'ws' | 'tcp' | 'tls';
@@ -187,6 +189,9 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 					},
 					signal: AbortSignal.timeout(2000),
 				});
+				// undici does not release the socket until the body is consumed, and this loop can
+				// run hundreds of times before the component mounts.
+				await res.text().catch(() => {});
 				if (res.status !== 404) {
 					ready = true;
 					break;
@@ -262,7 +267,7 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 
 	/** Waits minWaitMs, then polls until the log stops growing for one quiet interval (bounded) --
 	 * a condition-wait on the file transport actually flushing, not a fixed guess at how long. */
-	async function readServerLogStable(minWaitMs: number, quietMs = 250, maxExtraMs = 3000): Promise<string> {
+	async function readServerLogStable(minWaitMs: number, quietMs = 250, maxExtraMs = 10_000): Promise<string> {
 		await sleep(minWaitMs);
 		let text = readServerLog();
 		const deadline = Date.now() + maxExtraMs;
@@ -300,6 +305,7 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 			const probeAttempts: Record<string, number> = { ws: 0, tcp: 0, tls: 0 };
 			const usable = new Map<string, boolean>();
 			const probeFailure = new Map<string, string>();
+			const probeWedges: Array<{ surface: string; attempt: number; detail: string }> = [];
 			for (const s of surfaces) {
 				const deadline = Date.now() + PROBE_DEADLINE_MS;
 				do {
@@ -307,6 +313,7 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 					const r = await attemptConnect(s.url, authOpts(ctx, `qa649-probe-${s.surface}-${n}`));
 					usable.set(s.surface, r.kind === 'completed');
 					if (r.kind !== 'completed') probeFailure.set(s.surface, `${r.kind}: ${r.detail}`);
+					if (r.kind === 'wedged') probeWedges.push({ surface: s.surface, attempt: n, detail: r.detail });
 					await endQuiet(r.client);
 					if (usable.get(s.surface)) break;
 					await sleep(500);
@@ -318,6 +325,15 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 						`attempts=${probeAttempts[s.surface]} ${probeFailure.get(s.surface) ?? ''}`
 				);
 			}
+			// Checked before the usability assertion below, and before the storm: a wedged probe IS
+			// the defect this file exists to catch, arriving early. Retrying past it would discard
+			// the only evidence, because probe attempts are deliberately excluded from `results`
+			// and so are invisible to assertNoWedge.
+			strictEqual(
+				probeWedges.length,
+				0,
+				`baseline probe WEDGED before the restart was even triggered: ${JSON.stringify(probeWedges)}`
+			);
 			for (const s of surfaces) {
 				ok(
 					usable.get(s.surface),
@@ -376,7 +392,18 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				await Promise.all(pending);
 			}
 
-			const stormPromises = surfaces.map((s) => runStorm(s.surface, s.url, s.intervalMs));
+			// Each storm's rejection is handled AT CREATION, not by the `Promise.all` in `finally`
+			// seconds later: an unhandled rejection in between takes down the whole runner process
+			// and every sibling suite with it. Recorded rather than swallowed -- a storm that died
+			// early just leaves fewer attempts behind, and every oracle below is count-based, so
+			// swallowing it would read as a green run on a broken harness.
+			const stormFailures: unknown[] = [];
+			const stormPromises = surfaces.map((s) =>
+				runStorm(s.surface, s.url, s.intervalMs).catch((err) => {
+					stormFailures.push(err);
+					stormOver = true;
+				})
+			);
 
 			let tBeforeRestart = 0;
 			let tJobComplete: number | undefined;
@@ -438,19 +465,32 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				// wedged=0. Worker identity is the evidence. QA-642 established that COMPLETE
 				// correlates with the pool having FULLY rotated, so a survivor is a real finding
 				// about that signal, not a tolerance to widen.
-				const workersAfter = await httpWorkerThreadIds();
+				// Re-sampled to a deadline rather than once. system_information is served by the very
+				// pool being rotated, so a single snapshot taken immediately after COMPLETE can
+				// still describe the outgoing workers; polling makes "never rotated" mean it,
+				// instead of meaning we looked too early.
+				const rotationDeadline = Date.now() + ROTATION_PROOF_MS;
+				let workersAfter: number[] = [];
+				let survivors: number[] = [];
+				for (;;) {
+					workersAfter = await httpWorkerThreadIds();
+					survivors = workersAfter.filter((id) => workersBefore.includes(id));
+					if (survivors.length === 0 && workersAfter.length === workersBefore.length) break;
+					if (Date.now() >= rotationDeadline) break;
+					await sleep(100);
+				}
 				console.log(
 					`[QA-649] http worker threadIds ${JSON.stringify(workersBefore)} -> ${JSON.stringify(workersAfter)}`
 				);
-				ok(
-					workersAfter.length >= 2,
-					`expected >= 2 HTTP worker threads after the restart, observed ${workersAfter.length} [${workersAfter}]`
-				);
-				const survivors = workersAfter.filter((id) => workersBefore.includes(id));
 				strictEqual(
 					survivors.length,
 					0,
-					`restart_service http_workers reported COMPLETE but thread(s) [${survivors}] of [${workersBefore}] never rotated -- the restart window this test measures was not fully opened`
+					`restart_service http_workers reported COMPLETE but thread(s) [${survivors}] of [${workersBefore}] never rotated within ${ROTATION_PROOF_MS}ms -- the restart window this test measures was not fully opened`
+				);
+				strictEqual(
+					workersAfter.length,
+					workersBefore.length,
+					`HTTP worker pool came back at ${workersAfter.length} thread(s) [${workersAfter}], not the ${workersBefore.length} it started with [${workersBefore}]`
 				);
 
 				// --- Tail: keep storming past COMPLETE, to see whether the window truly closes.
@@ -474,8 +514,15 @@ suite('QA-649 MQTT connect wedge across an HTTP-worker restart', { skip: skipSui
 				// every 50/100/200ms past teardownHarper and hang the whole integration shard
 				// instead of just failing this test.
 				stormOver = true;
-				await Promise.all(stormPromises).catch(() => {});
+				await Promise.all(stormPromises);
 			}
+
+			// After the `finally`, so a genuine assertion failure inside the try reports first and
+			// is never masked by this one.
+			ok(
+				stormFailures.length === 0,
+				`connect storm(s) threw: ${stormFailures.map((e: any) => e?.stack ?? String(e)).join(' | ')}`
+			);
 
 			// Promise.all(stormPromises) above already waited for every launched attempt to be
 			// CLASSIFIED (up to WALL_CLOCK_MS after launch); only the LATE_GRACE_MS late-connect

--- a/integrationTests/mqtt/qa649-mqtt-restart-wedge/config.yaml
+++ b/integrationTests/mqtt/qa649-mqtt-restart-wedge/config.yaml
@@ -1,0 +1,6 @@
+# QA-649 — MQTT connect wedge across an HTTP-worker restart fixture.
+# Minimal table only for a REST readiness-probe route; the experiment itself is all MQTT connects.
+graphqlSchema:
+  files: '*.graphql'
+rest: true
+mqtt: true

--- a/integrationTests/mqtt/qa649-mqtt-restart-wedge/schema.graphql
+++ b/integrationTests/mqtt/qa649-mqtt-restart-wedge/schema.graphql
@@ -1,0 +1,5 @@
+# QA-649 — trivial table, used only to give the readiness poll a route to probe.
+type Probe @table @export {
+	id: ID @primaryKey
+	value: String
+}


### PR DESCRIPTION
## Summary

Promotes qa-explorer candidate P-425 (QA-649) into `integrationTests/mqtt/qa649-mqtt-restart-wedge.test.ts`: an MQTT connect attempt, on every usable transport (WS `/mqtt`, raw TCP `:1883`, TLS `:8883`), must never wedge — neither complete nor cleanly error — across a `restart_service {service:'http_workers'}` rotation. It is the MQTT-side companion to `deploy-restart-topic-availability.test.ts`'s REST-side restart contract, and a clean-negative anchor: it retires a suspected 600s+ deploy-time MQTT wedge and is the falsifier if that class returns. Test-only — no product code and no existing test is touched.

The anchor is two-sided by construction. Client side, every attempt is bounded and accounted for as exactly one of completed / refused / wedged. Server side, the transport-accept trace lines `server/mqtt.ts` emits *before* the CONNECT packet is parsed are counted and bounded against the client's own accounting ([the two-sided accept bound](https://github.com/HarperFast/harper/pull/2488/changes?w=1#diff-4714c035775037d592bf5a4e678f4cebccaf99662317ec09b9156ac8d4f82691R737)). Neither half is trusted alone, and the restart is proven to have actually rotated the pool rather than merely reported COMPLETE ([the rotation proof](https://github.com/HarperFast/harper/pull/2488/changes?w=1#diff-4714c035775037d592bf5a4e678f4cebccaf99662317ec09b9156ac8d4f82691R518)).

## For the human reviewer

Ten independent review rounds ran on this branch. Six were the earlier session's; this session ran four more (two `--full`, then two deltas) because those earlier receipts were written against a worktree path rather than `HarperFast/harper` and so were invisible to the settle gate. Re-reviewing was not ceremony: every finding below is a way the anchor could have reported **green while testing less than it claims**, and the last round converged with no functional findings left. What changed is worth reading:

1. **The restart was never proven to have rotated anything.** `get_job` COMPLETE is a documented completion signal, not evidence. A `restart_service http_workers` regressed to a no-op still reports COMPLETE, and then every assertion passes on a window that never opened. Worker thread ids are now sampled before the trigger and re-sampled to a deadline after COMPLETE, requiring a full rotation and the pool back at its original width ([the rotation proof](https://github.com/HarperFast/harper/pull/2488/changes?w=1#diff-4714c035775037d592bf5a4e678f4cebccaf99662317ec09b9156ac8d4f82691R518)). Found by the Harper-domain adjudicator; no outside leg saw it.
2. **A transport could disappear from a passing run.** A single failed baseline probe marked a surface unusable and skipped its storm *and every assertion*, so a regression that stopped `:1883` binding would have read as "skipped". Every surface is now required, probed to a deadline so a slow bind is waited out ([every surface required](https://github.com/HarperFast/harper/pull/2488/changes?w=1#diff-4714c035775037d592bf5a4e678f4cebccaf99662317ec09b9156ac8d4f82691R364)), and the restart-window precondition is asserted per surface rather than WS-only.
3. **Fixing (2) opened a new hole, caught the next round.** Probe attempts are excluded from `results`, so retrying past a probe that *wedged* discarded the exact defect this file exists to catch. Probe wedges are now collected and asserted, ahead of the usability check ([probe wedges asserted](https://github.com/HarperFast/harper/pull/2488/changes?w=1#diff-4714c035775037d592bf5a4e678f4cebccaf99662317ec09b9156ac8d4f82691R359)).
4. **The "two-sided" oracle was upper-bound only.** One rename in `server/mqtt.ts` would have zeroed `acceptedLines` and left `0 <= completed + refused + probes` true forever. It is now closed at both ends, per surface ([the two-sided accept bound](https://github.com/HarperFast/harper/pull/2488/changes?w=1#diff-4714c035775037d592bf5a4e678f4cebccaf99662317ec09b9156ac8d4f82691R737)) — and because the lower bound made a truncated log a false *red*, `logging.rotation` is disabled for the suite (the default is on at 64M ([rotation disabled for the suite](https://github.com/HarperFast/harper/pull/2488/changes?w=1#diff-4714c035775037d592bf5a4e678f4cebccaf99662317ec09b9156ac8d4f82691R186))) and the settle-wait now waits on the accept counts themselves rather than on whole-file length ([`readServerLogStable`](https://github.com/HarperFast/harper/pull/2488/changes?w=1#diff-4714c035775037d592bf5a4e678f4cebccaf99662317ec09b9156ac8d4f82691R283)).
5. **Recovery was keyed to the job's own report, not to proven rotation.** The rotation proof can settle later than `get_job` COMPLETE — measured at t+4180ms against a COMPLETE near t+3400ms in one run — so an outgoing worker serving a single connect inside that gap satisfied "the surface came back" while every replacement listener could be refusing the tail. Recovery now requires a completion launched at or after the moment rotation was proven.
6. **`refused` was an unbounded sink.** The likeliest regression shape — a listener that accepts the transport and never sends CONNACK — is closed by mqtt.js's own `connectTimeout`, lands in `refused`, and every oracle treated refused as accounted-for. Baseline refusals are now bounded at zero per surface, so the bucket carries signal; in-window refusals stay legitimate ([baseline refusals bounded](https://github.com/HarperFast/harper/pull/2488/changes?w=1#diff-4714c035775037d592bf5a4e678f4cebccaf99662317ec09b9156ac8d4f82691R649)).

**Declined, and why:**

- **Scoping `assertNoWedge` to `[trigger, COMPLETE)`** rather than the whole storm. Raised twice; the adjudicator dropped it as factually wrong in its premise — a merely slow connect cannot reach the 10s cap, because mqtt.js's 6s `connectTimeout` closes the stream first and it lands in `refused`. Reaching `wedged` requires that watchdog to have failed too, which is itself the reported symptom. Kept whole-run.
- **Tolerating a lost `restart_service` ack.** `rolling-restart.test.ts` can tolerate one because it uses worker count as its done signal; this test needs the `job_id` from that response. Not seen in 20+ runs, and the failure is loud and attributable rather than a silent pass.
- **Comment density**, flagged in every round against Harper's zero-new-comments default. Declined, consistent with the call this repo already made for comparable QA-anchor promotions: each block states a non-obvious why — why job completion *plus* thread rotation is the gate, why `refused` counts in the accept oracle, why cleanup is bounded — rather than narrating the adjacent line.
- **Nulling `AttemptResult.client` after teardown.** Raised as a nit in three rounds; the "~8k retained clients" figure assumes a far longer run than this one, which tops out near 250 records at the configured cadences. Declined because the change touches the classification path — the one path the whole anchor rests on — for a GC nit.
- **Allocation and sync-read concerns in the log reader** (`readFileSync` per poll, `String.match` arrays, `Math.min(...spread)`), raised repeatedly and escalated to "major" in the last round on the theory that they skew `WALL_CLOCK_MS` classification. The adjudicator refuted this twice and the refutation still holds: all of it runs *after* `Promise.all(stormPromises)`, when every attempt is already classified.
- **Failing loudly when `readServerLogStable` hits its ceiling** instead of returning the last read. The root cause was fixed — it now settles on the accept counts it asserts on, not on whole-file length, so background trace chatter no longer prevents stability — and the residue only affects message quality: an unstable log still fails, via `SERVER-SIDE TRACE MISSING`, which names the log as the problem. A one-line follow-up if anyone wants the sharper message.

**Open decisions left for you** (from the adjudicator's ledger, none blocking):

- This lands in the **default MQTT integration shard**, costing ~20s per PR run, for a defect never reproduced locally. A nightly-only home is one file move away.
- The server half of the oracle **parses log wording** (`server/mqtt.ts`), which couples it to uncontracted internal strings. The lower bound is the mitigation — a rename now fails loudly instead of silently disabling the check — but an operations/metrics counter would be better if one exists.
- **A degenerate restart window fails loudly** rather than narrowing the anchor. Measured windows are 3.2–4.3s against a 200ms worst-case cadence, so this is a wide margin, but it is a deliberate fail-loud choice.

## Verification

- **Cold runs on this branch: 10 in this session, all green** (2 per fix round, re-run after every change, plus the earlier session's 14). Every run: 0 wedged on all three transports, rotation observed `[1,2,3,4] → [6,7,8,9]`, accept counts exactly `completed + 1` per surface.
- **CI on this head: all 38 checks green**, and the spec itself ran green on both runtimes — Integration 1/6 (Node v24) 22.2s, ws 151/151 + tcp 76/76 + tls 39/39; 1/6 (uWS HTTP) 28.5s, ws 184/184 + tcp 94/94 + tls 47/47. 0 wedged everywhere. Bun and Windows skip the suite, as it declares. Worth noting: the CI runners proved rotation at **t+4643ms and t+6426ms**, well past `get_job` COMPLETE — the gap that made keying recovery to COMPLETE a real false-negative, not a theoretical one.
- `npx oxlint` and `npx prettier --check` clean on the changed files; `node --experimental-strip-types --check` passes. (`tsconfig.json`'s `include` does not cover `integrationTests/`, so no `tsc` pass applies.)
- Isolation: the runner gives each file its own process and its own Harper instance on its own loopback address, so nothing is declared — matching the rest of `integrationTests/mqtt/`.
- `test:integration:all` was not run: this is an isolated new file plus fixture directory with no shared-file overlap, matching the verification scope prior QA-promotion PRs (#2449, #1900) used.
- The previous head saw one unrelated failure, `integrationTests/apiTests/blob.test.mjs` in shard 3/6 — a different shard and runner from this test, against a green main (see #2379). It did not recur on this head.

Complexity: medium

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=4 @ 38077aa4eea7</sub>

<sub>Human-Review-Need: 3 @ 38077aa4eea7</sub>
