### PR TITLE
Make an audit entry's field offsets independent of its previousVersion value (harper#2247)

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -104,6 +104,8 @@ export type Entry = {
 export const TIMESTAMP_PLACEHOLDER = new Uint8Array([1, 1, 1, 1, 4, 0x40, 0, 0]);
 // the first byte here indicates that we use the last timestamp
 export const LAST_TIMESTAMP_PLACEHOLDER = new Uint8Array([1, 1, 1, 1, 1, 0, 0, 0]);
+// Never write this into an audit entry value: the substitution resolves to 2.0 when no previous time
+// was recorded, and the audit format reads a leading byte other than 0x42 as "no field here". See harper#2247.
 export const PREVIOUS_TIMESTAMP_PLACEHOLDER = new Uint8Array([1, 1, 1, 1, 3, 0x40, 0, 0]);
 export const NEW_TIMESTAMP_PLACEHOLDER = new Uint8Array([1, 1, 1, 1, 0, 0x40, 0, 0]);
 export const LOCAL_TIMESTAMP = Symbol('local-timestamp');

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -4,7 +4,7 @@ import { AUDIT_STORE_NAME } from '../utility/lmdb/terms.ts';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import { getWorkerIndex, getWorkerCount } from '../server/threads/manageThreads.js';
 import { convertToMS } from '../utility/common_utils.ts';
-import { PREVIOUS_TIMESTAMP_PLACEHOLDER, LAST_TIMESTAMP_PLACEHOLDER } from './RecordEncoder.ts';
+import { LAST_TIMESTAMP_PLACEHOLDER, HAS_STRUCTURE_UPDATE } from './RecordEncoder.ts';
 import * as harperLogger from '../utility/logging/harper_logger.ts';
 import { getRecordAtTime } from './crdt.ts';
 import { decodeFromDatabase } from './blob.ts';
@@ -116,6 +116,10 @@ const MAX_CLEANUP_DELAY = 2 ** 31 - 1;
 // mint latch keyed per (table, type) so one entry type can't silence another's producer stack
 const warnedBodylessMints = new Set<string>();
 const warnedBodylessTables = new Set<number>();
+// legacy-format latches: one warn per process each, so a range scan over millions of pre-#2247
+// entries cannot turn a recovered read into a log flood
+let warnedRecoveredPrefix = false;
+let warnedUndecodableHeader = false;
 const FLOAT_TARGET = new Float64Array(1);
 const FLOAT_BUFFER = new Uint8Array(FLOAT_TARGET.buffer);
 
@@ -482,6 +486,46 @@ const EVENT_TYPES = {
 	remoteSequenceUpdate: REMOTE_SEQUENCE_UPDATE,
 	[REMOTE_SEQUENCE_UPDATE]: 'remoteSequenceUpdate',
 };
+/**
+ * The LMDB audit entry states the presence of its leading 8-byte previousVersion field with that
+ * field's own first byte. The same test is what harperdb 4.x's reader uses and what both versions'
+ * replication senders use to strip the field before framing an entry for the wire, so it is a
+ * cross-version contract, not a local convention: a field written with any other leading byte is
+ * skipped by every reader and shifts action/nodeId/tableId/recordId/version by 8. See harper#2247.
+ */
+const PREVIOUS_VERSION_FIRST_BYTE = 66;
+/**
+ * Which first bytes can begin an action, and so cannot be a previousVersion field. The single-byte
+ * form is an EVENT_TYPES value, optionally with HAS_RECORD cleared for a bodyless mint; the extended
+ * form is written with setUint32 as `action | extendedType | 0xc0000000`. 0xff is excluded because
+ * Decoder.readInt reads it as a five-byte form this writer never emits.
+ */
+const ACTION_FIRST_BYTE = new Uint8Array(256);
+for (const type in EVENT_TYPES) {
+	if (Number.isNaN(Number(type))) {
+		const action = EVENT_TYPES[type];
+		ACTION_FIRST_BYTE[action] = 1;
+		ACTION_FIRST_BYTE[action & ~HAS_RECORD] = 1;
+	}
+}
+for (let firstByte = 0xc0; firstByte < 0xff; firstByte++) ACTION_FIRST_BYTE[firstByte] = 1;
+/**
+ * Every bit this version can decode out of an action word. Used only to accept or reject a legacy
+ * prefix recovery — never to validate a normally-framed entry, where an unknown future flag must
+ * stay forwards-compatible rather than corrupt.
+ */
+const KNOWN_ACTION_FLAGS =
+	0xf |
+	HAS_RECORD |
+	HAS_PARTIAL_RECORD |
+	HAS_STRUCTURE_UPDATE |
+	HAS_CURRENT_RESIDENCY_ID |
+	HAS_PREVIOUS_RESIDENCY_ID |
+	HAS_ORIGINATING_OPERATION |
+	HAS_EXPIRATION_EXTENDED_TYPE |
+	HAS_BLOBS |
+	HAS_ADDITIONAL_AUDIT_REFS |
+	LOCAL_ONLY;
 const ORIGINATING_OPERATIONS = {
 	insert: 1,
 	update: 2,
@@ -547,12 +591,28 @@ export function createAuditEntry(auditRecord: AuditRecord, start = 0) {
 		}
 		action &= ~HAS_RECORD;
 	}
-	let position = start + 1;
-	if (previousVersion) {
-		if (previousVersion > 1) ENTRY_DATAVIEW.setFloat64(start, previousVersion);
-		else ENTRY_HEADER.set(PREVIOUS_TIMESTAMP_PLACEHOLDER, start);
-		position = start + 9;
+	let hasPreviousVersion: boolean;
+	if (start > 0) {
+		// RocksTransactionLogStore states presence with its own prelude flag, derived from this same
+		// truthiness, so this container's field stays unconditional and its value is unconstrained.
+		hasPreviousVersion = !!previousVersion;
+		if (hasPreviousVersion) ENTRY_DATAVIEW.setFloat64(start, previousVersion);
+	} else if (previousVersion == null || previousVersion === 0) {
+		// absence is stated, not inferred from truthiness: NaN is falsy and would otherwise be
+		// silently dropped rather than rejected below
+		hasPreviousVersion = false;
+	} else {
+		ENTRY_DATAVIEW.setFloat64(start, previousVersion);
+		if (ENTRY_HEADER[start] !== PREVIOUS_VERSION_FIRST_BYTE) {
+			throw new Error(
+				`Audit entry previousVersion ${previousVersion} for record ${recordId} in table ${tableId} is not representable. ` +
+					'The LMDB audit format signals this field with its own leading 0x42 byte, so only values in [2**33, 2**49) can be written; ' +
+					'writing any other value produces an entry every reader parses 8 bytes off.'
+			);
+		}
+		hasPreviousVersion = true;
 	}
+	let position = start + (hasPreviousVersion ? 9 : 1);
 	if (extendedType) {
 		if (extendedType & 0xff) {
 			throw new Error('Illegal extended type');
@@ -591,8 +651,9 @@ export function createAuditEntry(auditRecord: AuditRecord, start = 0) {
 
 	if (user) writeValue(user);
 	else ENTRY_HEADER[position++] = 0;
-	if (extendedType) ENTRY_DATAVIEW.setUint32(start + (previousVersion ? 8 : 0), action | extendedType | 0xc0000000);
-	else ENTRY_HEADER[start + (previousVersion ? 8 : 0)] = action;
+	const actionPosition = start + (hasPreviousVersion ? 8 : 0);
+	if (extendedType) ENTRY_DATAVIEW.setUint32(actionPosition, action | extendedType | 0xc0000000);
+	else ENTRY_HEADER[actionPosition] = action;
 	const header = ENTRY_HEADER.subarray(0, position);
 	if (encodedRecord) {
 		return Buffer.concat([header, encodedRecord]);
@@ -650,11 +711,44 @@ export function readAuditEntry(buffer: Uint8Array, start = 0, end = undefined): 
 			((buffer as any).decoder = new Decoder(buffer.buffer, buffer.byteOffset, buffer.byteLength));
 		decoder.position = start;
 		let previousVersion;
-		if (buffer[decoder.position] == 66) {
-			// 66 is the first byte in a date double.
+		let entryStart = start;
+		const firstByte = buffer[start];
+		if (firstByte === PREVIOUS_VERSION_FIRST_BYTE) {
 			previousVersion = decoder.readFloat64();
+		} else if (ACTION_FIRST_BYTE[firstByte] !== 1) {
+			// Written before the writer enforced the leading-0x42 contract (harper#2247): the field is
+			// physically here but does not announce itself, so the action sits 8 bytes further on.
+			// Recover only when the bytes cannot be anything else, and never for the RocksDB container,
+			// whose prelude flag already consumed its previousVersion before this offset.
+			if (start !== 0 || start + 9 > buffer.byteLength || ACTION_FIRST_BYTE[buffer[start + 8]] !== 1) {
+				return corruptEntry(buffer, start, end, firstByte);
+			}
+			const candidate = decoder.getFloat64(start);
+			// > 1 is exactly what the superseded writer's own guard could emit, which is the tightest
+			// bound available on "these bytes really are an old previousVersion".
+			if (!(candidate > 1)) return corruptEntry(buffer, start, end, firstByte);
+			entryStart = decoder.position = start + 8;
+			previousVersion = candidate;
 		}
 		const action = decoder.readInt();
+		if (entryStart !== start) {
+			if (EVENT_TYPES[action & 0xf] === undefined || action & ~KNOWN_ACTION_FLAGS) {
+				return corruptEntry(buffer, start, end, firstByte);
+			}
+			// 2.0 is what lmdb-js's instructed-write substitution leaves in the slot when no previous
+			// time was recorded, so it is a "no previous version" sentinel rather than a log position.
+			// Any other recovered value is kept: it may be a real back-edge, and dropping it would
+			// truncate the record's history chain.
+			if (previousVersion === 2) previousVersion = undefined;
+			if (!warnedRecoveredPrefix) {
+				warnedRecoveredPrefix = true;
+				warnContained('Audit entry carries an unannounced previousVersion field; recovering its field offsets', {
+					previousVersion,
+					firstByte,
+					entry: Buffer.from(buffer.subarray(start, start + 24)).toString('hex'),
+				});
+			}
+		}
 		const nodeId = decoder.readInt();
 		const tableId = decoder.readInt();
 		let length = decoder.readInt();
@@ -742,10 +836,14 @@ export function readAuditEntry(buffer: Uint8Array, start = 0, end = undefined): 
 				}
 			},
 			get encoded() {
-				return start ? buffer.subarray(start, end) : buffer;
+				// On a recovered entry this drops the unannounced prefix, so a replication sender —
+				// which strips by the same leading-0x42 test and frames by encoded.length — forwards a
+				// clean entry instead of passing the same misparse to the next hop.
+				return entryStart ? buffer.subarray(entryStart, end) : buffer;
 			},
 			get size() {
-				return start !== undefined && end !== undefined ? end - start : buffer.byteLength;
+				// only the recovered prefix is discounted; every other case keeps its existing basis
+				return (end !== undefined ? end - start : buffer.byteLength) - (entryStart - start);
 			},
 			getValue(store, fullRecord?, auditTime?) {
 				if (action & HAS_RECORD || (action & HAS_PARTIAL_RECORD && !fullRecord)) {
@@ -792,6 +890,22 @@ export function readAuditEntry(buffer: Uint8Array, start = 0, end = undefined): 
 		harperLogger.error('Reading audit entry error', error, buffer);
 		return createCorruptAuditSentinel(buffer, start, end);
 	}
+}
+
+/**
+ * Reject a header whose first byte can be neither an action nor a previousVersion field. Returns the
+ * sentinel directly rather than throwing into readAuditEntry's catch, whose error log is not
+ * contained: a throwing log sink there would escape the decoder and stall the iteration it runs in.
+ */
+function corruptEntry(buffer: Uint8Array, start: number, end: number | undefined, firstByte: number): AuditRecord {
+	if (!warnedUndecodableHeader) {
+		warnedUndecodableHeader = true;
+		warnContained('Audit entry header begins with neither an action nor a previousVersion; treating as corrupt', {
+			firstByte,
+			entry: Buffer.from(buffer.subarray(start, Math.min(start + 24, buffer.byteLength))).toString('hex'),
+		});
+	}
+	return createCorruptAuditSentinel(buffer, start, end);
 }
 
 /**

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -503,7 +503,7 @@ const PREVIOUS_VERSION_FIRST_BYTE = 66;
  * entry types, and a peer one version ahead must keep decoding rather than look corrupt here.
  */
 const ACTION_FIRST_BYTE = new Uint8Array(256);
-// single-byte form: the entry type in the low nibble (0 is not a type) plus the two record flags
+// single-byte form; 0 is not an entry type, so a zero low nibble cannot start one
 for (let firstByte = 1; firstByte <= (HAS_RECORD | HAS_PARTIAL_RECORD | 0xf); firstByte++) {
 	if (firstByte & 0xf) ACTION_FIRST_BYTE[firstByte] = 1;
 }
@@ -608,12 +608,11 @@ export function createAuditEntry(auditRecord: AuditRecord, start = 0) {
 		// silently dropped rather than rejected below
 		hasPreviousVersion = false;
 	} else if (previousVersion === PENDING_LOCAL_TIME) {
-		// The previous entry's log position is not assigned yet. The superseded code deferred this to
-		// lmdb-js's instructed-write substitution, which resolves to 2.0 whenever no previous time was
-		// recorded — the unreadable entry this guard exists to prevent. A format whose presence signal
-		// is the value's own first byte cannot express "to be filled in at commit", so the back-edge is
-		// dropped rather than gambled on. Not a throw: a pending previous is a legitimate producer
-		// state, unlike a value the format simply cannot hold.
+		// The previous entry has no log position yet, and a format whose presence signal is the value's
+		// own first byte cannot express "to be filled in at commit". The superseded code deferred to
+		// lmdb-js's substitution, which resolves to 2.0 when no previous time was recorded — the
+		// unreadable entry this guard exists to prevent. Not a throw: a pending previous is a producer
+		// state, unlike a value the format cannot hold.
 		hasPreviousVersion = false;
 		if (!warnedPendingPreviousVersion.has(`${tableId}:${type}`)) {
 			warnedPendingPreviousVersion.add(`${tableId}:${type}`);

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -4,7 +4,7 @@ import { AUDIT_STORE_NAME } from '../utility/lmdb/terms.ts';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import { getWorkerIndex, getWorkerCount } from '../server/threads/manageThreads.js';
 import { convertToMS } from '../utility/common_utils.ts';
-import { LAST_TIMESTAMP_PLACEHOLDER, HAS_STRUCTURE_UPDATE } from './RecordEncoder.ts';
+import { LAST_TIMESTAMP_PLACEHOLDER, HAS_STRUCTURE_UPDATE, PENDING_LOCAL_TIME } from './RecordEncoder.ts';
 import * as harperLogger from '../utility/logging/harper_logger.ts';
 import { getRecordAtTime } from './crdt.ts';
 import { decodeFromDatabase } from './blob.ts';
@@ -116,10 +116,13 @@ const MAX_CLEANUP_DELAY = 2 ** 31 - 1;
 // mint latch keyed per (table, type) so one entry type can't silence another's producer stack
 const warnedBodylessMints = new Set<string>();
 const warnedBodylessTables = new Set<number>();
-// legacy-format latches: one warn per process each, so a range scan over millions of pre-#2247
-// entries cannot turn a recovered read into a log flood
-let warnedRecoveredPrefix = false;
+// legacy-format latches, mirroring the bodyless ones above: a range scan over millions of pre-#2247
+// entries must not turn a recovered read into a log flood. Recovery latches per table (the table is
+// known by then); an undecodable header has no table, so it latches once per process.
+const warnedRecoveredTables = new Set<number>();
 let warnedUndecodableHeader = false;
+// keyed per (table, type) like warnedBodylessMints, so one entry type cannot silence another's stack
+const warnedPendingPreviousVersion = new Set<string>();
 const FLOAT_TARGET = new Float64Array(1);
 const FLOAT_BUFFER = new Uint8Array(FLOAT_TARGET.buffer);
 
@@ -495,37 +498,40 @@ const EVENT_TYPES = {
  */
 const PREVIOUS_VERSION_FIRST_BYTE = 66;
 /**
- * Which first bytes can begin an action, and so cannot be a previousVersion field. The single-byte
- * form is an EVENT_TYPES value, optionally with HAS_RECORD cleared for a bodyless mint; the extended
- * form is written with setUint32 as `action | extendedType | 0xc0000000`. 0xff is excluded because
- * Decoder.readInt reads it as a five-byte form this writer never emits.
+ * Which first bytes can begin an action, and so cannot be a previousVersion field. Derived from what
+ * the encoding can express, not from the types defined today: nibbles 9-15 are reserved for future
+ * entry types, and a peer one version ahead must keep decoding rather than look corrupt here.
  */
 const ACTION_FIRST_BYTE = new Uint8Array(256);
-for (const type in EVENT_TYPES) {
-	if (Number.isNaN(Number(type))) {
-		const action = EVENT_TYPES[type];
-		ACTION_FIRST_BYTE[action] = 1;
-		ACTION_FIRST_BYTE[action & ~HAS_RECORD] = 1;
-	}
+// single-byte form: the entry type in the low nibble (0 is not a type) plus the two record flags
+for (let firstByte = 1; firstByte <= (HAS_RECORD | HAS_PARTIAL_RECORD | 0xf); firstByte++) {
+	if (firstByte & 0xf) ACTION_FIRST_BYTE[firstByte] = 1;
 }
+// extended form, written as `action | extendedType | 0xc0000000`; 0xff is the five-byte readInt form
 for (let firstByte = 0xc0; firstByte < 0xff; firstByte++) ACTION_FIRST_BYTE[firstByte] = 1;
+let knownActionFlags: number | undefined;
 /**
- * Every bit this version can decode out of an action word. Used only to accept or reject a legacy
- * prefix recovery — never to validate a normally-framed entry, where an unknown future flag must
- * stay forwards-compatible rather than corrupt.
+ * Whether an action word decodes wholly into what this version understands. Consulted only to accept
+ * or reject a legacy prefix recovery — never to validate a normally-framed entry, where an unknown
+ * future flag must stay forwards-compatible rather than corrupt. The mask is built on first use
+ * because HAS_STRUCTURE_UPDATE crosses the RecordEncoder import cycle: read at module scope it
+ * resolves to undefined whenever RecordEncoder is the cycle's entry, silently dropping that bit.
  */
-const KNOWN_ACTION_FLAGS =
-	0xf |
-	HAS_RECORD |
-	HAS_PARTIAL_RECORD |
-	HAS_STRUCTURE_UPDATE |
-	HAS_CURRENT_RESIDENCY_ID |
-	HAS_PREVIOUS_RESIDENCY_ID |
-	HAS_ORIGINATING_OPERATION |
-	HAS_EXPIRATION_EXTENDED_TYPE |
-	HAS_BLOBS |
-	HAS_ADDITIONAL_AUDIT_REFS |
-	LOCAL_ONLY;
+function isDecodableAction(action: number) {
+	knownActionFlags ??=
+		0xf |
+		HAS_RECORD |
+		HAS_PARTIAL_RECORD |
+		HAS_STRUCTURE_UPDATE |
+		HAS_CURRENT_RESIDENCY_ID |
+		HAS_PREVIOUS_RESIDENCY_ID |
+		HAS_ORIGINATING_OPERATION |
+		HAS_EXPIRATION_EXTENDED_TYPE |
+		HAS_BLOBS |
+		HAS_ADDITIONAL_AUDIT_REFS |
+		LOCAL_ONLY;
+	return (action & 0xf) !== 0 && !(action & ~knownActionFlags);
+}
 const ORIGINATING_OPERATIONS = {
 	insert: 1,
 	update: 2,
@@ -601,6 +607,21 @@ export function createAuditEntry(auditRecord: AuditRecord, start = 0) {
 		// absence is stated, not inferred from truthiness: NaN is falsy and would otherwise be
 		// silently dropped rather than rejected below
 		hasPreviousVersion = false;
+	} else if (previousVersion === PENDING_LOCAL_TIME) {
+		// The previous entry's log position is not assigned yet. The superseded code deferred this to
+		// lmdb-js's instructed-write substitution, which resolves to 2.0 whenever no previous time was
+		// recorded — the unreadable entry this guard exists to prevent. A format whose presence signal
+		// is the value's own first byte cannot express "to be filled in at commit", so the back-edge is
+		// dropped rather than gambled on. Not a throw: a pending previous is a legitimate producer
+		// state, unlike a value the format simply cannot hold.
+		hasPreviousVersion = false;
+		if (!warnedPendingPreviousVersion.has(`${tableId}:${type}`)) {
+			warnedPendingPreviousVersion.add(`${tableId}:${type}`);
+			harperLogger.warn(
+				`Audit entry (${type}) for record ${recordId} in table ${tableId} has a pending previous version; recording it without a previous-version link`,
+				new Error('pending audit previousVersion')
+			);
+		}
 	} else {
 		ENTRY_DATAVIEW.setFloat64(start, previousVersion);
 		if (ENTRY_HEADER[start] !== PREVIOUS_VERSION_FIRST_BYTE) {
@@ -732,25 +753,23 @@ export function readAuditEntry(buffer: Uint8Array, start = 0, end = undefined): 
 		}
 		const action = decoder.readInt();
 		if (entryStart !== start) {
-			if (EVENT_TYPES[action & 0xf] === undefined || action & ~KNOWN_ACTION_FLAGS) {
-				return corruptEntry(buffer, start, end, firstByte);
-			}
+			if (!isDecodableAction(action)) return corruptEntry(buffer, start, end, firstByte);
 			// 2.0 is what lmdb-js's instructed-write substitution leaves in the slot when no previous
 			// time was recorded, so it is a "no previous version" sentinel rather than a log position.
 			// Any other recovered value is kept: it may be a real back-edge, and dropping it would
 			// truncate the record's history chain.
 			if (previousVersion === 2) previousVersion = undefined;
-			if (!warnedRecoveredPrefix) {
-				warnedRecoveredPrefix = true;
-				warnContained('Audit entry carries an unannounced previousVersion field; recovering its field offsets', {
-					previousVersion,
-					firstByte,
-					entry: Buffer.from(buffer.subarray(start, start + 24)).toString('hex'),
-				});
-			}
 		}
 		const nodeId = decoder.readInt();
 		const tableId = decoder.readInt();
+		if (entryStart !== start && !warnedRecoveredTables.has(tableId)) {
+			warnedRecoveredTables.add(tableId);
+			warnContained('Audit entry carries an unannounced previousVersion field; recovering its field offsets', {
+				tableId,
+				firstByte,
+				previousVersion,
+			});
+		}
 		let length = decoder.readInt();
 		// A corrupt length field (e.g., a 0xff-prefixed uint32) would otherwise push
 		// decoder.position hundreds of megabytes past the buffer; the next readFloat64
@@ -902,7 +921,8 @@ function corruptEntry(buffer: Uint8Array, start: number, end: number | undefined
 		warnedUndecodableHeader = true;
 		warnContained('Audit entry header begins with neither an action nor a previousVersion; treating as corrupt', {
 			firstByte,
-			entry: Buffer.from(buffer.subarray(start, Math.min(start + 24, buffer.byteLength))).toString('hex'),
+			// the 8 prefix bytes plus the action byte: the classifying bytes, stopping before the recordId
+			header: Buffer.from(buffer.subarray(start, Math.min(start + 9, buffer.byteLength))).toString('hex'),
 		});
 	}
 	return createCorruptAuditSentinel(buffer, start, end);

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -610,13 +610,14 @@ export function createAuditEntry(auditRecord: AuditRecord, start = 0) {
 	} else if (previousVersion === PENDING_LOCAL_TIME) {
 		// The previous entry has no log position yet, and a format whose presence signal is the value's
 		// own first byte cannot express "to be filled in at commit". The superseded code deferred to
-		// lmdb-js's substitution, which resolves to 2.0 when no previous time was recorded — the
-		// unreadable entry this guard exists to prevent. Not a throw: a pending previous is a producer
-		// state, unlike a value the format cannot hold.
+		// lmdb-js's instructed-write substitution, which resolves to 2.0 whenever no previous time was
+		// recorded — the unreadable entry behind harper-pro#737. It resolved correctly when one was, so
+		// this trades a lost link on that path for never minting the unreadable form. Not a throw: a
+		// pending previous is a producer state, unlike a value the format cannot hold.
 		hasPreviousVersion = false;
 		if (!warnedPendingPreviousVersion.has(`${tableId}:${type}`)) {
 			warnedPendingPreviousVersion.add(`${tableId}:${type}`);
-			harperLogger.warn(
+			warnContained(
 				`Audit entry (${type}) for record ${recordId} in table ${tableId} has a pending previous version; recording it without a previous-version link`,
 				new Error('pending audit previousVersion')
 			);
@@ -743,21 +744,18 @@ export function readAuditEntry(buffer: Uint8Array, start = 0, end = undefined): 
 			if (start !== 0 || start + 9 > buffer.byteLength || ACTION_FIRST_BYTE[buffer[start + 8]] !== 1) {
 				return corruptEntry(buffer, start, end, firstByte);
 			}
-			const candidate = decoder.getFloat64(start);
-			// > 1 is exactly what the superseded writer's own guard could emit, which is the tightest
-			// bound available on "these bytes really are an old previousVersion".
-			if (!(candidate > 1)) return corruptEntry(buffer, start, end, firstByte);
+			// > 1 is exactly what the superseded writer's own guard could emit, the tightest available
+			// bound on "these bytes really are an old previousVersion"
+			if (!(decoder.getFloat64(start) > 1)) return corruptEntry(buffer, start, end, firstByte);
 			entryStart = decoder.position = start + 8;
-			previousVersion = candidate;
+			// The value itself is dropped, not reported. It cannot lead with 0x42 (that is the branch
+			// above), and audit keys carry the same constraint, so it could never have addressed a
+			// retrievable entry; reporting it would only feed an unrepresentable value back to
+			// createAuditEntry through the resolveRecord re-mint in RecordEncoder, which now rejects it.
 		}
 		const action = decoder.readInt();
-		if (entryStart !== start) {
-			if (!isDecodableAction(action)) return corruptEntry(buffer, start, end, firstByte);
-			// 2.0 is what lmdb-js's instructed-write substitution leaves in the slot when no previous
-			// time was recorded, so it is a "no previous version" sentinel rather than a log position.
-			// Any other recovered value is kept: it may be a real back-edge, and dropping it would
-			// truncate the record's history chain.
-			if (previousVersion === 2) previousVersion = undefined;
+		if (entryStart !== start && !isDecodableAction(action)) {
+			return corruptEntry(buffer, start, end, firstByte);
 		}
 		const nodeId = decoder.readInt();
 		const tableId = decoder.readInt();
@@ -766,7 +764,6 @@ export function readAuditEntry(buffer: Uint8Array, start = 0, end = undefined): 
 			warnContained('Audit entry carries an unannounced previousVersion field; recovering its field offsets', {
 				tableId,
 				firstByte,
-				previousVersion,
 			});
 		}
 		let length = decoder.readInt();

--- a/storage-format.md
+++ b/storage-format.md
@@ -57,6 +57,18 @@ The audit entry data follows the transaction log header and contains the actual 
 - **Present when:** The first byte is `0x42` (66 decimal, which is the first byte of an IEEE 754 double)
 - **Format:** 8-byte IEEE 754 double-precision float
 - **Purpose:** Stores the previous version timestamp for change tracking
+- **Representable range:** `[2^33, 2^49)`. A float64 leads with `0x42` only inside that band, and the
+  leading byte is the field's _only_ presence signal, so a value outside it would be written and then
+  skipped by every reader, shifting every following field by 8 bytes. The writer therefore rejects an
+  unrepresentable value rather than emitting one (harper#2247). Millisecond epoch timestamps sit at
+  roughly `2^40.7`, so the band covers every real log position through the year 19857.
+- **Cross-version contract:** the same leading-byte test decodes this field in harperdb 4.x and is how
+  both versions' replication senders strip it before framing an entry for the wire. It cannot be
+  replaced by a header flag without a coordinated change across all of them.
+- **Entries written before that rule was enforced** carry an unannounced field. The reader recognizes
+  them by a first byte that can begin neither an action nor this field, recovers the following
+  offsets, and exposes the entry without the stray prefix. An action's first byte is never `0x42`,
+  which is what keeps the two distinguishable.
 
 ### Action + Flags
 
@@ -86,15 +98,21 @@ Variable-length integer encoding the operation type and extended type flags.
 
 **Additional Flags (upper bits):**
 
-| Value         | Name                         | Description                         |
-| ------------- | ---------------------------- | ----------------------------------- |
-| 64 (0x40)     | HAS_PREVIOUS_VERSION         | Previous version timestamp included |
-| 128 (0x80)    | HAS_EXTENDED_TYPE            | Extended type information           |
-| 512 (0x200)   | HAS_CURRENT_RESIDENCY_ID     | Current residency ID included       |
-| 1024 (0x400)  | HAS_PREVIOUS_RESIDENCY_ID    | Previous residency ID included      |
-| 2048 (0x800)  | HAS_ORIGINATING_OPERATION    | Originating operation type included |
-| 4096 (0x1000) | HAS_EXPIRATION_EXTENDED_TYPE | Expiration timestamp included       |
-| 8192 (0x2000) | HAS_BLOBS                    | Binary blob data included           |
+The extended type must leave the low byte clear (`createAuditEntry` throws on
+`extendedType & 0xff`), so no flag below `0x100` exists here. In particular there is no
+`HAS_PREVIOUS_VERSION` flag in this word: the previous local time announces itself by its own leading
+byte, and it precedes this word, so a reader cannot consult a flag before deciding whether to skip it.
+
+| Value          | Name                         | Description                          |
+| -------------- | ---------------------------- | ------------------------------------ |
+| 256 (0x100)    | HAS_STRUCTURE_UPDATE         | Entry advances the structure set     |
+| 512 (0x200)    | HAS_CURRENT_RESIDENCY_ID     | Current residency ID included        |
+| 1024 (0x400)   | HAS_PREVIOUS_RESIDENCY_ID    | Previous residency ID included       |
+| 2048 (0x800)   | HAS_ORIGINATING_OPERATION    | Originating operation type included  |
+| 4096 (0x1000)  | HAS_EXPIRATION_EXTENDED_TYPE | Expiration timestamp included        |
+| 8192 (0x2000)  | HAS_BLOBS                    | Binary blob data included            |
+| 16384 (0x4000) | HAS_ADDITIONAL_AUDIT_REFS    | Additional audit references included |
+| 32768 (0x8000) | LOCAL_ONLY                   | Never forwarded to replication peers |
 
 ### Variable-Length Integer Encoding
 
@@ -149,8 +167,10 @@ Transaction log keys are timestamps encoded as IEEE 754 doubles:
 - **Format:** 8-byte IEEE 754 double-precision float
 - **Value:** Milliseconds since Unix epoch (Date.now())
 - **Special Values:**
-  - `LAST_TIMESTAMP_PLACEHOLDER`: Reserved placeholder value
-  - `PREVIOUS_TIMESTAMP_PLACEHOLDER`: Reserved placeholder value
+  - `LAST_TIMESTAMP_PLACEHOLDER`: instructed-write directive; lmdb-js substitutes the timestamp at commit
+
+Keys carry the same representability constraint as the previous local time, and for the same reason:
+a numeric key is written as a float64 but read back only when it leads with `0x42`.
 
 ## Size Constraints
 

--- a/storage-format.md
+++ b/storage-format.md
@@ -61,7 +61,7 @@ The audit entry data follows the transaction log header and contains the actual 
   leading byte is the field's _only_ presence signal, so a value outside it would be written and then
   skipped by every reader, shifting every following field by 8 bytes. The writer therefore rejects an
   unrepresentable value rather than emitting one (harper#2247). Millisecond epoch timestamps sit at
-  roughly `2^40.7`, so the band covers every real log position through the year 19857.
+  roughly `2^40.7`, so the band covers every real log position through roughly the year 19800.
 - **Cross-version contract:** the same leading-byte test decodes this field in harperdb 4.x and is how
   both versions' replication senders strip it before framing an entry for the wire. It cannot be
   replaced by a header flag without a coordinated change across all of them.

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -25,6 +25,7 @@ const { execFileSync } = require('node:child_process');
 const { tmpdir } = require('node:os');
 const { join } = require('node:path');
 const { waitFor } = require('../waitFor');
+const { transaction } = require('#src/resources/transaction');
 const harperLogger = require('#src/utility/logging/harper_logger');
 require('#src/server/serverHelpers/serverUtilities');
 describe('Audit log', () => {
@@ -1922,9 +1923,9 @@ describe('audit entry previousVersion presence', () => {
 		});
 	});
 
-	// The pending branch is only meaningful on LMDB, where previousVersion is the previous entry's
-	// separately stored localTime. This drives it from a real table write rather than the codec, which
-	// is the only way to learn whether PENDING_LOCAL_TIME reaches createAuditEntry at all.
+	// Both review rounds asked whether PENDING_LOCAL_TIME is reachable from a real producer. Two
+	// separately awaited puts do not answer it: each commits its own transaction, so the second sees a
+	// committed timestamp. The pending sentinel needs both writes inside ONE transaction.
 	describe('through a real table write', function () {
 		let PendingTable;
 		before(async function () {
@@ -1937,22 +1938,27 @@ describe('audit entry previousVersion presence', () => {
 			});
 		});
 
-		it('links the second of two writes to one key back to the first', async () => {
+		it('decodes both entries of a same-transaction double write, with no link on the second', async () => {
 			const id = 'pending-' + Date.now();
-			await PendingTable.put({ id, name: 'first' });
-			await PendingTable.put({ id, name: 'second' });
+			await transaction(async () => {
+				await PendingTable.put({ id, name: 'first' });
+				await PendingTable.put({ id, name: 'second' });
+			});
 			const entries = [];
 			for (const entry of PendingTable.auditStore.getRange({ start: 0 })) {
 				if (entry.recordId === id) entries.push(entry);
 			}
-			assert.ok(entries.length >= 2, `expected at least two audit entries, got ${entries.length}`);
-			const [first, second] = entries.slice(-2);
-			// The back-edge survives, which also establishes that PENDING_LOCAL_TIME does not reach the
-			// codec from an ordinary write: by the time the second entry is minted, existingEntry.localTime
-			// is a committed 0x42-band timestamp. That makes the pending branch defensive rather than
-			// routine, and it is the case a dropped link would otherwise break.
-			assert.strictEqual(second.previousVersion, first.key);
-			assert.notStrictEqual(second.previousVersion, undefined);
+			assert.strictEqual(entries.length, 2, 'both writes should be audited');
+			const second = entries[1];
+			// Measured on this branch and on origin/main: identical. The second entry carries no
+			// back-edge either way, because the first write of the same transaction has not published a
+			// localTime for the second to point at. What this pins is that neither entry misparses —
+			// recordId and type survive, which is what a written-but-skipped prefix would destroy.
+			assert.strictEqual(second.previousVersion, undefined);
+			for (const entry of entries) {
+				assert.strictEqual(entry.recordId, id);
+				assert.strictEqual(entry.type, 'put');
+			}
 		});
 	});
 

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -21,6 +21,7 @@ const {
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { setTimeout: delay } = require('node:timers/promises');
 const { mkdtempSync, readdirSync, rmSync } = require('node:fs');
+const { execFileSync } = require('node:child_process');
 const { tmpdir } = require('node:os');
 const { join } = require('node:path');
 const { waitFor } = require('../waitFor');
@@ -1655,7 +1656,6 @@ describe('audit entry previousVersion presence', () => {
 			['2 ** 49 (0x43)', 2 ** 49],
 			['2.0, the lmdb-js substitution sentinel (0x40)', 2],
 			['1.5 (0x3f)', 1.5],
-			['1, the removed placeholder trigger (0x3f)', 1],
 			['Infinity (0x7f)', Infinity],
 			['NaN, which is falsy and would otherwise be dropped silently', NaN],
 			['a negative value', -1787198768741.378],
@@ -1678,6 +1678,19 @@ describe('audit entry previousVersion presence', () => {
 				assertTrailingFields(record, label);
 			});
 		}
+
+		it('records without a link, rather than throwing, when the previous version is still pending', () => {
+			// PENDING_LOCAL_TIME: the previous entry has no log position yet. The superseded code wrote
+			// an lmdb-js substitution placeholder here, which resolves to 2.0 when no previous time was
+			// recorded — the unreadable entry this guard exists to prevent. A pending previous is a
+			// legitimate producer state, so it must not abort the user's write.
+			let buffer;
+			assert.doesNotThrow(() => (buffer = mint(1)));
+			assert.notStrictEqual(buffer[0], 0x42);
+			const record = readAuditEntry(buffer);
+			assert.strictEqual(record.previousVersion, undefined);
+			assertTrailingFields(record, 'pending previous version');
+		});
 
 		it('keeps the action offset agreeing with the field it actually wrote', () => {
 			assert.strictEqual(mint(0)[0], 0x11, 'no field: the action leads the entry');
@@ -1726,13 +1739,13 @@ describe('audit entry previousVersion presence', () => {
 	// Fixture bytes, not a live write: these are the shapes already on disk and on the wire from
 	// writers that predate the guard, including harperdb 4.x, which still mints them today.
 	describe('entries written before the guard', () => {
-		function legacyEntry(prefix, { actionByte = 0x11 } = {}) {
+		function legacyEntry(prefix, { actionByte = 0x11, tableId = 7 } = {}) {
 			const recordId = Buffer.from('historical_orders-0');
 			const version = Buffer.alloc(8);
 			version.writeDoubleBE(VERSION);
 			return Buffer.concat([
 				prefix,
-				Buffer.from([actionByte, 0x03, 0x07, recordId.length]),
+				Buffer.from([actionByte, 0x03, tableId, recordId.length]),
 				recordId,
 				version,
 				Buffer.from([5]),
@@ -1760,13 +1773,15 @@ describe('audit entry previousVersion presence', () => {
 			['2 ** 33 - 1 (0x41)', 2 ** 33 - 1],
 			['2 ** 32 (0x41)', 2 ** 32],
 			['2 ** 49 (0x43)', 2 ** 49],
-			['1.5 (0x3f)', 1.5],
 			['Infinity (0x7f)', Infinity],
 		]) {
-			it(`recovers the field offsets and keeps the back-edge for ${label}`, () => {
+			it(`recovers the field offsets and preserves the value for ${label}`, () => {
 				const record = readAuditEntry(legacyEntry(asDouble(previousVersion)));
 				assertTrailingFields(record, label);
-				assert.strictEqual(record.previousVersion, previousVersion, 'a recovered link must not be discarded');
+				// Preserved rather than discarded so a real link is never dropped. It is not resolvable as
+				// an audit key: the key codec makes the same leading-byte test, so a position outside the
+				// representable band could not have been stored as a key either.
+				assert.strictEqual(record.previousVersion, previousVersion, 'a recovered value must not be discarded');
 			});
 		}
 
@@ -1794,6 +1809,32 @@ describe('audit entry previousVersion presence', () => {
 			});
 		}
 
+		// Reserved entry-type nibbles must keep decoding: a peer one version ahead mints them, and
+		// classifying one as a stray prefix would drop it at this hop instead of forwarding it.
+		for (const [label, actionByte] of [
+			['a reserved entry type (nibble 9)', 0x09],
+			['a reserved entry type with HAS_RECORD (nibble 12)', 0x1c],
+			['nibble 15 (0x3f)', 0x3f],
+		]) {
+			it(`treats ${label} as an action rather than a stray prefix`, () => {
+				const recordId = Buffer.from('historical_orders-0');
+				const version = Buffer.alloc(8);
+				version.writeDoubleBE(VERSION);
+				const entry = Buffer.concat([
+					Buffer.from([actionByte, 0x03, 0x07, recordId.length]),
+					recordId,
+					version,
+					Buffer.from([0]),
+				]);
+				const record = readAuditEntry(entry);
+				// the type is unknown to this build, but every positional field must still decode
+				assert.strictEqual(record.tableId, 7);
+				assert.strictEqual(record.nodeId, 3);
+				assert.strictEqual(record.recordId, 'historical_orders-0');
+				assert.strictEqual(record.version, VERSION);
+			});
+		}
+
 		it('refuses to recover a candidate the superseded writer could not have emitted', () => {
 			// The old guard was `previousVersion > 1`, so anything at or below 1 was never written here.
 			const record = readAuditEntry(legacyEntry(asDouble(0.5)));
@@ -1812,16 +1853,72 @@ describe('audit entry previousVersion presence', () => {
 		// turn a recoverable entry into a corrupt sentinel — or escape the decoder entirely.
 		it('still recovers when the logging sink throws', () => {
 			const originalWarn = harperLogger.warn;
+			let reached = false;
 			harperLogger.warn = () => {
+				reached = true;
 				throw new Error('simulated logging failure');
 			};
 			try {
 				let record;
-				assert.doesNotThrow(() => (record = readAuditEntry(legacyEntry(asDouble(2 ** 49)))));
-				assertTrailingFields(record, 'throwing sink');
+				// a table no earlier case has warned for, so the per-table latch cannot mask the sink
+				const entry = legacyEntry(asDouble(2 ** 49), { tableId: 61 });
+				assert.doesNotThrow(() => (record = readAuditEntry(entry)));
+				assert.ok(reached, 'the throwing sink must actually be reached, or this proves nothing');
+				assert.strictEqual(record.type, 'put');
+				assert.strictEqual(record.tableId, 61);
+				assert.strictEqual(record.recordId, 'historical_orders-0');
+				assert.strictEqual(record.version, VERSION);
 			} finally {
 				harperLogger.warn = originalWarn;
 			}
+		});
+
+		it('recovers an extended action carrying a flag defined in another module', () => {
+			// HAS_STRUCTURE_UPDATE (0x100) lives in RecordEncoder, across an import cycle with this
+			// module. Building the known-flag mask at module scope resolved that bit to undefined
+			// whenever RecordEncoder was the cycle's entry point, and the recovery below was then
+			// rejected as corrupt depending only on which module loaded first.
+			const action = Buffer.alloc(4);
+			action.writeUInt32BE((0xc0000000 | 0x100 | 0x11) >>> 0);
+			const recordId = Buffer.from('historical_orders-0');
+			const version = Buffer.alloc(8);
+			version.writeDoubleBE(VERSION);
+			const entry = Buffer.concat([
+				asDouble(2 ** 49),
+				action,
+				Buffer.from([0x03, 0x07, recordId.length]),
+				recordId,
+				version,
+				Buffer.from([0]),
+			]);
+			const record = readAuditEntry(entry);
+			assert.strictEqual(record.type, 'put');
+			assert.strictEqual(record.tableId, 7);
+			assert.strictEqual(record.recordId, 'historical_orders-0');
+		});
+
+		// The cycle only bites when RecordEncoder is the entry, which cannot be arranged in-process
+		// once mocha has loaded both modules.
+		it('recovers identically when RecordEncoder is the import-cycle entry point', () => {
+			const auditStorePath = require.resolve('#src/resources/auditStore');
+			const recordEncoderPath = require.resolve('#src/resources/RecordEncoder');
+			const script = `
+				require(${JSON.stringify(recordEncoderPath)});
+				const { readAuditEntry } = require(${JSON.stringify(auditStorePath)});
+				const recordId = Buffer.from('historical_orders-0');
+				const version = Buffer.alloc(8); version.writeDoubleBE(${VERSION});
+				const prefix = Buffer.alloc(8); prefix.writeDoubleBE(2 ** 49);
+				const action = Buffer.alloc(4); action.writeUInt32BE((0xc0000000 | 0x100 | 0x11) >>> 0);
+				const entry = Buffer.concat([prefix, action, Buffer.from([0x03, 0x07, recordId.length]), recordId, version, Buffer.from([0])]);
+				const record = readAuditEntry(entry);
+				process.stdout.write(JSON.stringify({ type: record.type, tableId: record.tableId }));
+			`;
+			const output = execFileSync(process.execPath, ['-e', script], {
+				cwd: process.cwd(),
+				encoding: 'utf8',
+				stdio: ['ignore', 'pipe', 'ignore'],
+			});
+			assert.deepStrictEqual(JSON.parse(output), { type: 'put', tableId: 7 });
 		});
 	});
 

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -1766,7 +1766,7 @@ describe('audit entry previousVersion presence', () => {
 			// is what threw RangeError inside the audit-forwarding loop.
 			const record = readAuditEntry(legacyEntry(asDouble(2)));
 			assertTrailingFields(record, '2.0 sentinel');
-			assert.strictEqual(record.previousVersion, undefined, '2.0 means "no previous version"');
+			assert.strictEqual(record.previousVersion, undefined);
 		});
 
 		for (const [label, previousVersion] of [
@@ -1775,13 +1775,13 @@ describe('audit entry previousVersion presence', () => {
 			['2 ** 49 (0x43)', 2 ** 49],
 			['Infinity (0x7f)', Infinity],
 		]) {
-			it(`recovers the field offsets and preserves the value for ${label}`, () => {
+			it(`recovers the field offsets for ${label}`, () => {
 				const record = readAuditEntry(legacyEntry(asDouble(previousVersion)));
 				assertTrailingFields(record, label);
-				// Preserved rather than discarded so a real link is never dropped. It is not resolvable as
-				// an audit key: the key codec makes the same leading-byte test, so a position outside the
-				// representable band could not have been stored as a key either.
-				assert.strictEqual(record.previousVersion, previousVersion, 'a recovered value must not be discarded');
+				// The value is dropped, not reported: it cannot lead with 0x42, audit keys carry the same
+				// constraint so it never addressed a retrievable entry, and reporting it would feed an
+				// unrepresentable value back into the writer through RecordEncoder's resolveRecord re-mint.
+				assert.strictEqual(record.previousVersion, undefined);
 			});
 		}
 

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -1922,6 +1922,40 @@ describe('audit entry previousVersion presence', () => {
 		});
 	});
 
+	// The pending branch is only meaningful on LMDB, where previousVersion is the previous entry's
+	// separately stored localTime. This drives it from a real table write rather than the codec, which
+	// is the only way to learn whether PENDING_LOCAL_TIME reaches createAuditEntry at all.
+	describe('through a real table write', function () {
+		let PendingTable;
+		before(async function () {
+			if (process.env.HARPER_STORAGE_ENGINE !== 'lmdb') return this.skip();
+			setupTestDBPath();
+			setMainIsWorker(true);
+			PendingTable = table({
+				table: 'PendingPreviousVersionTable',
+				attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+			});
+		});
+
+		it('links the second of two writes to one key back to the first', async () => {
+			const id = 'pending-' + Date.now();
+			await PendingTable.put({ id, name: 'first' });
+			await PendingTable.put({ id, name: 'second' });
+			const entries = [];
+			for (const entry of PendingTable.auditStore.getRange({ start: 0 })) {
+				if (entry.recordId === id) entries.push(entry);
+			}
+			assert.ok(entries.length >= 2, `expected at least two audit entries, got ${entries.length}`);
+			const [first, second] = entries.slice(-2);
+			// The back-edge survives, which also establishes that PENDING_LOCAL_TIME does not reach the
+			// codec from an ordinary write: by the time the second entry is minted, existingEntry.localTime
+			// is a committed 0x42-band timestamp. That makes the pending branch defensive rather than
+			// routine, and it is the case a dropped link would otherwise break.
+			assert.strictEqual(second.previousVersion, first.key);
+			assert.notStrictEqual(second.previousVersion, undefined);
+		});
+	});
+
 	describe('over a real LMDB audit store', () => {
 		let directory;
 		let store;

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -9,6 +9,7 @@ const {
 	createAuditEntry,
 	transactionKeyEncoder,
 	removeAuditEntry,
+	AUDIT_STORE_OPTIONS,
 } = require('#src/resources/auditStore');
 const { RocksTransactionLogStore } = require('#src/resources/RocksTransactionLogStore');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
@@ -1598,4 +1599,270 @@ describe('Audit cleanup retirement', () => {
 			}
 		});
 	}
+});
+
+// The LMDB audit entry announces its optional leading previousVersion field with that field's own
+// first byte (0x42). harperdb 4.x's reader and both versions' replication senders make the same
+// test, so a value written with any other leading byte is skipped by every reader and shifts
+// action/nodeId/tableId/recordId/version by 8 bytes. See harper#2247.
+describe('audit entry previousVersion presence', () => {
+	const VERSION = 1787229175163.2493;
+	const BASE = {
+		version: VERSION,
+		tableId: 7,
+		recordId: 'historical_orders-0',
+		nodeId: 3,
+		user: 'alice',
+		type: 'put',
+		encodedRecord: Buffer.from([0x80]),
+		extendedType: 0,
+		expiresAt: 0,
+		originatingOperation: 'insert',
+	};
+	const mint = (previousVersion) => Buffer.from(createAuditEntry({ ...BASE, previousVersion }));
+	// The whole point of the field's presence signal is that everything after it keeps its offsets.
+	function assertTrailingFields(record, context) {
+		assert.strictEqual(record.type, 'put', `${context}: type`);
+		assert.strictEqual(record.nodeId, 3, `${context}: nodeId`);
+		assert.strictEqual(record.tableId, 7, `${context}: tableId`);
+		assert.strictEqual(record.recordId, 'historical_orders-0', `${context}: recordId`);
+		assert.strictEqual(record.version, VERSION, `${context}: version`);
+		assert.strictEqual(record.user, 'alice', `${context}: user`);
+	}
+
+	describe('writer', () => {
+		// The representable band is exactly the values whose float64 leads with 0x42.
+		for (const [label, previousVersion] of [
+			['a millisecond epoch timestamp', 1787198768741.378],
+			['2 ** 33, the low edge', 2 ** 33],
+			['just under 2 ** 49, the high edge', 2 ** 49 - 1],
+		]) {
+			it(`round-trips ${label}`, () => {
+				const buffer = mint(previousVersion);
+				assert.strictEqual(buffer[0], 0x42, 'the field must announce itself');
+				const record = readAuditEntry(buffer);
+				assert.strictEqual(record.previousVersion, previousVersion);
+				assertTrailingFields(record, label);
+			});
+		}
+
+		// Each of these was written by the superseded `previousVersion > 1` guard and then skipped by
+		// every reader. Rejecting is deliberate: previousVersion is the record-history back-edge, so
+		// silently omitting it would trade a mis-decoded entry for a silently truncated history.
+		for (const [label, previousVersion] of [
+			['2 ** 33 - 1 (0x41)', 2 ** 33 - 1],
+			['2 ** 32 (0x41)', 2 ** 32],
+			['2 ** 49 (0x43)', 2 ** 49],
+			['2.0, the lmdb-js substitution sentinel (0x40)', 2],
+			['1.5 (0x3f)', 1.5],
+			['1, the removed placeholder trigger (0x3f)', 1],
+			['Infinity (0x7f)', Infinity],
+			['NaN, which is falsy and would otherwise be dropped silently', NaN],
+			['a negative value', -1787198768741.378],
+		]) {
+			it(`rejects ${label} instead of writing an unreadable field`, () => {
+				assert.throws(() => mint(previousVersion), /is not representable/);
+			});
+		}
+
+		for (const [label, previousVersion] of [
+			['0', 0],
+			['null', null],
+			['undefined', undefined],
+		]) {
+			it(`treats ${label} as absent`, () => {
+				const buffer = mint(previousVersion);
+				assert.notStrictEqual(buffer[0], 0x42, 'an absent field must not announce one');
+				const record = readAuditEntry(buffer);
+				assert.strictEqual(record.previousVersion, undefined);
+				assertTrailingFields(record, label);
+			});
+		}
+
+		it('keeps the action offset agreeing with the field it actually wrote', () => {
+			assert.strictEqual(mint(0)[0], 0x11, 'no field: the action leads the entry');
+			assert.strictEqual(mint(2 ** 33)[8], 0x11, 'field present: the action follows its 8 bytes');
+		});
+	});
+
+	// RocksTransactionLogStore states presence with an explicit flag in its own uint32 prelude, so its
+	// value is unconstrained and must stay that way — the LMDB leading-byte rule would desynchronize
+	// that flag from the field it describes.
+	describe('RocksDB container', () => {
+		const HAS_PREVIOUS_VERSION = 0x20000000;
+		// Mirrors RocksTransactionLogStore.put: prelude word, then the entry at the following offset.
+		function mintWithPrelude(previousVersion) {
+			const entry = Buffer.from(createAuditEntry({ ...BASE, previousVersion }, 4));
+			entry.writeUInt32BE(previousVersion ? HAS_PREVIOUS_VERSION : 0, 0);
+			return entry;
+		}
+		// Mirrors the prelude decode in RocksTransactionLogStore's map callback.
+		function readWithPrelude(entry) {
+			const flags = entry.readUInt32BE(0);
+			let position = 4;
+			let previousVersion;
+			if (flags & HAS_PREVIOUS_VERSION) {
+				previousVersion = entry.readDoubleBE(position);
+				position += 8;
+			}
+			return { previousVersion, record: readAuditEntry(entry, position, undefined) };
+		}
+
+		for (const [label, previousVersion] of [
+			['a value outside the LMDB representable band', 2 ** 49],
+			['the LMDB substitution sentinel', 2],
+			['a millisecond epoch timestamp', 1787198768741.378],
+			['no previous version', 0],
+		]) {
+			it(`still carries ${label} unconstrained`, () => {
+				const entry = mintWithPrelude(previousVersion);
+				const { previousVersion: decoded, record } = readWithPrelude(entry);
+				assert.strictEqual(decoded, previousVersion || undefined);
+				assertTrailingFields(record, label);
+			});
+		}
+	});
+
+	// Fixture bytes, not a live write: these are the shapes already on disk and on the wire from
+	// writers that predate the guard, including harperdb 4.x, which still mints them today.
+	describe('entries written before the guard', () => {
+		function legacyEntry(prefix, { actionByte = 0x11 } = {}) {
+			const recordId = Buffer.from('historical_orders-0');
+			const version = Buffer.alloc(8);
+			version.writeDoubleBE(VERSION);
+			return Buffer.concat([
+				prefix,
+				Buffer.from([actionByte, 0x03, 0x07, recordId.length]),
+				recordId,
+				version,
+				Buffer.from([5]),
+				Buffer.from('alice'),
+				Buffer.from([0x80]),
+			]);
+		}
+		const asDouble = (value) => {
+			const bytes = Buffer.alloc(8);
+			bytes.writeDoubleBE(value);
+			return bytes;
+		};
+
+		it('decodes the poisoned entry captured from a v4 leader (harper-pro#737)', () => {
+			// 40 00 00 00 00 00 00 00 — float64 2.0, the value lmdb-js's instructed-write substitution
+			// leaves when no previous time was recorded. Before the fix this entry decoded as
+			// action 64, tableId 0 and a null recordId, and the misaligned walk into the record body
+			// is what threw RangeError inside the audit-forwarding loop.
+			const record = readAuditEntry(legacyEntry(asDouble(2)));
+			assertTrailingFields(record, '2.0 sentinel');
+			assert.strictEqual(record.previousVersion, undefined, '2.0 means "no previous version"');
+		});
+
+		for (const [label, previousVersion] of [
+			['2 ** 33 - 1 (0x41)', 2 ** 33 - 1],
+			['2 ** 32 (0x41)', 2 ** 32],
+			['2 ** 49 (0x43)', 2 ** 49],
+			['1.5 (0x3f)', 1.5],
+			['Infinity (0x7f)', Infinity],
+		]) {
+			it(`recovers the field offsets and keeps the back-edge for ${label}`, () => {
+				const record = readAuditEntry(legacyEntry(asDouble(previousVersion)));
+				assertTrailingFields(record, label);
+				assert.strictEqual(record.previousVersion, previousVersion, 'a recovered link must not be discarded');
+			});
+		}
+
+		it('hands a sender the entry without the unannounced prefix', () => {
+			const buffer = legacyEntry(asDouble(2));
+			const record = readAuditEntry(buffer);
+			// A sender strips by the same leading-0x42 test and frames by encoded.length, so a prefix
+			// left in place here is forwarded whole and misparsed by the next hop.
+			assert.strictEqual(record.encoded[0], 0x11, 'encoded must begin at the action');
+			assert.strictEqual(record.encoded.length, buffer.length - 8);
+			assert.strictEqual(record.size, buffer.length - 8, 'size with no end supplied');
+			assert.strictEqual(readAuditEntry(buffer, 0, buffer.length).size, buffer.length - 8, 'size with an end supplied');
+		});
+
+		// Recovery must not become a way to launder arbitrary bytes into a plausible record.
+		for (const [label, byteAtEight] of [
+			['0xbf, a two-byte integer prefix this writer never emits', 0xbf],
+			['0xff, which readInt takes as a five-byte form', 0xff],
+			['0x5a, not an action at all', 0x5a],
+		]) {
+			it(`refuses to recover when byte 8 is ${label}`, () => {
+				const record = readAuditEntry(legacyEntry(asDouble(2 ** 49), { actionByte: byteAtEight }));
+				assert.strictEqual(record.type, undefined);
+				assert.strictEqual(record.tableId, undefined);
+			});
+		}
+
+		it('refuses to recover a candidate the superseded writer could not have emitted', () => {
+			// The old guard was `previousVersion > 1`, so anything at or below 1 was never written here.
+			const record = readAuditEntry(legacyEntry(asDouble(0.5)));
+			assert.strictEqual(record.type, undefined);
+			assert.strictEqual(record.tableId, undefined);
+		});
+
+		it('does not throw or falsely recover on a truncated header', () => {
+			let record;
+			assert.doesNotThrow(() => (record = readAuditEntry(Buffer.from([0x40, 0x00, 0x00, 0x00]))));
+			assert.strictEqual(record.type, undefined);
+			assert.strictEqual(typeof record.getValue, 'function');
+		});
+
+		// readAuditEntry's outer catch logs uncontained, so an uncontained warn on a new path would
+		// turn a recoverable entry into a corrupt sentinel — or escape the decoder entirely.
+		it('still recovers when the logging sink throws', () => {
+			const originalWarn = harperLogger.warn;
+			harperLogger.warn = () => {
+				throw new Error('simulated logging failure');
+			};
+			try {
+				let record;
+				assert.doesNotThrow(() => (record = readAuditEntry(legacyEntry(asDouble(2 ** 49)))));
+				assertTrailingFields(record, 'throwing sink');
+			} finally {
+				harperLogger.warn = originalWarn;
+			}
+		});
+	});
+
+	describe('over a real LMDB audit store', () => {
+		let directory;
+		let store;
+		before(function () {
+			setupTestDBPath();
+			directory = mkdtempSync(join(tmpdir(), 'harper-audit-prev-version-'));
+			store = open({ path: join(directory, 'audit.mdb'), ...AUDIT_STORE_OPTIONS });
+		});
+		after(async function () {
+			if (store?.status !== 'closed') await store?.close();
+			if (directory) rmSync(directory, { recursive: true, force: true });
+		});
+
+		it('decodes a legacy entry that is already persisted', async () => {
+			const recordId = Buffer.from('historical_orders-0');
+			const version = Buffer.alloc(8);
+			version.writeDoubleBE(VERSION);
+			// A Uint8Array value bypasses createAuditEntry, so this lands on disk exactly as an older
+			// writer left it.
+			const legacy = Buffer.concat([
+				Buffer.from([0x40, 0, 0, 0, 0, 0, 0, 0]),
+				Buffer.from([0x11, 0x03, 0x07, recordId.length]),
+				recordId,
+				version,
+				Buffer.from([0]),
+			]);
+			await store.put(1787198768741.378, legacy);
+			const decoded = store.get(1787198768741.378);
+			assert.strictEqual(decoded.type, 'put');
+			assert.strictEqual(decoded.tableId, 7);
+			assert.strictEqual(decoded.recordId, 'historical_orders-0');
+			assert.strictEqual(decoded.version, VERSION);
+		});
+
+		it('leaves nothing behind when an unrepresentable previousVersion is rejected', async () => {
+			const key = 1787198768741.5;
+			assert.throws(() => store.put(key, { ...BASE, previousVersion: 2 ** 49 }), /is not representable/);
+			assert.strictEqual(store.get(key), undefined, 'the rejected entry must not be persisted');
+		});
+	});
 });


### PR DESCRIPTION
The LMDB audit entry announces its optional leading 8-byte `previousVersion` field with that field's
own first byte being `0x42`. The writer instead emitted the field for any truthy value, so a
`previousVersion` outside `[2**33, 2**49)` was written and then skipped by every reader, leaving the
entry 8 bytes longer than the reader believed. `action`, `nodeId`, `tableId`, `recordId` and
`version` then all parsed from the wrong offsets, with no corruption detector on the path.

That leading-byte test is a **cross-version contract, not a local convention**. It is how harperdb
4.7.36's reader decodes the field, and it is how both versions' replication senders decide to strip
the field before framing an entry for the wire (`encoded[0] === 66 ? 8 : 0`), after which the
receiver hands the raw frame back to this same `readAuditEntry`. Three of the five implementations
are outside this repo. That is why presence is enforced at the value here rather than restated as a
header flag: the only word that could carry a flag is the action word, and it sits *after* the
optional field, so a reader cannot consult it before deciding whether to skip. Moving the header in
front would make an unmodified sender stop stripping and forward the field to a v4 reader that
parses the entry 8 bytes off — the same defect, relocated onto a shipped version.

## What changed

The writer derives presence from [the byte it actually encoded](https://github.com/HarperFast/harper/pull/2499/changes?w=1#diff-db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356baR627) and uses that one boolean for both the field and the action offset, so the two can no longer
disagree. A value that cannot announce itself is rejected rather than written. Absence is now stated explicitly (`undefined`, `null`, `0`) instead
of inferred from truthiness, which is what stops `NaN` from being silently dropped.

The reader [recovers entries already written the old way](https://github.com/HarperFast/harper/pull/2499/changes?w=1#diff-db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356baR739), including by a v4 peer: when the first byte can begin neither an action nor a previousVersion,
the field is physically present and the header follows it. The set of bytes that [can begin an action](https://github.com/HarperFast/harper/pull/2499/changes?w=1#diff-db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356baR505) is derived from what the encoding can express, so a reserved entry type minted by a newer peer
still decodes. Recovery is gated on the LMDB container, on a candidate the superseded writer could
actually have emitted (`> 1`, its own guard), and on the byte at offset 8 being a legal action start.
Recovery restores the field *offsets*; the recovered value itself is dropped. It cannot lead with
`0x42` by construction, and audit keys carry the same constraint, so it could never have addressed a
retrievable entry. A recovered entry [hands a sender the bytes without the stray prefix](https://github.com/HarperFast/harper/pull/2499/changes?w=1#diff-db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356baR853), so the same misparse is not passed to the next hop. Anything else that cannot begin an entry now returns the existing corrupt
sentinel instead of decoding at the wrong offset.

[The `previousVersion <= 1` placeholder branch](https://github.com/HarperFast/harper/pull/2499/changes?w=1#diff-db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356baR610) is gone. lmdb-js substitutes `previousTime ^ 0x40` at
commit, which is `2.0` whenever no previous time was recorded — that is precisely the poisoned entry
in the byte-level capture on HarperFast/harper-pro#737 — [decoded correctly by this reader](https://github.com/HarperFast/harper/pull/2499/changes?w=1#diff-044077436ab82ecf6c481205bdf0ac84571b38edf4ce663842e72349c3a7b38cR1763) — so the branch could not satisfy the invariant even in principle.

`RocksTransactionLogStore` is untouched and keeps its unconditional write, because its uint32 prelude
flag already states presence there, making its value unconstrained.

## For the human reviewer

**Three judgment calls worth your attention, in order.**

**1. The writer throws.** An unrepresentable `previousVersion` now aborts the audit-entry encode, and
that encode runs inside a user write. I chose this over silently omitting the field because
`previousVersion` is the record-history back-edge, so dropping it would trade this bug's silent
mis-decode for a silently truncated history — the same class of defect. Every producer that can
reach the LMDB container was enumerated and is already in range, so the throw should be unreachable:
`RecordEncoder` passes a decoded `localTime`, which always leads with `0x42` because `getTimestamp`
XORs `0x40` into a byte that had to be `0x02`; the other site passes a value that came back out of
`readAuditEntry`; and harper-pro's two call sites pass `null`. If you would rather this degrade than
fail, it is a two-line change.

**2. `PENDING_LOCAL_TIME` does not throw, it drops the link.** This is the one place the change can
lose something real. `previousVersion === 1` is the
"previous entry has no log position yet" sentinel, and `RecordEncoder` feeds `existingEntry.localTime`
straight through on the LMDB path with no pending guard, so throwing there could abort a real write.
The entry is recorded without a back-edge and warns with the producer stack. This is the one place I
accept losing a link, because a format whose presence signal is the value's own first byte cannot
express "to be filled in at commit". The pre-push review caught this; I had originally removed the branch outright.
The review asked twice what this costs, naming the concrete case: two writes to one key inside one
transaction. I measured it rather than arguing it, and my first attempt was wrong in a way worth
recording — two separately awaited puts commit independently, so they never reach the pending path.
With both writes in one transaction the second entry carries no back-edge, **and `origin/main`
produces the identical result on the same scenario**, because the first write of a transaction has
not published a `localTime` for the second to point at. So this change does not alter that path. The [test in the diff](https://github.com/HarperFast/harper/pull/2499/changes?w=1#diff-044077436ab82ecf6c481205bdf0ac84571b38edf4ce663842e72349c3a7b38cR1941) pins what does matter there: neither entry misparses. I have not found a producer
that reaches the pending branch, which leaves it defensive; if one exists, it loses a link there.

**3. Recovery discards the value it finds.** An earlier revision preserved it, on the reasoning that
a real link should never be dropped. That was wrong in a way worth recording: `RecordEncoder`'s
`resolveRecord` branch re-mints an audit entry from `replacingEntry.previousVersion`, so a preserved
out-of-band value flowed straight back into `createAuditEntry`, which now rejects it — and it does so
*after* the primary `store.put` has been issued, so the user's write fails and the record change can
commit with no audit entry. The value bought nothing anyway, since it could never address a
retrievable entry.

**What this does not do.** It does not fix the recurring red on harper-pro `main`
(`replicationTopology.test.mjs`, "Replicate larger v4 dataset"). In run 33709678114 every frame of
the `RangeError: ... cannot be converted to a BigInt` stack is under
`/tmp/harperdb-legacy/node_modules/harperdb/`, thrown from the legacy node's own `recordId` getter
inside its own audit-forwarding loop, which then closes its subscription. The mint, the misparse and
the throw all happen inside harperdb 4.7 before any v5 code runs. That trigger was addressed by
harper-pro#740; this PR closes the format hazard it left open.

**Coverage gaps, stated rather than papered over.** The RocksDB suite mirrors
`RocksTransactionLogStore`'s prelude encode/decode rather than driving the real store, so it pins the
contract, not the store; the existing suites cover the real store on every audit write. No in-repo
test exercises a real replication sender or a v4 receiver, so the claim that a cleaned entry forwards
correctly is argued from the byte layout, not observed. The rejection test proves the audit value is
absent, not transactional atomicity with the primary record write.

**Deliberately not fixed here.** The audit *key* codec makes the same value-shaped inference. Its
`writeKey` runs on every audit key, so a warn-only guard would add per-key work without preventing an
unreadable key, and actually re-encoding keys would change key ordering and every key already
written. Worth its own issue.

**Framing:** `Framing-Verdict: better-alternative-exists` (round 1) → adopted → `chosen-approach-sound`
(round 2). Round 1's alternative was fail-closed enforcement at the codec boundary plus exact-action
legacy recovery; I rewrote the design around it rather than overruling.

## Verification

Fails-on-base, with `dist/resources/auditStore.js` deleted and a full `tsc` before each run (the
built artifact was checked for `previousVersion > 1` before the red run and for the new guard before
the green one):

```
origin/main source + new tests   16 passing, 19 failing
this branch      + new tests     35 passing,  0 failing
```

The 19 red failures are the writer-rejection cases, the legacy-recovery cases including the
harper-pro#737 hexdump, the `encoded`/`size` normalization case, and both real-LMDB cases.

The import-cycle regression test spawns a child node process that requires `RecordEncoder` first,
because the cycle only bites when it is the entry point and that order cannot be arranged in-process
once mocha has loaded both modules. Reproduced before the fix: under CommonJS the flag mask silently lost a bit and a valid recovery was
rejected as corrupt, decided only by load order. [The mask is now built on first use](https://github.com/HarperFast/harper/pull/2499/changes?w=1#diff-db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356baR520), and [the test](https://github.com/HarperFast/harper/pull/2499/changes?w=1#diff-044077436ab82ecf6c481205bdf0ac84571b38edf4ce663842e72349c3a7b38cR1903) spawns the child process.

Gates, run under an isolated HOME so another worktree's suite could not contend for the shared
system database (that contention, not this diff, produced the failures in my earlier runs):

| leg | result |
| --- | --- |
| `unitTests/resources/auditLog.test.js` | 77 passing (lmdb) / 76 (rocksdb), 0 failing |
| `test:unit:resources` (rocksdb) | 2043 passing, 0 failing |
| `test:unit:resources` (lmdb) | 1659 passing, 2 failing |
| `test:unit:bin` (lmdb) | 274 passing, 0 failing |
| `test:unit:main` | 5290 passing, 1 failing |

Both non-green cells are pre-existing and were confirmed against `origin/main` sources rather than
assumed. The two lmdb failures are `subscriptionReplay`'s "count: empty initial state" and "count:
only other-table records exist", each a 2000ms `waitFor` timeout; that file passes 36/36 when run
alone on this branch, and the same two fail on `origin/main` in the same full-leg run. The
`test:unit:main` failure is `configValidator`'s domain-socket path-length test, which resolves a
relative rootPath against `process.cwd()` and so fails in any deeply nested worktree.

Reader cost was measured baseline vs patched over a 2000-entry decode scan, interleaved in one
process. The result is below the measurement floor on this machine: the same binary against itself
varies by about 23% run to run, and the measured delta swings between -12.8% and +4.9% across runs.
Structurally the added work is one 256-byte table load, and it runs only for entries that carry no
previousVersion, since a `0x42` first byte takes the earlier branch.

Refs #2247




🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLaWQDpmKH9qXfMbuMbWWB

<sub>Review-Coverage: authored=claude; ran=codex; adjudicated=domain; declined=gemini,cursor-grok,cursor-composer; rounds=6 @ 3cb5b7125ba4</sub>

<sub>Human-Review-Need: 3 (decisions: parity-with-main-as-sufficient-evidence, pending-link-dropped-vs-deferred, throw-vs-warn-on-unrepresentable, reader-side-recovery-vs-migration, encoded-strips-prefix-silently, format-band-documented-as-permanent) @ 3cb5b7125ba4</sub>
