### PR TITLE
Take install_node_modules off the npm registry so the Node 22 unit job stops timing out

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,11 +27,11 @@ jobs:
   unit-test:
     name: Unit Test (Node.js v${{ matrix.node-version }})
     runs-on: ubuntu-latest
-    # A job that hits this cap is reported as `cancelled`, not `failure`, so it reads as non-red
-    # on the required-check status — the long steps below carry their own caps for that reason.
-    # This one only has to exceed their sum: dependency install and the unit run measure ~2.5 and
-    # ~7.5 minutes, and the remaining steps under a minute.
-    timeout-minutes: 20
+    # GitHub reports a job that hits this cap as `cancelled`, not `failure`, so it reads as
+    # non-red on the required check — which is how a wedged v22 leg went unnoticed for 9 runs.
+    # Every step below is capped in its own right and this sits above their sum (33 on the
+    # longest leg), so a stall always surfaces as a step failure and this is only a backstop.
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
@@ -48,24 +48,29 @@ jobs:
           package-manager-cache: false
 
       - name: Install dependencies
-        timeout-minutes: 10 # measures ~2.5 minutes; bounded so a registry stall fails loudly
+        timeout-minutes: 6
         run: npm install --ignore-scripts
 
       - name: Build
+        timeout-minutes: 3
         run: npm run build || true # we currently have type errors so just ignore that
 
       - name: Type contract tests
         if: matrix.node-version == 22
+        timeout-minutes: 3
         run: npm run test:types # strict tsc over unitTests/types/ — asserts the shipped public types
 
       - name: Benchmark unit tests
+        timeout-minutes: 3
         run: npm run test:bench # pure-logic tests for benchmarks/ converters; doesn't need a running Harper instance
 
       - name: Review-coverage action tests
         if: matrix.node-version == 24
+        timeout-minutes: 3
         run: node --test .github/actions/review-coverage/*.test.mjs
 
       - name: Setup Harper
+        timeout-minutes: 3
         env:
           DEFAULTS_MODE: 'dev'
           HDB_ADMIN_USERNAME: 'admin'
@@ -76,10 +81,8 @@ jobs:
 
         run: node --enable-source-maps ./dist/bin/harper.js install
 
-      # Bounded below the job so a hung suite fails the step rather than cancelling the job.
-      # `.mocharc.json` sets `timeout: 0`, so no individual test can ever time out on its own:
-      # anything that blocks — a registry call, a lock wait — stops the run until something above
-      # it gives up, and before this cap that something was the job timeout, which is silent.
+      # `.mocharc.json` sets `timeout: 0`, so nothing inside the run can time out on its own —
+      # this cap is the only thing that turns a wedged suite into a reported failure.
       - name: Run tests
         timeout-minutes: 15
         run: npm run test:unit:all

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,11 +27,10 @@ jobs:
   unit-test:
     name: Unit Test (Node.js v${{ matrix.node-version }})
     runs-on: ubuntu-latest
-    # GitHub reports a job that hits this cap as `cancelled`, not `failure`, so it reads as
-    # non-red on the required check — which is how a wedged v22 leg went unnoticed for 9 runs.
-    # Every step below is capped in its own right and this sits above their sum (33 on the
-    # longest leg), so a stall always surfaces as a step failure and this is only a backstop.
-    timeout-minutes: 35
+    # A job that hits this cap is reported as `cancelled`, not `failure`, so it reads as non-red
+    # on a required check. Every step below is capped in its own right and this sits above their
+    # sum (41 on the longest leg), so a stall surfaces as a step failure and this stays a backstop.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -39,9 +38,11 @@ jobs:
 
     steps:
       - name: Checkout code
+        timeout-minutes: 3
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Node.js ${{ matrix.node-version }}
+        timeout-minutes: 5
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,7 +27,11 @@ jobs:
   unit-test:
     name: Unit Test (Node.js v${{ matrix.node-version }})
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # A job that hits this cap is reported as `cancelled`, not `failure`, so it reads as non-red
+    # on the required-check status — the long steps below carry their own caps for that reason.
+    # This one only has to exceed their sum: dependency install and the unit run measure ~2.5 and
+    # ~7.5 minutes, and the remaining steps under a minute.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +48,7 @@ jobs:
           package-manager-cache: false
 
       - name: Install dependencies
+        timeout-minutes: 10 # measures ~2.5 minutes; bounded so a registry stall fails loudly
         run: npm install --ignore-scripts
 
       - name: Build
@@ -71,7 +76,12 @@ jobs:
 
         run: node --enable-source-maps ./dist/bin/harper.js install
 
+      # Bounded below the job so a hung suite fails the step rather than cancelling the job.
+      # `.mocharc.json` sets `timeout: 0`, so no individual test can ever time out on its own:
+      # anything that blocks — a registry call, a lock wait — stops the run until something above
+      # it gives up, and before this cap that something was the job timeout, which is silent.
       - name: Run tests
+        timeout-minutes: 15
         run: npm run test:unit:all
 
   # Windows had no unit-level coverage at all before this job: every job above pins

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -522,7 +522,11 @@ A package-manager timeout must not release this lock while npm descendants are s
 
 Boot's `harper-application-lock.json` records an application configuration only after preparation fulfills. Recording at queue time would make a failed install look complete and suppress its retry on the next boot.
 
-Automatic npm component installation is production-only and uses `--omit=dev --no-audit --no-fund`.
+Every npm install Harper runs — automatic component installation and the deprecated
+`install_node_modules` operation alike — composes its arguments in `packageManagerInstallArguments()`,
+which is production-only and adds `--omit=dev --no-audit --no-fund`. `--no-audit` is load-bearing, not
+hygiene: npm 10 puts even a `file:` link into its audit bulk request, and the registry's answer to that
+is unbounded from Harper's side.
 `installApplication()` skips the package-manager child entirely when the root manifest declares no
 production dependencies, non-empty workspaces, or enabled install lifecycle. An explicitly selected
 non-npm manager still runs so it can discover workspace configuration outside `package.json`, and it

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -522,7 +522,7 @@ A package-manager timeout must not release this lock while npm descendants are s
 
 Boot's `harper-application-lock.json` records an application configuration only after preparation fulfills. Recording at queue time would make a failed install look complete and suppress its retry on the next boot.
 
-Every npm install Harper runs — automatic component installation and the deprecated
+Every npm install Harper invokes directly — automatic component installation and the deprecated
 `install_node_modules` operation alike — composes its arguments in `packageManagerInstallArguments()`,
 which is production-only and adds `--omit=dev --no-audit --no-fund`. `--no-audit` is load-bearing, not
 hygiene: npm 10 puts even a `file:` link into its audit bulk request, and the registry's answer to that

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -3794,7 +3794,7 @@ export function buildNpmrcContent(registryCredentials: ResolvedRegistryCredentia
  * @param command The command to run.
  * @param args The arguments to pass to the command.
  * @param cwd The working directory for the command.
- * @param timeoutMs The timeout for the command in milliseconds. Defaults to 5 minutes.
+ * @param timeoutMs The timeout for the command in milliseconds. Defaults to DEFAULT_COMMAND_TIMEOUT_MS.
  * @returns A promise that resolves when the command completes.
  */
 /**

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -2934,7 +2934,16 @@ async function rollbackExtractedDirectory(
 	await cleanupExtractionPaths(application, asideStagingDir, transactionPaths);
 }
 
-function automaticInstallArguments(packageManagerName: string, allowInstallScripts: boolean, force = false): string[] {
+/**
+ * The one definition of how Harper invokes a package manager to install dependencies. Every npm
+ * entry point goes through it: `install_node_modules` diverging from it is what left that operation
+ * auditing against the registry, and a stalled audit response then wedged CI for nine runs.
+ */
+export function packageManagerInstallArguments(
+	packageManagerName: string,
+	allowInstallScripts: boolean,
+	force = false
+): string[] {
 	const args = ['install'];
 	if (force) args.push('--force');
 	if (packageManagerName === 'npm') args.push('--omit=dev', '--no-audit', '--no-fund');
@@ -3062,7 +3071,7 @@ export async function installApplication(application: Application, buildDirPath 
 		const { stdout, stderr, code } = await nonInteractiveSpawn(
 			application.name,
 			(application.packageManagerPrefix ? application.packageManagerPrefix + ' ' : '') + packageManager.name,
-			automaticInstallArguments(packageManager.name, allowInstallScripts),
+			packageManagerInstallArguments(packageManager.name, allowInstallScripts),
 			buildDirPath,
 			application.install?.timeout,
 			pmOnLine,
@@ -3111,7 +3120,7 @@ export async function installApplication(application: Application, buildDirPath 
 	}
 
 	// Finally, default to running `npm install`
-	const npmInstallArgs = automaticInstallArguments('npm', allowInstallScripts, true);
+	const npmInstallArgs = packageManagerInstallArguments('npm', allowInstallScripts, true);
 	// A candidate build is installed at a staging path and then RENAMED to the live path, so nothing npm
 	// writes may depend on the build location. npm links a `file:` dependency relatively on POSIX, which
 	// survives the move — but as an absolute junction on Windows, which does not, so the dependency stops
@@ -3785,19 +3794,6 @@ export function buildNpmrcContent(registryCredentials: ResolvedRegistryCredentia
 }
 
 /**
- * Execute a command (using `spawn`) with stdin ignored.
- *
- * Stdout is logged chunk-by-chunk. Stderr is buffered and then logged line-by-line.
- *
- * Rejects with an error if the command fails or times out.
- *
- * @param command The command to run.
- * @param args The arguments to pass to the command.
- * @param cwd The working directory for the command.
- * @param timeoutMs The timeout for the command in milliseconds. Defaults to DEFAULT_COMMAND_TIMEOUT_MS.
- * @returns A promise that resolves when the command completes.
- */
-/**
  * Line-buffered split that emits complete `\n`-terminated lines as they
  * arrive, holding any partial trailing fragment until the next chunk or `flush()`.
  * Required because `child_process` stdout/stderr `'data'` events fire per OS-level
@@ -3838,9 +3834,20 @@ function createLineSplitter(onLine: (line: string) => void): {
 }
 
 /**
- * Run a command with the deploy's SSH key material materialized only for the duration of the
- * spawn. The keys are decrypted to a transient 0700 dir (see `materializeGitSSH`) and removed as
- * soon as the process settles — on success, failure, and timeout alike.
+ * Execute a command (using `spawn`) with stdin ignored, with the deploy's SSH key material
+ * materialized only for the duration of the spawn. The keys are decrypted to a transient 0700 dir
+ * (see `materializeGitSSH`) and removed as soon as the process settles — on success, failure, and
+ * timeout alike.
+ *
+ * Stdout is logged chunk-by-chunk. Stderr is buffered and then logged line-by-line.
+ *
+ * Rejects with an error if the command fails or times out.
+ *
+ * @param command The command to run.
+ * @param args The arguments to pass to the command.
+ * @param cwd The working directory for the command.
+ * @param timeoutMs The timeout for the command in milliseconds. Defaults to DEFAULT_COMMAND_TIMEOUT_MS.
+ * @returns A promise that resolves when the command completes.
  */
 export async function nonInteractiveSpawn(
 	applicationName: string,

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -2935,9 +2935,8 @@ async function rollbackExtractedDirectory(
 }
 
 /**
- * The one definition of how Harper invokes a package manager to install dependencies. Every npm
- * entry point goes through it: `install_node_modules` diverging from it is what left that operation
- * auditing against the registry, and a stalled audit response then wedged CI for nine runs.
+ * The one definition of how Harper invokes a package manager to install dependencies; every npm
+ * entry point composes its arguments here rather than assembling its own.
  */
 export function packageManagerInstallArguments(
 	packageManagerName: string,

--- a/unitTests/utility/npmUtilities.test.js
+++ b/unitTests/utility/npmUtilities.test.js
@@ -13,9 +13,7 @@ const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
 const { installModules } = require('#src/utility/npmUtilities');
 
 describe('install_node_modules', function () {
-	// .mocharc.json sets `timeout: 0`, and these cases spawn real npm; without a bound here a
-	// registry stall wedges the whole run instead of failing it
-	this.timeout(60_000);
+	this.timeout(60_000); // .mocharc.json sets `timeout: 0`, and these cases spawn real npm
 
 	let componentsRoot;
 
@@ -105,8 +103,6 @@ describe('install_node_modules', function () {
 		await assert.rejects(installModules({ dry_run: true }), { statusCode: 400, message: /'projects'/ });
 	});
 
-	// npm 10 puts a `file:` link into its audit bulk request, and the registry's answer to that is
-	// unbounded from here, so `--no-audit` is an invariant of this operation, not a preference
 	it('runs npm with the registry audit disabled', async function () {
 		if (process.platform === 'win32') return this.skip(); // the shim below is a POSIX shell script
 		const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harper-npm-shim-'));

--- a/unitTests/utility/npmUtilities.test.js
+++ b/unitTests/utility/npmUtilities.test.js
@@ -52,6 +52,9 @@ describe('install_node_modules', () => {
 
 	function assertInstalled(response) {
 		assert.equal(response.application.npm_output.added, 1, JSON.stringify(response.application));
+		// npm reports an `audit` block only when it made the registry audit call, and that call is
+		// what wedged this suite past the CI job budget on npm 10 — the install must stay local
+		assert.equal(response.application.npm_output.audit, undefined, JSON.stringify(response.application));
 		assert.equal(installedDependencyExists(), true);
 	}
 

--- a/unitTests/utility/npmUtilities.test.js
+++ b/unitTests/utility/npmUtilities.test.js
@@ -52,9 +52,6 @@ describe('install_node_modules', () => {
 
 	function assertInstalled(response) {
 		assert.equal(response.application.npm_output.added, 1, JSON.stringify(response.application));
-		// npm reports an `audit` block only when it made the registry audit call, and that call is
-		// what wedged this suite past the CI job budget on npm 10 — the install must stay local
-		assert.equal(response.application.npm_output.audit, undefined, JSON.stringify(response.application));
 		assert.equal(installedDependencyExists(), true);
 	}
 
@@ -102,5 +99,35 @@ describe('install_node_modules', () => {
 
 	it('rejects a request without projects', async () => {
 		await assert.rejects(installModules({ dry_run: true }), { statusCode: 400, message: /'projects'/ });
+	});
+
+	// npm 10 puts a `file:` link into its audit bulk request, and the registry's answer to that is
+	// unbounded from here, so the flags that keep this operation off the registry are the invariant
+	it('runs npm with the registry audit and funding lookups disabled', async function () {
+		if (process.platform === 'win32') return this.skip(); // the shim below is a POSIX shell script
+		const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harper-npm-shim-'));
+		const argvPath = path.join(shimDir, 'argv.txt');
+		fs.writeFileSync(
+			path.join(shimDir, 'npm'),
+			`#!/bin/sh\nprintf '%s\\n' "$@" > ${JSON.stringify(argvPath)}\necho '{"added":0}'\n`,
+			{ mode: 0o755 }
+		);
+		const originalPath = process.env.PATH;
+		process.env.PATH = `${shimDir}${path.delimiter}${originalPath}`;
+		try {
+			await installModules({ projects: ['application'] });
+		} finally {
+			process.env.PATH = originalPath;
+		}
+
+		assert.deepEqual(fs.readFileSync(argvPath, 'utf8').split('\n').filter(Boolean), [
+			'install',
+			'--force',
+			'--omit=dev',
+			'--no-audit',
+			'--no-fund',
+			'--json',
+		]);
+		fs.rmSync(shimDir, { recursive: true, force: true });
 	});
 });

--- a/unitTests/utility/npmUtilities.test.js
+++ b/unitTests/utility/npmUtilities.test.js
@@ -106,19 +106,19 @@ describe('install_node_modules', function () {
 	it('runs npm with the registry audit disabled', async function () {
 		if (process.platform === 'win32') return this.skip(); // the shim below is a POSIX shell script
 		const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harper-npm-shim-'));
-		const argvPath = path.join(shimDir, 'argv.txt');
-		// the destination travels as an environment value, not as text in the script: a `$` or a
-		// backtick in TMPDIR would otherwise be expanded by the shell that runs this
-		fs.writeFileSync(
-			path.join(shimDir, 'npm'),
-			'#!/bin/sh\nprintf \'%s\\n\' "$@" > "$HARPER_TEST_NPM_ARGV_PATH"\necho \'{"added":0}\'\n',
-			{ mode: 0o755 }
-		);
 		const originalPath = process.env.PATH;
-		process.env.PATH = `${shimDir}${path.delimiter}${originalPath}`;
-		process.env.HARPER_TEST_NPM_ARGV_PATH = argvPath;
 		let argv;
 		try {
+			const argvPath = path.join(shimDir, 'argv.txt');
+			// the destination travels as an environment value, not as text in the script: a `$` or a
+			// backtick in TMPDIR would otherwise be expanded by the shell that runs this
+			fs.writeFileSync(
+				path.join(shimDir, 'npm'),
+				'#!/bin/sh\nprintf \'%s\\n\' "$@" > "$HARPER_TEST_NPM_ARGV_PATH"\necho \'{"added":0}\'\n',
+				{ mode: 0o755 }
+			);
+			process.env.PATH = `${shimDir}${path.delimiter}${originalPath}`;
+			process.env.HARPER_TEST_NPM_ARGV_PATH = argvPath;
 			await installModules({ projects: ['application'] });
 			argv = fs.readFileSync(argvPath, 'utf8').split('\n').filter(Boolean);
 		} finally {
@@ -127,6 +127,6 @@ describe('install_node_modules', function () {
 			fs.rmSync(shimDir, { recursive: true, force: true });
 		}
 
-		assert.deepEqual(argv, ['install', '--force', '--omit=dev', '--no-audit', '--no-fund', '--json']);
+		assert.deepStrictEqual(argv, ['install', '--force', '--omit=dev', '--no-audit', '--no-fund', '--json']);
 	});
 });

--- a/unitTests/utility/npmUtilities.test.js
+++ b/unitTests/utility/npmUtilities.test.js
@@ -12,7 +12,11 @@ const env = require('#src/utility/environment/environmentManager');
 const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
 const { installModules } = require('#src/utility/npmUtilities');
 
-describe('install_node_modules', () => {
+describe('install_node_modules', function () {
+	// .mocharc.json sets `timeout: 0`, and these cases spawn real npm; without a bound here a
+	// registry stall wedges the whole run instead of failing it
+	this.timeout(60_000);
+
 	let componentsRoot;
 
 	before(() => {
@@ -102,32 +106,31 @@ describe('install_node_modules', () => {
 	});
 
 	// npm 10 puts a `file:` link into its audit bulk request, and the registry's answer to that is
-	// unbounded from here, so the flags that keep this operation off the registry are the invariant
-	it('runs npm with the registry audit and funding lookups disabled', async function () {
+	// unbounded from here, so `--no-audit` is an invariant of this operation, not a preference
+	it('runs npm with the registry audit disabled', async function () {
 		if (process.platform === 'win32') return this.skip(); // the shim below is a POSIX shell script
 		const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harper-npm-shim-'));
 		const argvPath = path.join(shimDir, 'argv.txt');
+		// the destination travels as an environment value, not as text in the script: a `$` or a
+		// backtick in TMPDIR would otherwise be expanded by the shell that runs this
 		fs.writeFileSync(
 			path.join(shimDir, 'npm'),
-			`#!/bin/sh\nprintf '%s\\n' "$@" > ${JSON.stringify(argvPath)}\necho '{"added":0}'\n`,
+			'#!/bin/sh\nprintf \'%s\\n\' "$@" > "$HARPER_TEST_NPM_ARGV_PATH"\necho \'{"added":0}\'\n',
 			{ mode: 0o755 }
 		);
 		const originalPath = process.env.PATH;
 		process.env.PATH = `${shimDir}${path.delimiter}${originalPath}`;
+		process.env.HARPER_TEST_NPM_ARGV_PATH = argvPath;
+		let argv;
 		try {
 			await installModules({ projects: ['application'] });
+			argv = fs.readFileSync(argvPath, 'utf8').split('\n').filter(Boolean);
 		} finally {
 			process.env.PATH = originalPath;
+			delete process.env.HARPER_TEST_NPM_ARGV_PATH;
+			fs.rmSync(shimDir, { recursive: true, force: true });
 		}
 
-		assert.deepEqual(fs.readFileSync(argvPath, 'utf8').split('\n').filter(Boolean), [
-			'install',
-			'--force',
-			'--omit=dev',
-			'--no-audit',
-			'--no-fund',
-			'--json',
-		]);
-		fs.rmSync(shimDir, { recursive: true, force: true });
+		assert.deepEqual(argv, ['install', '--force', '--omit=dev', '--no-audit', '--no-fund', '--json']);
 	});
 });

--- a/utility/npmUtilities.ts
+++ b/utility/npmUtilities.ts
@@ -12,7 +12,7 @@ import harperLogger from './logging/harper_logger.ts';
 
 import { CONFIG_PARAMS } from './hdbTerms.ts';
 import { getConfigPath } from '../config/configUtils.ts';
-import { nonInteractiveSpawn } from '../components/Application.ts';
+import { nonInteractiveSpawn, packageManagerInstallArguments } from '../components/Application.ts';
 import { withComponentPreparationLock } from '../components/componentPreparationLock.ts';
 import { isThreadRunning } from '../server/threads/manageThreads.js';
 
@@ -37,10 +37,10 @@ export async function installModules(req: any) {
 
 	const responseObject: any = {};
 
-	// npm 10 puts even a `file:` link into its audit bulk request, and the registry's answer to that
-	// is unbounded from here, so `--no-audit --no-fund` is what keeps a local dependency graph off
-	// the network — the same reason the component install path passes them.
-	const args = ['install', '--force', '--omit=dev', '--no-audit', '--no-fund', '--json'];
+	// `allowInstallScripts` is true because this operation has always run a project's install
+	// lifecycle; the flags that come with the shared builder include `--no-audit`, without which npm
+	// 10 puts even a `file:` link into an audit bulk request whose registry answer is unbounded here
+	const args = [...packageManagerInstallArguments('npm', true, true), '--json'];
 	if (dryRun) args.push('--dry-run');
 
 	for (const project of projects) {

--- a/utility/npmUtilities.ts
+++ b/utility/npmUtilities.ts
@@ -37,9 +37,9 @@ export async function installModules(req: any) {
 
 	const responseObject: any = {};
 
-	// `--no-audit --no-fund` matches the component install path (Application.ts) and, for a purely
-	// local dependency graph, is what keeps the install off the network entirely: npm 10 puts even a
-	// `file:` link in its audit bulk request, and that registry round trip is unbounded from here.
+	// npm 10 puts even a `file:` link into its audit bulk request, and the registry's answer to that
+	// is unbounded from here, so `--no-audit --no-fund` is what keeps a local dependency graph off
+	// the network — the same reason the component install path passes them.
 	const args = ['install', '--force', '--omit=dev', '--no-audit', '--no-fund', '--json'];
 	if (dryRun) args.push('--dry-run');
 

--- a/utility/npmUtilities.ts
+++ b/utility/npmUtilities.ts
@@ -37,9 +37,7 @@ export async function installModules(req: any) {
 
 	const responseObject: any = {};
 
-	// `allowInstallScripts` is true because this operation has always run a project's install
-	// lifecycle; the flags that come with the shared builder include `--no-audit`, without which npm
-	// 10 puts even a `file:` link into an audit bulk request whose registry answer is unbounded here
+	// `allowInstallScripts` is true because this operation has always run a project's install lifecycle
 	const args = [...packageManagerInstallArguments('npm', true, true), '--json'];
 	if (dryRun) args.push('--dry-run');
 

--- a/utility/npmUtilities.ts
+++ b/utility/npmUtilities.ts
@@ -37,7 +37,10 @@ export async function installModules(req: any) {
 
 	const responseObject: any = {};
 
-	const args = ['install', '--force', '--omit=dev', '--json'];
+	// `--no-audit --no-fund` matches the component install path (Application.ts) and, for a purely
+	// local dependency graph, is what keeps the install off the network entirely: npm 10 puts even a
+	// `file:` link in its audit bulk request, and that registry round trip is unbounded from here.
+	const args = ['install', '--force', '--omit=dev', '--no-audit', '--no-fund', '--json'];
 	if (dryRun) args.push('--dry-run');
 
 	for (const project of projects) {


### PR DESCRIPTION
`Unit Test (Node.js v22)` has hit its 10-minute `timeout-minutes` cap on every `main` run since 2026-09-03T22:01Z. GitHub reports a job that hits that cap as `cancelled`, not `failure`, so the required check never went red and the entire Node-22 unit suite has been silently skipped since.

## Root cause

The leg stalls in `unitTests/utility/npmUtilities.test.js` › `install_node_modules` › `installs when dry_run is false` — the first case in that suite that runs a real, non-dry-run `installModules()`. That spawns `npm install --force --omit=dev --json` against a fixture whose only dependency is `file:../dependency`.

npm 10.9.x — the npm bundled with Node 22, and only with Node 22 — puts that `file:` link into its audit bulk request and POSTs it to the registry. npm 11 (Node 24/26) sends an empty payload and issues no request at all:

| npm | `silly audit bulk request` | real install |
|---|---|---|
| 10.9.8 (Node 22) | `{ 'local-dependency': [ '1.0.0' ] }` | hangs |
| 11.17.0 (Node 24) | `{}` → `audit report null` | 0.506s |

The registry no longer answers that payload. Measured directly against `POST https://registry.npmjs.org/-/npm/v1/security/advisories/bulk`:

```
{"lodash":["4.17.21"]}          -> 200 in 0.18s
{"local-dependency":["1.0.0"]}  -> no response within 60s
```

An npm debug log from one attempt that did eventually return records `http fetch POST 200 .../security/advisories/bulk 160214ms`. The same install took 467ms on the last green run, so this is a registry-side latency change rather than a code change — the single-commit bisect onto #2493 is a false positive; that commit touches `resources/search.ts` and tests under `unitTests/resources/`, none of which this path reaches. What #2493 *did* contribute is ~2 minutes of new `test:unit:resources` time, which is why the v24/v26 legs are now landing at ~9m50s of a 10-minute budget.

Nothing bounded the wait below the job cap: `.mocharc.json` sets `timeout: 0`, so no individual test can time out, and `nonInteractiveSpawn` defaults to `DEFAULT_COMMAND_TIMEOUT_MS` — one hour.

## The fix

The two npm entry points having separate argument lists is how this happened: the automatic component install has always passed `--no-audit --no-fund`, and `install_node_modules` hand-rolled its own list without them. Rather than adding the flags in a second place, [`installModules` now composes its arguments with the same builder](https://github.com/HarperFast/harper/pull/2501/changes?w=1#diff-aab51787131300406743175a786a0896ca9bdc7ce9b86458c3d1fdc36cf34aebR41), exported from `components/Application.ts` as [`packageManagerInstallArguments`](https://github.com/HarperFast/harper/pull/2501/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R2941), so a registry-avoidance flag can no longer be added to one path and missed by the other. `allowInstallScripts: true` reproduces the operation's existing behaviour exactly — its argv is byte-identical to before plus `--no-audit --no-fund`.

`--no-audit` is the flag that matters; `--no-fund` only suppresses the funding message. The suite goes from wedged-past-10-minutes to 202ms on Node 22.

A [new case pins the composed argv](https://github.com/HarperFast/harper/pull/2501/changes?w=1#diff-f0ada45d0d4b92fce70a6e89934360d60e453be2bd36f99b55c6b4a478699c53R119) by putting an `npm` shim on `PATH` and asserting what the real spawn receives — the idiom `unitTests/components/applicationInstall.test.js` already uses for the automatic path. Removing either flag fails it (verified).

## Budget and loud failures

Every step in the job now carries its own `timeout-minutes`, mirroring what the Windows job already does: a step that exceeds its cap **fails**, so the job's conclusion is `failure` and not `cancelled`. [The job cap becomes a pure backstop](https://github.com/HarperFast/harper/pull/2501/changes?w=1#diff-d4223b44df678cece85f2542c19b9cd060d43b22f753c25214d5942ef2ca5d18R33) — set above the sum of the step caps (41 on the longest leg) so a stall can only ever surface as a [step failure on `Run tests`](https://github.com/HarperFast/harper/pull/2501/changes?w=1#diff-d4223b44df678cece85f2542c19b9cd060d43b22f753c25214d5942ef2ca5d18R88). That is why it moves 10 → 45; the numbers that actually bound the run are the step caps, each roughly 2x its measured cost.

Measured on the v22 leg of run 33835237287: checkout + Node setup 6s, dependency install 2m24s, build 10s, type contract tests 1s, benchmark tests 1s, Harper setup 5s, and the unit run ~7m20s (taken from the v24 leg, which completed). That is ~10m05s against the old 10-minute cap — the leg had no headroom left even without the hang.

The real-npm cases also set their own 60s mocha timeout, so the same class of stall fails the run in the dev loop too, not only under a GitHub step cap.

## For the human reviewer

- **`install_node_modules` responses no longer carry npm's `audit` or funding fields.** The operation is deprecated and passes npm's raw `--json` output through verbatim, so this is a change in what npm reports rather than in Harper's own contract — but it is observable to anyone parsing those fields. `--no-fund` in particular comes along for parity rather than for the bug; splitting it out would leave the two paths diverging again, which is the thing being fixed.
- **`packageManagerInstallArguments` is exported from `components/Application.ts`**, a ~4000-line module, and `utility/` now imports it for pure argument construction. The `nonInteractiveSpawn` import already crosses that boundary so there is no new cycle, but a reviewer who wants this in a small shared module would be reasonable — it is a mechanical move.
- **The DESIGN.md claim is deliberately narrower than "every npm install".** npm's own nested install inside `npm pack <git-ref>` is not composed here and cannot be; binding that would mean `npm_config_audit=false` in the spawn environment instead of argv. Not done here — the argv builder is what the diverging path broke, and it is what the tests can pin.
- **The argv pin is skipped on Windows** (the shim is a `/bin/sh` script) while `windowsGate.mjs` runs the rest of the file. The flag set is platform-independent, so a regression fails the three Linux legs before Windows sees it; a `.cmd` shim was judged more likely to produce a Windows-only flake than to catch anything.
- **Declined: tightening this call's spawn timeout.** A review leg proposed a shorter `timeoutMs` for `installModules` so a regression fails fast everywhere. `DEFAULT_COMMAND_TIMEOUT_MS` is shared with the component install path, where hour-long installs are legitimate; lowering it for one caller trades a known hang for an unknown truncation. The mocha-level bound covers the test path, which is what was wedging.
- Not addressed: `.mocharc.json`'s repo-wide `timeout: 0` still means a hung unit test cannot fail on its own. Changing that is its own blast radius; the step caps and this suite's own bound are the backstop until then.

## Verification

- Reproduced the hang on Node 22.23.1 / npm 10.9.8: `npm run test:unit:main` stalls right after `honors the undocumented camelCase dryRun spelling`, with a live `npm install` child sitting in `ep_poll` on an established socket to the registry — the same signature as the CI job's orphan-process list (`Terminate orphan process: pid (5992) (npm install)`).
- Isolated it away from Harper: the same `npm install --force --omit=dev --json` over the same two-package fixture hangs under npm 10.9.8 and completes in 0.506s under npm 11.17.0; the raw `curl` measurements above confirm which request is stalling.
- Fails-on-base for the new guard: removing `--no-audit --no-fund` fails the argv assertion.
- `npx mocha unitTests/utility/npmUtilities.test.js` on Node 22: 8 passing in ~1s, real installs at ~200ms each. `unitTests/components/applicationInstall.test.js` also passes, covering the renamed builder's other two call sites.
- `npm run test:unit:main` on Node 22: 5411 passing, 196 pending, 2 failing — both failures are local-environment artefacts, not regressions. `configValidator.test.js:394` resolves `'relative/root'` against `process.cwd()`, so it warns from a deep worktree path and passes on CI's short runner cwd; `tokenAuthentication.test.js:247` is the known shared-fixture flake and passes on its own (58 passing). The same two pass on CI's v24 leg, whose 5412 total matches this run's 5413 (5411 + 2) once the new case is counted.
- `npm run test:unit:resources` on Node 22: 2042 passing, 0 failing.
- End-to-end route, executed: [run 33874421548](https://github.com/HarperFast/harper/actions/runs/33874421548) on this PR — all four Unit Test legs report a real `success`: Windows/v24 3m01s, v24 8m13s, v26 8m11s, **v22 10m21s**, its `install_node_modules` real installs down to 165ms from the hang. Note the v22 number: with the stall gone the leg still takes 10m21s, so the old 10-minute cap was already too small on its own — the `Run tests` step used 9m32s of its 15-minute cap. Every other check on the PR is green (41 pass, 4 skipping).


Complexity: medium

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=5 @ ceebeaf810a5</sub>

<sub>Human-Review-Need: 3 @ ceebeaf810a5</sub>
