### PR TITLE
Document why a storage-oracle test must read a RocksDB checkpoint, not the live database directory

### DIFF
--- a/integrationTests/README.md
+++ b/integrationTests/README.md
@@ -107,17 +107,24 @@ A test that reads the server's storage as an oracle must not open the **live** d
 the MANIFEST into a file list and then opens those files holding no reference on any of them, so a
 compaction in the Harper process under test can unlink one inside that window. The open then fails
 naming the file that vanished, wrapped in RocksDB's generic "the MANIFEST may be corrupted" phrasing
-— nothing is corrupt, the reader raced a compaction (HarperFast/rocksdb-js#812). That was #2500, and
-a loop measured it at 7% of opens against a directory under compaction.
+— nothing is corrupt, the reader raced a compaction ([rocksdb-js#812: `readOnly:true` open races a
+live writer's compaction](https://github.com/HarperFast/rocksdb-js/issues/812)). That was
+[#2500: delete-index-atomicity-rocksdb flakes](https://github.com/HarperFast/harper/issues/2500),
+and a loop measured it at 7% of opens against a directory under compaction.
 
 Have the fixture publish a checkpoint (`rootStore.createCheckpoint(path)`) and open that instead.
-Nothing writes to a checkpoint, so the window does not exist; the copy is hardlinked, so it is cheap;
-and taking one flushes the memtable, which such a test needs anyway, since Harper opens table and
-index column families with `disableWAL` defaulting to true — a committed write can otherwise sit only
-in the writer's memtable and never reach an external reader. Put the checkpoint beside `database/`,
-not inside it: `database/` is the directory scanned for databases (`resources/databases.ts`), and a
-checkpoint left in it would be loaded as one. `database/delete-index-atomicity-rocksdb.test.ts` and
-its fixture are the worked example.
+Nothing writes to a checkpoint, so the window does not exist, and taking one flushes the memtable,
+which such a test needs anyway, since Harper opens table and index column families with `disableWAL`
+defaulting to true — a committed write can otherwise sit only in the writer's memtable and never
+reach an external reader.
+
+Two things the recipe depends on. Put the checkpoint beside `database/`, not inside it: `database/`
+is the directory scanned for databases (`resources/databases.ts`), and any directory in it with a
+`CURRENT` and a `MANIFEST-*` is loaded as one. And close the handles and delete the previous
+checkpoint before taking the next — a checkpoint is hardlinked, so it is cheap to take but it also
+keeps every SST it names alive through the live database's compactions, and a suite that refreshes
+before each read would otherwise pin every historical file version for the length of the run.
+`database/delete-index-atomicity-rocksdb.test.ts` and its fixture are the worked example.
 
 ### Template
 

--- a/integrationTests/README.md
+++ b/integrationTests/README.md
@@ -100,6 +100,25 @@ This is how CI captures logs for failed jobs — the log directory is uploaded a
 
 The runner executes each file in its own process. For concurrent execution to be safe, every test file must be **independent** (no shared state with other files), **hermetic** (no external side-effects), and **deterministic** (same output for the same input, every time). See the [framework documentation](https://github.com/HarperFast/integration-testing-framework#testing-ethos) for more on why these properties matter.
 
+### Reading storage directly
+
+A test that reads the server's storage as an oracle must not open the **live** database directory.
+`RocksDatabase.open(dir, { readOnly: true })` maps to `rocksdb::DB::OpenForReadOnly`, which replays
+the MANIFEST into a file list and then opens those files holding no reference on any of them, so a
+compaction in the Harper process under test can unlink one inside that window. The open then fails
+naming the file that vanished, wrapped in RocksDB's generic "the MANIFEST may be corrupted" phrasing
+— nothing is corrupt, the reader raced a compaction (HarperFast/rocksdb-js#812). That was #2500, and
+a loop measured it at 7% of opens against a directory under compaction.
+
+Have the fixture publish a checkpoint (`rootStore.createCheckpoint(path)`) and open that instead.
+Nothing writes to a checkpoint, so the window does not exist; the copy is hardlinked, so it is cheap;
+and taking one flushes the memtable, which such a test needs anyway, since Harper opens table and
+index column families with `disableWAL` defaulting to true — a committed write can otherwise sit only
+in the writer's memtable and never reach an external reader. Put the checkpoint beside `database/`,
+not inside it: `database/` is the directory scanned for databases (`resources/databases.ts`), and a
+checkpoint left in it would be loaded as one. `database/delete-index-atomicity-rocksdb.test.ts` and
+its fixture are the worked example.
+
 ### Template
 
 ```ts

--- a/integrationTests/README.md
+++ b/integrationTests/README.md
@@ -118,12 +118,14 @@ which such a test needs anyway, since Harper opens table and index column famili
 defaulting to true — a committed write can otherwise sit only in the writer's memtable and never
 reach an external reader.
 
-Two things the recipe depends on. Put the checkpoint beside `database/`, not inside it: `database/`
-is the directory scanned for databases (`resources/databases.ts`), and any directory in it with a
-`CURRENT` and a `MANIFEST-*` is loaded as one. And close the handles and delete the previous
-checkpoint before taking the next — a checkpoint is hardlinked, so it is cheap to take but it also
-keeps every SST it names alive through the live database's compactions, and a suite that refreshes
-before each read would otherwise pin every historical file version for the length of the run.
+Two things the recipe depends on. Put the checkpoint outside every directory Harper scans for
+databases — the `storage.path` root, which is `database/` by default, and any per-database `path`
+the config sets: `resources/databases.ts` walks each of them and adopts any child holding a `CURRENT`
+and a `MANIFEST-*` as a database, so a checkpoint under one would be loaded as one. And close the
+handles and delete the previous checkpoint before taking the next — a checkpoint is hardlinked, so it
+is cheap to take but it also keeps every SST it names alive through the live database's compactions,
+and a suite that refreshes before each read would otherwise pin every historical file version for the
+length of the run.
 `database/delete-index-atomicity-rocksdb.test.ts` and its fixture are the worked example.
 
 ### Template

--- a/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
+++ b/integrationTests/database/delete-index-atomicity-rocksdb.test.ts
@@ -28,8 +28,8 @@
  * The oracle reads a RocksDB checkpoint, never the live database directory. `readOnly: true` maps
  * to `rocksdb::DB::OpenForReadOnly`, which replays the MANIFEST into a file list and then opens
  * those files while holding no reference on any of them, so a compaction in the process under test
- * can unlink one inside that window and the open fails as MANIFEST corruption
- * (HarperFast/rocksdb-js#812). Nothing writes to a checkpoint, so the race cannot happen there, and
+ * can unlink one inside that window and the open fails as MANIFEST corruption (#2500,
+ * HarperFast/rocksdb-js#812). Nothing writes to a checkpoint, so the race cannot happen there, and
  * `createCheckpoint()` flushes the memtable — which the oracle needs anyway, since Harper opens
  * table/index column families with `disableWAL` defaulting to true (resources/databases.ts
  * openRocksDatabase) and a committed write can otherwise sit only in the writer's memtable. One


### PR DESCRIPTION
`integrationTests/database/delete-index-atomicity-rocksdb.test.ts` reddened `Integration Tests 3/6` on main three times on 2026-09-01/02 with `Corruption: IO error: No such file or directory ... 000021.sst`. The throw came from the test's own oracle handle, never from Harper, and #2452 already fixed that one suite by reading a RocksDB checkpoint instead of the live database directory. What the repo never got was the rule: nothing tells the author of the next storage-oracle test not to do the same thing. This writes it into `integrationTests/README.md` as [the rule that a test must not open the live database directory](https://github.com/HarperFast/harper/pull/2502/changes?w=1#diff-4f06a8a419c06a2493830fd0e2ccca75b7bbc5f71d1bb841f85e66d55b6dfbd2R105), followed by [the checkpoint recipe](https://github.com/HarperFast/harper/pull/2502/changes?w=1#diff-4f06a8a419c06a2493830fd0e2ccca75b7bbc5f71d1bb841f85e66d55b6dfbd2R115) and [the two things that recipe depends on](https://github.com/HarperFast/harper/pull/2502/changes?w=1#diff-4f06a8a419c06a2493830fd0e2ccca75b7bbc5f71d1bb841f85e66d55b6dfbd2R120), and points [the suite's header](https://github.com/HarperFast/harper/pull/2502/changes?w=1#diff-5097b51cdc22ddf502301cd56053dc01c2199c4051a6eb408c7b6213fa62a266R31) at the flake's tracking issue (#2500). No behavior changes.

Root cause, measured rather than assumed. `readOnly: true` maps to `rocksdb::DB::OpenForReadOnly`, which replays the MANIFEST into a file list and then opens those files while holding no reference on any of them, so a compaction in the process under test can unlink one inside that window and the open fails naming the file that vanished. Two processes against one RocksDB directory (`@harperfast/rocksdb-js` 2.8.0; writer doing 3,000 puts + `flush()` per iteration to keep L0→L1 compaction running): **273 of 3,804** read-only opens of the live directory failed, against **0 of 5,804** opens of a checkpoint of the same database taken by the same writer. The writer itself never failed. So this is the reader's window, not an SST disappearing under the server's own reader — the storage-engine-defect hypothesis was ruled out, not assumed away. Engine-side that is HarperFast/rocksdb-js#812, where the measurements are now recorded; the checkpoint is a workaround for it, and #2500 stays open to drop the workaround once a follower-mode open exists.

## For the human reviewer

1. **The deliverable is a docs rule, not another fix — say if you wanted code.** The flake was already eliminated at its cause by #2452, which landed 2026-09-02T22:58Z, about twenty hours after the last CI failure in the report that sent me here. I verified rather than re-fixed: the suite opens no live directory anywhere (`openDbi()` throws without a checkpoint, `refreshOracle()` asserts the published path equals the per-sequence checkpoint path), and the only other integration test that opens a Harper storage directory raw — `integrationTests/upgrade/4.x-upgrade.test.ts` — does so after `killHarper(ctx)`, so nothing can be compacting. There is no violating call site left to fix. I deliberately did not invent a code change to make the PR look bigger.
2. **Prose rule vs. a helper that makes the mistake unreachable.** A README section is opt-in: the next storage-oracle test can reintroduce the 7% flake by not reading it. The alternative is a `withCheckpointOracle()` helper in `@harperfast/integration-testing` that never exposes the live path. I did not build it — it is a change to a different repo's public surface off the back of one flake — but if you want it, this section becomes its rationale rather than being wasted.
3. **The rule is written as permanent, not as a workaround conditioned on rocksdb-js#812.** If #812 lands a read-only open that pins the files it lists, live opens become safe and this section is over-strict. I chose the unconditional wording because an over-strict test rule costs a checkpoint and an under-strict one costs a flake nobody can reproduce; #2500 is the thing that stays open to come back and amend it.
4. **Declined, raised in three rounds:** the review wants the `#2500` in the suite's JSDoc header to be a titled hyperlink like the README's. Left bare — that header already carries `#1854`, `#1869` and `HarperFast/rocksdb-js#812` as bare refs, a source comment is a grep token rather than something rendered clickable, and converting one of four would just make the block inconsistent. The README, which readers actually render, does use links.
5. **The section is long for a README.** The alternative was a two-line rule linking out to #2500 and rocksdb-js#812. I kept the mechanism inline because the failure reads as data corruption and the reason it is not is the whole point — someone who only sees "don't do this" will reasonably conclude the database was damaged. The cost is drift if the engine behavior changes; #2500 is where that gets caught.
6. **The one claim most worth a second pair of eyes** is where the checkpoint may live. It is load-bearing, and round 3 caught it being too narrow: `resources/databases.ts` walks the `storage.path` root, the legacy schema directory, *and* every per-database `path` the config sets, adopting any child with a `CURRENT` and a `MANIFEST-*`. [The rule now names all of them](https://github.com/HarperFast/harper/pull/2502/changes?w=1#diff-4f06a8a419c06a2493830fd0e2ccca75b7bbc5f71d1bb841f85e66d55b6dfbd2R120) rather than only `database/`.

## Verification

Route: existing integration test, run repeatedly, plus a standalone reproduction of the mechanism. Nothing executable changed, so the tests establish that the current suite is stable, and the standalone repro establishes the root cause.

- `npm run build`, then `npm run test:integration -- "integrationTests/database/delete-index-atomicity-rocksdb.test.ts"` ×12 — 12/12 green, all 9 cases each run (both oracle proofs and Arms A and B on both tables).
- Standalone two-process reproduction of the mechanism — the numbers above (273/3,804 vs 0/5,804).
- In-situ contrast: a scratch copy of the suite differing only in opening `rootPath` instead of the checkpoint passed 15/15 on an idle box. Reported because it is the honest result: the test's own database is tiny, so its compactions finish too fast to hit the window without load, which is also why this flake only surfaced 3 times in CI rather than every run. The amplified standalone repro is what carries the proof.
- `npm run lint:required` clean; `npx prettier --check` clean on both changed files.
- CI on this PR: everything green except `Integration Tests 5/6 (uWS HTTP)`, which failed on `integrationTests/resources/ttl-rate-limiter-concurrent.test.ts` — the already-open [#2127: CRDT counter increments can be lost under multi-worker contention](https://github.com/HarperFast/harper/issues/2127), on a shard this diff does not touch. Shard 3, which runs the suite this PR is about, passed on all four runtime variants.

Refs #2500, #2452, HarperFast/rocksdb-js#812

Complexity: easy

<sub>Review-Coverage: authored=claude; ran=gemini,codex; declined=cursor-grok,cursor-composer,domain; rounds=4 @ f593e62b1acc</sub>

<sub>Human-Review-Need: 2 @ f593e62b1acc</sub>
