### PR TITLE
Apply audit retention continuously to RocksDB transaction logs (v5.2)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -193,6 +193,70 @@ The cross-thread subscription path (default `crossThreads`) drives every `Table.
 - **`notifyScheduled` + `setImmediate`** in the `'committed'` listener defers the iteration off the commit microtask. Multiple `'committed'` events that land in the same event-loop turn collapse into one notify pass. `notifyScheduled` stays set for the entire drain — including across yield-and-resume turns — so a re-entry from a new `'committed'` event cannot spawn a second concurrent notify on the same iterator.
 - **Batched yielding** in `notifyFromTransactionData` (`NOTIFY_BATCH_SIZE`) is gated by `allowYield`. The `'committed'` path passes `allowYield = true`; the `listenToCommits` (same-thread `aftercommit`) path does not, because that path holds an inter-thread `'thread-local-writes'` lock that must not span event-loop turns. `subscribersWithTxns` is carried across yields via `subscriptions.pendingTxnSubscribers` so the `end_txn` signal fires exactly once when the iterator truly drains. When `activeCount` drops to zero mid-yield, the next continuation drops the carry-over to avoid invoking ended subscribers' listeners.
 
+## Audit retention cleanup is a self-rearming, engine-independent lifecycle
+
+One call to `scheduleAuditCleanup` establishes a retention cadence that ends when the root store closes
+(or immediately in process-wide read-only mode). Storage-engine selection changes the work inside each pass, not whether the timer,
+serialization barrier, error containment, and re-arm exist. LMDB removes bounded batches of audit
+entries; RocksDB asks rocksdb-js to purge conservatively eligible log segments before the same time
+cutoff. Disk-pressure callbacks may accelerate the next pass and shorten the effective window, but
+ordinary retention progress must not depend on pressure.
+
+The two engines do not share a cadence rule, because their units of progress differ. LMDB's adaptive
+backoff reads a per-entry delete count: it speeds up while entries are being removed and doubles while
+idle. Rocks reclaims whole segments whose eligibility changes only on rotation/flush, so the same
+signal would only make it rescan the same files — its delay is instead a pure function of the
+pressure-adjusted retention window (a tenth of it, floored at `DEFAULT_AUDIT_CLEANUP_DELAY`).
+
+Exactly one Rocks purge loop exists per store, and that is owned by the **arming** sites, not the
+re-arm: `onStorageReclamation` registers its handler only on the last worker (it takes no
+`skipThreadCheck`), and the store-open arm gates on the same index. The last-worker conjunct on the
+re-arm is therefore unreachable through either of those paths; it is a backstop for a direct caller
+of the exported `scheduleAuditCleanup`, because a store-wide segment purge looping on every worker is
+duplicated work. If a future change passes `skipThreadCheck: true` at the registration site, that
+backstop — not the registration — becomes the thing keeping the loop single.
+
+Both re-arm guards are **Rocks-only**, deliberately: the LMDB arm keeps `origin/main`'s unconditional
+re-arm, so it neither yields to an already-pending pass (a pressure-armed 100ms pass can be cancelled
+and replaced by the idle backoff) nor restricts itself to one worker. Those are pre-existing LMDB
+behaviours, not invariants this section establishes — don't read the paragraphs above as
+engine-independent.
+
+Two things a purge does **not** need to coordinate, both load-bearing for the continuous cadence.
+Unlinking a segment a consumer has mapped is safe **on POSIX**: the inode outlives the unlink, and the
+mapping cache (`_logBuffers`) holds `WeakRef`s, with a strong ref only on the newest segment, which is
+never purge-eligible — so nothing pins a purged inode and no cross-worker cache invalidation is
+required. Windows does not share that property: deleting a mapped segment raises a sharing violation,
+so the purge throws, is warn-logged, re-arms, and makes no progress for as long as a consumer holds the
+mapping. The continuous cadence therefore turns a Windows retention stall into a steady state rather
+than a one-off, and nothing covers it — the Rocks retention integration test skips win32.
+What is _not_ covered is the segment a lagging consumer has not mapped yet: `TransactionLog.query()`'s
+iterator returns `done` when its next segment cannot be mapped, indistinguishable from being caught up
+(rocksdb-js `src/transaction-log-reader.ts`). A consumer that far behind needs a full copy rather than
+log replay, so the gap is a missing escalation signal in the reader, not a reason to hold retention —
+tracked as HarperFast/rocksdb-js#805. Continuous retention is what moves it from unreachable-in-steady-state
+to routine: a peer offline longer than `logging.auditRetention` now resumes into a purged prefix and is
+recorded as caught up, and `txnlogReplayGapBytes` observes the gap without escalating on it.
+
+Retirement is two things, and teardown needs both. `stopAuditCleanup()` latches the loop closed and
+cancels the pending timer, and it **returns a drain barrier** — a promise that settles once the pass
+already running has finished. The barrier is what makes closing stores safe: lmdb-js stamps the DBI
+number into its write instruction synchronously and the native writer consumes it later
+(`node_modules/lmdb/write.js`), so a pass suspended inside `await removeAuditEntry()` still has a
+delete pending against the primary and audit DBIs, and LMDB forbids closing a DBI an existing
+transaction has modified. `dropDatabase()` and the legacy arm of `Table.dropTable()` await it.
+`closeDatabase()` is synchronous and cannot; what covers it is that every
+environment touch remaining in a resumed pass — cursor advance, cursor release, marker write, re-arm —
+re-checks `rootStore.status`, plus the fact that its production callers reach it only for RocksDB
+stores, whose pass is one synchronous `purgeLogs()` call with nothing suspended mid-removal.
+`resetDatabases()` closes LMDB roots with no retirement call at all, so that re-check is a routine
+path rather than a defensive one.
+
+The last-removed marker is retained until it commits. A rejected write is logged and carried to the
+next pass rather than dropped: a pass that deletes nothing never reaches the write again, so one
+transient failure would otherwise leave the recorded boundary permanently behind the entries that
+were already removed.
+
 ## `createBlob(readable)` and `table.put()` don't synchronously drain the source
 
 When a blob attribute is created from a Node `Readable` (e.g. `createBlob(stream)` then `row.payload_blob = blob; await table.put(row)`), the put does **not** wait for the underlying stream to fully drain into the file before resolving. Internally `saveBlob` kicks off a `writeBlobWithStream` pipeline whose `storageInfo.saving` promise is tracked separately. The put resolves once encoding has captured the blob reference; the bytes finish writing concurrently.

--- a/integrationTests/database/audit-retention-lmdb.test.ts
+++ b/integrationTests/database/audit-retention-lmdb.test.ts
@@ -15,9 +15,10 @@
  *     ITSELF from its own `finally` (line 216), backing off when idle. That self-re-arm is the
  *     whole mechanism under test: if it ever stops re-arming, audit entries grow without bound
  *     and the only recovery is an explicit operator prune.
- *   - `resources/auditStore.ts:164-172` — the RocksDB branch calls `purgeLogs()` once and
- *     returns with no re-arm (F-218). That asymmetry is deliberately NOT asserted here; this
- *     file pins only the behavior that is correct today, so it stays green.
+ *   - The RocksDB branch now shares the same self-rearming lifecycle but purges whole native
+ *     transaction-log segments. This file keeps the LMDB per-entry oracle; Rocks retention is covered
+ *     by `audit-retention-rocks.test.ts`, because cached log mappings make `read_audit_log` an
+ *     invalid deletion oracle for RocksDB.
  *   - `resources/databases.ts:862` — `HARPER_STORAGE_ENGINE` wins over config, which is how the
  *     LMDB arm is selected (same mechanism as `eviction-secondary-index.test.ts`).
  *
@@ -216,7 +217,7 @@ suite(
 						`If this fails, F-218's "RocksDB-specific" framing does not hold — LMDB fails too, which is a bigger/different finding.`
 				);
 				lmdbFindings.push(
-					`2. VERDICT: LMDB's self-re-arming scheduleAuditCleanup branch (auditStore.ts:174-222) DID purge aged audit entries with no operator intervention, confirming the RocksDB gap is engine-specific.`
+					`2. VERDICT: LMDB's scheduleAuditCleanup pass DID purge aged audit entries with no operator intervention, preserving the engine-independent retention cadence.`
 				);
 			}
 		);

--- a/integrationTests/database/audit-retention-lmdb/resources.js
+++ b/integrationTests/database/audit-retention-lmdb/resources.js
@@ -31,3 +31,15 @@ export class StorageEngineInfo extends Resource {
 		};
 	}
 }
+
+export class TransactionLogStats extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		const rootStore = tables['Ledger']?.primaryStore?.rootStore;
+		if (!rootStore?.auditStore?.log) throw new Error('RocksDB transaction log is not available');
+		if (typeof rootStore.auditStore.log.getStats !== 'function') {
+			throw new Error('RocksDB transaction-log statistics are not available');
+		}
+		return rootStore.auditStore.log.getStats();
+	}
+}

--- a/integrationTests/database/audit-retention-rocks.test.ts
+++ b/integrationTests/database/audit-retention-rocks.test.ts
@@ -1,0 +1,99 @@
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+	setupHarperWithFixture,
+	teardownHarper,
+	sendOperation,
+	type ContextWithHarper,
+} from '@harperfast/integration-testing';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'audit-retention-lmdb');
+const skipSuite = process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun';
+
+function authHeader(ctx: ContextWithHarper): string {
+	const { username, password } = ctx.harper.admin;
+	return 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
+}
+
+async function getStats(ctx: ContextWithHarper): Promise<any> {
+	const response = await fetch(`${ctx.harper.httpURL}/TransactionLogStats/`, {
+		headers: { Authorization: authHeader(ctx) },
+	});
+	ok(response.ok, `TransactionLogStats failed with ${response.status}`);
+	return response.json();
+}
+
+async function waitForStats(ctx: ContextWithHarper): Promise<void> {
+	const deadline = Date.now() + 60_000;
+	while (Date.now() < deadline) {
+		try {
+			if (await getStats(ctx)) return;
+		} catch {}
+		await sleep(250);
+	}
+	throw new Error('TransactionLogStats did not become ready');
+}
+
+async function waitForPurgeRun(ctx: ContextWithHarper, previousRuns: number): Promise<number> {
+	const deadline = Date.now() + 25_000;
+	while (Date.now() < deadline) {
+		try {
+			const runs = (await getStats(ctx))?.totals?.purgeRuns;
+			if (typeof runs === 'number' && runs > previousRuns) return runs;
+		} catch {}
+		await sleep(250);
+	}
+	throw new Error(`RocksDB transaction-log cleanup did not advance past purgeRuns=${previousRuns}`);
+}
+
+suite(
+	'RocksDB audit retention self-rearms without storage pressure (#2140)',
+	{ skip: skipSuite },
+	(ctx: ContextWithHarper) => {
+		before(async () => {
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+				config: {
+					threads: { count: 1 },
+					logging: { auditLog: true, auditRetention: 2 },
+				},
+				env: {
+					HARPER_STORAGE_ENGINE: 'rocksdb',
+					STORAGE_RECLAMATION_THRESHOLD: 0,
+				},
+			});
+			await waitForStats(ctx);
+		});
+
+		after(async () => {
+			await teardownHarper(ctx);
+		});
+
+		test('runs more than one passive purge pass', { timeout: 90_000 }, async () => {
+			const engineResponse = await fetch(`${ctx.harper.httpURL}/StorageEngineInfo/`, {
+				headers: { Authorization: authHeader(ctx) },
+			});
+			const engine = await engineResponse.json();
+			strictEqual(engine.engineGuess, 'rocksdb');
+
+			await sendOperation(ctx.harper, {
+				operation: 'insert',
+				schema: 'data',
+				table: 'Ledger',
+				records: [{ id: 'first-pass', seq: 1, payload: 'first-pass' }],
+			});
+			const initialRuns = (await getStats(ctx))?.totals?.purgeRuns ?? 0;
+			const firstRun = await waitForPurgeRun(ctx, initialRuns);
+
+			await sendOperation(ctx.harper, {
+				operation: 'insert',
+				schema: 'data',
+				table: 'Ledger',
+				records: [{ id: 'second-pass', seq: 2, payload: 'second-pass' }],
+			});
+			const secondRun = await waitForPurgeRun(ctx, firstRun);
+			ok(secondRun > firstRun, `expected a re-armed purge pass after ${firstRun}, got ${secondRun}`);
+		});
+	}
+);

--- a/integrationTests/database/blob-delete-reclaim-audit-expiry.test.ts
+++ b/integrationTests/database/blob-delete-reclaim-audit-expiry.test.ts
@@ -2,8 +2,7 @@
  * QA-802 — Blob GC vs audit-log expiry (harper#708, "Blob GC: files not deleted on
  * audit-log expiry when using RocksDB audit store").
  *
- * #708's claim: `scheduleAuditCleanup()` (resources/auditStore.ts) branches on the audit
- * store type; for RocksDB it calls `rootStore.purgeLogs()` and returns WITHOUT ever calling
+ * #708's claim: RocksDB audit expiry purges whole transaction-log segments without calling
  * `removeAuditEntry()` — the function that invokes the blob-file delete callbacks — so blob
  * files supposedly accumulate forever once a blob-bearing record is deleted.
  *

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -86,7 +86,7 @@ import { rebuildUpdateBefore } from './crdt.ts';
 import { appendHeader } from '../server/serverHelpers/Headers.ts';
 import fs from 'node:fs';
 import { Blob, deleteBlobsInObject, findBlobsInObject, startPreCommitBlobsForRecord } from './blob.ts';
-import { onStorageReclamation, getStorageSpaceStats } from '../server/storageReclamation.ts';
+import { onStorageReclamation, removeStorageReclamation, getStorageSpaceStats } from '../server/storageReclamation.ts';
 import { RequestTarget } from './RequestTarget.ts';
 import harperLogger from '../utility/logging/harper_logger.ts';
 import { throttle } from '../server/throttle.ts';
@@ -1564,7 +1564,12 @@ export function makeTable(options) {
 					if (removeTombstonedCatalog()) await dbisDb.committed;
 				}
 			} else {
-				// legacy table per database
+				// legacy table per database. The store to retire is this table's own audit store: nothing
+				// assigns `primaryStore.auditStore` — openAuditStore() assigns `rootStore.auditStore`, and
+				// this is the reference makeTable() was handed. Awaited so a pass suspended mid-removal has
+				// released the primary DBI before it is closed and unlinked.
+				await auditStore?.stopAuditCleanup?.();
+				removeStorageReclamation(primaryStore.path);
 				await primaryStore.close();
 				fs.unlinkSync(primaryStore.path);
 			}

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -118,6 +118,13 @@ const warnedBodylessMints = new Set<string>();
 const warnedBodylessTables = new Set<number>();
 const FLOAT_TARGET = new Float64Array(1);
 const FLOAT_BUFFER = new Uint8Array(FLOAT_TARGET.buffer);
+
+/** Last resort on a detached path: a failing log sink must not itself become an unhandled rejection. */
+function warnContained(message: string, error: unknown) {
+	try {
+		harperLogger.warn(message, error);
+	} catch {}
+}
 let DEFAULT_AUDIT_CLEANUP_DELAY = 10000; // default delay of 10 seconds
 let timestampErrored = false;
 export function openAuditStore(rootStore) {
@@ -133,7 +140,10 @@ export function openAuditStore(rootStore) {
 		if (!auditStore) {
 			// this means we are creating a new audit store. Initialize with the last removed timestamp (we don't want to put this in legacy audit logs since we don't know if they have had deletions or not).
 			auditStore = rootStore.openDB(AUDIT_STORE_NAME, AUDIT_STORE_OPTIONS);
-			updateLastRemoved(auditStore, 1);
+			// this open path is synchronous, so nothing downstream can own the write's rejection
+			updateLastRemoved(auditStore, 1)?.catch?.((error) =>
+				warnContained('Error initializing the audit log last-removed marker', error)
+			);
 		}
 		const superGetRange = auditStore.getRange.bind(auditStore);
 		auditStore.getRange = function (options) {
@@ -164,7 +174,15 @@ export function openAuditStore(rootStore) {
 	let pendingCleanupResolve: (() => void) | null = null;
 	let lastCleanupResolution: Promise<void>;
 	let cleanupPriority = 0;
-	let auditCleanupDelay = DEFAULT_AUDIT_CLEANUP_DELAY;
+	auditStore.auditCleanupDelay = DEFAULT_AUDIT_CLEANUP_DELAY;
+	let cleanupStopped = false;
+	// a last-removed marker whose write failed, retried on later passes: dropping it would leave
+	// getLastRemoved() reporting a boundary the entries behind it have already been deleted past
+	let pendingLastRemoved: number | undefined;
+	const isRocksAuditStore = auditStore instanceof RocksTransactionLogStore;
+	// A pass yields, so the store can be closed underneath it. Every touch of the environment after a
+	// resume — cursor advance, cursor release, marker write, re-arm — has to re-check.
+	const storeClosing = () => auditStore.rootStore.status === 'closed' || auditStore.rootStore.status === 'closing';
 	onStorageReclamation(rootStore.path, (priority) => {
 		cleanupPriority = priority; // update the priority
 		if (priority) {
@@ -175,28 +193,23 @@ export function openAuditStore(rootStore) {
 	/**
 	 * Schedules a pass of the audit cleanup loop. The returned promise fulfills once the pass that
 	 * serves this call has finished, so callers (notably tests) can await completion instead of
-	 * guessing a delay. Two things it does not promise: a pass removes at most
+	 * guessing a delay. Two things it does not promise: an LMDB pass removes at most
 	 * MAX_DELETES_PER_CLEANUP entries before rescheduling itself, so fulfillment means "that pass
 	 * finished", not "the audit log is fully pruned"; and a pass that failed logs and fulfills rather
 	 * than rejecting, since this promise doubles as the loop's serialization barrier.
 	 */
 	function scheduleAuditCleanup(newCleanupDelay?: number): Promise<void> {
 		// Skip audit cleanup/purge in read-only mode
-		if (isReadOnlyMode()) return Promise.resolve();
-		if (auditStore instanceof RocksTransactionLogStore) {
-			auditStore.rootStore.purgeLogs({
-				before: Date.now() - auditRetention / (1 + cleanupPriority * cleanupPriority),
-			});
-			return Promise.resolve();
-		}
+		if (cleanupStopped || isReadOnlyMode()) return Promise.resolve();
 
-		if (newCleanupDelay) auditCleanupDelay = newCleanupDelay;
+		if (newCleanupDelay) auditStore.auditCleanupDelay = newCleanupDelay;
 		// the pass we are about to cancel has not started, so its callers are handed over to this one
 		const supersededResolve = pendingCleanupResolve;
 		clearTimeout(pendingCleanup);
 		const resolution = new Promise<void>((resolve) => {
 			pendingCleanupResolve = resolve;
-			pendingCleanup = setTimeout(async () => {
+			const runCleanupPass = async () => {
+				pendingCleanup = null;
 				pendingCleanupResolve = null; // started, so a later schedule can no longer cancel this pass
 				// claim the serialization slot before yielding: assigning it after the await lets every
 				// pass released by the same resolution run concurrently over the same range
@@ -204,67 +217,146 @@ export function openAuditStore(rootStore) {
 				lastCleanupResolution = resolution;
 				await previousCleanup;
 				// query for audit entries that are old
-				if (auditStore.rootStore.status === 'closed' || auditStore.rootStore.status === 'closing') {
+				if (cleanupStopped || storeClosing()) {
 					// nothing to clean up and nothing to reschedule, but leaving `resolution` pending would
 					// wedge the loop permanently: it is now the resolution every later pass awaits
 					resolve();
 					return;
 				}
+				const passCleanupPriority = cleanupPriority;
 				let deleted = 0;
 				let lastKey: any;
 				try {
-					for (const auditRecord of auditStore.getRange({
-						start: 1, // must not be zero or it will be interpreted as null and overlap with symbols in search
-						snapshot: false,
-						end: Date.now() - auditRetention / (1 + cleanupPriority * cleanupPriority), // remove up until the audit retention time, reducing audit retention time if cleanup is higher priority
-					})) {
+					if (isRocksAuditStore) {
+						auditStore.rootStore.purgeLogs({
+							before: Date.now() - auditRetention / (1 + passCleanupPriority * passCleanupPriority),
+						});
+					} else {
+						// Driven explicitly rather than with for-of: this loop suspends on the awaits below, and a
+						// close landing mid-pass closes the env under it. for-of calls next() before the body, so a
+						// check inside the body advances the cursor first — the guard has to precede every next().
+						const entries = auditStore
+							.getRange({
+								start: 1, // must not be zero or it will be interpreted as null and overlap with symbols in search
+								snapshot: false,
+								end: Date.now() - auditRetention / (1 + passCleanupPriority * passCleanupPriority), // remove up until the audit retention time, reducing audit retention time if cleanup is higher priority
+							})
+							[Symbol.iterator]();
 						try {
-							// awaited so a rejection (not just a synchronous throw) is caught here instead of
-							// escaping as an unhandled rejection once a later iteration's promise replaces this one
-							await removeAuditEntry(auditStore, auditRecord);
-						} catch (error) {
-							harperLogger.warn('Error removing audit entry', error);
-						}
-						lastKey = auditRecord.key;
-						await new Promise(setImmediate);
-						if (++deleted >= MAX_DELETES_PER_CLEANUP) {
-							// limit the amount we cleanup per event turn so we don't use too much memory/CPU
-							auditCleanupDelay = 10; // and keep trying very soon
-							break;
+							while (!cleanupStopped && !storeClosing()) {
+								const entry = entries.next();
+								if (entry.done) break;
+								const auditRecord = entry.value;
+								try {
+									// awaited so a rejection (not just a synchronous throw) is caught here instead of
+									// escaping as an unhandled rejection once a later iteration's promise replaces this one
+									await removeAuditEntry(auditStore, auditRecord);
+								} catch (error) {
+									harperLogger.warn('Error removing audit entry', error);
+								}
+								lastKey = auditRecord.key;
+								await new Promise(setImmediate);
+								if (++deleted >= MAX_DELETES_PER_CLEANUP) {
+									// limit the amount we cleanup per event turn so we don't use too much memory/CPU
+									auditStore.auditCleanupDelay = 10; // and keep trying very soon
+									break;
+								}
+							}
+						} finally {
+							// for-of released the underlying cursor on break; an explicit loop owes that itself.
+							// Skipped only once the root is closing: releasing a cursor into a closed env reaches
+							// native code, while a retirement that leaves the env open still owes the release.
+							if (!storeClosing()) entries.return?.();
 						}
 					}
 				} catch (error) {
-					// the timer callback is detached, so anything escaping here lands as an unhandled
-					// rejection instead of a log line — and skips the reschedule below with it
+					// a failed scan is a log line, not a retired loop: the bookkeeping and reschedule below
+					// still run
 					harperLogger.warn('Error during audit log cleanup', error);
 				} finally {
-					// resolve() first and unconditionally: updateLastRemoved() below can throw
-					// synchronously if the store transitions to closing/closed mid-pass, and a throw
-					// from the rest of this block must not skip settling `resolution` — that's the
-					// serialization barrier every later pass awaits, and never settling it wedges the
-					// cleanup loop for the life of the store.
-					resolve();
-					if (deleted === 0) {
-						// if we didn't delete anything, we can increase the delay (double until we get to one tenth of
-						// the retention time). Plain arithmetic, not `<<`/`>>`: those coerce to int32, so a
-						// sub-millisecond retention collapsed the delay to 0 permanently (0 << 1 is 0), and a
-						// retention over ~248 days grows it past 2^31 where halving it wraps negative.
-						auditCleanupDelay = Math.max(1, Math.min(auditCleanupDelay * 2, auditRetention / 10, MAX_CLEANUP_DELAY));
-					} else {
-						// if we did delete something, update our updates since timestamp
-						updateLastRemoved(auditStore, lastKey);
-						// and do updates faster
-						if (auditCleanupDelay > 100) auditCleanupDelay = auditCleanupDelay / 2;
+					try {
+						if (isRocksAuditStore) {
+							// eligibility only changes on rotation/flush, so the LMDB backoff — keyed on a per-entry
+							// delete count — would only rescan the same segments
+							auditStore.auditCleanupDelay = Math.max(
+								DEFAULT_AUDIT_CLEANUP_DELAY,
+								Math.min(auditRetention / (1 + cleanupPriority * cleanupPriority) / 10, MAX_CLEANUP_DELAY)
+							);
+						} else {
+							if (deleted === 0) {
+								// if we didn't delete anything, we can increase the delay (double until we get to one tenth of
+								// the retention time). Plain arithmetic, not `<<`/`>>`: those coerce to int32, so a
+								// sub-millisecond retention collapsed the delay to 0 permanently (0 << 1 is 0), and a
+								// retention over ~248 days grows it past 2^31 where halving it wraps negative.
+								auditStore.auditCleanupDelay = Math.max(
+									1,
+									Math.min(auditStore.auditCleanupDelay * 2, auditRetention / 10, MAX_CLEANUP_DELAY)
+								);
+							} else {
+								pendingLastRemoved = lastKey;
+								// and do updates faster
+								if (auditStore.auditCleanupDelay > 100) auditStore.auditCleanupDelay = auditStore.auditCleanupDelay / 2;
+							}
+							// skipped when the store was retired or closed mid-pass — this writes to the audit
+							// store — and carried to the next pass instead, so a failed write is not lost
+							if (pendingLastRemoved !== undefined && !cleanupStopped && !storeClosing()) {
+								const marker = pendingLastRemoved;
+								try {
+									// awaited so the barrier below covers the write, and so a rejection is logged
+									// here rather than escaping the detached timer callback
+									await updateLastRemoved(auditStore, marker);
+									if (pendingLastRemoved === marker) pendingLastRemoved = undefined;
+								} catch (error) {
+									harperLogger.warn('Error recording the last removed audit entry', error);
+								}
+							}
+						}
+					} finally {
+						// settled and re-armed whatever the bookkeeping above threw: this promise is both the
+						// serialization barrier every later pass awaits and the drain barrier
+						// stopAuditCleanup() hands its callers, so never settling it wedges both
+						resolve();
+						// both conjuncts are backstops, not the ownership rule — see DESIGN.md: the arming
+						// sites already restrict Rocks to the last worker
+						if (
+							!cleanupStopped &&
+							!storeClosing() &&
+							(!isRocksAuditStore || (getWorkerIndex() === getWorkerCount() - 1 && !pendingCleanupResolve))
+						) {
+							scheduleAuditCleanup();
+						}
 					}
-					scheduleAuditCleanup();
 				}
 				// we can run this pretty frequently since there is very little overhead to these queries
-			}, auditCleanupDelay).unref();
+			};
+			pendingCleanup = setTimeout(() => {
+				// nothing owns the timer callback's promise, so anything the pass lets escape — including a
+				// throw from the logging inside its own containment — would land as an unhandled rejection
+				runCleanupPass().catch((error) => {
+					warnContained('Error during audit log cleanup', error);
+					resolve();
+				});
+			}, auditStore.auditCleanupDelay).unref();
 		});
 		if (supersededResolve) resolution.then(supersededResolve);
 		return resolution;
 	}
 	auditStore.scheduleAuditCleanup = scheduleAuditCleanup;
+	/**
+	 * Retires the cleanup loop for good, and returns a drain barrier: the promise settles once the pass
+	 * that was already running has finished. Retirement alone only stops the loop admitting more work —
+	 * a pass suspended inside `await removeAuditEntry()` still has a write queued whose DBI the native
+	 * writer consumes later, so a caller that closes or unlinks stores must await this first. The
+	 * synchronous teardown paths cannot; the in-pass status checks are what covers them.
+	 */
+	auditStore.stopAuditCleanup = function (): Promise<void> {
+		cleanupStopped = true;
+		clearTimeout(pendingCleanup);
+		pendingCleanup = null;
+		pendingCleanupResolve?.();
+		pendingCleanupResolve = null;
+		return lastCleanupResolution ?? Promise.resolve();
+	};
 	if (getWorkerIndex() === getWorkerCount() - 1) {
 		scheduleAuditCleanup();
 	}
@@ -296,7 +388,7 @@ export function removeAuditEntry(auditStore: any, auditRecord: AuditRecord): Pro
 
 function updateLastRemoved(auditStore, lastKey) {
 	FLOAT_TARGET[0] = lastKey;
-	auditStore.put(Symbol.for('last-removed'), FLOAT_BUFFER);
+	return auditStore.put(Symbol.for('last-removed'), FLOAT_BUFFER);
 }
 
 export function getLastRemoved(auditStore) {

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -29,6 +29,7 @@ import harperLogger from '../utility/logging/harper_logger.ts';
 const { forComponent } = harperLogger;
 import * as manageThreads from '../server/threads/manageThreads.js';
 import { openAuditStore, readAuditEntry, createAuditEntry, type AuditRecord } from './auditStore.ts';
+import { removeStorageReclamation } from '../server/storageReclamation.ts';
 import { handleLocalTimeForGets } from './RecordEncoder.ts';
 import { deleteRootBlobPathsForDB } from './blob.ts';
 import { CUSTOM_INDEXES } from './indexes/customIndexes.ts';
@@ -1253,6 +1254,10 @@ export async function dropDatabase(databaseName) {
 		databaseEventsEmitter.emit('dropDatabase', databaseName);
 
 		if (rootStore) {
+			// awaited: retirement stops the loop admitting work, the barrier is what says the pass that was
+			// already running has released the stores this is about to close and unlink
+			await rootStore.auditStore?.stopAuditCleanup?.();
+			removeStorageReclamation(rootStore.path);
 			if (rootStore.status === 'open') {
 				if (rootStore instanceof RocksDatabase) {
 					rootStore.close();
@@ -1267,6 +1272,8 @@ export async function dropDatabase(databaseName) {
 			// a tableless database resolves its root store here rather than in the loop above, so take
 			// the drop lock now (still before any destructive step)
 			if (rootStore instanceof RocksDatabase) lockDatabaseForDrop(rootStore.path, databaseName, restoreLocks);
+			await rootStore.auditStore?.stopAuditCleanup?.();
+			removeStorageReclamation(rootStore.path);
 			if (rootStore instanceof RocksDatabase) {
 				rootStore.close();
 				rootStore.destroy();
@@ -1304,17 +1311,27 @@ export function closeDatabase(databaseName: string): boolean {
 		const table: any = dbTables[tableName];
 		if (!table?.primaryStore) continue;
 		if (table.primaryStore.rootStore) rootStores.add(table.primaryStore.rootStore);
-		for (const indexName in table.indices || {}) {
-			closeStore(table.indices[indexName], `index ${tableName}.${indexName}`);
-		}
-		closeStore(table.primaryStore, `table ${tableName}`);
 	}
 	// a database with no tables (an empty schema, or one whose tables were all dropped) still holds
 	// an open root store, tracked only on the defined-database entry rather than any table — include
 	// it so its handles are released too (the Set dedupes it against the per-table root stores above)
 	const definedRoot = (definedDatabases?.get(databaseName) as any)?.rootStore;
 	if (definedRoot) rootStores.add(definedRoot);
+	// before any table store closes, so no further pass is admitted. This is synchronous, so it cannot
+	// await the drain barrier stopAuditCleanup() returns; what covers it is the in-pass status checks,
+	// plus the fact that its production callers reach it only for RocksDB databases, whose pass is one
+	// synchronous purgeLogs() call with nothing suspended mid-removal.
+	for (const rootStore of rootStores) rootStore.auditStore?.stopAuditCleanup?.();
+	for (const tableName in dbTables) {
+		const table: any = dbTables[tableName];
+		if (!table?.primaryStore) continue;
+		for (const indexName in table.indices || {}) {
+			closeStore(table.indices[indexName], `index ${tableName}.${indexName}`);
+		}
+		closeStore(table.primaryStore, `table ${tableName}`);
+	}
 	for (const rootStore of rootStores) {
+		removeStorageReclamation(rootStore.path);
 		closeStore(rootStore.dbisDb, 'attributes store');
 		closeStore(rootStore, 'root store');
 		lmdbDatabaseEnvs.delete(rootStore.path);

--- a/server/storageReclamation.ts
+++ b/server/storageReclamation.ts
@@ -118,6 +118,16 @@ export function onStorageReclamation(
 		if (!reclamationTimer) reclamationTimer = setTimeout(runReclamationHandlers, RECLAMATION_INTERVAL).unref();
 	}
 }
+
+/**
+ * Drop every reclamation handler registered for `path`. Registration is process-global and keyed by
+ * storage path with no lifetime of its own, so a store that is closed and discarded leaves both its
+ * handler and the closure holding the closed store alive for the life of the process, and every
+ * re-open of the same path appends another.
+ */
+export function removeStorageReclamation(path: string): boolean {
+	return reclamationHandlers.delete(path);
+}
 let reclamationTimer: NodeJS.Timeout;
 
 export type StorageSpaceStats = {

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -1,16 +1,28 @@
 const assert = require('assert');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
+const { open } = require('lmdb');
 const {
 	setAuditRetention,
+	openAuditStore,
 	readAuditEntry,
 	createAuditEntry,
 	transactionKeyEncoder,
 } = require('#src/resources/auditStore');
 const { RocksTransactionLogStore } = require('#src/resources/RocksTransactionLogStore');
+const { RocksDatabase } = require('@harperfast/rocksdb-js');
+const {
+	removeStorageReclamation,
+	runReclamationHandlers,
+	setAvailableSpaceRatioGetter,
+} = require('#src/server/storageReclamation');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { setTimeout: delay } = require('node:timers/promises');
+const { mkdtempSync, readdirSync, rmSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
 const { waitFor } = require('../waitFor');
+const harperLogger = require('#src/utility/logging/harper_logger');
 require('#src/server/serverHelpers/serverUtilities');
 describe('Audit log', () => {
 	let AuditedTable;
@@ -124,6 +136,154 @@ describe('Audit log', () => {
 		assert.equal(AuditedTable.primaryStore.getEntry(1), undefined); // verify that the delete entry was removed
 		// verify that the twice-written entry was not removed
 		assert.equal(AuditedTable.primaryStore.getEntry(2)?.value?.name, 'two-changed');
+	});
+	it('re-arms Rocks audit cleanup without another pressure signal', async function () {
+		const store = AuditedTable.auditStore;
+		if (!(store instanceof RocksTransactionLogStore)) this.skip();
+
+		const rootStore = store.rootStore;
+		const originalPurgeLogs = rootStore.purgeLogs;
+		let purgeCalls = 0;
+		rootStore.purgeLogs = () => {
+			purgeCalls++;
+			return [];
+		};
+		setAuditRetention(100, 1);
+		try {
+			await store.scheduleAuditCleanup(1);
+			await waitFor(() => purgeCalls >= 2, {
+				timeout: 1000,
+				message: 'Rocks audit cleanup did not schedule a later retention pass',
+			});
+		} finally {
+			rootStore.purgeLogs = originalPurgeLogs;
+			setAuditRetention(60_000, 10_000);
+		}
+	});
+	// Reads the store's own cadence rather than replacing the global setTimeout: that global is shared by
+	// every audit store in the process, so a stub keyed on the delay swallows other loops' re-arms.
+	it('holds Rocks cleanup at the retention-derived cadence whatever a pass purges', async function () {
+		const scratch = mkdtempSync(join(tmpdir(), 'harper-audit-retention-cadence-'));
+		const rootStore = new RocksDatabase(scratch).open();
+		let purgeCalls = 0;
+		// alternate empty and productive passes: the LMDB backoff would double on the first and halve on
+		// the second, so a shared cadence rule shows up here as a changing delay
+		rootStore.purgeLogs = () => (++purgeCalls % 2 ? [] : ['purged.txnlog']);
+		setAuditRetention(1_000, 10);
+		let store;
+		try {
+			store = openAuditStore(rootStore);
+			for (const pass of [1, 2, 3, 4]) {
+				// an explicit delay wins for the pass it schedules, and the pass then re-derives the cadence
+				await store.scheduleAuditCleanup(1);
+				assert.equal(store.auditCleanupDelay, 100, `pass ${pass} should hold the retention-derived cadence`);
+			}
+			assert.equal(purgeCalls, 4, 'every pass should have reached purgeLogs');
+		} finally {
+			setAuditRetention(60_000, 10_000);
+			store?.stopAuditCleanup();
+			removeStorageReclamation(scratch);
+			if (rootStore.status !== 'closed') rootStore.close();
+			rmSync(scratch, { recursive: true, force: true });
+		}
+	});
+	// stopAuditCleanup() is irreversible, so this runs against its own store rather than the shared fixture
+	it('stops scheduling Rocks cleanup once the audit store is retired', async function () {
+		const scratch = mkdtempSync(join(tmpdir(), 'harper-audit-retention-stop-'));
+		const rootStore = new RocksDatabase(scratch).open();
+		let purgeCalls = 0;
+		rootStore.purgeLogs = () => {
+			purgeCalls++;
+			return [];
+		};
+		setAuditRetention(100, 1);
+		try {
+			const auditStore = openAuditStore(rootStore);
+			const pending = auditStore.scheduleAuditCleanup(1);
+			auditStore.stopAuditCleanup();
+			await pending;
+			const purgeCallsAtStop = purgeCalls;
+			await delay(20);
+			assert.equal(purgeCalls, purgeCallsAtStop, 'a retired cleanup loop kept purging');
+			await auditStore.scheduleAuditCleanup(1);
+			await delay(20);
+			assert.equal(purgeCalls, purgeCallsAtStop, 'a retired cleanup loop accepted a new pass');
+		} finally {
+			setAuditRetention(60_000, 10_000);
+			removeStorageReclamation(scratch);
+			if (rootStore.status !== 'closed') rootStore.close();
+			rmSync(scratch, { recursive: true, force: true });
+		}
+	});
+	it('shortens the Rocks cadence while disk pressure is reported', async function () {
+		const scratch = mkdtempSync(join(tmpdir(), 'harper-audit-retention-pressure-'));
+		const rootStore = new RocksDatabase(scratch).open();
+		let purgeCalls = 0;
+		rootStore.purgeLogs = () => {
+			purgeCalls++;
+			return [];
+		};
+		// only the scratch path reports pressure, so no other open store's handler is invoked
+		setAvailableSpaceRatioGetter(async (path) => (path === scratch ? 0.2 : 0.8));
+		setAuditRetention(1_000, 10);
+		let store;
+		try {
+			store = openAuditStore(rootStore);
+			// the handler arms its pass and awaits it, so a settled reclamation run means the pass ran
+			await runReclamationHandlers();
+			assert.ok(purgeCalls > 0, 'a pressure signal should run a cleanup pass');
+			// priority 0.4/0.2 = 2, so the window is retention/(1+4) and the cadence a tenth of that
+			assert.equal(store.auditCleanupDelay, 20, 'pressure should shorten the cadence, not just the cutoff');
+		} finally {
+			setAvailableSpaceRatioGetter();
+			setAuditRetention(60_000, 10_000);
+			store?.stopAuditCleanup();
+			removeStorageReclamation(scratch);
+			if (rootStore.status !== 'closed') rootStore.close();
+			rmSync(scratch, { recursive: true, force: true });
+		}
+	});
+	it('purges aged, flushed Rocks segments through the Harper retention pass', async function () {
+		const scratch = mkdtempSync(join(tmpdir(), 'harper-audit-retention-'));
+		const rootStore = new RocksDatabase(scratch, { transactionLogMaxSize: 128 }).open();
+		const originalPurgeLogs = rootStore.purgeLogs;
+		let purgeCalls = 0;
+		rootStore.purgeLogs = function (options) {
+			purgeCalls++;
+			return originalPurgeLogs.call(this, options);
+		};
+		setAuditRetention(60_000, 10_000);
+		try {
+			const auditStore = openAuditStore(rootStore);
+			const log = rootStore.useLog('retention-test');
+			for (let sequence = 1; sequence <= 3; sequence++) {
+				await rootStore.transaction(async (transaction) => {
+					const value = Buffer.alloc(256, sequence);
+					log.addEntry(value, transaction.id);
+					rootStore.putSync(`key-${sequence}`, value, { transaction });
+				});
+				if (sequence < 3) rootStore.flushSync();
+				if (sequence === 2) {
+					await delay(75);
+					setAuditRetention(50, 1);
+				}
+			}
+
+			await auditStore.scheduleAuditCleanup(1);
+			const logDirectory = join(scratch, 'transaction_logs', 'retention-test');
+			const segments = readdirSync(logDirectory).filter((name) => name.endsWith('.txnlog'));
+			assert.deepEqual(segments, ['3.txnlog']);
+
+			rootStore.close();
+			const purgeCallsAtClose = purgeCalls;
+			await delay(20);
+			assert.equal(purgeCalls, purgeCallsAtClose, 'cleanup continued after the root store closed');
+		} finally {
+			setAuditRetention(60_000, 10_000);
+			removeStorageReclamation(scratch);
+			if (rootStore.status !== 'closed') rootStore.close();
+			rmSync(scratch, { recursive: true, force: true });
+		}
 	});
 	it('check log after operations and prune', async () => {
 		await AuditedTable.operation({
@@ -714,4 +874,227 @@ describe('Audit log', () => {
 			assert.equal(events[i].length, 1);
 		}
 	});
+});
+
+// Retirement has to stop a pass that is already suspended inside removeAuditEntry, not just decline
+// to start another one: lmdb-js stamps the DBI number into the write instruction synchronously
+// (node_modules/lmdb/write.js) and the native writer consumes it later, so the promise the pass
+// awaits is exactly the window in which those handles must stay open.
+describe('Audit cleanup retirement', () => {
+	const scratchDirs = [];
+	const openScratchStore = () => {
+		const directory = mkdtempSync(join(tmpdir(), 'harper-audit-retire-'));
+		scratchDirs.push(directory);
+		return open({ path: join(directory, 'retire.mdb') });
+	};
+
+	before(function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+	});
+	afterEach(function () {
+		setAuditRetention(60_000, 10_000);
+	});
+	after(function () {
+		for (const directory of scratchDirs) rmSync(directory, { recursive: true, force: true });
+	});
+
+	/**
+	 * Arms a real audit store over a real LMDB environment with a controllable range, so a pass can be
+	 * suspended at the exact point teardown lands on it in production: inside the awaited removal.
+	 * `entries` bounds how many records the range yields across all passes.
+	 */
+	function armGatedPass(rootStore, { entries = Infinity } = {}) {
+		const auditStore = openAuditStore(rootStore);
+		const counts = { advances: 0, releases: 0, removals: 0, markerWrites: 0 };
+		const markerValues = [];
+		auditStore.getRange = () => ({
+			[Symbol.iterator]: () => ({
+				next() {
+					if (counts.advances++ >= entries) return { done: true, value: undefined };
+					return { done: false, value: { key: 1000 + counts.advances, type: 'put' } };
+				},
+				return() {
+					counts.releases++;
+					return { done: true, value: undefined };
+				},
+			}),
+		});
+		let releaseRemoval;
+		const removalGate = new Promise((resolve) => (releaseRemoval = resolve));
+		auditStore.remove = () => {
+			counts.removals++;
+			return removalGate;
+		};
+		const realPut = auditStore.put.bind(auditStore);
+		auditStore.put = (key, value) => {
+			counts.markerWrites++;
+			// the marker buffer is reused across writes, so record the value rather than the reference
+			markerValues.push(new Float64Array(value.slice().buffer)[0]);
+			return realPut(key, value);
+		};
+		return { auditStore, counts, markerValues, releaseRemoval };
+	}
+
+	it('drains the in-flight removal before stopAuditCleanup() reports the pass retired', async function () {
+		const rootStore = openScratchStore();
+		try {
+			const { auditStore, counts, releaseRemoval } = armGatedPass(rootStore);
+			const pass = auditStore.scheduleAuditCleanup(1);
+			await waitFor(() => counts.removals === 1, { timeout: 1000, message: 'the gated pass never started' });
+
+			const barrier = auditStore.stopAuditCleanup();
+			let drained = false;
+			barrier.then(() => (drained = true));
+			await delay(20);
+			assert.equal(drained, false, 'the barrier must not settle while a removal is still in flight');
+
+			releaseRemoval();
+			await barrier;
+			await pass;
+			assert.equal(counts.advances, 1, 'a retired pass must not advance the cursor again');
+			assert.equal(counts.releases, 1, 'a retirement that leaves the environment open still owes the cursor release');
+			assert.equal(counts.markerWrites, 0, 'a retired pass must not write the last-removed marker');
+			await delay(20);
+			assert.equal(counts.advances, 1, 'a retired pass must not re-arm');
+		} finally {
+			removeStorageReclamation(rootStore.path);
+			if (rootStore.status !== 'closed') await rootStore.close();
+		}
+	});
+
+	it('touches nothing further once the root store closes under a suspended pass', async function () {
+		const rootStore = openScratchStore();
+		let unhandledRejection;
+		const onUnhandledRejection = (reason) => (unhandledRejection = reason);
+		process.on('unhandledRejection', onUnhandledRejection);
+		try {
+			const { auditStore, counts, releaseRemoval } = armGatedPass(rootStore);
+			const pass = auditStore.scheduleAuditCleanup(1);
+			await waitFor(() => counts.removals === 1, { timeout: 1000, message: 'the gated pass never started' });
+
+			// the resetDatabases() shape: the root closes with no stopAuditCleanup() call at all
+			const closed = rootStore.close();
+			releaseRemoval();
+			await pass;
+			await closed;
+
+			assert.equal(counts.advances, 1, 'a pass resuming onto a closing environment must not advance the cursor');
+			assert.equal(counts.releases, 0, 'releasing a cursor into a closing environment reaches native code');
+			assert.equal(counts.markerWrites, 0, 'a pass resuming onto a closing environment must not write the marker');
+			await delay(20);
+			assert.equal(counts.advances, 1, 'a pass must not re-arm onto a closed store');
+			assert.equal(unhandledRejection, undefined, 'the detached timer callback must not reject');
+		} finally {
+			process.off('unhandledRejection', onUnhandledRejection);
+			removeStorageReclamation(rootStore.path);
+			if (rootStore.status !== 'closed') await rootStore.close();
+		}
+	});
+
+	// Both logger shapes: a throwing sink is what a try/catch around the marker write alone does not
+	// contain, and this file's deleteHistory regressions establish it as a real failure model.
+	for (const loggingThrows of [true, false]) {
+		it(`contains and retries a failed last-removed write (failure logging ${
+			loggingThrows ? 'throws' : 'succeeds'
+		})`, async function () {
+			const rootStore = openScratchStore();
+			const originalWarn = harperLogger.warn;
+			let unhandledRejection;
+			const onUnhandledRejection = (reason) => (unhandledRejection = reason);
+			process.on('unhandledRejection', onUnhandledRejection);
+			const { auditStore, counts, markerValues, releaseRemoval } = armGatedPass(rootStore, { entries: 1 });
+			try {
+				releaseRemoval(); // this test is about the marker write, so let the removal settle at once
+				let markerRejects = true;
+				const countingPut = auditStore.put;
+				auditStore.put = (key, value) => {
+					// still issued, so the failure under test is the rejection rather than a skipped write
+					const write = countingPut(key, value);
+					return markerRejects ? write.then(() => Promise.reject(new Error('simulated marker write failure'))) : write;
+				};
+				const warnings = [];
+				harperLogger.warn = (...args) => {
+					warnings.push(args);
+					if (loggingThrows) throw new Error('simulated logging failure');
+				};
+
+				await auditStore.scheduleAuditCleanup(1);
+				assert.equal(counts.markerWrites, 1, 'the pass should have attempted the marker write');
+				assert.equal(
+					warnings[0]?.[0],
+					'Error recording the last removed audit entry',
+					'a rejected marker write must be logged, not dropped'
+				);
+				assert.equal(warnings[0]?.[1]?.message, 'simulated marker write failure');
+
+				// A later pass deletes nothing, so without a retained watermark it never writes the marker
+				// again and the recorded boundary stays behind the entries that were already removed.
+				markerRejects = false;
+				harperLogger.warn = originalWarn;
+				await waitFor(() => counts.markerWrites >= 2, {
+					timeout: 2000,
+					message: 'the failed last-removed marker was never retried',
+				});
+				assert.deepEqual(markerValues, [1001, 1001], 'the retry must carry the watermark the failed write had');
+				await delay(20);
+				assert.equal(counts.markerWrites, 2, 'a committed marker must not be rewritten by later empty passes');
+				assert.equal(unhandledRejection, undefined, 'the detached timer callback must not reject');
+			} finally {
+				harperLogger.warn = originalWarn;
+				process.off('unhandledRejection', onUnhandledRejection);
+				auditStore.stopAuditCleanup();
+				removeStorageReclamation(rootStore.path);
+				if (rootStore.status !== 'closed') await rootStore.close();
+			}
+		});
+	}
+
+	// The initializing marker write has no downstream owner: openAuditStore() is synchronous and returns
+	// the store, so a rejection here escapes unless it is contained at the call site — and the
+	// containment has to survive its own log sink throwing.
+	for (const loggingThrows of [true, false]) {
+		it(`contains a rejected last-removed initialization write (failure logging ${
+			loggingThrows ? 'throws' : 'succeeds'
+		})`, async function () {
+			const rootStore = openScratchStore();
+			const originalWarn = harperLogger.warn;
+			let unhandledRejection;
+			const onUnhandledRejection = (reason) => (unhandledRejection = reason);
+			process.on('unhandledRejection', onUnhandledRejection);
+			const realOpenDB = rootStore.openDB.bind(rootStore);
+			let opens = 0;
+			// the scratch environment has no audit store yet, so the create:false probe returns nothing and
+			// openAuditStore takes the initialize-a-new-store branch on its own
+			rootStore.openDB = (name, options) => {
+				opens++;
+				const store = realOpenDB(name, options);
+				if (store) store.put = () => Promise.reject(new Error('simulated marker initialization failure'));
+				return store;
+			};
+			const warnings = [];
+			harperLogger.warn = (...args) => {
+				warnings.push(args);
+				if (loggingThrows) throw new Error('simulated logging failure');
+			};
+			let auditStore;
+			try {
+				auditStore = openAuditStore(rootStore);
+				assert.equal(opens, 2, 'the fixture must take the branch that initializes a new audit store');
+				await waitFor(
+					() => warnings.some(([message]) => message === 'Error initializing the audit log last-removed marker'),
+					{ timeout: 1000, message: 'the rejected initialization write was never logged' }
+				);
+				await delay(20);
+				assert.equal(unhandledRejection, undefined, 'the initialization write must not escape the synchronous open');
+			} finally {
+				harperLogger.warn = originalWarn;
+				process.off('unhandledRejection', onUnhandledRejection);
+				rootStore.openDB = realOpenDB;
+				auditStore?.stopAuditCleanup();
+				removeStorageReclamation(rootStore.path);
+				if (rootStore.status !== 'closed') await rootStore.close();
+			}
+		});
+	}
 });

--- a/unitTests/resources/databases.test.js
+++ b/unitTests/resources/databases.test.js
@@ -175,3 +175,219 @@ describe('dropDatabase restore serialization', () => {
 		assert.ok(existsSync(reservedDir), 'the reserved dir itself is left in place (used for lifecycle metadata)');
 	});
 });
+
+describe('storage-reclamation deregistration on teardown', () => {
+	before(function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+	});
+
+	it('deregisters the storage-reclamation handler when an ordinary database is closed', async function () {
+		const { runReclamationHandlers, setAvailableSpaceRatioGetter } = require('#src/server/storageReclamation');
+		const { closeDatabase } = require('#src/resources/databases');
+		const queried = [];
+		setAvailableSpaceRatioGetter(async (path) => {
+			queried.push(path);
+			return 1; // no pressure, so no handler runs and only the path registry is observed
+		});
+		try {
+			const ReclaimProbe = table({
+				table: 'ReclaimProbe',
+				database: 'reclaimprobe',
+				attributes: [{ name: 'id', isPrimaryKey: true }],
+			});
+			const rootPath = ReclaimProbe.primaryStore.rootStore.path;
+			await runReclamationHandlers();
+			assert.ok(queried.includes(rootPath), 'opening a database registers a reclamation handler for its root path');
+
+			closeDatabase('reclaimprobe');
+			queried.length = 0;
+			await runReclamationHandlers();
+
+			assert.ok(!queried.includes(rootPath), 'closeDatabase must drop the handler pinning the closed store');
+		} finally {
+			setAvailableSpaceRatioGetter();
+		}
+	});
+
+	it('deregisters the storage-reclamation handler when a database is dropped', async function () {
+		const { runReclamationHandlers, setAvailableSpaceRatioGetter } = require('#src/server/storageReclamation');
+		const queried = [];
+		setAvailableSpaceRatioGetter(async (path) => {
+			queried.push(path);
+			return 1;
+		});
+		try {
+			const DropProbe = table({
+				table: 'DropProbe',
+				database: 'dropprobe',
+				attributes: [{ name: 'id', isPrimaryKey: true }],
+			});
+			const rootPath = DropProbe.primaryStore.rootStore.path;
+			await runReclamationHandlers();
+			assert.ok(queried.includes(rootPath), 'opening a database registers a reclamation handler for its root path');
+
+			await dropDatabase('dropprobe');
+			queried.length = 0;
+			await runReclamationHandlers();
+
+			assert.ok(!queried.includes(rootPath), 'dropDatabase must drop the handler pinning the dropped store');
+		} finally {
+			setAvailableSpaceRatioGetter();
+		}
+	});
+});
+
+describe('audit cleanup retirement on teardown', () => {
+	const { readMetaDb, databases } = require('#src/resources/databases');
+	const { mkdtempSync, rmSync } = require('node:fs');
+	const { tmpdir } = require('node:os');
+	const { open } = require('lmdb');
+	const { setTimeout: delay } = require('node:timers/promises');
+	const { waitFor } = require('../waitFor');
+	const scratchDirs = [];
+
+	before(function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+	});
+	after(function () {
+		for (const directory of scratchDirs) rmSync(directory, { recursive: true, force: true });
+	});
+
+	/** Suspends the store's next cleanup pass inside its removal, where teardown lands on it. */
+	function gateCleanupPass(auditStore) {
+		const state = { removals: 0, released: false };
+		auditStore.getRange = () => ({
+			[Symbol.iterator]: () => ({
+				next: () => ({ done: false, value: { key: 1000 + state.removals, type: 'put' } }),
+				return: () => ({ done: true, value: undefined }),
+			}),
+		});
+		const gate = new Promise((resolve) => {
+			state.release = () => {
+				state.released = true;
+				resolve();
+			};
+		});
+		auditStore.remove = () => {
+			state.removals++;
+			return gate;
+		};
+		return state;
+	}
+
+	it('makes dropDatabase wait for an in-flight cleanup pass before it closes the stores', async function () {
+		const Probe = table({
+			table: 'AuditDrainProbe',
+			database: 'auditdrain',
+			audit: true,
+			attributes: [{ name: 'id', isPrimaryKey: true }],
+		});
+		const rootStore = Probe.primaryStore.rootStore;
+		// the Rocks pass is a single synchronous purgeLogs() call, so it has nothing to suspend
+		if (rootStore instanceof RocksDatabase) return this.skip();
+		const auditStore = rootStore.auditStore;
+		const pass = gateCleanupPass(auditStore);
+		let closedBeforeRelease = false;
+		const realClose = rootStore.close.bind(rootStore);
+		rootStore.close = (...args) => {
+			if (!pass.released) closedBeforeRelease = true;
+			return realClose(...args);
+		};
+
+		auditStore.scheduleAuditCleanup(1);
+		await waitFor(() => pass.removals === 1, { timeout: 1000, message: 'the gated cleanup pass never started' });
+
+		let dropped = false;
+		const drop = dropDatabase('auditdrain').then(() => (dropped = true));
+		await delay(50);
+		assert.equal(dropped, false, 'dropDatabase must not finish while a cleanup pass still holds the stores');
+		assert.equal(closedBeforeRelease, false, 'dropDatabase must not close the root store under a suspended pass');
+
+		pass.release();
+		await drop;
+		assert.equal(closedBeforeRelease, false, 'dropDatabase must not close the root store under a suspended pass');
+	});
+
+	// The legacy per-table drop has no sibling coverage, and the store it retires is the one makeTable()
+	// was handed - not `primaryStore.auditStore`, which nothing assigns.
+	it('retires the legacy per-table drop against the table its own audit store, before closing it', async function () {
+		const base = mkdtempSync(join(tmpdir(), 'harper-legacy-drop-'));
+		scratchDirs.push(base);
+		const tablePath = join(base, 'schema', 'legacydrop', 'dog.mdb');
+		const auditPath = join(base, 'audit', 'legacydrop', 'dog.mdb');
+		mkdirSync(dirname(tablePath), { recursive: true });
+		mkdirSync(dirname(auditPath), { recursive: true });
+		// initStores only adopts an audit path that already exists, so seed a real (empty) environment there
+		await open({ path: auditPath }).close();
+		let legacyAuditEnv;
+
+		try {
+			// the first load has no attributes to build a table from; it is what creates the catalog store
+			// with the encoding initStores expects, so the attribute below is written the way production does
+			const rootStore = readMetaDb(tablePath, 'dog', 'legacydrop', auditPath, true);
+			// audit:false because a legacy audit store has no addDeleteRemovalCallback, so makeTable()
+			// throws while loading an audited legacy table - a separate, pre-existing defect
+			rootStore.dbisDb.putSync('id', { isPrimaryKey: true, name: 'id', tableId: 91, audit: false });
+			readMetaDb(tablePath, 'dog', 'legacydrop', auditPath, true);
+
+			const Dog = databases.legacydrop?.dog;
+			assert.ok(Dog, 'the legacy fixture did not load a table');
+			assert.notEqual(Dog.databasePath, Dog.databaseName, 'the fixture must take the legacy drop branch');
+			legacyAuditEnv = Dog.auditStore;
+			assert.equal(legacyAuditEnv?.isLegacy, true, 'the table should hold the legacy audit environment');
+			assert.equal(
+				Dog.primaryStore.auditStore,
+				undefined,
+				'nothing assigns primaryStore.auditStore, so a drop reading it retires nothing'
+			);
+
+			const { runReclamationHandlers, setAvailableSpaceRatioGetter } = require('#src/server/storageReclamation');
+			const queried = [];
+			setAvailableSpaceRatioGetter(async (path) => {
+				queried.push(path);
+				return 1;
+			});
+			const events = [];
+			let releaseRetirement;
+			const retired = new Promise((resolve) => (releaseRetirement = resolve));
+			// legacy audit stores are opened with a plain open() rather than openAuditStore(), so they arm no
+			// loop today; the spy is what an openAuditStore()-armed store on this branch would look like
+			Dog.auditStore.stopAuditCleanup = () => {
+				events.push('retired');
+				return retired;
+			};
+			const realClose = Dog.primaryStore.close.bind(Dog.primaryStore);
+			Dog.primaryStore.close = (...args) => {
+				events.push('closed');
+				return realClose(...args);
+			};
+			const primaryPath = Dog.primaryStore.path;
+
+			try {
+				await runReclamationHandlers();
+				assert.ok(queried.includes(primaryPath), 'a loaded table registers a reclamation handler for its path');
+
+				let dropped = false;
+				const drop = Dog.dropTable().then(() => (dropped = true));
+				await delay(50);
+				assert.deepEqual(events, ['retired'], 'the drop must retire the audit store and wait, before closing');
+				assert.equal(dropped, false);
+
+				releaseRetirement();
+				await drop;
+				assert.deepEqual(events, ['retired', 'closed']);
+				assert.ok(!existsSync(primaryPath), 'the legacy store file should be unlinked');
+
+				queried.length = 0;
+				await runReclamationHandlers();
+				assert.ok(!queried.includes(primaryPath), 'the drop must drop the handler pinning the dropped store');
+			} finally {
+				setAvailableSpaceRatioGetter();
+			}
+		} finally {
+			if (legacyAuditEnv && legacyAuditEnv.status !== 'closed') await legacyAuditEnv.close();
+		}
+	});
+});


### PR DESCRIPTION
Backports [Apply audit retention continuously to RocksDB transaction logs](https://github.com/HarperFast/harper/pull/2338) to the `v5.2` release line. On RocksDB, audit retention ran exactly one `purgeLogs()` per boot: the pass returned before scheduling its successor, so a long-lived node's transaction logs grew without bound until a restart or a disk-pressure signal. The Rocks pass now re-arms on a cadence derived from the pressure-adjusted retention window, and every teardown path — `closeDatabase`, `dropDatabase`, and the legacy per-table drop — retires the loop and deregisters its storage-reclamation handler before releasing the stores it holds.

`v5.2` already pins `@harperfast/rocksdb-js` 2.8.0 (6ca418d74), which is the version #2338 needed for the purge extent-resolution fix, and `msgpackr` 2.0.6. No dependency change is required here, and the unreleased rocksdb-js [Keep transaction-log retention on a durable sequence floor](https://github.com/HarperFast/rocksdb-js/pull/799) is not a prerequisite — it is a further safety improvement on top (contiguous-prefix deletion), not something continuous retention depends on.

## For the human reviewer

The cherry-pick did not apply cleanly; five files conflicted, all because `main` carries work `v5.2` does not.

1. **Whether the behavior change belongs on `v5.2` at all.** This carries one cadence change alongside the crash-safety and handler-leak fixes: `v5.2` nodes gain a permanent background purge loop they did not have before, where Rocks previously purged only on a pressure event. I kept #2338 whole rather than splitting the loop from the fixes, because the fixes exist *because* of the loop — the teardown races and the reclamation-handler leak only become reachable once a pass can be in flight at close time — and a split would ship half of a reviewed change. Reversible only by a further cherry-pick, not a local revert, so it is worth ruling on before merge.

2. **`removeStorageReclamation()` is new to `v5.2`.** #2338 calls it from three teardown sites, but the helper was added to `main` by #2285/#2381, not by #2338. I copied the function verbatim from `main` into `server/storageReclamation.ts` rather than open-coding `reclamationHandlers.delete(path)` at each call site. It is a pure addition — nothing on `v5.2` called it before — so inlining would only duplicate the same one-liner three times and diverge the two branches' modules for no gain.

3. **The branch-database hunks are dropped.** #2338 added a `stopAuditCleanup()` call inside `closeBranchHandles()` plus its `openBranchDatabase` test additions. Neither the function nor the suite exists on `v5.2` (harper#643 is `main`-only), so there is nothing on this line to retire; the alternative would be backporting the whole branch feature.

4. **Two tests moved out of the `openBranchDatabase` suite.** #2338 put `deregisters the storage-reclamation handler when an ordinary database is closed` and `… when a database is dropped` inside that describe, but they exercise `closeDatabase`/`dropDatabase`, not branches — they were there for the fixture. On `v5.2` they get their own `storage-reclamation deregistration on teardown` describe with the same `setupTestDBPath()` / `setMainIsWorker(true)` `before`. The behavior under test is unchanged; only the enclosing block is.

5. **`Table.ts`'s import keeps only what `v5.2` uses.** #2338's version of that import lists `removeStorageReclamationHandler` because `main`'s `Table.ts` already used it; `v5.2`'s does not, and importing it fails lint as unused. Same reason `removeAuditEntry` is absent from `auditLog.test.js`'s import here — the `main`-only harper#F-264 removal-loop tests that used it are not on this line.

Two smaller adaptations, for completeness rather than decision: DESIGN.md gains only #2338's new retention section (the removal-loop section it sat below is `main`-only), with its one sentence about branch `close()` trimmed; and #2338's `unitTests/resources/query-array-scoping.test.js` formatting commit is dropped, since it repaired a `main`-only Format Check break against a file that does not exist on `v5.2`.

`resources/auditStore.ts` applied with no conflict, and diffing this branch's copy against `origin/main`'s leaves only pre-existing `main`-only differences (the tombstone-removal tracking and the `put: 4` audit type, both from other PRs) — #2338's content is carried in full.

The pre-push review's two surviving findings — that the Rocks integration test asserts purge cadence rather than actual segment deletion, and that #2338's added comments are denser than Harper's zero-new-comment default — both describe code that is already merged on `main`. I left them alone deliberately: fixing them here would make `v5.2` diverge from `main` for the same feature. They belong on `main` first, if at all.

## Verification

End-to-end route: the existing integration suite, extended by #2338's own new RocksDB retention test.

- `npx harper-integration-test-run "integrationTests/database/audit-retention-*.test.ts" "integrationTests/database/blob-delete-reclaim-audit-expiry.test.ts"` — 8 tests, 8 pass, 0 fail. That includes #2338's new `RocksDB audit retention self-rearms without storage pressure (#2140)` suite, which drives a live instance and asserts more than one passive purge pass.
- `npx mocha unitTests/resources/auditLog.test.js unitTests/resources/databases.test.js` — 43 passing / 1 pending on RocksDB (the pending one is the LMDB-only drain-barrier test), and 35 passing / 9 pending under `HARPER_STORAGE_ENGINE=lmdb`. All five new Rocks cadence/retirement tests ran and passed.
- `npm run test:unit:resources` — 1718 passing / 17 pending / 0 failing. Under `HARPER_STORAGE_ENGINE=lmdb` (the `test:unit:lmdb` gate's first leg) — 1464 passing / 130 pending / 0 failing.
- `npm run test:unit:main` — 4525 passing / 195 pending / 2 failing. Both failures are known local-environment artifacts unrelated to this diff: `nonInteractiveSpawn git credential scoping` (a tmpdir leak between runs) and `configValidator getDomainSocketPathLengthWarning` (sensitive to the checkout path's length). Neither touches audit retention.
- `npm run test:unit:server` — not run to completion: `unitTests/server/threads/fixtures/processGroupOwnerWorker.js` is picked up by that suite's glob and throws at load on `v5.2` before any test runs. Pre-existing, not in CI's `test:unit:all`, and untouched by this diff; `npx mocha unitTests/server/storageReclamation.test.js` — the file that actually covers the changed module — passes 44/44.
- `test:unit:apitests` did not run: these runs used a private `HOME` so the shared system database on this box could not skew them, and that root has no `harper install`, so the API tests' server bootstrap has no `hdb_role` to read.
- `npm run build`, `npm run typecheck`, `npm run lint:required`, and `npm run format:check` all clean.

Complexity: complicated

<sub>Review-Coverage: authored=claude; ran=gemini,codex; adjudicated=domain; blocked=cursor-grok(failed); declined=cursor-composer; rounds=1 @ 221ebf104c73</sub>

<sub>Human-Review-Need: 3 (decisions: v5-2-cherry-pick-scope, closedatabase-engine-invariant, rocks-cadence-pressure-floor, rocks-only-rearm-guards) @ 221ebf104c73</sub>
