### PR TITLE
feat(branches): remove an application's branched databases on drop_component

### DIFF
--- a/bin/restart.ts
+++ b/bin/restart.ts
@@ -9,6 +9,7 @@ import { compactOnStart } from './copyDb.ts';
 import {
 	beginProcessShutdown,
 	restartWorkers,
+	isThreadRunning,
 	onMessageByType,
 	shutdownWorkersNow,
 } from '../server/threads/manageThreads.js';
@@ -16,6 +17,8 @@ import { handleHDBError, hdbErrors } from '../utility/errors/hdbError.ts';
 const { HTTP_STATUS_CODES } = hdbErrors;
 import * as envMgr from '../utility/environment/environmentManager.ts';
 import * as path from 'node:path';
+import { getConfigObj, getConfigPath } from '../config/configUtils.ts';
+import { withComponentPreparationLock } from '../components/componentPreparationLock.ts';
 import { rmSync } from 'node:fs';
 import { getThisNodeName } from '../server/nodeName.ts';
 import { armRestartExitWatchdog } from './restartExitWatchdog.ts';
@@ -31,10 +34,63 @@ export { restart, restartService };
 // Add ITC event listener to main thread which will be called from child that receives restart request.
 if (isMainThread) {
 	onMessageByType(hdbTerms.ITC_EVENT_TYPES.RESTART, async (message, port) => {
-		if (message.workerType) await restartService({ service: message.workerType });
-		else restart({ operation: 'restart' });
-		port.postMessage({ type: 'restart-complete' });
+		try {
+			if (message.removeBranchesFor) await restartThenRemoveBranches(message.workerType, message.removeBranchesFor);
+			else if (message.workerType) await restartService({ service: message.workerType });
+			else restart({ operation: 'restart' });
+		} finally {
+			port.postMessage({ type: 'restart-complete' });
+		}
 	});
+}
+
+/**
+ * Restart, then remove the branches of an application dropped on a worker (which cannot outlive the
+ * restart it asked for). The restart happens even if the component lock cannot be taken.
+ */
+async function restartThenRemoveBranches(service: string, project: string): Promise<void> {
+	let restarted = false;
+	const restartHttpWorkers = async () => {
+		restarted = true;
+		processMan.expectedRestartOfChildren();
+		hdbLogger.notify('Restarting http_workers');
+		return restartWorkers('http');
+	};
+	try {
+		const componentPath = path.join(getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT) as string, project);
+		await withComponentPreparationLock(
+			componentPath,
+			async () => {
+				const outcome: any = await restartHttpWorkers();
+				if (!outcome || outcome.declined || outcome.workersKeptOnOldCode) {
+					hdbLogger.warn(
+						`Branched database storage of ${project} was left in place: the restart did not replace every worker`
+					);
+					return;
+				}
+				// The worker's drop lock was released before this one was taken; a same-name deploy that landed
+				// in between owns these branches now.
+				if (getConfigObj()?.[project]) {
+					hdbLogger.warn(`${project} was deployed again since it was dropped; leaving its branched databases in place`);
+					return;
+				}
+				const { removeBranchesForApplication } = await import('../resources/branchDatabase.ts');
+				await removeBranchesForApplication(project);
+			},
+			{
+				timeoutMs: 5 * 60 * 1000,
+				onWait: (owner) =>
+					hdbLogger.debug?.(
+						`Waiting to restart after dropping ${project}` +
+							(owner ? ` behind process ${owner.pid}, thread ${owner.threadId}` : '')
+					),
+				isOwnerAlive: (owner) => owner.pid !== process.pid || isThreadRunning(owner.threadId),
+			}
+		);
+	} catch (error) {
+		hdbLogger.error(`Could not remove the branched database storage of ${project}`, error);
+		if (!restarted) await restartService({ service });
+	}
 }
 
 /**

--- a/components/operations.js
+++ b/components/operations.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('node:path');
-const { isMainThread } = require('node:worker_threads');
+const { isMainThread, parentPort } = require('node:worker_threads');
 const fs = require('fs-extra');
 const fg = require('fast-glob');
 const normalize = require('normalize-path');
@@ -537,6 +537,9 @@ async function validateComponentLoadsExclusive(candidateDirPath, emit) {
 		if (lastError) throw lastError;
 	}
 }
+
+const BRANCH_STORAGE_RETAINED =
+	'. Any branched database storage this application owns was left in place; drop it again with restart: true to discard that data';
 
 /** Report a restart outcome the operation's own success message cannot convey. */
 function logRestartOutcome(restart, what) {
@@ -1309,6 +1312,7 @@ async function dropComponent(req) {
 	const componentPath = path.join(componentsRoot, project);
 	const pathToComponent = path.join(componentsRoot, projectPath);
 
+	let response;
 	await withComponentPreparationLock(
 		componentPath,
 		async () => {
@@ -1333,20 +1337,56 @@ async function dropComponent(req) {
 			}
 
 			configUtils.deleteConfigFromFile([project]);
+			// The main thread's cached config still names the project; the restart below installs every
+			// package application in that cache, and installing this one would take the lock held here.
+			// (A worker's RESTART message refreshes main's config the same way.)
+			if (isMainThread) env.initSync(true);
+			response = await server.replication.replicateOperation(req);
+			const { applicationHasBranchStorage, removeBranchesForApplication } = require('../resources/branchDatabase.ts');
+			const branched = !file && applicationHasBranchStorage(project);
+			if (req.restart !== true) {
+				response.message = `Successfully dropped: ${projectPath}`;
+				if (branched) response.message += BRANCH_STORAGE_RETAINED;
+				return;
+			}
+			// The branches go after the restart, under this lock; a worker is one of the threads being
+			// replaced, so it hands both to the main thread.
+			response.message = `Successfully dropped: ${projectPath}, restarting Harper`;
+			if (!isMainThread) {
+				parentPort.postMessage({
+					type: hdbTerms.ITC_EVENT_TYPES.RESTART,
+					workerType: 'http',
+					removeBranchesFor: file ? undefined : project,
+				});
+				if (branched) {
+					response.message +=
+						'; the main thread removes its branched database storage after the restart and logs the outcome';
+				}
+				return;
+			}
+			const { awaitRestart } = require('./awaitRestart.ts');
+			const restart = await awaitRestart((onProgress) =>
+				manageThreads.restartWorkers('http', undefined, undefined, onProgress)
+			);
+			logRestartOutcome(restart, `dropping ${projectPath}`);
+			if (!branched) return;
+			if (restart.completed && !restart.workersKeptOnOldCode) {
+				try {
+					await removeBranchesForApplication(project);
+				} catch (error) {
+					log.error(`Branched database storage of ${project} could not be removed`, error);
+					throw new Error(
+						`Successfully dropped: ${projectPath}, but its branched database storage could not be removed and ` +
+							`was left in place: ${error.message}. Drop it again with restart: true to retry.`
+					);
+				}
+			} else {
+				log.warn(`Branched database storage of ${project} was left in place: the restart did not complete`);
+				response.message += BRANCH_STORAGE_RETAINED;
+			}
 		},
 		componentDropLockOptions(project)
 	);
-	const response = await server.replication.replicateOperation(req);
-	if (req.restart === true) {
-		// Same race as a deploy, in the removal direction: until a worker is replaced it still serves the
-		// dropped component's resources, so a caller that reads success as "it is gone" can be wrong.
-		const { awaitRestart } = require('./awaitRestart.ts');
-		const restart = await awaitRestart((onProgress) =>
-			manageThreads.restartWorkers('http', undefined, undefined, onProgress)
-		);
-		logRestartOutcome(restart, `dropping ${projectPath}`);
-		response.message = `Successfully dropped: ${projectPath}, restarting Harper`;
-	} else response.message = `Successfully dropped: ${projectPath}`;
 	return response;
 }
 

--- a/resources/branchDatabase.ts
+++ b/resources/branchDatabase.ts
@@ -1,14 +1,16 @@
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, realpathSync } from 'node:fs';
 import { mkdir, rename, rm, rmdir, writeFile } from 'node:fs/promises';
 import { basename, dirname, join, relative } from 'node:path';
 import logger from '../utility/logging/harper_logger.ts';
-import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
+import { CONFIG_PARAMS, DEFAULT_DATABASE_NAME } from '../utility/hdbTerms.ts';
 import { commonValidators } from '../validation/common_validators.ts';
 import * as env from '../utility/environment/environmentManager.ts';
 import { copyTree } from '../dataLayer/blobBackup.ts';
 import { getBlobPathsForDatabaseName, getRootBlobPathsForDB } from './blob.ts';
-import type { RocksDatabase } from '@harperfast/rocksdb-js';
+import { registryStatus, type RocksDatabase } from '@harperfast/rocksdb-js';
 import {
+	BRANCH_REMOVING_SUFFIX,
+	BRANCH_ROOT_DIR,
 	type BranchDatabase,
 	database,
 	databases,
@@ -20,6 +22,7 @@ import {
 	releaseBranchIdentity,
 	reserveBranchIdentity,
 	resolveBranchPath,
+	resolveDatabaseStorageRoot,
 	retakeBranchIdentity,
 } from './databases.ts';
 import { replayLogs, replayTimeBudgetMs } from './replayLogs.ts';
@@ -461,6 +464,7 @@ async function openOrCreate(baseName: string, appName: string, branchPath: strin
 					// every restart after the first the directory is already here. What it is, though, is a
 					// question -- the blob roots are published separately from the directory, so existence
 					// alone proves nothing and the marker is what has to be read.
+					await finishInterruptedRemoval(branchPath, storeName, { identityHeld: true });
 					const existing = readBranchState(branchPath, storeName);
 					if (existing.state === 'damaged' || existing.state === 'unmarked') {
 						const problem = existing.state === 'damaged' ? existing.problem : existing.why;
@@ -575,34 +579,58 @@ async function closeBranchAt(branchPath: string): Promise<void> {
 }
 
 /**
- * Release the handle and delete the directory. A branch is durable, so nothing calls this on
- * shutdown; it is how an application's data is discarded deliberately — undeploying it, or a test
- * cleaning up — and it is only safe once nothing else is using the directory.
+ * Open references to this branch's store anywhere in the process (rocksdb-js's registry spans worker
+ * threads). A registry read that fails propagates and refuses the removal rather than reading as zero.
  */
-async function removeBranchAt(branchPath: string): Promise<void> {
-	const pending = branchesByPath.get(branchPath);
-	branchesByPath.delete(branchPath);
-	const opened = await pending?.catch(() => null);
+function branchReferenceCount(branchPath: string): number {
+	let resolved = branchPath;
+	try {
+		resolved = realpathSync(branchPath);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 0;
+		throw error;
+	}
+	return (
+		registryStatus().find((entry: any) => entry.path === resolved || canonicalOrSelf(entry.path) === resolved)
+			?.refCount ?? 0
+	);
+}
+
+function canonicalOrSelf(path: string): string {
+	try {
+		return realpathSync(path);
+	} catch {
+		return path;
+	}
+}
+
+/**
+ * Destroy a branch's storage: checkpoint, blob roots and claim, the way `dropDatabase` does for a real
+ * database. Only safe as the last step of the undeploy sequence -- component dropped, workers
+ * restarted -- and it does not take that on trust: any remaining open reference to the store refuses
+ * the removal before anything is unlinked.
+ *
+ * The branch is first renamed to its `removing` sibling so a removal cut short by a crash is finished
+ * later instead of being read as damage. `opened` is the handle this thread held, if any, already closed.
+ */
+async function destroyBranchStorage(branchPath: string, opened: OpenBranch | null): Promise<void> {
+	const held = branchReferenceCount(branchPath);
+	if (held > 0) {
+		throw new Error(
+			`Cannot remove the branch at ${branchPath}: ${held} open reference(s) to its store remain in this ` +
+				`process. Restart the workers that loaded the application first; removing it now would unlink ` +
+				`storage out from under a live reader.`
+		);
+	}
+
 	const storeName = branchStoreNameFor(branchPath);
-	// What this branch owns is what it published, not what is configured now: an entry appended to
-	// `storage.blobPaths` since may already hold a `<storeName>` directory this branch never wrote.
-	// The open handle is already pinned to them; otherwise the marker still on disk names them.
 	const blobRoots = opened?.blobRoots ?? recordedBlobRootsAt(branchPath, storeName);
-	// The identity has to be held for every deletion below, not just checked before them:
-	// `isBranchIdentity` is what stops `table()` claiming this name, and once the directory is gone its
-	// on-disk half sees nothing either, so the reservation is the only thing left holding the name while
-	// the blob roots are still being removed.
 	let holdsIdentity = true;
 	let blobRootsStranded = false;
 	if (opened) {
-		opened.branch.close();
-		// Same turn as the close that released it, so nothing can slip into the gap.
 		retakeBranchIdentity(storeName);
-		Atomics.store(opened.claimState, CLAIM_STATE, UNCLAIMED);
-		wakeWaiters(opened.claimState);
+		releaseClaim(opened.claimState);
 	} else {
-		// Never opened here, so the name has to be claimed outright. Failing means something else already
-		// answers to it, and then the blob root it resolves to is not ours to delete.
 		try {
 			reserveBranchIdentity(storeName);
 		} catch (error) {
@@ -610,29 +638,36 @@ async function removeBranchAt(branchPath: string): Promise<void> {
 			logger.warn?.(`Leaving the blob roots of the branch at ${branchPath} in place: its identity is in use`, error);
 		}
 	}
+	branchesByPath.delete(branchPath);
+	const removing = `${branchPath}${BRANCH_REMOVING_SUFFIX}`;
 	try {
-		await rm(branchPath, { recursive: true, force: true }).catch((error) =>
-			logger.warn?.(`Could not remove branch directory ${branchPath}`, error)
-		);
-		// The clone gives a branch blob roots of its own, outside its directory, so removing only the
-		// directory strands them -- and because they are hard links, the bytes survive the base deleting
-		// its own copies. Only once the directory is actually gone: removing them while it survives (a
-		// held handle, permissions) would leave a branch that still looks adoptable but whose allocator
-		// restarts from an empty root and remints ids its own rows hold. Leaking them the other way round
-		// is recoverable; that is not.
+		await rm(removing, { recursive: true, force: true });
+		if (existsSync(branchPath)) await rename(branchPath, removing);
 		if (holdsIdentity && !existsSync(branchPath)) {
-			// A root that survived still holds this branch's blob files, so the name is not handed back to
-			// a database: one taking it would resolve its own new file ids onto them.
 			if (!(await removeBlobRoots(blobRoots))) {
 				blobRootsStranded = true;
 				logger.warn?.(
 					`Refusing '${storeName}' to new databases on this worker for the life of the process: the ` +
 						`branch at ${branchPath} left blob files behind and a database under that name would ` +
-						`resolve onto them. Other workers no longer see the branch directory, so remove those ` +
-						`files by hand to make the name safe again`
+						`resolve onto them`
 				);
 			}
 		}
+		// only while the base exists: `claimStateFor` goes through `database()`, which recreates a dropped one
+		if (!opened && databases[basename(branchPath)]) {
+			try {
+				releaseClaim(claimStateFor(basename(branchPath), branchPath));
+			} catch (error) {
+				logger.warn?.(`Could not release the branch claim for ${branchPath}`, error);
+			}
+		}
+		if (blobRootsStranded) {
+			throw new Error(
+				`The branch at ${branchPath} was not fully removed: one or more of its blob roots could not be ` +
+					`deleted. Its \`removing\` tombstone was kept; retry the removal once the cause is fixed.`
+			);
+		}
+		await rm(removing, { recursive: true, force: true });
 		await pruneEmptyParents(branchRootOf(branchPath), branchPath);
 	} finally {
 		if (holdsIdentity) {
@@ -640,6 +675,70 @@ async function removeBranchAt(branchPath: string): Promise<void> {
 			else releaseBranchIdentity(storeName);
 		}
 	}
+}
+
+/**
+ * Finish a removal that was interrupted; a `removing` sibling can only mean that.
+ *
+ * `identityHeld`: the caller already reserved the store identity (the load path does). Otherwise it is
+ * reserved here, and a database that already took the name owns the root it resolves to.
+ */
+async function finishInterruptedRemoval(
+	branchPath: string,
+	storeName: string,
+	{ identityHeld }: { identityHeld: boolean }
+): Promise<void> {
+	const removing = `${branchPath}${BRANCH_REMOVING_SUFFIX}`;
+	if (!existsSync(removing)) return;
+	logger.warn?.(`Finishing an interrupted removal of the branch at ${branchPath}`);
+	if (!identityHeld) reserveBranchIdentity(storeName);
+	let stranded = false;
+	try {
+		// Only what the tombstone's own marker names. The marker goes with the final delete, after the
+		// roots have; a tombstone without one had its roots removed already, or lost the record of them
+		// -- and guessing from configuration would take a same-named directory on a volume this branch
+		// never wrote.
+		const published = readBranchState(removing, storeName);
+		if (published.state === 'complete' || published.state === 'damaged') {
+			const configured = getBlobPathsForDatabaseName(storeName);
+			if (!(await removeBlobRoots(published.blobRoots.filter((root) => configured.includes(root))))) {
+				stranded = true;
+				throw new Error(
+					`Could not finish removing the branch at ${branchPath}: its blob roots could not be deleted; ` +
+						`the \`removing\` tombstone was kept`
+				);
+			}
+		} else {
+			stranded = true;
+			logger.warn?.(
+				`The removal tombstone of the branch at ${branchPath} no longer names its blob roots; leaving any ` +
+					`that remain in place and refusing '${storeName}' to new databases`
+			);
+		}
+		await rm(removing, { recursive: true, force: true });
+	} finally {
+		if (stranded) quarantineBranchIdentity(storeName);
+		else if (!identityHeld) releaseBranchIdentity(storeName);
+	}
+}
+
+/**
+ * Hand a branch's claim back, but only from READY: a CREATING word belongs to a loader that won the
+ * claim since, and must not be clobbered into making a second waiter the creator.
+ */
+function releaseClaim(claimState: BigInt64Array): void {
+	if (Atomics.compareExchange(claimState, CLAIM_STATE, READY, UNCLAIMED) === READY) wakeWaiters(claimState);
+}
+
+/**
+ * Release this thread's handle, then destroy the storage. Deliberate removal only.
+ */
+async function removeBranchAt(branchPath: string): Promise<void> {
+	const pending = branchesByPath.get(branchPath);
+	branchesByPath.delete(branchPath);
+	const opened = (await pending?.catch(() => null)) ?? null;
+	opened?.branch.close();
+	await destroyBranchStorage(branchPath, opened);
 }
 
 /**
@@ -669,6 +768,89 @@ function branchStoreNameFor(branchPath: string): string {
  */
 export async function removeBranches(): Promise<void> {
 	for (const branchPath of [...branchesByPath.keys()]) await removeBranchAt(branchPath);
+}
+
+/** Every branch directory and removal tombstone an application owns, under every storage root a database could have. */
+function branchDirectoriesFor(appName: string): { branches: string[]; tombstones: string[]; failures: string[] } {
+	if (!appName || appName.includes('/') || appName.includes('\\') || appName === '.' || appName === '..') {
+		throw new Error(`Invalid application name for branch removal: ${JSON.stringify(appName)}`);
+	}
+	getDatabases();
+	const branches: string[] = [];
+	const tombstones: string[] = [];
+	const failures: string[] = [];
+	const fail = (what: string, error: unknown) => failures.push(`${what} (${(error as Error).message})`);
+	const baseNames = new Set<string>([
+		...Object.keys(databases),
+		DEFAULT_DATABASE_NAME,
+		// a dropped base with a dedicated path has left `databases`, not its branches
+		...Object.keys(env.get(CONFIG_PARAMS.DATABASES) ?? {}),
+	]);
+	const branchRoots = new Set<string>();
+	for (const baseName of baseNames) {
+		try {
+			branchRoots.add(join(resolveDatabaseStorageRoot(baseName), BRANCH_ROOT_DIR));
+		} catch (error) {
+			fail(`the storage root of database '${baseName}'`, error);
+		}
+	}
+	for (const root of branchRoots) {
+		const appDirectory = join(root, appName);
+		let entries;
+		try {
+			entries = readdirSync(appDirectory, { withFileTypes: true });
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== 'ENOENT') fail(appDirectory, error);
+			continue;
+		}
+		for (const entry of entries) {
+			if (!entry.isDirectory()) continue;
+			const entryPath = join(appDirectory, entry.name);
+			if (entry.name.endsWith(BRANCH_REMOVING_SUFFIX))
+				tombstones.push(entryPath.slice(0, -BRANCH_REMOVING_SUFFIX.length));
+			else if (entry.name.includes('`'))
+				fail(entryPath, new Error('not a branch directory and not a known control path'));
+			else branches.push(entryPath);
+		}
+	}
+	return { branches, tombstones, failures };
+}
+
+/** Whether undeploying this application would leave branched database storage behind. */
+export function applicationHasBranchStorage(appName: string): boolean {
+	const { branches, tombstones, failures } = branchDirectoriesFor(appName);
+	return branches.length > 0 || tombstones.length > 0 || failures.length > 0;
+}
+
+/**
+ * Discard every branch an application owns: what undeploying it means for its private data. A branch is
+ * durable, so if this does not happen nothing else ever will, and a redeploy under the same name would
+ * adopt the previous tenant's rows.
+ *
+ * Runs on the thread that saw the worker restart through, after it completed. Own handles are closed
+ * first; any reference held elsewhere refuses. Every failure is collected and thrown: an undeploy must
+ * not answer "dropped" with private data still on disk.
+ */
+export async function removeBranchesForApplication(appName: string): Promise<void> {
+	const { branches, tombstones, failures } = branchDirectoriesFor(appName);
+	const fail = (what: string, error: unknown) => failures.push(`${what} (${(error as Error).message})`);
+	for (const branchPath of tombstones) {
+		try {
+			await finishInterruptedRemoval(branchPath, branchStoreNameFor(branchPath), { identityHeld: false });
+		} catch (error) {
+			fail(`${branchPath}${BRANCH_REMOVING_SUFFIX}`, error);
+		}
+	}
+	for (const branchPath of branches) {
+		try {
+			await removeBranchAt(branchPath);
+		} catch (error) {
+			fail(branchPath, error);
+		}
+	}
+	if (failures.length) {
+		throw new Error(`Could not remove branch storage for application '${appName}': ${failures.join('; ')}`);
+	}
 }
 
 /**

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1373,6 +1373,13 @@ const openBranchIdentities = new Set<string>();
  * delete what it resolves to.
  */
 const BRANCH_STAGING_SUFFIX = '.staging';
+/**
+ * Suffix of the sibling a branch is renamed to while being removed. A backtick, not a dot:
+ * `schemaRegex` excludes 0x60, so no database can be named such that `<db>` + this suffix is another
+ * branch's directory (with `.removing`, an application branching both `data` and `data.removing`, both
+ * legal names, would destroy one by opening the other).
+ */
+export const BRANCH_REMOVING_SUFFIX = '`removing`';
 function branchIdentityPair(storeName: string): string[] {
 	return [storeName, storeName + BRANCH_STAGING_SUFFIX];
 }
@@ -1532,7 +1539,8 @@ function branchDirectoryExistsFor(storeName: string): boolean {
 	const baseName = storeName.slice(prefix[0].length + appLength + 2);
 	if (!baseName) return false;
 	try {
-		return existsSync(resolveBranchPath(baseName, appName));
+		const branchPath = resolveBranchPath(baseName, appName);
+		return existsSync(branchPath) || existsSync(branchPath + BRANCH_REMOVING_SUFFIX);
 	} catch {
 		// Not a name a branch path could hold, so no branch owns it.
 		return false;
@@ -1550,8 +1558,9 @@ function branchDirectoryExistsFor(storeName: string): boolean {
  * base's.
  *
  * The caller owns the returned handle; the only thing that closes it on the caller's behalf is
- * `closeBranchDatabases`, which `closeLoadedDatabases` runs at thread teardown so a branch left open
- * on an exiting worker does not leak its handles into the process-global RocksDB registry.
+ * `closeBranchDatabases`, run by an exiting job worker (via `closeLoadedDatabases`) and by an HTTP
+ * worker's shutdown path, so a branch left open on an exiting worker does not linger in the
+ * process-global RocksDB registry.
  *
  * NOT SAFE FOR SCHEMA MUTATION. A branch's Table classes carry the base's logical name, so a
  * `dropTable()` or equivalent through one resolves against the global schema and would delete the

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -225,6 +225,7 @@ function startServers() {
 							})
 							.then(() => closeServers())
 							.then(() => whenScopesClosed())
+							.then(() => require('../../resources/databases.ts').closeBranchDatabases())
 							.then(() => {
 								realExit(0);
 							});

--- a/unitTests/resources/branchDatabase.test.js
+++ b/unitTests/resources/branchDatabase.test.js
@@ -1027,7 +1027,9 @@ describeUnlessLmdb('branch blob-root safety (harper#644)', () => {
 
 		chmodSync(volume, 0o500);
 		try {
-			await removeBranches();
+			// The removal fails rather than reporting success with the root still on disk, and keeps its
+			// tombstone as the record of what is still owed.
+			await assert.rejects(removeBranches(), /blob roots could not be deleted/);
 			assert.ok(existsSync(root), 'sanity: the blob root outlived the branch directory');
 			assert.throws(
 				() => table({ table: 'Squatter', database: STORE, attributes: [{ name: 'id', isPrimaryKey: true }] }),
@@ -1038,9 +1040,15 @@ describeUnlessLmdb('branch blob-root safety (harper#644)', () => {
 			chmodSync(volume, 0o700);
 		}
 
-		// Materializing replaces those roots wholesale, so the branch is the one holder that may take the
-		// name back; otherwise one transient EBUSY makes the application unloadable for the process life.
+		// The next load finishes the interrupted removal (the roots can go now) and materializes afresh, so
+		// the branch is the one holder that may take the name back; otherwise one transient EBUSY makes
+		// the application unloadable for the process life.
 		const rebuilt = await getOrCreateBranch('safebase', 'safeApp');
+		assert.strictEqual(
+			existsSync(`${resolveBranchPath('safebase', 'safeApp')}\`removing\``),
+			false,
+			'the interrupted removal was finished on the way'
+		);
 		assert.ok(await rebuilt.tables.Safe.get('seed'), 'the application loads again');
 	});
 
@@ -1444,5 +1452,370 @@ describe('the claim budget follows the winner (harper#644)', () => {
 
 		reportClaimProgress(claimState);
 		assert.ok(deadline() > first, 'a unit of work finished buys the waiters another full budget');
+	});
+});
+
+describeUnlessLmdb('the undeploy sequence (harper#644)', () => {
+	const { rmSync, mkdirSync, existsSync: exists } = require('node:fs');
+	const { getBlobPathsForDatabaseName, createBlob } = require('#src/resources/blob');
+	const { removeBranchesForApplication } = require('#src/resources/branchDatabase');
+	const { database } = require('#src/resources/databases');
+	const STORE = `${'cycleApp'.length}_cycleApp__cyclebase`;
+
+	before(async function () {
+		this.timeout(30000);
+		setupTestDBPath();
+		setMainIsWorker(true);
+		table({
+			table: 'Cycle',
+			database: 'cyclebase',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'payload', type: 'Blob' },
+			],
+		});
+		await databases.cyclebase.Cycle.put({ id: 'seed', payload: await createBlob(Buffer.alloc(64 * 1024, 'z')) });
+	});
+
+	afterEach(async function () {
+		await removeBranches().catch(() => {});
+		const branchPath = resolveBranchPath('cyclebase', 'cycleApp');
+		rmSync(branchPath, { recursive: true, force: true });
+		rmSync(`${branchPath}\`removing\``, { recursive: true, force: true });
+		for (const root of getBlobPathsForDatabaseName(STORE)) rmSync(root, { recursive: true, force: true });
+	});
+
+	it('refuses to remove a branch while a reference it does not own is still held', async function () {
+		this.timeout(30000);
+		const { openBranchDatabase } = require('#src/resources/databases');
+		const branchPath = resolveBranchPath('cyclebase', 'cycleApp');
+		const branch = await getOrCreateBranch('cyclebase', 'cycleApp');
+		await branch.tables.Cycle.put({ id: 'held', kept: true });
+		branch.close();
+		// A holder this thread's cache knows nothing about, standing in for another thread's handle.
+		const foreign = openBranchDatabase(branchPath, 'cyclebase', STORE);
+		try {
+			await assert.rejects(removeBranchesForApplication('cycleApp'), /open reference\(s\) to its store remain/);
+			assert.ok(exists(branchPath), 'the checkpoint is untouched');
+			assert.ok(
+				getBlobPathsForDatabaseName(STORE).some((root) => exists(root)),
+				'and so are its blob roots'
+			);
+		} finally {
+			foreign.close();
+		}
+		const reopened = await getOrCreateBranch('cyclebase', 'cycleApp');
+		assert.ok(await reopened.tables.Cycle.get('held'), 'the refused branch is still fully usable');
+	});
+
+	it('closes its own handle, then removes the branch, its blob roots and its claim', async function () {
+		this.timeout(30000);
+		const branchPath = resolveBranchPath('cyclebase', 'cycleApp');
+		const claimWord = () =>
+			new BigInt64Array(
+				database({ database: 'cyclebase', table: undefined }).getUserSharedBuffer(
+					`branch-claim:${branchPath}`,
+					new BigInt64Array([0n]).buffer
+				)
+			);
+		await getOrCreateBranch('cyclebase', 'cycleApp');
+		// Not closed here: the removing thread loaded the application too, and its own handle is the one
+		// reference that is not evidence of a live reader.
+		Atomics.store(claimWord(), 0, 2n); // READY, as the worker that created it left it
+
+		await removeBranchesForApplication('cycleApp');
+
+		assert.strictEqual(exists(branchPath), false, 'the checkpoint is gone');
+		assert.ok(
+			getBlobPathsForDatabaseName(STORE).every((root) => !exists(root)),
+			'so are its blob roots'
+		);
+		assert.strictEqual(Atomics.load(claimWord(), 0), 0n, 'and the claim is released');
+		assert.ok(exists(getBlobPathsForDatabaseName('cyclebase')[0]), "the base's blob root is untouched");
+
+		const redeployed = await getOrCreateBranch('cyclebase', 'cycleApp');
+		assert.ok(await redeployed.tables.Cycle.get('seed'), 'a redeploy materializes cleanly');
+	});
+
+	it('publishes its intent before unlinking anything, so a removal cut short is finished, not lost', async function () {
+		this.timeout(30000);
+		if (process.platform === 'win32' || process.getuid?.() === 0) return this.skip(); // root ignores the permission that stands in for the crash
+		const { chmodSync, writeFileSync } = require('node:fs');
+		const { join } = require('node:path');
+		const branchPath = resolveBranchPath('cyclebase', 'cycleApp');
+		const removing = `${branchPath}\`removing\``;
+		const branch = await getOrCreateBranch('cyclebase', 'cycleApp');
+		branch.close();
+		// Standing in for a crash part-way through: an entry the final delete cannot unlink. Removal must
+		// already have moved the directory to its tombstone by then -- deleting in place would leave a
+		// half-gone branch that reads as damaged, with no record of what was being removed.
+		const hold = join(branchPath, 'hold');
+		mkdirSync(hold);
+		writeFileSync(join(hold, 'keep'), '');
+		chmodSync(hold, 0o555);
+		try {
+			await assert.rejects(removeBranchesForApplication('cycleApp'), /Could not remove branch storage/);
+			assert.strictEqual(exists(branchPath), false, 'the branch directory was renamed away, not deleted in place');
+			assert.ok(exists(removing), 'and the tombstone says which removal was interrupted');
+		} finally {
+			for (const dir of [join(removing, 'hold'), hold]) if (exists(dir)) chmodSync(dir, 0o755);
+		}
+
+		const redeployed = await getOrCreateBranch('cyclebase', 'cycleApp');
+		assert.strictEqual(exists(removing), false, 'the next load finished the removal');
+		assert.ok(await redeployed.tables.Cycle.get('seed'), 'and then materialized afresh');
+	});
+
+	it('finishes an interrupted removal rather than refusing the branch forever', async function () {
+		this.timeout(30000);
+		const branchPath = resolveBranchPath('cyclebase', 'cycleApp');
+		await getOrCreateBranch('cyclebase', 'cycleApp');
+		await removeBranches();
+
+		// The state a crash between the rename and the delete leaves. Only the removal path can produce
+		// this name, so it is unambiguous -- which is the point: without it, a half-removed branch reads
+		// as damaged and is refused forever, needing an operator with a shell.
+		mkdirSync(`${branchPath}\`removing\``, { recursive: true });
+
+		const branch = await getOrCreateBranch('cyclebase', 'cycleApp');
+		assert.ok(await branch.tables.Cycle.get('seed'), 'the branch materializes rather than refusing');
+		assert.strictEqual(exists(`${branchPath}\`removing\``), false, 'and the interrupted removal is finished');
+	});
+
+	it('removes a branch this thread never opened, and hands back only a READY claim', async function () {
+		this.timeout(30000);
+		const { rename: mv, mkdir: mkd } = require('node:fs/promises');
+		const { join } = require('node:path');
+		const branchPath = resolveBranchPath('cyclebase', 'cycleApp');
+		const claimWord = () =>
+			new BigInt64Array(
+				database({ database: 'cyclebase', table: undefined }).getUserSharedBuffer(
+					`branch-claim:${branchPath}`,
+					new BigInt64Array([0n]).buffer
+				)
+			);
+		// Published by a previous boot, as the main thread sees a branch of an application it never loaded.
+		const staging = `${branchPath}.staging`;
+		await mkd(join(branchPath, '..'), { recursive: true });
+		await database({ database: 'cyclebase', table: undefined }).createCheckpoint(staging);
+		await mv(staging, branchPath);
+		publishHandBuiltBranch(branchPath, 'cycleApp', 'cyclebase');
+		for (const root of getBlobPathsForDatabaseName(STORE)) mkdirSync(root, { recursive: true });
+
+		// A loader that won the claim since must not be turned back into a waiter's opening.
+		Atomics.store(claimWord(), 0, 1n); // CREATING
+		await removeBranchesForApplication('cycleApp');
+		assert.strictEqual(exists(branchPath), false);
+		assert.strictEqual(Atomics.load(claimWord(), 0), 1n, 'a CREATING claim is left to its owner');
+
+		Atomics.store(claimWord(), 0, 2n); // READY, as the worker that created it left it
+		await mkd(join(branchPath, '..'), { recursive: true });
+		await database({ database: 'cyclebase', table: undefined }).createCheckpoint(staging);
+		await mv(staging, branchPath);
+		publishHandBuiltBranch(branchPath, 'cycleApp', 'cyclebase');
+		await removeBranchesForApplication('cycleApp');
+		assert.strictEqual(exists(branchPath), false, 'the never-opened branch is gone');
+		assert.ok(
+			getBlobPathsForDatabaseName(STORE).every((root) => !exists(root)),
+			'and its roots with it'
+		);
+		assert.strictEqual(Atomics.load(claimWord(), 0), 0n, 'a READY claim is handed back');
+	});
+
+	it('knows whether an application has branch storage to lose, tombstones included', async function () {
+		this.timeout(30000);
+		const { renameSync } = require('node:fs');
+		const { applicationHasBranchStorage } = require('#src/resources/branchDatabase');
+		assert.strictEqual(applicationHasBranchStorage('neverBranched'), false);
+		const branchPath = resolveBranchPath('cyclebase', 'cycleApp');
+		const branch = await getOrCreateBranch('cyclebase', 'cycleApp');
+		assert.strictEqual(applicationHasBranchStorage('cycleApp'), true);
+		branch.close();
+		renameSync(branchPath, `${branchPath}\`removing\``);
+		assert.strictEqual(applicationHasBranchStorage('cycleApp'), true, 'a tombstone still owes storage');
+		await removeBranchesForApplication('cycleApp');
+		assert.strictEqual(applicationHasBranchStorage('cycleApp'), false);
+	});
+
+	it('deletes no blob roots for a tombstone that lost its marker', async function () {
+		this.timeout(30000);
+		const { renameSync, rmSync: rmS, writeFileSync } = require('node:fs');
+		const { join } = require('node:path');
+		const branchPath = resolveBranchPath('cyclebase', 'cycleApp');
+		const removing = `${branchPath}\`removing\``;
+		const branch = await getOrCreateBranch('cyclebase', 'cycleApp');
+		branch.close();
+		renameSync(branchPath, removing);
+		// The final delete removed the marker and then died, leaving a marker-less tombstone. A same-named
+		// directory on a configured volume, from a restore say, is not this branch's to delete.
+		rmS(join(removing, '.branch-complete'));
+		const [root] = getBlobPathsForDatabaseName(STORE);
+		mkdirSync(root, { recursive: true });
+		writeFileSync(join(root, 'not-ours'), '');
+
+		await removeBranchesForApplication('cycleApp');
+
+		assert.strictEqual(exists(removing), false, 'the tombstone itself is cleared');
+		assert.ok(exists(join(root, 'not-ours')), 'but nothing outside it was touched');
+		rmS(root, { recursive: true, force: true });
+	});
+
+	it('finishes a removal tombstone during the undeploy walk instead of skipping it', async function () {
+		this.timeout(30000);
+		const { renameSync } = require('node:fs');
+		const branchPath = resolveBranchPath('cyclebase', 'cycleApp');
+		const removing = `${branchPath}\`removing\``;
+		const branch = await getOrCreateBranch('cyclebase', 'cycleApp');
+		branch.close();
+		// A crash after the tombstone rename and before the blob roots went.
+		renameSync(branchPath, removing);
+		assert.ok(
+			getBlobPathsForDatabaseName(STORE).some((root) => exists(root)),
+			'roots still present'
+		);
+
+		await removeBranchesForApplication('cycleApp');
+
+		assert.strictEqual(exists(removing), false, 'the tombstone was finished');
+		assert.ok(
+			getBlobPathsForDatabaseName(STORE).every((root) => !exists(root)),
+			'and its blob roots went with it'
+		);
+	});
+
+	it('keeps the store identity guarded while only the tombstone is on disk', async function () {
+		this.timeout(30000);
+		const { renameSync } = require('node:fs');
+		const { table, isBranchIdentity } = require('#src/resources/databases');
+		const branchPath = resolveBranchPath('cyclebase', 'cycleApp');
+		const removing = `${branchPath}\`removing\``;
+		const branch = await getOrCreateBranch('cyclebase', 'cycleApp');
+		branch.close();
+		renameSync(branchPath, removing);
+		// The blob roots the tombstone points at are still this branch's, so a database under the same
+		// name would mint its own file ids onto them.
+		assert.ok(isBranchIdentity(STORE), 'a tombstone is still a branch on disk');
+		assert.throws(
+			() => table({ table: 'Squatter', database: STORE, attributes: [{ name: 'id', isPrimaryKey: true }] }),
+			/branch store identity/
+		);
+		await removeBranchesForApplication('cycleApp');
+		assert.strictEqual(exists(removing), false);
+	});
+
+	it('will not finish a tombstone whose identity a database has since taken', async function () {
+		this.timeout(30000);
+		const { renameSync, rmSync: rmS } = require('node:fs');
+		const { resolveDatabasePath } = require('#src/resources/databases');
+		const branchPath = resolveBranchPath('cyclebase', 'cycleApp');
+		const removing = `${branchPath}\`removing\``;
+		const branch = await getOrCreateBranch('cyclebase', 'cycleApp');
+		branch.close();
+		renameSync(branchPath, removing);
+		// A database directory under the identity's name (created outside this process's guard, say by a
+		// restore) owns the blob root the tombstone still points at.
+		const squatter = resolveDatabasePath(STORE);
+		mkdirSync(squatter, { recursive: true });
+		try {
+			await assert.rejects(removeBranchesForApplication('cycleApp'), /already in use/);
+			assert.ok(exists(removing), 'the tombstone is kept');
+			assert.ok(
+				getBlobPathsForDatabaseName(STORE).some((root) => exists(root)),
+				"and the root, now the database's, is untouched"
+			);
+		} finally {
+			rmS(squatter, { recursive: true, force: true });
+		}
+		await removeBranchesForApplication('cycleApp');
+		assert.strictEqual(exists(removing), false, 'finished once the name is free again');
+	});
+
+	it('keeps the tombstone and fails when a blob root cannot be removed', async function () {
+		this.timeout(30000);
+		if (process.platform === 'win32' || process.getuid?.() === 0) return this.skip();
+		const { chmodSync, writeFileSync } = require('node:fs');
+		const { join } = require('node:path');
+		const branchPath = resolveBranchPath('cyclebase', 'cycleApp');
+		const removing = `${branchPath}\`removing\``;
+		await getOrCreateBranch('cyclebase', 'cycleApp');
+		const [root] = getBlobPathsForDatabaseName(STORE);
+		mkdirSync(root, { recursive: true });
+		writeFileSync(join(root, 'stuck'), '');
+		chmodSync(root, 0o555);
+		try {
+			await assert.rejects(removeBranchesForApplication('cycleApp'), /blob roots could not be deleted/);
+			assert.strictEqual(exists(branchPath), false, 'the checkpoint directory was renamed away');
+			assert.ok(exists(removing), 'and the tombstone records what is still owed');
+		} finally {
+			chmodSync(root, 0o755);
+		}
+
+		await removeBranchesForApplication('cycleApp');
+		assert.strictEqual(exists(removing), false, 'a retry finishes it');
+		assert.strictEqual(exists(root), false);
+	});
+
+	it('reports an application directory it cannot read instead of treating it as empty', async function () {
+		this.timeout(30000);
+		if (process.platform === 'win32' || process.getuid?.() === 0) return this.skip();
+		const { chmodSync } = require('node:fs');
+		const { dirname } = require('node:path');
+		const branchPath = resolveBranchPath('cyclebase', 'cycleApp');
+		const branch = await getOrCreateBranch('cyclebase', 'cycleApp');
+		branch.close();
+		const appDirectory = dirname(branchPath);
+		chmodSync(appDirectory, 0o000);
+		try {
+			await assert.rejects(removeBranchesForApplication('cycleApp'), /EACCES/);
+		} finally {
+			chmodSync(appDirectory, 0o755);
+		}
+		assert.ok(exists(branchPath), 'nothing was removed');
+		await removeBranchesForApplication('cycleApp');
+	});
+});
+
+describeUnlessLmdb('branch control paths cannot be spelled as a database name (harper#644)', () => {
+	const { rmSync } = require('node:fs');
+	const { getBlobPathsForDatabaseName } = require('#src/resources/blob');
+
+	before(function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		// Both are legal database names -- `schemaRegex` permits `.` -- and one is the other plus what
+		// used to be the removal suffix.
+		for (const db of ['collide', 'collide.removing']) {
+			table({ table: 'Row', database: db, attributes: [{ name: 'id', isPrimaryKey: true }] });
+		}
+	});
+
+	afterEach(async function () {
+		await removeBranches().catch(() => {});
+		for (const db of ['collide', 'collide.removing']) {
+			rmSync(resolveBranchPath(db, 'collideApp'), { recursive: true, force: true });
+			for (const root of getBlobPathsForDatabaseName(`${'collideApp'.length}_collideApp__${db}`)) {
+				rmSync(root, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it('opens a branch of `x` without destroying the branch of `x.removing`', async function () {
+		this.timeout(30000);
+		const other = await getOrCreateBranch('collide.removing', 'collideApp');
+		await other.tables.Row.put({ id: 'belongs-to-the-other-branch' });
+
+		// Deriving a control path by suffixing a user-chosen name made the ordinary load path destructive:
+		// opening the branch of `collide` saw `<app>/collide.removing` -- a healthy branch of a different
+		// database -- read it as an interrupted removal, and deleted it along with its blob roots.
+		await getOrCreateBranch('collide', 'collideApp');
+
+		assert.ok(existsSync(resolveBranchPath('collide.removing', 'collideApp')), 'the other branch survives');
+		assert.ok(await other.tables.Row.get('belongs-to-the-other-branch'), 'with its rows intact');
+		assert.ok(
+			getBlobPathsForDatabaseName(`${'collideApp'.length}_collideApp__collide.removing`).every((root) =>
+				existsSync(root)
+			),
+			'and its blob roots were not deleted either'
+		);
 	});
 });


### PR DESCRIPTION
## Summary

Removes an application's branched databases when it is undeployed. A branch is durable (harper#2426), so undeploying is the only point at which its private data can be discarded, and until now it never was: a redeploy under the same name adopted the previous tenant's rows.

Part of HarperFast/harper#642; closes the removal half of HarperFast/harper#644.

## The sequence

Removal is the last step of a fixed order and refuses to run in any other:

1. `drop_component` removes the application, so nothing will load the branch again.
2. The HTTP workers are restarted, so the threads that had the branch open are gone.
3. rocksdb-js's process-global registry (`registryStatus()`) is checked for open references to the store. This is a check that can fail, and then nothing is deleted.
4. Only then are the checkpoint, its hard-linked blob roots and its shared-buffer claim unlinked, as `drop_database` would.

**Which thread removes.** The operations API runs on the main thread, which performs the restart itself, so a local `drop_component` awaits completion and removes only when the restart completed with no workers kept on old code. A drop executed on a worker (a replicated operation on a peer) cannot outlive the restart it asks for, so it posts the `RESTART` message with `removeBranchesFor` and the main-thread handler in `bin/restart.ts` removes after the restart. HTTP workers now call `closeBranchDatabases()` on shutdown so the reference check never depends on native teardown timing. The removing thread closes its own handles first (it loaded the application too); any reference held elsewhere refuses.

**Serialized against redeploys.** On the main thread the whole drop (directory removal, replication, restart, branch removal) runs under one component preparation lock. The main thread's cached root config is refreshed right after the config file is rewritten, so the restart's application-install pass no longer sees the dropped package application: that both avoids it taking the lock the drop holds, and fixes a pre-existing stale-cache reinstall of a just-dropped package app on the main-thread path. Under that lock a same-name `deploy_component` waits until the branches are gone instead of adopting them or racing the unlink. On the worker-requested path the main thread takes the same lock (drop-lock timeout and owner-liveness check) and inside it restarts the HTTP workers, checks the outcome (removal is skipped with a warning if the restart was declined or left workers on old code), then removes. If the lock cannot be taken, the restart still runs and the failure is logged, so the caller is never told a restart is happening that then does not. The residual window is the ITC hop between the worker releasing its drop lock and the main thread acquiring it, milliseconds. A same-name deploy that lands in it is detected: if the root config names the project again after the restart, the main thread leaves the branches to the new deployment (which has adopted them) and never closes handles to a branch it is now serving. The claim word is released by compare-and-swap from READY only: a CREATING word belongs to a loader that won the claim since and is left alone.

**Interrupted removals.** Removal first renames the branch to a `` <db>`removing` `` sibling. A backtick, not a dot: `schemaRegex` excludes it, so no database name can spell that path, which a `.removing` suffix could not guarantee (both `data` and `data.removing` are legal names). While only the tombstone is on disk the store identity stays guarded (`isBranchIdentity` recognises it), so no database can take the name and resolve onto the surviving blob files. A tombstone is finished on the next load of the branch or the next undeploy walk, with the store identity reserved while its roots go; if a database has taken that name in the meantime the tombstone is kept and the undeploy fails. A blob root that cannot be deleted likewise keeps the tombstone and fails the undeploy rather than reporting success with data still on disk. Finishing a tombstone deletes only the roots its own marker names; a tombstone that lost its marker (the final delete died part-way, after the roots were already gone) deletes nothing outside itself rather than guessing from configuration.

**Response contract.** Unchanged for applications with no branch storage: `Successfully dropped: <project>` (with `, restarting Harper` when asked). When the application owns branch storage:
- restart completed → storage removed, or an explicit error naming what was left and how to retry (`drop_component` with `restart: true` again; the missing component directory is tolerated).
- restart not completed, or `restart` omitted → storage left in place; the response says so.
- worker-executed drop → the response says the main thread removes after the restart and logs the outcome.

## Verification

- `unitTests/resources/branchDatabase.test.js`: 83 passing, including 13 undeploy-sequence tests. Each new behaviour was mutation-checked (test fails with the fix removed): the reference gate, own-handle close, tombstone rename-before-unlink, tombstone recovery on load, tombstone finish on the undeploy walk, undeletable blob root keeps the tombstone, a marker-less tombstone deleting no roots, non-ENOENT enumeration errors reported, CAS claim release (a CREATING word survives removal), identity reservation while finishing a tombstone, the on-disk identity guard recognising a tombstone, the has-storage check counting tombstones, and the backtick suffix (a `.removing` spelling destroys the branch of `x.removing` when opening `x`).
- Worker-thread probe against rocksdb-js 2.8.0: the registry is visible across threads (main sees a worker's refCount), and a worker's entries are dropped on teardown both on a plain exit and on `worker.terminate()`, so a force-terminated worker cannot wedge the reference check. The explicit `closeBranchDatabases()` on shutdown makes the gate independent of that timing anyway.
- Adjacent suites (`deployComponentBranchedDatabases`, `closeLoadedDatabases`, `extractApplicationSwap`, `agent/session`) pass; lint passes by exit code.

**Not covered by a test:** an end-to-end `drop_component` with `restart: true` through `components/operations.js` (main-thread orchestration and response messaging), and the worker→main `removeBranchesFor` hand-off. Both are glue over tested helpers; an integration test would need a real worker pool.

## Decisions taken (reviewers flagged these as open; stating the choice)

- **Worker-path outcome is log-only.** A drop executed on a worker answers 200 before the restart, and the main thread logs whether removal succeeded. The worker cannot outlive the restart, so there is no channel back to the caller without a job. A job or status hook is a reasonable follow-up.
- **`restart: false` retains the branches** and the response says so. Silent removal without a restart would unlink stores that workers still hold.
- **Removal proceeds under a CREATING claim** (leaves the word to its owner) rather than refusing. Under the drop's component lock no loader can be in flight, so the case is unreachable from `drop_component`; a dead creator would otherwise wedge removal for the process life.
- **Refusal, not waiting, on a live reference.** A retry is one `drop_component` away and the message names it.

## Out of scope, filed or noted

- HarperFast/harper#2514: the pre-existing `.staging` sibling collision (same class as the `.removing` one fixed here).
- `drop_custom_function_project` (legacy path) does not remove branches.
- `DESIGN.md` still states that a thread exiting without closing leaks its registry refcount; the probe above contradicts that for rocksdb-js 2.8.0. Left as is; worth a doc follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=claude; ran=cursor-composer,codex,gemini; adjudicated=domain; declined=cursor-grok; rounds=10 @ c8546484e258</sub>

<sub>Human-Review-Need: 3 (decisions: removal-gated-on-restart-flag, worker-path-fire-and-forget, refuse-on-open-reference, quarantine-identity-for-process-life, backtick-suffix-tombstone, http-only-restart-before-removal) @ c8546484e258</sub>
