### PR TITLE
feat(threads): run an isolated application in a dedicated worker thread

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1955,10 +1955,10 @@ the table first), and who owns the column-family wrappers the declaration opens.
 An application that declared `branchedDatabases` declares through `scopedTableFactory(branches)`, which
 routes each declaration by database name — to the branch of that name, or to `table()` itself. GraphQL
 `@table` (`graphql.ts`), `scope.ensureTable` (`components/Scope.ts`, `componentLoader.ts`) and
-`defineTable` (`defineTableUsing`, through `security/jsLoader.ts`) all go through it. **An unbranched
-application gets `table` and `defineTable` by identity** — `scopedTableFactory(undefined) === table` —
-so the request path of every application that does not branch is untouched; only a branched
-application pays for the routing, and only at declaration time.
+`defineTable` (`defineTableUsing`, through `security/jsLoader.ts`) all go through it. **An unbranched,
+shared application gets `table` and `defineTable` by identity** — `scopedTableFactory(undefined) ===
+table`. An isolated application gets a declaration-only wrapper even without branches, so its own
+schema can claim maintenance that no pool worker configured; hydrated tables remain pool-owned.
 
 Consequences to preserve:
 

--- a/bin/restart.ts
+++ b/bin/restart.ts
@@ -11,6 +11,7 @@ import {
 	restartWorkers,
 	isThreadRunning,
 	decodeRestartScope,
+	getRunningIsolatedApplications,
 	onMessageByType,
 	shutdownWorkersNow,
 } from '../server/threads/manageThreads.js';
@@ -39,7 +40,12 @@ if (isMainThread) {
 			// `scope` stays in its wire form ('' pool, a name, absent = all) until restartService decodes it once
 			if (message.removeBranchesFor)
 				await restartThenRemoveBranches(message.workerType, message.removeBranchesFor, message.scope);
-			else if (message.workerType) await restartService({ service: message.workerType, scope: message.scope });
+			else if (message.workerType)
+				await restartService({
+					service: message.workerType,
+					scope: message.scope,
+					scopeFallback: message.scopeFallback,
+				});
 			else restart({ operation: 'restart' });
 		} finally {
 			port.postMessage({ type: 'restart-complete' });
@@ -186,6 +192,21 @@ async function restartService(req: any) {
 	if (hdbTerms.HDB_PROCESS_SERVICES[service] === undefined) {
 		throw handleHDBError(new Error(), INVALID_SERVICE_ERR, HTTP_STATUS_CODES.BAD_REQUEST, undefined, undefined, true);
 	}
+	const requestedScope = decodeRestartScope(req);
+	if (typeof requestedScope === 'string' && requestedScope !== '*' && req.scopeFallback === undefined) {
+		envMgr.initSync(true);
+		const { isIsolatedApplication } = await import('../server/threads/isolatedApplications.ts');
+		if (!isIsolatedApplication(requestedScope)) {
+			throw handleHDBError(
+				new Error(),
+				`Unknown isolated application restart scope: ${requestedScope}`,
+				HTTP_STATUS_CODES.BAD_REQUEST,
+				undefined,
+				undefined,
+				true
+			);
+		}
+	}
 	processMan.expectedRestartOfChildren();
 	if (!isMainThread) {
 		if (req.replicated) {
@@ -195,6 +216,7 @@ async function restartService(req: any) {
 			type: hdbTerms.ITC_EVENT_TYPES.RESTART,
 			workerType: service,
 			scope: req.scope, // wire form, forwarded as received
+			scopeFallback: req.scopeFallback,
 		});
 		parentPort.ref(); // don't let the parent thread exit until we're done
 		await new Promise<void>((resolve) => {
@@ -269,8 +291,12 @@ async function restartService(req: any) {
 			if (calledFromCli) {
 				await processMan.restart(hdbTerms.PROCESS_DESCRIPTORS.HDB);
 			} else {
-				// scoped to one isolated application's worker when asked; otherwise every http worker
-				await restartWorkers('http', undefined, true, null, decodeRestartScope(req));
+				let scope = requestedScope;
+				if (req.scopeFallback !== undefined && typeof scope === 'string' && scope !== '*') {
+					const runningApplications = await getRunningIsolatedApplications();
+					if (!runningApplications.includes(scope)) scope = decodeRestartScope({ scope: req.scopeFallback });
+				}
+				await restartWorkers('http', undefined, true, null, scope);
 			}
 			break;
 		default:

--- a/bin/restart.ts
+++ b/bin/restart.ts
@@ -28,6 +28,7 @@ envMgr.initSync();
 
 const RESTART_RESPONSE = `Restarting Harper. This may take up to ${hdbTerms.RESTART_TIMEOUT_MS / 1000} seconds.`;
 const INVALID_SERVICE_ERR = 'Invalid service';
+const ISOLATED_TOPOLOGY_REQUEST_TIMEOUT_MS = 5000;
 
 let calledFromCli;
 
@@ -221,7 +222,9 @@ async function restartService(req: any) {
 		envMgr.initSync(true);
 		const { isIsolatedApplication } = await import('../server/threads/isolatedApplications.ts');
 		const configured = isIsolatedApplication(requestedScope);
-		const runningApplications = configured ? [] : await getRunningIsolatedApplications(5000);
+		const runningApplications = configured
+			? []
+			: await getRunningIsolatedApplications(ISOLATED_TOPOLOGY_REQUEST_TIMEOUT_MS);
 		if (!configured && !runningApplications.includes(requestedScope)) {
 			throw handleHDBError(
 				new Error(),
@@ -319,7 +322,7 @@ async function restartService(req: any) {
 			} else {
 				let scope = requestedScope;
 				if (req.scopeFallback !== undefined && typeof scope === 'string' && scope !== '*') {
-					const runningApplications = await getRunningIsolatedApplications();
+					const runningApplications = await getRunningIsolatedApplications(ISOLATED_TOPOLOGY_REQUEST_TIMEOUT_MS);
 					if (!runningApplications.includes(scope)) scope = fallbackScope;
 				}
 				await restartWorkers('http', undefined, true, null, scope);

--- a/bin/restart.ts
+++ b/bin/restart.ts
@@ -193,6 +193,16 @@ async function restartService(req: any) {
 		throw handleHDBError(new Error(), INVALID_SERVICE_ERR, HTTP_STATUS_CODES.BAD_REQUEST, undefined, undefined, true);
 	}
 	const requestedScope = decodeRestartScope(req);
+	if (requestedScope !== undefined && typeof requestedScope !== 'string') {
+		throw handleHDBError(
+			new Error(),
+			'Invalid HTTP worker restart scope: expected a string',
+			HTTP_STATUS_CODES.BAD_REQUEST,
+			undefined,
+			undefined,
+			true
+		);
+	}
 	if (typeof requestedScope === 'string' && requestedScope !== '*' && req.scopeFallback === undefined) {
 		envMgr.initSync(true);
 		const { isIsolatedApplication } = await import('../server/threads/isolatedApplications.ts');

--- a/bin/restart.ts
+++ b/bin/restart.ts
@@ -10,6 +10,7 @@ import {
 	beginProcessShutdown,
 	restartWorkers,
 	isThreadRunning,
+	decodeRestartScope,
 	onMessageByType,
 	shutdownWorkersNow,
 } from '../server/threads/manageThreads.js';
@@ -35,8 +36,10 @@ export { restart, restartService };
 if (isMainThread) {
 	onMessageByType(hdbTerms.ITC_EVENT_TYPES.RESTART, async (message, port) => {
 		try {
-			if (message.removeBranchesFor) await restartThenRemoveBranches(message.workerType, message.removeBranchesFor);
-			else if (message.workerType) await restartService({ service: message.workerType });
+			// `scope` stays in its wire form ('' pool, a name, absent = all) until restartService decodes it once
+			if (message.removeBranchesFor)
+				await restartThenRemoveBranches(message.workerType, message.removeBranchesFor, message.scope);
+			else if (message.workerType) await restartService({ service: message.workerType, scope: message.scope });
 			else restart({ operation: 'restart' });
 		} finally {
 			port.postMessage({ type: 'restart-complete' });
@@ -48,13 +51,13 @@ if (isMainThread) {
  * Restart, then remove the branches of an application dropped on a worker (which cannot outlive the
  * restart it asked for). The restart happens even if the component lock cannot be taken.
  */
-async function restartThenRemoveBranches(service: string, project: string): Promise<void> {
+async function restartThenRemoveBranches(service: string, project: string, scope: string | undefined): Promise<void> {
 	let restarted = false;
 	const restartHttpWorkers = async () => {
 		restarted = true;
 		processMan.expectedRestartOfChildren();
 		hdbLogger.notify('Restarting http_workers');
-		return restartWorkers('http');
+		return restartWorkers('http', undefined, true, null, decodeRestartScope({ scope }));
 	};
 	try {
 		const componentPath = path.join(getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT) as string, project);
@@ -89,7 +92,7 @@ async function restartThenRemoveBranches(service: string, project: string): Prom
 		);
 	} catch (error) {
 		hdbLogger.error(`Could not remove the branched database storage of ${project}`, error);
-		if (!restarted) await restartService({ service });
+		if (!restarted) await restartService({ service, scope });
 	}
 }
 
@@ -191,6 +194,7 @@ async function restartService(req: any) {
 		parentPort.postMessage({
 			type: hdbTerms.ITC_EVENT_TYPES.RESTART,
 			workerType: service,
+			scope: req.scope, // wire form, forwarded as received
 		});
 		parentPort.ref(); // don't let the parent thread exit until we're done
 		await new Promise<void>((resolve) => {
@@ -265,7 +269,8 @@ async function restartService(req: any) {
 			if (calledFromCli) {
 				await processMan.restart(hdbTerms.PROCESS_DESCRIPTORS.HDB);
 			} else {
-				await restartWorkers('http');
+				// scoped to one isolated application's worker when asked; otherwise every http worker
+				await restartWorkers('http', undefined, true, null, decodeRestartScope(req));
 			}
 			break;
 		default:

--- a/bin/restart.ts
+++ b/bin/restart.ts
@@ -196,7 +196,9 @@ async function restartService(req: any) {
 	if (typeof requestedScope === 'string' && requestedScope !== '*' && req.scopeFallback === undefined) {
 		envMgr.initSync(true);
 		const { isIsolatedApplication } = await import('../server/threads/isolatedApplications.ts');
-		if (!isIsolatedApplication(requestedScope)) {
+		const configured = isIsolatedApplication(requestedScope);
+		const runningApplications = configured ? [] : await getRunningIsolatedApplications(5000);
+		if (!configured && !runningApplications.includes(requestedScope)) {
 			throw handleHDBError(
 				new Error(),
 				`Unknown isolated application restart scope: ${requestedScope}`,

--- a/bin/restart.ts
+++ b/bin/restart.ts
@@ -203,6 +203,20 @@ async function restartService(req: any) {
 			true
 		);
 	}
+	let fallbackScope;
+	if (req.scopeFallback !== undefined) {
+		fallbackScope = decodeRestartScope({ scope: req.scopeFallback });
+		if (fallbackScope !== undefined) {
+			throw handleHDBError(
+				new Error(),
+				'Invalid HTTP worker restart scope fallback: expected the pool scope',
+				HTTP_STATUS_CODES.BAD_REQUEST,
+				undefined,
+				undefined,
+				true
+			);
+		}
+	}
 	if (typeof requestedScope === 'string' && requestedScope !== '*' && req.scopeFallback === undefined) {
 		envMgr.initSync(true);
 		const { isIsolatedApplication } = await import('../server/threads/isolatedApplications.ts');
@@ -306,7 +320,7 @@ async function restartService(req: any) {
 				let scope = requestedScope;
 				if (req.scopeFallback !== undefined && typeof scope === 'string' && scope !== '*') {
 					const runningApplications = await getRunningIsolatedApplications();
-					if (!runningApplications.includes(scope)) scope = decodeRestartScope({ scope: req.scopeFallback });
+					if (!runningApplications.includes(scope)) scope = fallbackScope;
 				}
 				await restartWorkers('http', undefined, true, null, scope);
 			}

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -220,9 +220,13 @@ export function assertApplicationConfig(
 		}
 	}
 	assertBranchedDatabases(applicationName, applicationConfig.branchedDatabases);
-	if (applicationConfig.isolated !== undefined && typeof applicationConfig.isolated !== 'boolean') {
+	assertIsolationConfig(applicationName, applicationConfig.isolated);
+}
+
+export function assertIsolationConfig(applicationName: string, isolated: unknown): void {
+	if (isolated !== undefined && typeof isolated !== 'boolean') {
 		throw new TypeError(
-			`Invalid 'isolated' for application ${applicationName}: expected a boolean, got ${typeof applicationConfig.isolated}`
+			`Invalid 'isolated' for application ${applicationName}: expected a boolean, got ${typeof isolated}`
 		);
 	}
 }

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -84,6 +84,8 @@ interface ApplicationConfig {
 	 * Per-application globals are a property of thread-level isolation, not of branching.
 	 */
 	branchedDatabases?: string[] | true;
+	/** Run in a worker thread of its own that loads no other application. */
+	isolated?: boolean;
 	// an application config can have other arbitrary properties
 	[key: string]: unknown;
 }
@@ -218,6 +220,11 @@ export function assertApplicationConfig(
 		}
 	}
 	assertBranchedDatabases(applicationName, applicationConfig.branchedDatabases);
+	if (applicationConfig.isolated !== undefined && typeof applicationConfig.isolated !== 'boolean') {
+		throw new TypeError(
+			`Invalid 'isolated' for application ${applicationName}: expected a boolean, got ${typeof applicationConfig.isolated}`
+		);
+	}
 }
 
 /**

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -3455,6 +3455,7 @@ export function shouldPackLocalDirectory(packageIdentifier: string | undefined, 
  * @returns A promise that resolves when all preparation steps complete.
  */
 export type PrepareApplicationOptions = {
+	beforePrepare?: () => Promise<void>;
 	/**
 	 * Runs against the built candidate while the live version is still serving, and BEFORE the swap. A
 	 * throw here means the candidate never goes live — which is the whole difference from the previous
@@ -3471,6 +3472,7 @@ export async function prepareApplication(application: Application, options: Prep
 		await withComponentPreparationLock(
 			application.dirPath,
 			async () => {
+				await options.beforePrepare?.();
 				const asideStagingDir = extractionStagingDirectory(application.dirPath);
 				let recoveryPending = true;
 				try {

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -20,6 +20,7 @@ import {
 } from './componentSecrets.ts';
 import type { SecretsView } from './componentSecrets.ts';
 import { deployLifecycle } from './deployLifecycle.ts';
+import { thisThreadOwnsApplication } from '../server/threads/isolatedApplications.ts';
 
 export class MissingDefaultFilesOptionError extends Error {
 	constructor() {
@@ -241,7 +242,10 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 
 	ensureTable<TableResourceType = unknown>(options: any): TableResourceType {
 		options.origin = this.#origin;
-		return scopedTableFactory(this.applicationScope?.branches)<TableResourceType>(options);
+		return scopedTableFactory(
+			this.applicationScope?.branches,
+			thisThreadOwnsApplication(this.applicationScope?.name)
+		)<TableResourceType>(options);
 	}
 
 	#handleOptionsWatcherReady(): void {

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -34,7 +34,11 @@ import { trackScopeClose } from './scopeShutdown.ts';
 import { deployLifecycle } from './deployLifecycle.ts';
 import { assertBranchedDatabases } from './Application.ts';
 import { prepareBranches } from '../resources/branchDatabase.ts';
-import { isIsolatedApplication, shouldLoadApplicationHere } from '../server/threads/isolatedApplications.ts';
+import {
+	isIsolatedApplication,
+	shouldLoadApplicationHere,
+	thisThreadOwnsApplication,
+} from '../server/threads/isolatedApplications.ts';
 import { toScopeMount, nestScopeMount, type ScopeMount } from './scopeMount.ts';
 import { scopedImport } from '../security/jsLoader.ts';
 import { server } from '../server/Server.ts';
@@ -966,7 +970,10 @@ export async function loadComponent(
 				// our own trusted modules can be directly retrieved from our map, otherwise use the (configurable) secure module loader
 				const ensureTable = (options: any) => {
 					options.origin = origin;
-					return scopedTableFactory(applicationScope.branches)(options);
+					return scopedTableFactory(
+						applicationScope.branches,
+						thisThreadOwnsApplication(applicationScope.name)
+					)(options);
 				};
 				// call the main start hook
 				const network =

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -34,6 +34,7 @@ import { trackScopeClose } from './scopeShutdown.ts';
 import { deployLifecycle } from './deployLifecycle.ts';
 import { assertBranchedDatabases } from './Application.ts';
 import { prepareBranches } from '../resources/branchDatabase.ts';
+import { isIsolatedApplication, shouldLoadApplicationHere } from '../server/threads/isolatedApplications.ts';
 import { toScopeMount, nestScopeMount, type ScopeMount } from './scopeMount.ts';
 import { scopedImport } from '../security/jsLoader.ts';
 import { server } from '../server/Server.ts';
@@ -162,6 +163,26 @@ function rootConfigBranchedDatabases(appName: string): string[] | true | undefin
 }
 
 /**
+ * Whether this thread is the one that loads `appName` (harper#642, tier 2). An isolated application
+ * is loaded by its dedicated worker and by nothing else; every other thread loads only the
+ * applications that are not isolated. Decided before any of the application's modules are imported.
+ * With no worker threads at all there is nowhere for an isolated application to run, so it fails
+ * closed here rather than silently sharing the only thread.
+ */
+function placedOnThisThread(appName: string): boolean {
+	if (Object.hasOwn(TRUSTED_RESOURCE_PLUGINS, appName)) return true;
+	if (isIsolatedApplication(appName) && isMainThread && getWorkerIndex() === 0) {
+		componentLifecycle.failed(
+			appName,
+			new Error(`Application '${appName}' is isolated, which needs a worker thread of its own, but threads.count is 0`),
+			`Component '${appName}' failed to load`
+		);
+		return false;
+	}
+	return shouldLoadApplicationHere(appName);
+}
+
+/**
  * Resolves the mount for `appName`, or reports the failure and returns `undefined` if the
  * configured `host`/`urlPath` is invalid. The caller must skip loading the application in that
  * case rather than loading it anyway: an invalid mount is a request to CONSTRAIN where the app is
@@ -268,6 +289,7 @@ export async function loadComponentDirectories(
 						}
 						return;
 					}
+					if (!placedOnThisThread(appName)) return;
 					const mountResult = tryRootConfigMount(appName);
 					if (!mountResult.ok) return;
 					const loadedModules = new Set<any>();
@@ -316,6 +338,7 @@ export async function loadComponentDirectories(
 				);
 				continue;
 			}
+			if (!placedOnThisThread(appName)) continue;
 			const appFolder = join(CF_ROUTES_DIR, appName);
 			const mountResult = tryRootConfigMount(appName);
 			if (!mountResult.ok) continue;
@@ -347,7 +370,7 @@ export async function loadComponentDirectories(
 	if (hdbAppFolder) {
 		if (getWorkerIndex() === 0) harperLogger.info?.('Loading application from ' + hdbAppFolder);
 		const mountResult = tryRootConfigMount(basename(hdbAppFolder));
-		if (mountResult.ok) {
+		if (mountResult.ok && placedOnThisThread(basename(hdbAppFolder))) {
 			cfsLoaded.push(
 				serializeComponentLoad(hdbAppFolder, () =>
 					loadComponent(hdbAppFolder, cycleResources, hdbAppFolder, {
@@ -849,6 +872,9 @@ export async function loadComponent(
 			if (!componentConfig) continue;
 
 			// Initialize loading status for all components (applications and extensions)
+			// A root-config application (`package:`) is placed like a directory one: an isolated application
+			// loads only in its dedicated worker, and that worker loads no other application.
+			if (isRoot && componentConfig.package && !placedOnThisThread(componentName)) continue;
 			componentLifecycle.loading(componentStatusName);
 
 			const subApplicationScope = isRoot
@@ -1160,7 +1186,7 @@ export async function loadComponent(
 						// — not abort the loop and discard a pending follow-up, like the save that fixes it.
 						try {
 							await loadComponentDirectories();
-							await restartWorkers();
+							await restartWorkers(undefined, undefined, true, null, '*');
 						} catch (error) {
 							harperLogger.error('Error during component reload', error);
 						}

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -32,7 +32,7 @@ import { restartWorkers, getWorkerIndex } from '../server/threads/manageThreads.
 import { resetRestartNeeded, subscribeToRestartRequests } from './requestRestart.ts';
 import { trackScopeClose } from './scopeShutdown.ts';
 import { deployLifecycle } from './deployLifecycle.ts';
-import { assertBranchedDatabases } from './Application.ts';
+import { assertBranchedDatabases, assertIsolationConfig } from './Application.ts';
 import { prepareBranches } from '../resources/branchDatabase.ts';
 import {
 	isIsolatedApplication,
@@ -175,6 +175,12 @@ function rootConfigBranchedDatabases(appName: string): string[] | true | undefin
  */
 function placedOnThisThread(appName: string): boolean {
 	if (Object.hasOwn(TRUSTED_RESOURCE_PLUGINS, appName)) return true;
+	try {
+		assertIsolationConfig(appName, (getConfigObj()?.[appName] as any)?.isolated);
+	} catch (error) {
+		componentLifecycle.failed(appName, error, `Component '${appName}' failed to load`);
+		return false;
+	}
 	if (isIsolatedApplication(appName) && isMainThread && getWorkerIndex() === 0) {
 		componentLifecycle.failed(
 			appName,

--- a/components/operations.js
+++ b/components/operations.js
@@ -588,6 +588,42 @@ async function deployComponent(req) {
 	// replicated ciphertext (reference, not embed); already-reference entries pass through, and with
 	// no custody a literal token stays as a transient, this-node-only fallback (#1158). Peers
 	// re-running a replicated deploy already carry references and never re-ingest.
+	const { isIsolatedApplication } = require('../server/threads/isolatedApplications.ts');
+	// this thread's cached config may predate an earlier deploy that changed the entry without a restart
+	env.initSync(true);
+	const wasIsolated = isIsolatedApplication(req.project);
+	if (req.isolated !== undefined && !req.package) {
+		throw handleHDBError(
+			new Error(),
+			`'isolated' is only supported for package deployments; set it on the application's root config entry instead`,
+			HTTP_STATUS_CODES.BAD_REQUEST
+		);
+	}
+	// Admission is checked here, where the caller can be told, not only at worker start where a refusal
+	// is a log line: an isolated application nothing could reach, or one past threads.maxIsolated, does
+	// not deploy.
+	const nowIsolated = req.isolated ?? wasIsolated;
+	if (nowIsolated) {
+		const {
+			isolatedApplicationRefusal,
+			maxIsolatedApplications,
+		} = require('../server/threads/isolatedApplications.ts');
+		const { runningIsolatedApplications } = require('../server/threads/socketRouter.ts');
+		// counted like the reconcile counts: applications that actually hold a dedicated worker
+		const others = runningIsolatedApplications().filter((name) => name !== req.project).length;
+		const refusal =
+			isolatedApplicationRefusal(req.project) ??
+			(!wasIsolated && others >= maxIsolatedApplications()
+				? `the instance already runs ${maxIsolatedApplications()} isolated application(s) (threads.maxIsolated)`
+				: undefined);
+		if (refusal) {
+			throw handleHDBError(
+				new Error(),
+				`Cannot deploy '${req.project}' as an isolated application: ${refusal}`,
+				HTTP_STATUS_CODES.CONFLICT
+			);
+		}
+	}
 	const { ingestCredentials, resolveCredentials } = require('./secretOperations.ts');
 	req.credentials = await ingestCredentials(req, req.credentials, req.project);
 	// References are safe to persist (config + deployment row) and replicate; a no-custody literal
@@ -624,10 +660,13 @@ async function deployComponent(req) {
 		// application which believed it had a private fork resumes sharing the base after the next
 		// restart, with nothing in this operation to say so.
 		if (req.branchedDatabases !== undefined) applicationConfig.branchedDatabases = req.branchedDatabases;
+		// Kept across a redeploy that omits it: losing it would silently move the application onto the pool.
+		if (nowIsolated) applicationConfig.isolated = true;
 		// Persist credential references (never tokens) so every cold install of this component —
 		// reboot, new peer, rollback — re-resolves the credential from the store.
 		if (credentialReferences.length) applicationConfig.credentials = credentialReferences;
 		await configUtils.addConfig(req.project, applicationConfig);
+		env.initSync(true); // addConfig writes the file, not this thread's cache
 	}
 
 	// Create a hdb_deployment row up front so the deploy is observable and auditable
@@ -803,6 +842,10 @@ async function deployComponent(req) {
 			// when the per-peer callback already fired for these.
 			recorder.recordPeers(response.replicated);
 		}
+		// A still-isolated application restarts only its own dedicated worker. Everything else restarts the
+		// pool: a shared application, and either direction of an isolation flip, where the reconcile in
+		// restartWorkers starts or stops the moving application's own worker.
+		const restartScope = wasIsolated && nowIsolated ? application.name : undefined;
 		if (req.restart === true) {
 			emit('phase', { phase: 'restart', status: 'start' });
 			// Workers not yet replaced keep serving the pre-deploy component set, and where the OS lets
@@ -811,7 +854,7 @@ async function deployComponent(req) {
 			// never heard of it.
 			const { awaitRestart } = require('./awaitRestart.ts');
 			const restart = await awaitRestart((onProgress) =>
-				manageThreads.restartWorkers('http', undefined, undefined, onProgress)
+				manageThreads.restartWorkers('http', undefined, undefined, onProgress, restartScope)
 			);
 			emit('phase', { phase: 'restart', status: 'done' });
 			logRestartOutcome(restart, `deploying ${application.name}`);
@@ -822,6 +865,7 @@ async function deployComponent(req) {
 			const jobResponse = await serverUtilities.executeJob({
 				operation: 'restart_service',
 				service: 'http',
+				scope: manageThreads.encodeRestartScope(restartScope),
 				replicated: true,
 			});
 			emit('phase', { phase: 'restart', status: 'done' });
@@ -1311,6 +1355,9 @@ async function dropComponent(req) {
 	const componentsRoot = configUtils.getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT);
 	const componentPath = path.join(componentsRoot, project);
 	const pathToComponent = path.join(componentsRoot, projectPath);
+	// Read before the config entry goes: an isolated application's drop restarts only its own worker.
+	const { isIsolatedApplication } = require('../server/threads/isolatedApplications.ts');
+	const restartScope = isIsolatedApplication(project) ? project : undefined;
 
 	let response;
 	await withComponentPreparationLock(
@@ -1356,6 +1403,7 @@ async function dropComponent(req) {
 				parentPort.postMessage({
 					type: hdbTerms.ITC_EVENT_TYPES.RESTART,
 					workerType: 'http',
+					scope: manageThreads.encodeRestartScope(restartScope),
 					removeBranchesFor: file ? undefined : project,
 				});
 				if (branched) {
@@ -1366,7 +1414,7 @@ async function dropComponent(req) {
 			}
 			const { awaitRestart } = require('./awaitRestart.ts');
 			const restart = await awaitRestart((onProgress) =>
-				manageThreads.restartWorkers('http', undefined, undefined, onProgress)
+				manageThreads.restartWorkers('http', undefined, undefined, onProgress, restartScope)
 			);
 			logRestartOutcome(restart, `dropping ${projectPath}`);
 			if (!branched) return;

--- a/components/operations.js
+++ b/components/operations.js
@@ -600,14 +600,15 @@ async function deployComponent(req) {
 			HTTP_STATUS_CODES.BAD_REQUEST
 		);
 	}
-	// Admission is checked here, where the caller can be told, not only at worker start where a refusal
-	// is a log line: an isolated application nothing could reach, or one past threads.maxIsolated, does
-	// not deploy.
+	// Only the originating node rejects admission: replicated peers must commit the same desired config,
+	// then report any node-local inability to run it through component lifecycle status.
 	const nowIsolated = req.isolated ?? wasIsolated;
-	if (nowIsolated) {
+	const isReplicatedExecution = typeof req._deploymentId === 'string';
+	if (nowIsolated && !isReplicatedExecution) {
 		const {
 			isolatedApplicationRefusal,
 			isolatedApplicationCapacityRefusal,
+			presentIsolatedApplicationNames,
 		} = require('../server/threads/isolatedApplications.ts');
 		let runningApplications;
 		try {
@@ -616,9 +617,10 @@ async function deployComponent(req) {
 			throw handleHDBError(
 				error,
 				`Cannot deploy '${req.project}' as an isolated application: the main thread's worker topology is unavailable: ${error.message}`,
-				HTTP_STATUS_CODES.CONFLICT
+				HTTP_STATUS_CODES.SERVICE_UNAVAILABLE
 			);
 		}
+		runningApplications = new Set([...runningApplications, ...presentIsolatedApplicationNames()]);
 		const refusal =
 			isolatedApplicationRefusal(req.project) ?? isolatedApplicationCapacityRefusal(req.project, runningApplications);
 		if (refusal) {
@@ -682,7 +684,6 @@ async function deployComponent(req) {
 	// recording so we don't accumulate one row per node for the same deploy. The row
 	// reaches peers via the table's standard replication; the peer-side branch below
 	// reads payload_blob back from there.
-	const isReplicatedExecution = typeof req._deploymentId === 'string';
 	// An SSE-bound caller already attached a ProgressEmitter (created in the server
 	// handler so it can also drive the response stream). Reuse it; otherwise spin up a
 	// fresh emitter so the recorder still gets phase events for non-SSE deploys.

--- a/components/operations.js
+++ b/components/operations.js
@@ -1369,17 +1369,17 @@ async function dropComponent(req) {
 	const componentsRoot = configUtils.getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT);
 	const componentPath = path.join(componentsRoot, project);
 	const pathToComponent = path.join(componentsRoot, projectPath);
-	// Read before the config entry goes: an isolated application's drop restarts only its own worker.
+	// Read before a full drop removes the config entry; a file drop retains it and the same restart scope.
 	const { isIsolatedApplication } = require('../server/threads/isolatedApplications.ts');
 	env.initSync(true);
-	const restartScope = !file && isIsolatedApplication(project) ? project : undefined;
+	const restartScope = isIsolatedApplication(project) ? project : undefined;
 
 	let response;
 	await withComponentPreparationLock(
 		componentPath,
 		async () => {
 			const componentSymlink = path.join(env.get(hdbTerms.CONFIG_PARAMS.ROOTPATH), 'node_modules', project);
-			if (await fs.pathExists(componentSymlink)) {
+			if (!file && (await fs.pathExists(componentSymlink))) {
 				await fs.unlink(componentSymlink);
 			}
 
@@ -1390,7 +1390,7 @@ async function dropComponent(req) {
 			}
 
 			const packageJsonPath = path.join(env.get(hdbTerms.CONFIG_PARAMS.ROOTPATH), 'package.json');
-			if (await fs.pathExists(packageJsonPath)) {
+			if (!file && (await fs.pathExists(packageJsonPath))) {
 				const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
 				if (packageJson?.dependencies?.[project]) {
 					delete packageJson.dependencies[project];
@@ -1398,11 +1398,11 @@ async function dropComponent(req) {
 				await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8');
 			}
 
-			configUtils.deleteConfigFromFile([project]);
+			if (!file) configUtils.deleteConfigFromFile([project]);
 			// The main thread's cached config still names the project; the restart below installs every
 			// package application in that cache, and installing this one would take the lock held here.
 			// (A worker's RESTART message refreshes main's config the same way.)
-			if (isMainThread) env.initSync(true);
+			if (!file && isMainThread) env.initSync(true);
 			response = await server.replication.replicateOperation(req);
 			const { applicationHasBranchStorage, removeBranchesForApplication } = require('../resources/branchDatabase.ts');
 			const branched = !file && applicationHasBranchStorage(project);

--- a/components/operations.js
+++ b/components/operations.js
@@ -604,6 +604,7 @@ async function deployComponent(req) {
 	// then report any node-local inability to run it through component lifecycle status.
 	const nowIsolated = req.isolated ?? wasIsolated;
 	const isReplicatedExecution = typeof req._deploymentId === 'string';
+	if (!isReplicatedExecution && req.package) req.isolated = nowIsolated;
 	if (nowIsolated && !isReplicatedExecution) {
 		const {
 			isolatedApplicationRefusal,
@@ -620,7 +621,10 @@ async function deployComponent(req) {
 				HTTP_STATUS_CODES.SERVICE_UNAVAILABLE
 			);
 		}
-		runningApplications = new Set([...runningApplications, ...presentIsolatedApplicationNames()]);
+		runningApplications = new Set([
+			...runningApplications,
+			...presentIsolatedApplicationNames().filter((application) => !isolatedApplicationRefusal(application)),
+		]);
 		const refusal =
 			isolatedApplicationRefusal(req.project) ?? isolatedApplicationCapacityRefusal(req.project, runningApplications);
 		if (refusal) {
@@ -872,6 +876,7 @@ async function deployComponent(req) {
 				operation: 'restart_service',
 				service: 'http',
 				scope: manageThreads.encodeRestartScope(restartScope),
+				scopeFallback: restartScope === undefined ? undefined : manageThreads.encodeRestartScope(undefined),
 				replicated: true,
 			});
 			emit('phase', { phase: 'restart', status: 'done' });
@@ -1366,6 +1371,7 @@ async function dropComponent(req) {
 	const pathToComponent = path.join(componentsRoot, projectPath);
 	// Read before the config entry goes: an isolated application's drop restarts only its own worker.
 	const { isIsolatedApplication } = require('../server/threads/isolatedApplications.ts');
+	env.initSync(true);
 	const restartScope = isIsolatedApplication(project) ? project : undefined;
 
 	let response;

--- a/components/operations.js
+++ b/components/operations.js
@@ -590,10 +590,12 @@ async function deployComponent(req) {
 	// no custody a literal token stays as a transient, this-node-only fallback (#1158). Peers
 	// re-running a replicated deploy already carry references and never re-ingest.
 	const { isIsolatedApplication } = require('../server/threads/isolatedApplications.ts');
+	const requestedIsolation = req.isolated;
+	const isReplicatedExecution = typeof req._deploymentId === 'string';
 	// this thread's cached config may predate an earlier deploy that changed the entry without a restart
 	env.initSync(true);
-	const wasIsolated = isIsolatedApplication(req.project);
-	if (req.isolated !== undefined && !req.package) {
+	const initiallyIsolated = isIsolatedApplication(req.project);
+	if (requestedIsolation !== undefined && !req.package) {
 		throw handleHDBError(
 			new Error(),
 			`'isolated' is only supported for package deployments; set it on the application's root config entry instead`,
@@ -602,10 +604,8 @@ async function deployComponent(req) {
 	}
 	// Only the originating node rejects admission: replicated peers must commit the same desired config,
 	// then report any node-local inability to run it through component lifecycle status.
-	const nowIsolated = req.isolated ?? wasIsolated;
-	const isReplicatedExecution = typeof req._deploymentId === 'string';
-	if (!isReplicatedExecution && req.package) req.isolated = nowIsolated;
-	if (nowIsolated && !isReplicatedExecution) {
+	const assertIsolationAdmission = async (isolated) => {
+		if (!isolated || isReplicatedExecution) return;
 		const {
 			isolatedApplicationRefusal,
 			isolatedApplicationCapacityRefusal,
@@ -634,14 +634,14 @@ async function deployComponent(req) {
 				HTTP_STATUS_CODES.CONFLICT
 			);
 		}
-	}
+	};
+	await assertIsolationAdmission(requestedIsolation ?? initiallyIsolated);
 	const { ingestCredentials, resolveCredentials } = require('./secretOperations.ts');
 	req.credentials = await ingestCredentials(req, req.credentials, req.project);
 	// References are safe to persist (config + deployment row) and replicate; a no-custody literal
 	// token is not — it is used only for this node's install below, then stripped before replication.
 	const credentialReferences = (req.credentials ?? []).filter((entry) => entry && entry.secret !== undefined);
 
-	// Write to root config if the request contains a package identifier
 	if (req.package) {
 		// Check if trying to overwrite a core component (requires force)
 		// Lazy-load to avoid circular dependency with componentLoader
@@ -653,32 +653,9 @@ async function deployComponent(req) {
 				HTTP_STATUS_CODES.CONFLICT
 			);
 		}
-
-		const applicationConfig = { package: req.package };
-		// Avoid writing an empty `install:` block
-		if (req.install_command || req.install_timeout || req.install_allow_scripts !== undefined) {
-			applicationConfig.install = {
-				command: req.install_command,
-				timeout: req.install_timeout,
-				allowInstallScripts: req.install_allow_scripts,
-			};
-		}
-		if (req.urlPath !== undefined) applicationConfig.urlPath = req.urlPath;
-		if (req.host !== undefined) applicationConfig.host = req.host;
-		// Same convention as host/urlPath above, and for the same reason: a package redeploy rebuilds
-		// this application's whole root-config entry from request fields, so a deployment-level key that
-		// isn't re-supplied here is silently dropped -- for branchedDatabases specifically, that means an
-		// application which believed it had a private fork resumes sharing the base after the next
-		// restart, with nothing in this operation to say so.
-		if (req.branchedDatabases !== undefined) applicationConfig.branchedDatabases = req.branchedDatabases;
-		// Kept across a redeploy that omits it: losing it would silently move the application onto the pool.
-		if (nowIsolated) applicationConfig.isolated = true;
-		// Persist credential references (never tokens) so every cold install of this component —
-		// reboot, new peer, rollback — re-resolves the credential from the store.
-		if (credentialReferences.length) applicationConfig.credentials = credentialReferences;
-		await configUtils.addConfig(req.project, applicationConfig);
-		env.initSync(true); // addConfig writes the file, not this thread's cache
 	}
+	let wasIsolated;
+	let nowIsolated;
 
 	// Create a hdb_deployment row up front so the deploy is observable and auditable
 	// even if the CLI disconnects. The row also holds the payload in a Blob attribute,
@@ -805,6 +782,29 @@ async function deployComponent(req) {
 		// is the authority on whether the deploy landed, not the phase stream.
 		emit('phase', { phase: 'prepare', status: 'start' });
 		await prepareApplication(application, {
+			beforePrepare: async () => {
+				env.initSync(true);
+				wasIsolated = isIsolatedApplication(req.project);
+				nowIsolated = requestedIsolation ?? wasIsolated;
+				await assertIsolationAdmission(nowIsolated);
+				if (!isReplicatedExecution && req.package) req.isolated = nowIsolated;
+				if (!req.package) return;
+				const applicationConfig = { package: req.package };
+				if (req.install_command || req.install_timeout || req.install_allow_scripts !== undefined) {
+					applicationConfig.install = {
+						command: req.install_command,
+						timeout: req.install_timeout,
+						allowInstallScripts: req.install_allow_scripts,
+					};
+				}
+				if (req.urlPath !== undefined) applicationConfig.urlPath = req.urlPath;
+				if (req.host !== undefined) applicationConfig.host = req.host;
+				if (req.branchedDatabases !== undefined) applicationConfig.branchedDatabases = req.branchedDatabases;
+				if (nowIsolated) applicationConfig.isolated = true;
+				if (credentialReferences.length) applicationConfig.credentials = credentialReferences;
+				await configUtils.addConfig(req.project, applicationConfig);
+				env.initSync(true);
+			},
 			validateCandidate: async (candidateDirPath) => {
 				emit('phase', { phase: 'prepare', status: 'done' });
 				await validateComponentLoads(candidateDirPath, emit);
@@ -1370,24 +1370,26 @@ async function dropComponent(req) {
 	const componentPath = path.join(componentsRoot, project);
 	const pathToComponent = path.join(componentsRoot, projectPath);
 	let restartScope;
-	if (req.restart === true) {
-		let runningApplications;
-		try {
-			runningApplications = await manageThreads.getRunningIsolatedApplications(ISOLATED_TOPOLOGY_REQUEST_TIMEOUT_MS);
-		} catch (error) {
-			throw handleHDBError(
-				error,
-				`Cannot drop '${project}' with a restart: the main thread's worker topology is unavailable: ${error.message}`,
-				HTTP_STATUS_CODES.SERVICE_UNAVAILABLE
-			);
-		}
-		if (runningApplications.includes(project)) restartScope = project;
-	}
 
 	let response;
 	await withComponentPreparationLock(
 		componentPath,
 		async () => {
+			if (req.restart === true) {
+				let runningApplications;
+				try {
+					runningApplications = await manageThreads.getRunningIsolatedApplications(
+						ISOLATED_TOPOLOGY_REQUEST_TIMEOUT_MS
+					);
+				} catch (error) {
+					throw handleHDBError(
+						error,
+						`Cannot drop '${project}' with a restart: the main thread's worker topology is unavailable: ${error.message}`,
+						HTTP_STATUS_CODES.SERVICE_UNAVAILABLE
+					);
+				}
+				if (runningApplications.includes(project)) restartScope = project;
+			}
 			const componentSymlink = path.join(env.get(hdbTerms.CONFIG_PARAMS.ROOTPATH), 'node_modules', project);
 			if (!file && (await fs.pathExists(componentSymlink))) {
 				await fs.unlink(componentSymlink);

--- a/components/operations.js
+++ b/components/operations.js
@@ -1372,7 +1372,7 @@ async function dropComponent(req) {
 	// Read before the config entry goes: an isolated application's drop restarts only its own worker.
 	const { isIsolatedApplication } = require('../server/threads/isolatedApplications.ts');
 	env.initSync(true);
-	const restartScope = isIsolatedApplication(project) ? project : undefined;
+	const restartScope = !file && isIsolatedApplication(project) ? project : undefined;
 
 	let response;
 	await withComponentPreparationLock(

--- a/components/operations.js
+++ b/components/operations.js
@@ -48,6 +48,7 @@ const {
 const { ProgressEmitter } = require('../server/serverHelpers/progressEmitter.ts');
 
 const DROP_COMPONENT_LOCK_TIMEOUT_MS = 5 * 60 * 1000;
+const ISOLATED_TOPOLOGY_REQUEST_TIMEOUT_MS = 5000;
 
 function componentDropLockOptions(project) {
 	return {
@@ -606,16 +607,20 @@ async function deployComponent(req) {
 	if (nowIsolated) {
 		const {
 			isolatedApplicationRefusal,
-			maxIsolatedApplications,
+			isolatedApplicationCapacityRefusal,
 		} = require('../server/threads/isolatedApplications.ts');
-		const { runningIsolatedApplications } = require('../server/threads/socketRouter.ts');
-		// counted like the reconcile counts: applications that actually hold a dedicated worker
-		const others = runningIsolatedApplications().filter((name) => name !== req.project).length;
+		let runningApplications;
+		try {
+			runningApplications = await manageThreads.getRunningIsolatedApplications(ISOLATED_TOPOLOGY_REQUEST_TIMEOUT_MS);
+		} catch (error) {
+			throw handleHDBError(
+				error,
+				`Cannot deploy '${req.project}' as an isolated application: the main thread's worker topology is unavailable: ${error.message}`,
+				HTTP_STATUS_CODES.CONFLICT
+			);
+		}
 		const refusal =
-			isolatedApplicationRefusal(req.project) ??
-			(!wasIsolated && others >= maxIsolatedApplications()
-				? `the instance already runs ${maxIsolatedApplications()} isolated application(s) (threads.maxIsolated)`
-				: undefined);
+			isolatedApplicationRefusal(req.project) ?? isolatedApplicationCapacityRefusal(req.project, runningApplications);
 		if (refusal) {
 			throw handleHDBError(
 				new Error(),
@@ -885,10 +890,13 @@ async function deployComponent(req) {
 			// An existing component's watched files are handled by Scope/EntryHandler. Package
 			// metadata is deliberately outside most plugin globs, so compare it across the atomic
 			// swap as well: a dependency or module-entry change also invalidates loaded code.
-			if (application.isNewComponent || application.packageMetadataChanged) {
-				const { requestRestart } = require('./requestRestart.ts');
-				requestRestart();
-			}
+			const { requestRestartAfterDeploy } = require('./requestRestart.ts');
+			requestRestartAfterDeploy(
+				application.isNewComponent,
+				application.packageMetadataChanged,
+				wasIsolated,
+				nowIsolated
+			);
 			response.message = `Successfully deployed: ${application.name}`;
 		}
 

--- a/components/operations.js
+++ b/components/operations.js
@@ -1369,10 +1369,20 @@ async function dropComponent(req) {
 	const componentsRoot = configUtils.getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT);
 	const componentPath = path.join(componentsRoot, project);
 	const pathToComponent = path.join(componentsRoot, projectPath);
-	// Read before a full drop removes the config entry; a file drop retains it and the same restart scope.
-	const { isIsolatedApplication } = require('../server/threads/isolatedApplications.ts');
-	env.initSync(true);
-	const restartScope = isIsolatedApplication(project) ? project : undefined;
+	let restartScope;
+	if (req.restart === true) {
+		let runningApplications;
+		try {
+			runningApplications = await manageThreads.getRunningIsolatedApplications(ISOLATED_TOPOLOGY_REQUEST_TIMEOUT_MS);
+		} catch (error) {
+			throw handleHDBError(
+				error,
+				`Cannot drop '${project}' with a restart: the main thread's worker topology is unavailable: ${error.message}`,
+				HTTP_STATUS_CODES.SERVICE_UNAVAILABLE
+			);
+		}
+		if (runningApplications.includes(project)) restartScope = project;
+	}
 
 	let response;
 	await withComponentPreparationLock(
@@ -1399,9 +1409,6 @@ async function dropComponent(req) {
 			}
 
 			if (!file) configUtils.deleteConfigFromFile([project]);
-			// The main thread's cached config still names the project; the restart below installs every
-			// package application in that cache, and installing this one would take the lock held here.
-			// (A worker's RESTART message refreshes main's config the same way.)
 			if (!file && isMainThread) env.initSync(true);
 			response = await server.replication.replicateOperation(req);
 			const { applicationHasBranchStorage, removeBranchesForApplication } = require('../resources/branchDatabase.ts');

--- a/components/operationsValidation.js
+++ b/components/operationsValidation.js
@@ -534,6 +534,7 @@ function deployComponentValidator(req) {
 		// like urlPath/host above, not component config: reusing assertBranchedDatabases here (rather
 		// than re-deriving its rules in Joi) gives a synchronous 400 at deploy time instead of a load
 		// failure discovered much later and disconnected from the request that caused it.
+		isolated: Joi.boolean().optional(),
 		branchedDatabases: Joi.custom((value, helpers) => {
 			try {
 				assertBranchedDatabases(req.project, value);

--- a/components/requestRestart.ts
+++ b/components/requestRestart.ts
@@ -24,6 +24,17 @@ export function requestRestart() {
 	restartArrayBuffer.notify();
 }
 
+export function requestRestartAfterDeploy(
+	isNewComponent: boolean,
+	packageMetadataChanged: boolean,
+	wasIsolated: boolean,
+	isIsolated: boolean
+): boolean {
+	if (!isNewComponent && !packageMetadataChanged && wasIsolated === isIsolated) return false;
+	requestRestart();
+	return true;
+}
+
 export function restartNeeded() {
 	ensureInitialized();
 	return restartNeededArray[0] === 1;

--- a/config-root.schema.json
+++ b/config-root.schema.json
@@ -172,6 +172,10 @@
 					]
 				},
 				"maxHeapMemory": { "type": "number", "description": "Heap memory limit per thread (MB)." },
+				"maxIsolated": {
+					"type": "integer",
+					"description": "Most applications marked isolated that get a dedicated worker thread; the rest fail to load. Default 8."
+				},
 				"heapSnapshotNearLimit": { "type": "boolean", "description": "Take a heap snapshot when near the heap limit." },
 				"preload": {
 					"oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }],

--- a/integrationTests/components/fixtures/isolated-app-two/config.yaml
+++ b/integrationTests/components/fixtures/isolated-app-two/config.yaml
@@ -1,0 +1,3 @@
+rest: true
+jsResource:
+  files: resources.js

--- a/integrationTests/components/fixtures/isolated-app-two/resources.js
+++ b/integrationTests/components/fixtures/isolated-app-two/resources.js
@@ -1,0 +1,8 @@
+import { Resource } from 'harper';
+import { threadId } from 'node:worker_threads';
+
+export class IsolatedTwo extends Resource {
+	get() {
+		return { application: 'isolated-app-two', threadId };
+	}
+}

--- a/integrationTests/components/fixtures/isolated-app/config.yaml
+++ b/integrationTests/components/fixtures/isolated-app/config.yaml
@@ -1,0 +1,3 @@
+rest: true
+jsResource:
+  files: resources.js

--- a/integrationTests/components/fixtures/isolated-app/config.yaml
+++ b/integrationTests/components/fixtures/isolated-app/config.yaml
@@ -1,3 +1,5 @@
 rest: true
+graphqlSchema:
+  files: '*.graphql'
 jsResource:
   files: resources.js

--- a/integrationTests/components/fixtures/isolated-app/drop-me.txt
+++ b/integrationTests/components/fixtures/isolated-app/drop-me.txt
@@ -1,0 +1,1 @@
+This file exists only to exercise a file-only component drop.

--- a/integrationTests/components/fixtures/isolated-app/resources.js
+++ b/integrationTests/components/fixtures/isolated-app/resources.js
@@ -1,8 +1,10 @@
-import { Resource } from 'harper';
+import { Resource, tables } from 'harper';
 import { threadId } from 'node:worker_threads';
 
 export class Isolated extends Resource {
-	get() {
-		return { application: 'isolated-app', threadId };
+	async get() {
+		let rawTtlRecords = 0;
+		for await (const _ of tables.IsolatedTtl.search({ includeExpired: true })) rawTtlRecords++;
+		return { application: 'isolated-app', threadId, rawTtlRecords };
 	}
 }

--- a/integrationTests/components/fixtures/isolated-app/resources.js
+++ b/integrationTests/components/fixtures/isolated-app/resources.js
@@ -1,0 +1,8 @@
+import { Resource } from 'harper';
+import { threadId } from 'node:worker_threads';
+
+export class Isolated extends Resource {
+	get() {
+		return { application: 'isolated-app', threadId };
+	}
+}

--- a/integrationTests/components/fixtures/isolated-app/schema.graphql
+++ b/integrationTests/components/fixtures/isolated-app/schema.graphql
@@ -1,0 +1,4 @@
+type IsolatedTtl @table(expiration: 0.5, scanInterval: 0.1) @export {
+	id: ID @primaryKey
+	value: String
+}

--- a/integrationTests/components/fixtures/shared-sibling/config.yaml
+++ b/integrationTests/components/fixtures/shared-sibling/config.yaml
@@ -1,0 +1,3 @@
+rest: true
+jsResource:
+  files: resources.js

--- a/integrationTests/components/fixtures/shared-sibling/resources.js
+++ b/integrationTests/components/fixtures/shared-sibling/resources.js
@@ -1,0 +1,8 @@
+import { Resource } from 'harper';
+import { threadId } from 'node:worker_threads';
+
+export class Shared extends Resource {
+	get() {
+		return { application: 'shared-sibling', threadId };
+	}
+}

--- a/integrationTests/components/isolated-application.test.ts
+++ b/integrationTests/components/isolated-application.test.ts
@@ -1,0 +1,171 @@
+import { suite, test, before, after } from 'node:test';
+import { strictEqual, ok, deepStrictEqual } from 'node:assert';
+import { resolve, join, basename } from 'node:path';
+import { cp, mkdtemp, readdir, readFile } from 'node:fs/promises';
+import { request } from 'node:http';
+import { tmpdir } from 'node:os';
+import {
+	startHarper,
+	killHarper,
+	teardownHarper,
+	sendOperation,
+	type ContextWithHarper,
+} from '@harperfast/integration-testing';
+
+const ISOLATED = resolve(import.meta.dirname, 'fixtures/isolated-app');
+const SHARED = resolve(import.meta.dirname, 'fixtures/shared-sibling');
+const ISOLATED_TWO = resolve(import.meta.dirname, 'fixtures/isolated-app-two');
+const POOL = 2;
+const CONFIG = {
+	config: {
+		'threads': { count: POOL },
+		// a secure port (the harness adds one when tls is configured) and UDS mirrors: the only surface a
+		// dedicated worker binds
+		'tls': { unixDomainSockets: true },
+		'isolated-app': { isolated: true, host: 'iso.qa.test' },
+		'isolated-app-two': { isolated: true },
+	},
+};
+
+type ThreadInfo = { threadId: number; name: string; application?: string };
+
+async function threads(ctx: ContextWithHarper): Promise<ThreadInfo[]> {
+	const info = await sendOperation(ctx.harper, { operation: 'system_information', attributes: ['threads'] });
+	ok(Array.isArray(info.threads), 'system_information reports threads');
+	return info.threads as ThreadInfo[];
+}
+async function waitFor<T>(
+	probe: () => Promise<T>,
+	accept: (value: T) => boolean,
+	what: string,
+	ms = 20000
+): Promise<T> {
+	const deadline = Date.now() + ms;
+	let last: T;
+	do {
+		last = await probe();
+		if (accept(last)) return last;
+		await new Promise((r) => setTimeout(r, 250));
+	} while (Date.now() < deadline);
+	throw new Error(`${what}: ${JSON.stringify(last)}`);
+}
+const pool = (list: ThreadInfo[]) =>
+	list
+		.filter((t) => t.name === 'http' && !t.application)
+		.map((t) => t.threadId)
+		.sort();
+const dedicated = (list: ThreadInfo[], app = 'isolated-app') => list.filter((t) => t.application === app);
+
+// Windows has no UDS mirrors, so admission refuses a dedicated worker there by design; the Bun listener
+// path is not yet exercised (design note).
+const UNSUPPORTED_HERE = process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun';
+
+suite(
+	'an isolated application runs in a thread of its own (harper#642 tier 2)',
+	{ skip: UNSUPPORTED_HERE },
+	(ctx: ContextWithHarper) => {
+		before(async () => {
+			const dataRootDir = await mkdtemp(
+				join(process.env.HARPER_INTEGRATION_TEST_INSTALL_PARENT_DIR || tmpdir(), 'harper-integration-test-')
+			);
+			ctx.harper = { dataRootDir } as any;
+			for (const fixture of [ISOLATED, SHARED, ISOLATED_TWO]) {
+				await cp(fixture, join(dataRootDir, 'components', basename(fixture)), { recursive: true, dereference: true });
+			}
+			await startHarper(ctx, CONFIG);
+		});
+		after(async () => {
+			await killHarper(ctx);
+			await teardownHarper(ctx);
+		});
+
+		test('gets exactly one dedicated http worker, numbered past the pool', async () => {
+			const list = await threads(ctx);
+			strictEqual(dedicated(list).length, 1, JSON.stringify(list));
+			strictEqual(dedicated(list, 'isolated-app-two').length, 1, 'and so does its isolated sibling');
+			strictEqual(pool(list).length, POOL, 'the pool is untouched by the extra worker');
+		});
+
+		test('the shared port serves the shared application but never the isolated one', async () => {
+			// several requests so both pool workers are hit
+			for (let i = 0; i < 6; i++) {
+				const shared = await fetch(new URL('/Shared/probe', ctx.harper.httpURL));
+				strictEqual(shared.status, 200);
+				deepStrictEqual((await shared.json()).application, 'shared-sibling');
+				const isolated = await fetch(new URL('/Isolated/probe', ctx.harper.httpURL));
+				strictEqual(isolated.status, 404, 'no pool worker loaded the isolated application');
+			}
+		});
+
+		test('is reachable through its own application-named UDS mirror, which publishes its route', async () => {
+			const socketsDir = join(ctx.harper.dataRootDir, 'sockets');
+			const names = await readdir(socketsDir);
+			// the HTTPS mirror, not the one MQTT's per-thread listener publishes under the same application name
+			const mirror = names.find((name) => name.startsWith('app-isolated-app-') && name.endsWith(':9927.sock'));
+			ok(mirror, `no application mirror among ${names.join(', ')}`);
+			const yaml = await readFile(join(socketsDir, mirror.replace(/\.sock$/, '.yaml')), 'utf8');
+			ok(yaml.includes('application: "isolated-app"'), yaml);
+			ok(yaml.includes('- "iso.qa.test"'), yaml);
+
+			const body = await new Promise<string>((resolve, reject) => {
+				const req = request(
+					{
+						socketPath: join(socketsDir, mirror),
+						path: '/Isolated/probe',
+						headers: {
+							host: 'iso.qa.test',
+							// the mirror carries the secure port's chain, authentication included
+							authorization: `Basic ${Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64')}`,
+						},
+					},
+					(res) => {
+						strictEqual(res.statusCode, 200);
+						let data = '';
+						res.on('data', (chunk) => (data += chunk));
+						res.on('end', () => resolve(data));
+					}
+				);
+				req.on('error', reject);
+				req.end();
+			});
+			strictEqual(JSON.parse(body).application, 'isolated-app');
+		});
+
+		test('dropping a shared application restarts the pool and leaves the dedicated worker alone', async () => {
+			const beforeList = await threads(ctx);
+			const isolatedBefore = dedicated(beforeList)[0].threadId;
+			const poolBefore = pool(beforeList);
+
+			await sendOperation(ctx.harper, { operation: 'drop_component', project: 'shared-sibling', restart: true });
+
+			const afterList = await threads(ctx);
+			strictEqual(dedicated(afterList)[0]?.threadId, isolatedBefore, 'the isolated thread survived the restart');
+			const poolAfter = pool(afterList);
+			strictEqual(poolAfter.length, POOL);
+			for (const id of poolAfter) ok(!poolBefore.includes(id), `pool worker ${id} was replaced`);
+			const gone = await fetch(new URL('/Shared/probe', ctx.harper.httpURL));
+			strictEqual(gone.status, 404);
+		});
+
+		test('dropping the isolated application stops its worker and restarts nothing else', async () => {
+			const beforeList = await threads(ctx);
+			const poolBefore = pool(beforeList);
+			const siblingBefore = dedicated(beforeList, 'isolated-app-two')[0].threadId;
+
+			await sendOperation(ctx.harper, { operation: 'drop_component', project: 'isolated-app', restart: true });
+
+			// its shutdown drains asynchronously after the operation answers
+			const afterList = await waitFor(
+				() => threads(ctx),
+				(list) => dedicated(list).length === 0,
+				'dedicated worker still listed'
+			);
+			deepStrictEqual(pool(afterList), poolBefore, 'the pool was not restarted');
+			strictEqual(
+				dedicated(afterList, 'isolated-app-two')[0]?.threadId,
+				siblingBefore,
+				'nor was the other isolated application'
+			);
+		});
+	}
+);

--- a/integrationTests/components/isolated-application.test.ts
+++ b/integrationTests/components/isolated-application.test.ts
@@ -58,8 +58,7 @@ const pool = (list: ThreadInfo[]) =>
 		.sort();
 const dedicated = (list: ThreadInfo[], app = 'isolated-app') => list.filter((t) => t.application === app);
 
-// Windows has no UDS mirrors, so admission refuses a dedicated worker there by design; the Bun listener
-// path is not yet exercised (design note).
+// Windows has no UDS mirrors, so admission refuses a dedicated worker there; the Bun listener path is not yet exercised.
 const UNSUPPORTED_HERE = process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun';
 
 suite(

--- a/integrationTests/components/isolated-application.test.ts
+++ b/integrationTests/components/isolated-application.test.ts
@@ -121,7 +121,11 @@ suite(
 
 		test('is reachable through its own application-named UDS mirror, which publishes its route', async () => {
 			const socketsDir = join(ctx.harper.dataRootDir, 'sockets');
-			const names = await readdir(socketsDir);
+			const names = await waitFor(
+				() => readdir(socketsDir),
+				(entries) => entries.some((name) => name.startsWith('app-isolated%2Dapp-') && name.endsWith(':9927.sock')),
+				'application mirror was not created'
+			);
 			// the HTTPS mirror, not the one MQTT's per-thread listener publishes under the same application name
 			const mirror = names.find((name) => name.startsWith('app-isolated%2Dapp-') && name.endsWith(':9927.sock'));
 			ok(mirror, `no application mirror among ${names.join(', ')}`);

--- a/integrationTests/components/isolated-application.test.ts
+++ b/integrationTests/components/isolated-application.test.ts
@@ -97,7 +97,7 @@ suite(
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({
 					operation: 'deploy_component',
-					project: 'third-isolated',
+					project: 'third',
 					package: 'unused-because-admission-runs-first',
 					isolated: true,
 					restart: false,
@@ -123,7 +123,7 @@ suite(
 			const socketsDir = join(ctx.harper.dataRootDir, 'sockets');
 			const names = await readdir(socketsDir);
 			// the HTTPS mirror, not the one MQTT's per-thread listener publishes under the same application name
-			const mirror = names.find((name) => name.startsWith('app-isolated-app-') && name.endsWith(':9927.sock'));
+			const mirror = names.find((name) => name.startsWith('app-isolated%2Dapp-') && name.endsWith(':9927.sock'));
 			ok(mirror, `no application mirror among ${names.join(', ')}`);
 			const yaml = await readFile(join(socketsDir, mirror.replace(/\.sock$/, '.yaml')), 'utf8');
 			ok(yaml.includes('application: "isolated-app"'), yaml);

--- a/integrationTests/components/isolated-application.test.ts
+++ b/integrationTests/components/isolated-application.test.ts
@@ -129,28 +129,42 @@ suite(
 			ok(yaml.includes('application: "isolated-app"'), yaml);
 			ok(yaml.includes('- "iso.qa.test"'), yaml);
 
-			const body = await new Promise<string>((resolve, reject) => {
-				const req = request(
-					{
-						socketPath: join(socketsDir, mirror),
-						path: '/Isolated/probe',
-						headers: {
-							host: 'iso.qa.test',
-							// the mirror carries the secure port's chain, authentication included
-							authorization: `Basic ${Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64')}`,
+			const requestMirror = (path: string, method = 'GET', body?: string) =>
+				new Promise<{ status: number; body: string }>((resolve, reject) => {
+					const req = request(
+						{
+							socketPath: join(socketsDir, mirror),
+							path,
+							method,
+							headers: {
+								host: 'iso.qa.test',
+								...(body ? { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) } : {}),
+								// the mirror carries the secure port's chain, authentication included
+								authorization: `Basic ${Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64')}`,
+							},
 						},
-					},
-					(res) => {
-						strictEqual(res.statusCode, 200);
-						let data = '';
-						res.on('data', (chunk) => (data += chunk));
-						res.on('end', () => resolve(data));
-					}
-				);
-				req.on('error', reject);
-				req.end();
-			});
-			strictEqual(JSON.parse(body).application, 'isolated-app');
+						(res) => {
+							let data = '';
+							res.on('data', (chunk) => (data += chunk));
+							res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data }));
+						}
+					);
+					req.on('error', reject);
+					if (body) req.write(body);
+					req.end();
+				});
+			const probe = await requestMirror('/Isolated/probe');
+			strictEqual(probe.status, 200, probe.body);
+			strictEqual(JSON.parse(probe.body).application, 'isolated-app');
+
+			const put = await requestMirror('/IsolatedTtl/ttl-probe', 'PUT', JSON.stringify({ value: 'expires' }));
+			ok(put.status >= 200 && put.status < 300, put.body);
+			await waitFor(
+				async () => JSON.parse((await requestMirror('/Isolated/probe')).body).rawTtlRecords,
+				(count) => count === 0,
+				'isolated schema TTL did not physically evict its record',
+				5000
+			);
 		});
 
 		test('dropping a shared application restarts the pool and leaves the dedicated worker alone', async () => {

--- a/integrationTests/components/isolated-application.test.ts
+++ b/integrationTests/components/isolated-application.test.ts
@@ -183,6 +183,26 @@ suite(
 			strictEqual(gone.status, 404);
 		});
 
+		test('dropping one file preserves isolation and restarts only the dedicated worker', async () => {
+			const beforeList = await threads(ctx);
+			const isolatedBefore = dedicated(beforeList)[0].threadId;
+			const poolBefore = pool(beforeList);
+
+			await sendOperation(ctx.harper, {
+				operation: 'drop_component',
+				project: 'isolated-app',
+				file: 'drop-me.txt',
+				restart: true,
+			});
+
+			const afterList = await threads(ctx);
+			deepStrictEqual(pool(afterList), poolBefore, 'the pool was not restarted');
+			strictEqual(dedicated(afterList).length, 1, 'the application remains isolated');
+			ok(dedicated(afterList)[0].threadId !== isolatedBefore, 'the dedicated worker was replaced');
+			const publicRoute = await fetch(new URL('/Isolated/probe', ctx.harper.httpURL));
+			strictEqual(publicRoute.status, 404, 'the remaining application was not exposed on the shared port');
+		});
+
 		test('dropping the isolated application stops its worker and restarts nothing else', async () => {
 			const beforeList = await threads(ctx);
 			const poolBefore = pool(beforeList);

--- a/integrationTests/components/isolated-application.test.ts
+++ b/integrationTests/components/isolated-application.test.ts
@@ -15,15 +15,17 @@ import {
 const ISOLATED = resolve(import.meta.dirname, 'fixtures/isolated-app');
 const SHARED = resolve(import.meta.dirname, 'fixtures/shared-sibling');
 const ISOLATED_TWO = resolve(import.meta.dirname, 'fixtures/isolated-app-two');
+const ISOLATED_TWO_NAME = 'iso-two';
 const POOL = 2;
 const CONFIG = {
 	config: {
-		'threads': { count: POOL },
+		'threads': { count: POOL, maxIsolated: 2 },
 		// a secure port (the harness adds one when tls is configured) and UDS mirrors: the only surface a
 		// dedicated worker binds
 		'tls': { unixDomainSockets: true },
+		'stale-isolated': { isolated: true },
 		'isolated-app': { isolated: true, host: 'iso.qa.test' },
-		'isolated-app-two': { isolated: true },
+		[ISOLATED_TWO_NAME]: { isolated: true },
 	},
 };
 
@@ -69,9 +71,13 @@ suite(
 				join(process.env.HARPER_INTEGRATION_TEST_INSTALL_PARENT_DIR || tmpdir(), 'harper-integration-test-')
 			);
 			ctx.harper = { dataRootDir } as any;
-			for (const fixture of [ISOLATED, SHARED, ISOLATED_TWO]) {
+			for (const fixture of [ISOLATED, SHARED]) {
 				await cp(fixture, join(dataRootDir, 'components', basename(fixture)), { recursive: true, dereference: true });
 			}
+			await cp(ISOLATED_TWO, join(dataRootDir, 'components', ISOLATED_TWO_NAME), {
+				recursive: true,
+				dereference: true,
+			});
 			await startHarper(ctx, CONFIG);
 		});
 		after(async () => {
@@ -82,8 +88,25 @@ suite(
 		test('gets exactly one dedicated http worker, numbered past the pool', async () => {
 			const list = await threads(ctx);
 			strictEqual(dedicated(list).length, 1, JSON.stringify(list));
-			strictEqual(dedicated(list, 'isolated-app-two').length, 1, 'and so does its isolated sibling');
+			strictEqual(dedicated(list, ISOLATED_TWO_NAME).length, 1, 'and so does its isolated sibling');
 			strictEqual(pool(list).length, POOL, 'the pool is untouched by the extra worker');
+		});
+
+		test('rejects another isolated deployment when the dedicated-worker budget is full', async () => {
+			const response = await fetch(ctx.harper.operationsAPIURL, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					operation: 'deploy_component',
+					project: 'third-isolated',
+					package: 'unused-because-admission-runs-first',
+					isolated: true,
+					restart: false,
+				}),
+			});
+			const body = await response.text();
+			strictEqual(response.status, 409, body);
+			ok(body.includes('already runs 2 isolated application(s)'), body);
 		});
 
 		test('the shared port serves the shared application but never the isolated one', async () => {
@@ -150,7 +173,7 @@ suite(
 		test('dropping the isolated application stops its worker and restarts nothing else', async () => {
 			const beforeList = await threads(ctx);
 			const poolBefore = pool(beforeList);
-			const siblingBefore = dedicated(beforeList, 'isolated-app-two')[0].threadId;
+			const siblingBefore = dedicated(beforeList, ISOLATED_TWO_NAME)[0].threadId;
 
 			await sendOperation(ctx.harper, { operation: 'drop_component', project: 'isolated-app', restart: true });
 
@@ -162,7 +185,7 @@ suite(
 			);
 			deepStrictEqual(pool(afterList), poolBefore, 'the pool was not restarted');
 			strictEqual(
-				dedicated(afterList, 'isolated-app-two')[0]?.threadId,
+				dedicated(afterList, ISOLATED_TWO_NAME)[0]?.threadId,
 				siblingBefore,
 				'nor was the other isolated application'
 			);

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1599,7 +1599,7 @@ export function makeTable(options) {
 			}
 			// Re-evaluate an existing table-level scan after an ownership-only declaration, but do not
 			// create the default daily cleanup timer for a table that has only an @expiresAt field.
-			if (!preserveLoadedConfiguration || expirationScanScheduled) scheduleCleanup();
+			if (!preserveLoadedConfiguration || expirationScanScheduled || evictionMs) scheduleCleanup();
 			// @expiresAt has its own interval rather than the cleanup timer above. Arm it whenever a live
 			// declaration introduces the attribute, including after this application already claimed TTL.
 			if (expiresAtProperty && !recordExpirationInterval) runRecordExpirationEviction();

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1575,10 +1575,8 @@ export function makeTable(options) {
 				throw new Error('Invalid expiration value type');
 			const declaredHere = typeof opts === 'object' && opts.fromSchema;
 			const isolatedApplicationOwner = declaredHere && opts.isolatedApplicationOwner;
-			let becameApplicationOwner = false;
 			if (((!ttlFromLoad && !declaredHere) || isolatedApplicationOwner) && !ttlConfiguredByApplication) {
 				ttlConfiguredByApplication = true;
-				becameApplicationOwner = true;
 				// the scan owner may have changed with this: re-evaluate even if the interval did not
 				lastCleanupInterval = undefined;
 			}
@@ -1595,10 +1593,9 @@ export function makeTable(options) {
 			cleanupInterval = cleanupInterval || (expirationMs + evictionMs) / 4;
 			expirationScanScheduled = true;
 			scheduleCleanup();
-			// @expiresAt has its own interval rather than the cleanup timer above. A shared-store table
-			// hydrated in this worker did not arm it during construction, so the owning schema declaration does.
-			if (becameApplicationOwner && expiresAtProperty && !ownsStoreExpiration(primaryStore.path))
-				runRecordExpirationEviction();
+			// @expiresAt has its own interval rather than the cleanup timer above. Arm it whenever a live
+			// declaration introduces the attribute, including after this application already claimed TTL.
+			if (expiresAtProperty && !recordExpirationInterval) runRecordExpirationEviction();
 		}
 
 		static getResidencyRecord(id: Id) {
@@ -6375,7 +6372,7 @@ export function makeTable(options) {
 				ttlFromLoad = false;
 			}
 		}
-		if (expiresAtProperty) runRecordExpirationEviction();
+		if (expiresAtProperty && !recordExpirationInterval) runRecordExpirationEviction();
 	} catch (error) {
 		TableResource.cleanup();
 		throw error;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -96,7 +96,6 @@ import {
 	ownsStoreMaintenance,
 	ownsStoreExpiration,
 	runsApplicationCodeSingletons,
-	isDedicatedWorker,
 } from '../server/threads/manageThreads.js';
 import { HAS_BLOBS, LOCAL_ONLY, auditRetention, removeAuditEntry } from './auditStore.ts';
 import { derivedIndexWriteRejection, hasDerivedIndexRegistration } from './derivedIndexRegistry.ts';
@@ -7469,7 +7468,7 @@ export function makeTable(options) {
 		// Periodically evict expired records and deleted records searching for records who expiresAt timestamp is before now
 		if (cleanupInterval === lastCleanupInterval && !runImmediately) return;
 		lastCleanupInterval = cleanupInterval;
-		if (ownsStoreMaintenance(primaryStore.path) || (ttlConfiguredByApplication && isDedicatedWorker())) {
+		if (ownsStoreMaintenance(primaryStore.path)) {
 			// run on the last thread so we aren't overloading lower-numbered threads
 			if (cleanupTimer) clearTimeout(cleanupTimer);
 			if (!cleanupInterval) {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1558,7 +1558,8 @@ export function makeTable(options) {
 		 * This also informs the scheduling for record eviction.
 		 * @param opts Time in seconds until records expire, or an options object with `expiration`, `eviction`,
 		 * and `scanInterval` (all in seconds, all optional). Number form preserves any previously configured
-		 * eviction/scanInterval; object form replaces all three.
+		 * eviction/scanInterval; object form replaces all three. An internal schema ownership-only call with
+		 * none of those values preserves the settings already loaded from the catalog.
 		 */
 		static setTTLExpiration(
 			opts:
@@ -1575,6 +1576,8 @@ export function makeTable(options) {
 				throw new Error('Invalid expiration value type');
 			const declaredHere = typeof opts === 'object' && opts.fromSchema;
 			const isolatedApplicationOwner = declaredHere && opts.isolatedApplicationOwner;
+			const preserveLoadedConfiguration =
+				declaredHere && opts.expiration === undefined && opts.eviction === undefined && opts.scanInterval === undefined;
 			if (((!ttlFromLoad && !declaredHere) || isolatedApplicationOwner) && !ttlConfiguredByApplication) {
 				ttlConfiguredByApplication = true;
 				// the scan owner may have changed with this: re-evaluate even if the interval did not
@@ -1582,17 +1585,21 @@ export function makeTable(options) {
 			}
 			if (typeof opts === 'number') {
 				expirationMs = opts * 1000;
-			} else {
+			} else if (!preserveLoadedConfiguration) {
 				// `??` so an explicit 0 is treated as the user's chosen value, not as "missing"
 				expirationMs = (opts.expiration ?? 0) * 1000;
 				evictionMs = (opts.eviction ?? 0) * 1000;
 				cleanupInterval = (opts.scanInterval ?? 0) * 1000;
 			}
 			if (expirationMs < 0) throw new Error('Expiration can not be negative');
-			// default to one quarter of the total expiration+eviction window
-			cleanupInterval = cleanupInterval || (expirationMs + evictionMs) / 4;
-			expirationScanScheduled = true;
-			scheduleCleanup();
+			if (!preserveLoadedConfiguration) {
+				// default to one quarter of the total expiration+eviction window
+				cleanupInterval = cleanupInterval || (expirationMs + evictionMs) / 4;
+				expirationScanScheduled = true;
+			}
+			// Re-evaluate an existing table-level scan after an ownership-only declaration, but do not
+			// create the default daily cleanup timer for a table that has only an @expiresAt field.
+			if (!preserveLoadedConfiguration || expirationScanScheduled) scheduleCleanup();
 			// @expiresAt has its own interval rather than the cleanup timer above. Arm it whenever a live
 			// declaration introduces the attribute, including after this application already claimed TTL.
 			if (expiresAtProperty && !recordExpirationInterval) runRecordExpirationEviction();

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -7640,7 +7640,9 @@ export function makeTable(options) {
 			recordExpirationInterval = setInterval(async () => {
 				// go through each database and table and then search for expired entries
 				// find any entries that are set to expire before now
-				if (disposed || runningRecordExpiration) return;
+				// updatedAttributes() clears expiresAtProperty when a live redeclaration drops the directive,
+				// and there is nothing left for this interval to scan by
+				if (disposed || runningRecordExpiration || !expiresAtProperty) return;
 				runningRecordExpiration = true;
 				try {
 					const expiresAtName = expiresAtProperty.name;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5887,6 +5887,7 @@ export function makeTable(options) {
 			// Refresh on every call: schema reload mutates `attributes` in place, so the
 			// class-construction snapshot would otherwise go stale.
 			this.embedAttributes = (this.attributes as any[]).filter((a) => a?.embed);
+			expiresAtProperty = this.attributes.find((attribute) => attribute.expiresAt);
 			// Drop registry entries for attributes that are no longer `@embed`, so a dropped
 			// directive doesn't leave a stale embedder or block a default refresh on re-add.
 			const embedNames = new Set(this.embedAttributes.map((a) => a.name));

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -90,7 +90,14 @@ import {
 } from './tracked.ts';
 import { transaction, contextStorage } from './transaction.ts';
 import { MAXIMUM_KEY, writeKey, compareKeys } from 'ordered-binary';
-import { getWorkerIndex, getWorkerCount } from '../server/threads/manageThreads.js';
+import {
+	getWorkerIndex,
+	applicationWorkerIndex,
+	ownsStoreMaintenance,
+	ownsStoreExpiration,
+	runsApplicationCodeSingletons,
+	isDedicatedWorker,
+} from '../server/threads/manageThreads.js';
 import { HAS_BLOBS, LOCAL_ONLY, auditRetention, removeAuditEntry } from './auditStore.ts';
 import { derivedIndexWriteRejection, hasDerivedIndexRegistration } from './derivedIndexRegistry.ts';
 import { buildEmbedBefore, createDefaultEmbedder, type EmbedAttribute, type Embedder } from './models/embedHook.ts';
@@ -535,6 +542,10 @@ export function makeTable(options) {
 		isBranch,
 	} = options;
 	let { expirationMS: expirationMs, evictionMS: evictionMs, audit, trackDeletes } = options;
+	// set when application code (not the schema at load) configured the TTL: the application's own worker
+	// then owns the scan even for a shared store, since no other thread has that configuration
+	let ttlConfiguredByApplication = false;
+	let ttlFromLoad = false; // true only around the creation-time call below
 	evictionMs ??= 0;
 	// Eviction without explicit expiration means expiration:0. Apply at construction so
 	// describe_all sees it on every worker, not just ones that ran setTTLExpiration.
@@ -575,7 +586,7 @@ export function makeTable(options) {
 	let nonPrefetchSequence = 2;
 	let cleanupInterval = 86400000;
 	let cleanupPriority = 0;
-	let lastCleanupInterval: number;
+	let lastCleanupInterval: number | undefined;
 	let cleanupTimer: NodeJS.Timeout;
 	let recordExpirationInterval: NodeJS.Timeout;
 	// a reclamation pass awaits a scheduled cleanup, which only settles from its timer
@@ -1013,8 +1024,8 @@ export function makeTable(options) {
 						omitCurrent: true,
 					};
 					const subscribeOnThisThread = source.subscribeOnThisThread
-						? source.subscribeOnThisThread(getWorkerIndex(), subscriptionOptions)
-						: getWorkerIndex() === 0;
+						? source.subscribeOnThisThread(applicationWorkerIndex(), subscriptionOptions)
+						: runsApplicationCodeSingletons(); // set up by the defining application's code, so it runs where that code does
 					const subscription = hasSubscribe && subscribeOnThisThread && (await source.subscribe?.(subscriptionOptions));
 					if (subscription) {
 						let txnInProgress;
@@ -1551,6 +1562,11 @@ export function makeTable(options) {
 		static setTTLExpiration(opts: number | { expiration?: number; eviction?: number; scanInterval?: number }) {
 			if (opts == null || (typeof opts !== 'number' && typeof opts !== 'object'))
 				throw new Error('Invalid expiration value type');
+			if (!ttlFromLoad && !(typeof opts === 'object' && (opts as any).fromSchema) && !ttlConfiguredByApplication) {
+				ttlConfiguredByApplication = true;
+				// the scan owner may have changed with this: re-evaluate even if the interval did not
+				lastCleanupInterval = undefined;
+			}
 			if (typeof opts === 'number') {
 				expirationMs = opts * 1000;
 			} else {
@@ -6331,7 +6347,14 @@ export function makeTable(options) {
 
 	try {
 		TableResource.updatedAttributes(); // on creation, update accessors as well
-		if (expirationMs) TableResource.setTTLExpiration(expirationMs / 1000);
+		if (expirationMs) {
+			ttlFromLoad = true;
+			try {
+				TableResource.setTTLExpiration(expirationMs / 1000);
+			} finally {
+				ttlFromLoad = false;
+			}
+		}
 		if (expiresAtProperty) runRecordExpirationEviction();
 	} catch (error) {
 		TableResource.cleanup();
@@ -7446,7 +7469,7 @@ export function makeTable(options) {
 		// Periodically evict expired records and deleted records searching for records who expiresAt timestamp is before now
 		if (cleanupInterval === lastCleanupInterval && !runImmediately) return;
 		lastCleanupInterval = cleanupInterval;
-		if (getWorkerIndex() === getWorkerCount() - 1) {
+		if (ownsStoreMaintenance(primaryStore.path) || (ttlConfiguredByApplication && isDedicatedWorker())) {
 			// run on the last thread so we aren't overloading lower-numbered threads
 			if (cleanupTimer) clearTimeout(cleanupTimer);
 			if (!cleanupInterval) {
@@ -7588,7 +7611,7 @@ export function makeTable(options) {
 	}
 	function runRecordExpirationEviction() {
 		// Periodically evict expired records, searching for records who expiresAt timestamp is before now
-		if (getWorkerIndex() === 0) {
+		if (ownsStoreExpiration(primaryStore.path)) {
 			// we want to run the pruning of expired records on only one thread so we don't have conflicts in evicting
 			recordExpirationInterval = setInterval(async () => {
 				// go through each database and table and then search for expired entries

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -96,6 +96,7 @@ import {
 	ownsStoreMaintenance,
 	ownsStoreExpiration,
 	runsApplicationCodeSingletons,
+	isDedicatedWorker,
 } from '../server/threads/manageThreads.js';
 import { HAS_BLOBS, LOCAL_ONLY, auditRetention, removeAuditEntry } from './auditStore.ts';
 import { derivedIndexWriteRejection, hasDerivedIndexRegistration } from './derivedIndexRegistry.ts';
@@ -7468,7 +7469,7 @@ export function makeTable(options) {
 		// Periodically evict expired records and deleted records searching for records who expiresAt timestamp is before now
 		if (cleanupInterval === lastCleanupInterval && !runImmediately) return;
 		lastCleanupInterval = cleanupInterval;
-		if (ownsStoreMaintenance(primaryStore.path)) {
+		if (ownsStoreMaintenance(primaryStore.path) || (ttlConfiguredByApplication && isDedicatedWorker())) {
 			// run on the last thread so we aren't overloading lower-numbered threads
 			if (cleanupTimer) clearTimeout(cleanupTimer);
 			if (!cleanupInterval) {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -542,8 +542,9 @@ export function makeTable(options) {
 		isBranch,
 	} = options;
 	let { expirationMS: expirationMs, evictionMS: evictionMs, audit, trackDeletes } = options;
-	// set when application code (not the schema at load) configured the TTL: the application's own worker
-	// then owns the scan even for a shared store, since no other thread has that configuration
+	// Set when the TTL exists only on this thread: either application code configured it at runtime, or
+	// an isolated application's schema was declared here. Hydrating persisted metadata does not set it:
+	// dedicated workers open unrelated shared tables too, whose scan remains owned by the pool.
 	let ttlConfiguredByApplication = false;
 	let ttlFromLoad = false; // true only around the creation-time call below
 	evictionMs ??= 0;
@@ -1559,11 +1560,25 @@ export function makeTable(options) {
 		 * and `scanInterval` (all in seconds, all optional). Number form preserves any previously configured
 		 * eviction/scanInterval; object form replaces all three.
 		 */
-		static setTTLExpiration(opts: number | { expiration?: number; eviction?: number; scanInterval?: number }) {
+		static setTTLExpiration(
+			opts:
+				| number
+				| {
+						expiration?: number;
+						eviction?: number;
+						scanInterval?: number;
+						fromSchema?: boolean;
+						isolatedApplicationOwner?: boolean;
+				  }
+		) {
 			if (opts == null || (typeof opts !== 'number' && typeof opts !== 'object'))
 				throw new Error('Invalid expiration value type');
-			if (!ttlFromLoad && !(typeof opts === 'object' && (opts as any).fromSchema) && !ttlConfiguredByApplication) {
+			const declaredHere = typeof opts === 'object' && opts.fromSchema;
+			const isolatedApplicationOwner = declaredHere && opts.isolatedApplicationOwner;
+			let becameApplicationOwner = false;
+			if (((!ttlFromLoad && !declaredHere) || isolatedApplicationOwner) && !ttlConfiguredByApplication) {
 				ttlConfiguredByApplication = true;
+				becameApplicationOwner = true;
 				// the scan owner may have changed with this: re-evaluate even if the interval did not
 				lastCleanupInterval = undefined;
 			}
@@ -1580,6 +1595,10 @@ export function makeTable(options) {
 			cleanupInterval = cleanupInterval || (expirationMs + evictionMs) / 4;
 			expirationScanScheduled = true;
 			scheduleCleanup();
+			// @expiresAt has its own interval rather than the cleanup timer above. A shared-store table
+			// hydrated in this worker did not arm it during construction, so the owning schema declaration does.
+			if (becameApplicationOwner && expiresAtProperty && !ownsStoreExpiration(primaryStore.path))
+				runRecordExpirationEviction();
 		}
 
 		static getResidencyRecord(id: Id) {
@@ -7611,7 +7630,7 @@ export function makeTable(options) {
 	}
 	function runRecordExpirationEviction() {
 		// Periodically evict expired records, searching for records who expiresAt timestamp is before now
-		if (ownsStoreExpiration(primaryStore.path)) {
+		if (ownsStoreExpiration(primaryStore.path) || (ttlConfiguredByApplication && isDedicatedWorker())) {
 			// we want to run the pruning of expired records on only one thread so we don't have conflicts in evicting
 			recordExpirationInterval = setInterval(async () => {
 				// go through each database and table and then search for expired entries

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -2,7 +2,7 @@ import { readKey, writeKey } from 'ordered-binary';
 import { initSync, get as envGet } from '../utility/environment/environmentManager.ts';
 import { AUDIT_STORE_NAME } from '../utility/lmdb/terms.ts';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
-import { getWorkerIndex, getWorkerCount } from '../server/threads/manageThreads.js';
+import { getWorkerIndex, ownsStoreMaintenance } from '../server/threads/manageThreads.js';
 import { convertToMS } from '../utility/common_utils.ts';
 import { LAST_TIMESTAMP_PLACEHOLDER, HAS_STRUCTURE_UPDATE, PENDING_LOCAL_TIME } from './RecordEncoder.ts';
 import * as harperLogger from '../utility/logging/harper_logger.ts';
@@ -330,7 +330,7 @@ export function openAuditStore(rootStore) {
 						if (
 							!cleanupStopped &&
 							!storeClosing() &&
-							(!isRocksAuditStore || (getWorkerIndex() === getWorkerCount() - 1 && !pendingCleanupResolve))
+							(!isRocksAuditStore || (ownsStoreMaintenance(rootStore.path) && !pendingCleanupResolve))
 						) {
 							scheduleAuditCleanup();
 						}
@@ -366,7 +366,7 @@ export function openAuditStore(rootStore) {
 		pendingCleanupResolve = null;
 		return lastCleanupResolution ?? Promise.resolve();
 	};
-	if (getWorkerIndex() === getWorkerCount() - 1) {
+	if (ownsStoreMaintenance(rootStore.path)) {
 		scheduleAuditCleanup();
 	}
 	if (getWorkerIndex() === 0 && !timestampErrored) {

--- a/resources/dataLoader.ts
+++ b/resources/dataLoader.ts
@@ -2,7 +2,7 @@ import { basename, extname } from 'node:path';
 import { createHash } from 'node:crypto';
 import { parseDocument } from 'yaml';
 import { Databases, databases, table, Tables, tables } from './databases.ts';
-import { getWorkerIndex } from '../server/threads/manageThreads';
+import { isApplicationPrimaryWorker } from '../server/threads/manageThreads';
 import { HTTP_STATUS_CODES } from '../utility/errors/commonErrors.ts';
 import { ClientError } from '../utility/errors/hdbError.ts';
 import harperLogger from '../utility/logging/harper_logger.ts';
@@ -109,9 +109,8 @@ async function storeHash(
  * Set up file handlers for data files and loads them into the appropriate tables
  */
 export function handleApplication(scope) {
-	// Early return if this isn't worker zero
-	// Currently using getWorkerIndex() over server.workerIndex to appease ts. The latter defined in manageThreads.js.
-	if (getWorkerIndex() !== 0) {
+	// only the application's primary worker loads data: pool worker 0, or an isolated application's own worker
+	if (!isApplicationPrimaryWorker(scope.applicationScope?.name)) {
 		// debug and return
 		dataLoaderLogger.debug?.('Skipping data loader initialization on non-primary worker');
 		return;

--- a/resources/dataLoader.ts
+++ b/resources/dataLoader.ts
@@ -2,7 +2,7 @@ import { basename, extname } from 'node:path';
 import { createHash } from 'node:crypto';
 import { parseDocument } from 'yaml';
 import { Databases, databases, table, Tables, tables } from './databases.ts';
-import { isApplicationPrimaryWorker } from '../server/threads/manageThreads';
+import { isApplicationPrimaryWorker } from '../server/threads/manageThreads.js';
 import { HTTP_STATUS_CODES } from '../utility/errors/commonErrors.ts';
 import { ClientError } from '../utility/errors/hdbError.ts';
 import harperLogger from '../utility/logging/harper_logger.ts';

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -3100,12 +3100,7 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 	if ((hasChanges || refreshRelationshipAttributes) && !target.branch) {
 		databaseEventsEmitter.emit('updateTable', Table, origin !== 'cluster');
 	}
-	if (
-		expiration ||
-		eviction ||
-		scanInterval ||
-		(isolatedApplicationOwner && attributes.some((attribute) => attribute.expiresAt))
-	)
+	if (expiration || eviction || scanInterval || attributes.some((attribute) => attribute.expiresAt))
 		Table.setTTLExpiration({
 			expiration,
 			eviction,

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1800,6 +1800,8 @@ interface TableDefinition {
 	// default Cache-Control for anonymous REST reads; null = schema explicitly has none (clears a
 	// prior value on reload), undefined = caller is not schema-defining (leave the current value)
 	cacheControl?: string | null;
+	/** Internal: this declaration came from the application owned by the current dedicated worker. */
+	isolatedApplicationOwner?: boolean;
 }
 /**
  * Ensure that we have this database object (that holds a set of tables) set up
@@ -2336,13 +2338,18 @@ const GLOBAL_TARGET: TableTarget = {
 /**
  * The factory a branched application declares tables through: each declaration goes to the branch
  * of the database it names, or to `table()` itself for a database the application did not branch.
- * An unbranched application gets `table` by identity -- no wrapper, no per-call routing.
+ * An unbranched, shared application gets `table` by identity. An isolated application still gets a
+ * wrapper so its own declarations can claim their single-threaded maintenance work.
  */
-export function scopedTableFactory(branches?: Map<string, BranchDatabase>): typeof table {
-	if (!branches?.size) return table;
+export function scopedTableFactory(
+	branches?: Map<string, BranchDatabase>,
+	isolatedApplicationOwner = false
+): typeof table {
+	if (!branches?.size && !isolatedApplicationOwner) return table;
 	return function scopedTable<TableResourceType>(tableDefinition: TableDefinition): TableResourceType {
+		if (isolatedApplicationOwner) tableDefinition = { ...tableDefinition, isolatedApplicationOwner: true };
 		// `||`, not `??`: `table()` resolves every falsy name to the default database
-		const branch = branches.get(tableDefinition.database || DEFAULT_DATABASE_NAME);
+		const branch = branches?.get(tableDefinition.database || DEFAULT_DATABASE_NAME);
 		return branch ? declareTable(branchTarget(branch), tableDefinition) : table(tableDefinition);
 	};
 }
@@ -2420,6 +2427,7 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 		properties,
 		hidden,
 		cacheControl,
+		isolatedApplicationOwner,
 	} = tableDefinition;
 	if (!databaseName) databaseName = DEFAULT_DATABASE_NAME;
 	// Reject reserved names here too, not only at the operations API: a database
@@ -3092,13 +3100,19 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 	if ((hasChanges || refreshRelationshipAttributes) && !target.branch) {
 		databaseEventsEmitter.emit('updateTable', Table, origin !== 'cluster');
 	}
-	if (expiration || eviction || scanInterval)
+	if (
+		expiration ||
+		eviction ||
+		scanInterval ||
+		(isolatedApplicationOwner && attributes.some((attribute) => attribute.expiresAt))
+	)
 		Table.setTTLExpiration({
 			expiration,
 			eviction,
 			scanInterval,
-			fromSchema: true, // the load path: every thread that opens the table sees it
-		} as any);
+			fromSchema: true,
+			isolatedApplicationOwner,
+		});
 	logger.trace(`${tableName} table loaded`);
 
 	return Table as TableResourceType;

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1671,6 +1671,8 @@ export function openBranchDatabase(
 	openBranches.set(path, undefined);
 	retakeBranchIdentity(storeName);
 	try {
+		// before the open: table load schedules TTL, eviction and audit cleanup, which ask who owns this store
+		manageThreads.markBranchStorePath(path);
 		rootStore = readRocksMetaDb(path, null, databaseName, { destination: tables, storeName, openedStores });
 		// Pin the handle to the roots the caller proved this branch was published with, before it is
 		// handed out. A row's `storageIndex` is a position in that list, so resolving through current
@@ -1680,6 +1682,7 @@ export function openBranchDatabase(
 		if (blobRoots) databasePaths.set(rootStore as unknown as RootDatabase, blobRoots);
 	} catch (error) {
 		openBranches.delete(path);
+		manageThreads.markBranchStorePath(path, false);
 		releaseBranchIdentity(storeName);
 		const stranded = rocksdbDatabaseEnvs.get(path);
 		rocksdbDatabaseEnvs.delete(path);
@@ -1703,6 +1706,7 @@ export function openBranchDatabase(
 			openBranches.delete(path);
 			releaseBranchIdentity(storeName);
 			rocksdbDatabaseEnvs.delete(path);
+			manageThreads.markBranchStorePath(path, false);
 			closeBranchHandles(path, rootStore, openedStores, tables);
 		},
 	};
@@ -3093,7 +3097,8 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 			expiration,
 			eviction,
 			scanInterval,
-		});
+			fromSchema: true, // the load path: every thread that opens the table sees it
+		} as any);
 	logger.trace(`${tableName} table loaded`);
 
 	return Table as TableResourceType;

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -2486,6 +2486,7 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 	}
 	let hasChanges;
 	let refreshRelationshipAttributes = false;
+	let refreshedLiveAttributes = false;
 	let deferredPrimaryRow: any;
 	let unpublishedPrimaryStore: any;
 	let published = false;
@@ -2494,6 +2495,7 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 	const indicesToRemove = [];
 	try {
 		if (Table) {
+			refreshedLiveAttributes = true;
 			primaryKey = Table.primaryKey;
 			if (Table.primaryStore.rootStore.status === 'closed') {
 				throw new Error(`Can not use a closed data store from ${tableName} class`);
@@ -3074,10 +3076,8 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 	} finally {
 		releaseLock();
 	}
-	if (hasChanges || refreshRelationshipAttributes) {
-		Table.schemaVersion++;
-		Table.updatedAttributes();
-	}
+	if (hasChanges || refreshRelationshipAttributes) Table.schemaVersion++;
+	if (hasChanges || refreshRelationshipAttributes || refreshedLiveAttributes) Table.updatedAttributes();
 	logger.trace(`${tableName} table loading, running index`);
 	const branchPath = target.branch?.path;
 	if (attributesToIndex.length > 0 || indicesToRemove.length > 0) {

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -3,7 +3,7 @@ import { randomBytes } from 'node:crypto';
 import { initSync, getHdbBasePath, get as envGet } from '../utility/environment/environmentManager.ts';
 import { INTERNAL_DBIS_NAME } from '../utility/lmdb/terms.ts';
 import { open, compareKeys, type Database, type RootDatabase } from 'lmdb';
-import { join, extname, basename } from 'path';
+import { join, extname, basename } from 'node:path';
 import {
 	closeSync,
 	existsSync,

--- a/resources/graphql.ts
+++ b/resources/graphql.ts
@@ -2,6 +2,7 @@ import { dirname } from 'path';
 import { Script } from 'node:vm';
 import { scopedTableFactory, table } from './databases.ts';
 import { getWorkerIndex } from '../server/threads/manageThreads.js';
+import { thisThreadOwnsApplication } from '../server/threads/isolatedApplications.ts';
 import { Resources } from './Resources.ts';
 import type { NamedTypeNode, StringValueNode, ValueNode } from 'graphql';
 import { ClientError } from '../utility/errors/hdbError.ts';
@@ -79,7 +80,7 @@ export function handleApplication(scope: import('../components/Scope.ts').Scope)
 			entry.urlPath,
 			entry.absolutePath,
 			scope.resources,
-			scopedTableFactory(scope.applicationScope?.branches),
+			scopedTableFactory(scope.applicationScope?.branches, thisThreadOwnsApplication(scope.applicationScope?.name)),
 			scope.logger
 		);
 	});

--- a/resources/scheduler/scheduler.ts
+++ b/resources/scheduler/scheduler.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, join } from 'node:path';
-import { getWorkerIndex } from '../../server/threads/manageThreads.js';
+import { isApplicationPrimaryWorker } from '../../server/threads/manageThreads.js';
 import { ClientError } from '../../utility/errors/hdbError.ts';
 import { convertToMS } from '../../utility/common_utils.ts';
 import harperLogger from '../../utility/logging/harper_logger.ts';
@@ -94,12 +94,12 @@ export async function handleApplication(scope): Promise<void> {
 	}
 
 	// Activation gates: one worker owns scheduling for the whole node
-	// (getWorkerIndex() === 0 is correct in every threading mode, including
+	// (the application's primary worker is correct in every threading mode, including
 	// threads:0 where the main thread acts as worker 0), and a deploy
 	// pre-flight validation scope must never touch the live engine — it can
 	// share a running component's identity, so registering from it would
 	// displace the real component's jobs (review finding).
-	if (getWorkerIndex() !== 0) {
+	if (!isApplicationPrimaryWorker(scope.applicationScope?.name)) {
 		schedulerLogger.debug?.('Scheduler config validated; activation skipped on non-primary worker');
 		return;
 	}

--- a/resources/scheduler/scheduler.ts
+++ b/resources/scheduler/scheduler.ts
@@ -98,7 +98,7 @@ export async function handleApplication(scope): Promise<void> {
 	// threads:0 where the main thread acts as worker 0), and a deploy
 	// pre-flight validation scope must never touch the live engine — it can
 	// share a running component's identity, so registering from it would
-	// displace the real component's jobs (review finding).
+	// displace the real component's jobs.
 	if (!isApplicationPrimaryWorker(scope.applicationScope?.name)) {
 		schedulerLogger.debug?.('Scheduler config validated; activation skipped on non-primary worker');
 		return;

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -32,6 +32,7 @@ import {
 } from 'node:fs';
 import { EventEmitter } from 'node:events';
 import { whenComponentsLoaded } from '../server/threads/threadServer.js';
+import { thisThreadOwnsApplication } from '../server/threads/isolatedApplications.ts';
 
 type Lockdown = 'none' | 'freeze' | 'ses' | 'freeze-after-load';
 const APPLICATIONS_LOCKDOWN: Lockdown = env.get(CONFIG_PARAMS.APPLICATIONS_LOCKDOWN);
@@ -893,13 +894,14 @@ function scopedDatabaseBindings(scope: ApplicationScope): { databases: any; tabl
 }
 
 /**
- * `defineTable` for a branched application registers through that application's table factory, so
- * a branched name lands in its branch; an unbranched application gets `defineTable` itself.
+ * `defineTable` for a branched or isolated application registers through that application's table
+ * factory, so a branched name lands in its branch and an isolated schema is tagged with its owner.
  */
 function scopedDefineTable(scope: ApplicationScope): typeof defineTable {
 	const branches = scope.branches;
-	if (!branches?.size) return defineTable;
-	const declareTable = scopedTableFactory(branches);
+	const isolatedApplicationOwner = thisThreadOwnsApplication(scope.name);
+	if (!branches?.size && !isolatedApplicationOwner) return defineTable;
+	const declareTable = scopedTableFactory(branches, isolatedApplicationOwner);
 	return function (name: string, shape: any, options?: any) {
 		return defineTableUsing(declareTable, name, shape, options);
 	} as typeof defineTable;

--- a/server/http.ts
+++ b/server/http.ts
@@ -283,6 +283,19 @@ export function cleanupSocketsDirectory() {
 	} catch {}
 }
 
+export function cleanupApplicationSockets(application: string) {
+	const socketsDir = join(env.getHdbBasePath(), 'sockets');
+	const prefix = applicationSocketName(application, '');
+	try {
+		for (const file of readdirSync(socketsDir)) {
+			if (!file.startsWith(prefix) || (!file.endsWith('.sock') && !file.endsWith('.yaml'))) continue;
+			try {
+				unlinkSync(join(socketsDir, file));
+			} catch {}
+		}
+	} catch {}
+}
+
 // Entries in `universalHeaders` that were pushed by `applySecurityHeaders`, so a config
 // hot-reload can remove exactly the entries it owns without clobbering entries pushed by
 // other components.

--- a/server/http.ts
+++ b/server/http.ts
@@ -12,6 +12,11 @@ import * as env from '../utility/environment/environmentManager.ts';
 import * as terms from '../utility/hdbTerms.ts';
 import { getConfigPath } from '../config/configUtils.ts';
 import { getTicketKeys, getWorkerIndex } from './threads/manageThreads.js';
+import {
+	applicationSocketName,
+	isolatedApplicationRoute,
+	thisThreadsIsolatedApplication,
+} from './threads/isolatedApplications.ts';
 import { createTLSSelector, getEffectiveTlsCiphers } from '../security/keys.ts';
 import { createSecureServer, createServer as createH2CServer } from 'node:http2';
 import { createServer as createSecureServerHttp1 } from 'node:https';
@@ -196,10 +201,21 @@ export function writeUdsMetadata(
 	port: number | string,
 	secureServer: any,
 	protocol?: string,
-	mtlsForwarding = true
+	mtlsForwarding = true,
+	route: { application: string; hosts: string[] } | undefined = isolatedApplicationRoute()
 ) {
 	const contexts = secureServer.secureContexts;
 	let yaml = `pid: ${process.pid}\ntid: ${currentThreadId()}\nport: ${port}\n`;
+	// Routing identity, separate from certificate coverage: a proxy sends this application's hosts to
+	// this socket alone, whatever hostnames the (shared, possibly wildcard) certificates carry.
+	if (route) {
+		yaml += `application: ${JSON.stringify(route.application)}\n`;
+		if (route.hosts.length === 0) yaml += `applicationHosts: []\n`;
+		else {
+			yaml += `applicationHosts:\n`;
+			for (const host of route.hosts) yaml += `  - ${JSON.stringify(host)}\n`;
+		}
+	}
 	// Which application protocol this socket speaks (absent = http/1.1, the historical
 	// default) — lets a fronting proxy route by negotiated ALPN.
 	if (protocol) yaml += `protocol: ${protocol}\n`;
@@ -875,7 +891,10 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 		if (secure && env.get(terms.CONFIG_PARAMS.TLS_UNIXDOMAINSOCKETS)) {
 			const socketsDir = join(env.getHdbBasePath(), 'sockets');
 			mkdirSync(socketsDir, { recursive: true });
-			const socketName = `${getWorkerIndex()}-${port}`;
+			const isolatedApplication = thisThreadsIsolatedApplication();
+			const socketName = isolatedApplication
+				? applicationSocketName(isolatedApplication, port)
+				: `${getWorkerIndex()}-${port}`;
 			const udsPath = join(socketsDir, `${socketName}.sock`);
 			const yamlPath = join(socketsDir, `${socketName}.yaml`);
 

--- a/server/storageReclamation.ts
+++ b/server/storageReclamation.ts
@@ -1,7 +1,7 @@
 import { readFile, realpath } from 'node:fs/promises';
 import { statfs } from 'node:fs/promises';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
-import { getWorkerIndex, getWorkerCount } from '../server/threads/manageThreads.js';
+import { ownsStoreMaintenance } from '../server/threads/manageThreads.js';
 import { logger } from '../utility/logging/logger.ts';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import * as envMgr from '../utility/environment/environmentManager.ts';
@@ -106,7 +106,7 @@ export function onStorageReclamation(
 	handler: (priority: number) => Promise<void> | void,
 	skipThreadCheck?: boolean
 ) {
-	if (skipThreadCheck || getWorkerIndex() === getWorkerCount() - 1) {
+	if (skipThreadCheck || ownsStoreMaintenance(path)) {
 		// only run on one thread (last one)
 		if (!path) {
 			throw new Error('Storage reclamation path cannot be empty');

--- a/server/threads/isolatedApplications.ts
+++ b/server/threads/isolatedApplications.ts
@@ -93,6 +93,19 @@ export function shouldLoadApplicationHere(
 }
 
 /**
+ * Whether this thread starts the uWS listener for one `uwsServeConfigs` entry (see listenOnPorts()).
+ * A dedicated worker starts only its own per-application UDS mirrors -- the entries that carry a
+ * `socketPath` -- and never a global port listener, which the kernel would hand connections for every
+ * other application.
+ */
+export function shouldStartUwsListenerHere(
+	serveConfig: { socketPath?: string },
+	owner: string | undefined = thisThreadsIsolatedApplication()
+): boolean {
+	return owner === undefined || Boolean(serveConfig.socketPath);
+}
+
+/**
  * Whether a dedicated worker can be reached at all: it binds only UDS mirrors of the secure port, so
  * without `tls.unixDomainSockets` and a secure port an isolated application would load and answer
  * nothing, silently. Refused at admission instead. Returns the reason, or undefined when reachable.

--- a/server/threads/isolatedApplications.ts
+++ b/server/threads/isolatedApplications.ts
@@ -1,0 +1,110 @@
+/**
+ * Isolated applications: an application whose root-config entry carries `isolated: true` runs in a
+ * worker thread of its own that loads no other application (harper#642, tier 2).
+ *
+ * The invariant every helper here serves: an isolated application is loaded by exactly one thread,
+ * and that thread loads nothing else. The dedicated worker is an ordinary `http` worker by type --
+ * so restarts, overlap rules and shutdown treat it as one -- distinguished only by
+ * `workerData.isolatedApplication`. It binds none of the public ports (the kernel would hand it
+ * connections for every other application) and is reachable only through its own UDS mirror, whose
+ * metadata names the application and its hosts for the fronting proxy to route by.
+ */
+import { isMainThread, workerData } from 'node:worker_threads';
+import { getWorkerIndex } from './manageThreads.js';
+import { getConfigObj } from '../../config/configUtils.ts';
+import * as env from '../../utility/environment/environmentManager.ts';
+import { CONFIG_PARAMS } from '../../utility/hdbTerms.ts';
+import { isDomainSocketPathTooLong } from '../../utility/domainSocket.ts';
+import { join } from 'node:path';
+
+export const DEFAULT_MAX_ISOLATED_APPLICATIONS = 8;
+
+/** The application this thread is dedicated to, if it is a dedicated worker. */
+export function thisThreadsIsolatedApplication(): string | undefined {
+	return (workerData as any)?.isolatedApplication;
+}
+
+export function isIsolatedApplication(
+	appName: string,
+	config: Record<string, any> | undefined = getConfigObj()
+): boolean {
+	const entry = config?.[appName];
+	return typeof entry === 'object' && entry !== null && entry.isolated === true;
+}
+
+/** Every application the root config marks isolated, in config order. */
+export function isolatedApplicationNames(config: Record<string, any> | undefined = getConfigObj()): string[] {
+	if (!config) return [];
+	return Object.keys(config).filter((name) => isIsolatedApplication(name, config));
+}
+
+export function maxIsolatedApplications(): number {
+	const configured = Number(env.get(CONFIG_PARAMS.THREADS_MAXISOLATED));
+	return Number.isInteger(configured) && configured >= 0 ? configured : DEFAULT_MAX_ISOLATED_APPLICATIONS;
+}
+
+/**
+ * Whether the calling thread is the one that loads the application `appName` (an application: a
+ * directory under componentsRoot, or a root-config entry with `package`). A dedicated worker loads
+ * only its own application; every other thread -- pool workers and the main thread alike -- loads only
+ * the applications that are not isolated. Decided before any of the application's modules are
+ * imported, so a skipped application has no side effects on the thread that skipped it.
+ */
+export function shouldLoadApplicationHere(
+	appName: string,
+	owner: string | undefined = thisThreadsIsolatedApplication(),
+	config: Record<string, any> | undefined = getConfigObj()
+): boolean {
+	if (owner !== undefined) return appName === owner;
+	return !isIsolatedApplication(appName, config);
+}
+
+/**
+ * Whether a dedicated worker can be reached at all: it binds only UDS mirrors of the secure port, so
+ * without `tls.unixDomainSockets` and a secure port an isolated application would load and answer
+ * nothing, silently. Refused at admission instead. Returns the reason, or undefined when reachable.
+ */
+export function isolatedApplicationsUnreachableReason(): string | undefined {
+	// the main thread standing in as the only worker (threads.count: 0) has no thread to give
+	if (isMainThread && getWorkerIndex() === 0) return 'threads.count is 0, so there is no worker thread to dedicate';
+	if (!env.get(CONFIG_PARAMS.HTTP_SECUREPORT)) return 'no http.securePort is configured';
+	if (!env.get(CONFIG_PARAMS.TLS_UNIXDOMAINSOCKETS)) return 'tls.unixDomainSockets is not enabled';
+	return undefined;
+}
+
+/** Why `appName` cannot get a dedicated worker on this instance, or undefined when it can. */
+export function isolatedApplicationRefusal(appName: string): string | undefined {
+	const unreachable = isolatedApplicationsUnreachableReason();
+	if (unreachable) return `its worker would be unreachable: ${unreachable}`;
+	const socketPath = join(
+		env.getHdbBasePath(),
+		'sockets',
+		`${applicationSocketName(appName, env.get(CONFIG_PARAMS.HTTP_SECUREPORT))}.sock`
+	);
+	if (isDomainSocketPathTooLong(socketPath)) return `its UDS mirror path ${socketPath} exceeds the platform limit`;
+	return undefined;
+}
+
+/**
+ * The filesystem name of an isolated worker's UDS mirror for `port`: every UTF-8 byte outside
+ * `[A-Za-z0-9._-]` becomes a fixed-width `%XX`, which is injective (two application names never share
+ * a socket), and the `app-` prefix keeps it apart from the pool's `<workerIndex>-<port>` names.
+ */
+export function applicationSocketName(appName: string, port: number | string): string {
+	let encoded = '';
+	for (const byte of Buffer.from(appName, 'utf8')) {
+		const c = String.fromCharCode(byte);
+		encoded += byte < 0x80 && /[A-Za-z0-9._-]/.test(c) ? c : `%${byte.toString(16).toUpperCase().padStart(2, '0')}`;
+	}
+	return `app-${encoded}-${port}`;
+}
+
+/** What a dedicated worker publishes in its mirror metadata for the proxy to route by. */
+export function isolatedApplicationRoute(
+	appName: string | undefined = thisThreadsIsolatedApplication(),
+	config: Record<string, any> | undefined = getConfigObj()
+): { application: string; hosts: string[] } | undefined {
+	if (!appName) return undefined;
+	const host = config?.[appName]?.host; // a string, as the mount parser requires
+	return { application: appName, hosts: typeof host === 'string' && host ? [host] : [] };
+}

--- a/server/threads/isolatedApplications.ts
+++ b/server/threads/isolatedApplications.ts
@@ -11,11 +11,12 @@
  */
 import { isMainThread, workerData } from 'node:worker_threads';
 import { getWorkerIndex } from './manageThreads.js';
-import { getConfigObj } from '../../config/configUtils.ts';
+import { getConfigObj, getConfigPath } from '../../config/configUtils.ts';
 import * as env from '../../utility/environment/environmentManager.ts';
 import { CONFIG_PARAMS } from '../../utility/hdbTerms.ts';
 import { isDomainSocketPathTooLong } from '../../utility/domainSocket.ts';
-import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { basename, join } from 'node:path';
 
 export const DEFAULT_MAX_ISOLATED_APPLICATIONS = 8;
 
@@ -38,9 +39,27 @@ export function isolatedApplicationNames(config: Record<string, any> | undefined
 	return Object.keys(config).filter((name) => isIsolatedApplication(name, config));
 }
 
+export function presentIsolatedApplicationNames(
+	config: Record<string, any> | undefined = getConfigObj(),
+	componentsRoot: string = getConfigPath(CONFIG_PARAMS.COMPONENTSROOT) as string,
+	installedRoot: string = join(env.get(CONFIG_PARAMS.ROOTPATH), 'components'),
+	runApplicationPath: string | undefined = process.env.RUN_HDB_APP
+): string[] {
+	return isolatedApplicationNames(config).filter(
+		(application) =>
+			existsSync(join(componentsRoot, application)) ||
+			existsSync(join(installedRoot, application)) ||
+			(runApplicationPath && basename(runApplicationPath) === application)
+	);
+}
+
 export function maxIsolatedApplications(): number {
 	const configured = Number(env.get(CONFIG_PARAMS.THREADS_MAXISOLATED));
 	return Number.isInteger(configured) && configured >= 0 ? configured : DEFAULT_MAX_ISOLATED_APPLICATIONS;
+}
+
+export function isolatedWorkerHeapShareCount(poolSize: number, max = maxIsolatedApplications()): number {
+	return poolSize + max;
 }
 
 /** Why `appName` cannot claim a place in the dedicated-worker budget, if the budget is full. */
@@ -75,7 +94,8 @@ export function shouldLoadApplicationHere(
  * without `tls.unixDomainSockets` and a secure port an isolated application would load and answer
  * nothing, silently. Refused at admission instead. Returns the reason, or undefined when reachable.
  */
-export function isolatedApplicationsUnreachableReason(): string | undefined {
+export function isolatedApplicationsUnreachableReason(platform = process.platform): string | undefined {
+	if (platform === 'win32') return 'Windows does not support per-application UDS mirrors';
 	// the main thread standing in as the only worker (threads.count: 0) has no thread to give
 	if (isMainThread && getWorkerIndex() === 0) return 'threads.count is 0, so there is no worker thread to dedicate';
 	if (!env.get(CONFIG_PARAMS.HTTP_SECUREPORT)) return 'no http.securePort is configured';

--- a/server/threads/isolatedApplications.ts
+++ b/server/threads/isolatedApplications.ts
@@ -58,10 +58,6 @@ export function maxIsolatedApplications(): number {
 	return Number.isInteger(configured) && configured >= 0 ? configured : DEFAULT_MAX_ISOLATED_APPLICATIONS;
 }
 
-export function isolatedWorkerHeapShareCount(poolSize: number, max = maxIsolatedApplications()): number {
-	return poolSize + max;
-}
-
 /** Why `appName` cannot claim a place in the dedicated-worker budget, if the budget is full. */
 export function isolatedApplicationCapacityRefusal(
 	appName: string,

--- a/server/threads/isolatedApplications.ts
+++ b/server/threads/isolatedApplications.ts
@@ -25,6 +25,13 @@ export function thisThreadsIsolatedApplication(): string | undefined {
 	return (workerData as any)?.isolatedApplication;
 }
 
+export function thisThreadOwnsApplication(
+	appName: string | undefined,
+	owner: string | undefined = thisThreadsIsolatedApplication()
+): boolean {
+	return owner !== undefined && appName === owner;
+}
+
 export function isIsolatedApplication(
 	appName: string,
 	config: Record<string, any> | undefined = getConfigObj()

--- a/server/threads/isolatedApplications.ts
+++ b/server/threads/isolatedApplications.ts
@@ -114,14 +114,14 @@ export function isolatedApplicationRefusal(appName: string): string | undefined 
 
 /**
  * The filesystem name of an isolated worker's UDS mirror for `port`: every UTF-8 byte outside
- * `[A-Za-z0-9._-]` becomes a fixed-width `%XX`, which is injective (two application names never share
+ * `[A-Za-z0-9._]` becomes a fixed-width `%XX`, which is injective (two application names never share
  * a socket), and the `app-` prefix keeps it apart from the pool's `<workerIndex>-<port>` names.
  */
 export function applicationSocketName(appName: string, port: number | string): string {
 	let encoded = '';
 	for (const byte of Buffer.from(appName, 'utf8')) {
 		const c = String.fromCharCode(byte);
-		encoded += byte < 0x80 && /[A-Za-z0-9._-]/.test(c) ? c : `%${byte.toString(16).toUpperCase().padStart(2, '0')}`;
+		encoded += byte < 0x80 && /[A-Za-z0-9._]/.test(c) ? c : `%${byte.toString(16).toUpperCase().padStart(2, '0')}`;
 	}
 	return `app-${encoded}-${port}`;
 }

--- a/server/threads/isolatedApplications.ts
+++ b/server/threads/isolatedApplications.ts
@@ -43,6 +43,17 @@ export function maxIsolatedApplications(): number {
 	return Number.isInteger(configured) && configured >= 0 ? configured : DEFAULT_MAX_ISOLATED_APPLICATIONS;
 }
 
+/** Why `appName` cannot claim a place in the dedicated-worker budget, if the budget is full. */
+export function isolatedApplicationCapacityRefusal(
+	appName: string,
+	runningApplications: Iterable<string>,
+	max = maxIsolatedApplications()
+): string | undefined {
+	const running = new Set(runningApplications);
+	if (running.has(appName) || running.size < max) return undefined;
+	return `the instance already runs ${max} isolated application(s) (threads.maxIsolated)`;
+}
+
 /**
  * Whether the calling thread is the one that loads the application `appName` (an application: a
  * directory under componentsRoot, or a root-config entry with `package`). A dedicated worker loads

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -668,10 +668,14 @@ async function restartWorkers(
 		const freshlyStarted = new Set(); // dedicated workers the reconcile just started: already on the new code
 		// problematic cyclic dependency, bind late
 		const { resetRestartNeeded } = require('../../components/requestRestart.ts');
-		// The flag stands for pool-loaded code that a deploy left un-live, so only a restart that
-		// replaces the pool can clear it. A restart scoped to one application's dedicated worker leaves
-		// every pool worker on the old code, and clearing it there would report restartRequired: false
-		// while the pending component is still not loaded anywhere.
+		// One process-wide bit cannot say which application is pending, so it is cleared only by a restart
+		// that replaces the pool: that is the one scope guaranteed to load everything the bit could stand
+		// for. Clearing it on a restart scoped to a single dedicated worker would report
+		// restartRequired: false while every pool worker is still on the old code — a silent 404 with no
+		// signal. The cost is the opposite error in one case: a deploy of an already-isolated application
+		// without a restart sets the bit, and a later app-scoped restart of that same application brings
+		// it live without clearing it, so restartRequired stays true until some pool restart happens. A
+		// needless pool restart is recoverable and self-clearing; an un-live component with no signal is not.
 		if (application === undefined || application === '*') resetRestartNeeded();
 		// This is here to prevent circular dependencies
 		if (startReplacementThreads) {

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -598,7 +598,12 @@ function startWorker(path, options = {}) {
 	});
 	worker.on('exit', (_code) => {
 		workers.splice(workers.indexOf(worker), 1);
-		if (!processShuttingDown && !worker.wasShutdown && options.autoRestart !== false) {
+		if (
+			!processShuttingDown &&
+			!worker.wasShutdown &&
+			options.autoRestart !== false &&
+			options.shouldAutoRestart?.(worker) !== false
+		) {
 			// if this wasn't an intentional shutdown, restart now (unless we have tried too many times)
 			if (worker.unexpectedRestarts < MAX_UNEXPECTED_RESTARTS) {
 				options.unexpectedRestarts = worker.unexpectedRestarts + 1;

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -636,9 +636,9 @@ const OVERLAPPING_RESTART_TYPES = [hdbTerms.THREAD_TYPES.HTTP];
  */
 
 /**
- * `application` selects which workers of the type restart: undefined restarts the shared pool only
- * (workers dedicated to an isolated application keep running -- a redeploy of one application must not
- * restart another), a name restarts only that application's dedicated worker, and '*' restarts all.
+ * `application` selects which workers of the type restart: omitted preserves the historic all-worker
+ * behavior, explicit undefined restarts the shared pool only, a name restarts only that application's
+ * dedicated worker, and '*' restarts all.
  */
 async function restartWorkers(
 	name = null,
@@ -647,6 +647,7 @@ async function restartWorkers(
 	onProgress = null,
 	application = undefined
 ) {
+	if (arguments.length < 5) application = '*';
 	if (isMainThread) {
 		// Declining is not the same as delegating: a caller reporting on the restart must not read this
 		// as "another thread is completing it".
@@ -1427,7 +1428,13 @@ if (parentPort && workerData?.addPorts) {
 		});
 } else {
 	getThreadInfo = getChildWorkerInfo;
-	getRunningIsolatedApplications = () => runningIsolatedApplicationsGetter();
+	getRunningIsolatedApplications = isMainThread
+		? () => runningIsolatedApplicationsGetter()
+		: () => {
+				const error = new Error('No channel to the main thread for isolated application topology');
+				error.code = 'ERR_ISOLATED_APPLICATIONS_UNAVAILABLE';
+				return Promise.reject(error);
+			};
 	awaitProcessGroupTermination = (ownerThreadId) =>
 		pendingProcessGroupTerminations.get(ownerThreadId) ?? Promise.resolve();
 }

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -151,6 +151,18 @@ module.exports = {
 	workers,
 	setMonitorListener,
 	onMessageFromWorkers,
+	setIsolatedWorkerReconciler,
+	isApplicationPrimaryWorker,
+	applicationWorkerIndex,
+	runsApplicationCodeSingletons,
+	isDedicatedWorker,
+	markBranchStorePath,
+	ownsStoreMaintenance,
+	ownsStoreExpiration,
+	workersForApplication,
+	stopWorker,
+	encodeRestartScope,
+	decodeRestartScope,
 	onMessageByType,
 	broadcast,
 	broadcastWithAcknowledgement,
@@ -211,6 +223,101 @@ function setTerminateTimeout(newTimeout) {
 function getWorkerIndex() {
 	return workerData ? workerData.workerIndex : isMainWorker ? 0 : undefined;
 }
+/**
+ * The worker that owns `applicationName`'s per-application singletons (its scheduled jobs, its data
+ * files): pool worker 0 for a shared application and for root-level plugins (which pass no name), the
+ * dedicated worker for an isolated one -- never index 0, so node-wide duties stay on the pool, and
+ * never a dedicated worker for anything but its own application.
+ */
+function isApplicationPrimaryWorker(applicationName) {
+	if (workerData?.isolatedApplication !== undefined) return applicationName === workerData.isolatedApplication;
+	return getWorkerIndex() === 0;
+}
+/**
+ * Stores that exist only on this thread: the branch stores an isolated application opened in its
+ * dedicated worker. Registered by openBranchDatabase, so the ownership predicates below can tell them
+ * from the shared stores every thread has open.
+ */
+const branchStorePaths = new Set();
+function markBranchStorePath(path, isBranch = true) {
+	if (isBranch) branchStorePaths.add(path);
+	else branchStorePaths.delete(path);
+}
+/**
+ * Whether this thread runs the "last worker" per-store maintenance for `storePath` (TTL scans, storage
+ * reclamation, audit cleanup). Shared stores belong to the last pool worker; a dedicated worker
+ * maintains only its own branch stores, which no other thread has open.
+ */
+function ownsStoreMaintenance(storePath) {
+	if (workerData?.isolatedApplication !== undefined) return branchStorePaths.has(storePath);
+	return getWorkerIndex() === getWorkerCount() - 1;
+}
+/** The "worker 0" counterpart: expiration eviction for `storePath`. */
+function ownsStoreExpiration(storePath) {
+	if (workerData?.isolatedApplication !== undefined) return branchStorePaths.has(storePath);
+	return getWorkerIndex() === 0;
+}
+/**
+ * Whether a singleton set up by APPLICATION CODE runs here (a caching table's `sourcedFrom`
+ * subscription): pool worker 0, or a dedicated worker -- the only code that runs on one is its own
+ * application's, so whatever it sets up is that application's to run. Not for root-level plugins,
+ * which load on every thread and must use isApplicationPrimaryWorker(name).
+ */
+function runsApplicationCodeSingletons() {
+	return getWorkerIndex() === 0 || workerData?.isolatedApplication !== undefined;
+}
+/** Whether this thread is a worker dedicated to one isolated application. */
+function isDedicatedWorker() {
+	return workerData?.isolatedApplication !== undefined;
+}
+/** The worker index as the application sees it: a dedicated worker is its application's worker 0. */
+function applicationWorkerIndex() {
+	return workerData?.isolatedApplication !== undefined ? 0 : getWorkerIndex();
+}
+/** Every started worker dedicated to `application`, including a replacement still booting. */
+function workersForApplication(application) {
+	return workers.filter((worker) => worker.application === application);
+}
+/**
+ * Stop one worker for good: shut it down, honour the drain extension it may ask for, force it after
+ * the same backstop the rolling restart uses (FORCE_EXIT on Bun, where terminate() segfaults), and
+ * resolve once it has exited. Marked as shut down first so its exit does not start a replacement.
+ */
+function stopWorker(worker) {
+	worker.wasShutdown = true;
+	return new Promise((resolve) => {
+		const armTerminate = (delay) =>
+			setTimeout(() => {
+				harperLogger.warn('Thread did not voluntarily terminate, terminating from the outside', worker.threadId);
+				if (isBun) {
+					try {
+						worker.postMessage({ type: FORCE_EXIT });
+					} catch {}
+				} else {
+					worker.terminate();
+				}
+			}, delay).unref();
+		let timeout = armTerminate(threadTerminationTimeout * 2);
+		worker.extendTerminateDeadline = (deadlineMs) => {
+			clearTimeout(timeout);
+			const { boundedTerminateDelay, getShutdownDrainCeilingMs } = require('../../components/shutdownDrain.ts');
+			timeout = armTerminate(
+				boundedTerminateDelay(deadlineMs, Date.now(), threadTerminationTimeout * 2, getShutdownDrainCeilingMs())
+			);
+		};
+		worker.on('exit', () => {
+			clearTimeout(timeout);
+			worker.extendTerminateDeadline = undefined;
+			resolve();
+		});
+		try {
+			worker.postMessage({ restartNumber: module.exports.restartNumber, type: hdbTerms.ITC_EVENT_TYPES.SHUTDOWN });
+		} catch {
+			clearTimeout(timeout);
+			resolve(); // already gone
+		}
+	});
+}
 function getWorkerCount() {
 	return workerData ? workerData.workerCount : isMainWorker ? 1 : undefined;
 }
@@ -247,6 +354,7 @@ const RESERVED_WORKER_DATA_KEYS = [
 	'processIncarnation',
 	'ticketKeys',
 	'noServerStart',
+	'isolatedApplication',
 	'__proto__', // never a legitimate payload name; spread would define it as an own property
 ];
 const workerDataProviders = new Map();
@@ -300,14 +408,17 @@ function getTicketKeys() {
 	ticketKeys = isMainThread ? randomBytes(48) : workerData.ticketKeys;
 	return ticketKeys;
 }
+// What application code sees: a dedicated worker is its application's only worker, index 0 of 1, so
+// the documented partitioning idiom (`hash % server.workerCount === server.workerIndex`) covers
+// everything there. Node-wide duties keep using the raw getWorkerIndex/getWorkerCount.
 Object.defineProperty(server, 'workerIndex', {
 	get() {
-		return getWorkerIndex();
+		return applicationWorkerIndex();
 	},
 });
 Object.defineProperty(server, 'workerCount', {
 	get() {
-		return getWorkerCount();
+		return workerData?.isolatedApplication !== undefined ? 1 : getWorkerCount();
 	},
 });
 if (!parentPort) {
@@ -376,7 +487,7 @@ function startWorker(path, options = {}) {
 	availableMemory = Math.min(availableMemory, totalmem(), 20000 * MB);
 	const maxOldMemory =
 		resolveThreadHeapMemoryMb(envMgr.get(hdbTerms.CONFIG_PARAMS.THREADS_MAXHEAPMEMORY)) ??
-		Math.max(Math.floor(availableMemory / MB / (10 + (options.threadCount || 1) / 4)), 512);
+		Math.max(Math.floor(availableMemory / MB / (10 + (options.heapShareCount || options.threadCount || 1) / 4)), 512);
 	// Max young memory space (semi-space for scavenger) is 1/128 of max memory (limited to 16-64). For most of our m5
 	// machines this will be 64MB (less for t3's). This is based on recommendations from:
 	// https://www.alibabacloud.com/blog/node-js-application-troubleshooting-manual---comprehensive-gc-problems-and-optimization594965
@@ -438,6 +549,7 @@ function startWorker(path, options = {}) {
 			workerIndex: options.workerIndex,
 			workerCount: (workerCount = options.threadCount),
 			name: options.name,
+			isolatedApplication: options.application,
 			restartNumber: module.exports.restartNumber,
 			processIncarnation: module.exports.processIncarnation,
 			ticketKeys: getTicketKeys(),
@@ -488,6 +600,7 @@ function startWorker(path, options = {}) {
 	startMonitoring();
 	if (options.onStarted) options.onStarted(worker); // notify that it is ready
 	worker.name = options.name;
+	worker.application = options.application; // the isolated application this worker is dedicated to, if any
 	return worker;
 }
 
@@ -509,11 +622,17 @@ const OVERLAPPING_RESTART_TYPES = [hdbTerms.THREAD_TYPES.HTTP];
  * from a worker, nothing — the restart is handed to the main thread.
  */
 
+/**
+ * `application` selects which workers of the type restart: undefined restarts the shared pool only
+ * (workers dedicated to an isolated application keep running -- a redeploy of one application must not
+ * restart another), a name restarts only that application's dedicated worker, and '*' restarts all.
+ */
 async function restartWorkers(
 	name = null,
 	maxWorkersDown = Math.max(Math.floor(workerCount / 8), 1), // restart 1/8 of the threads at a time, but at least 1
 	startReplacementThreads = true,
-	onProgress = null
+	onProgress = null,
+	application = undefined
 ) {
 	if (isMainThread) {
 		// Declining is not the same as delegating: a caller reporting on the restart must not read this
@@ -527,6 +646,7 @@ async function restartWorkers(
 		} catch (e) {
 			harperLogger.error('Unable to reestablish current working directory', e);
 		}
+		const freshlyStarted = new Set(); // dedicated workers the reconcile just started: already on the new code
 		// problematic cyclic dependency, bind late
 		const { resetRestartNeeded } = require('../../components/requestRestart.ts');
 		resetRestartNeeded();
@@ -539,6 +659,13 @@ async function restartWorkers(
 			const loading = setInterval(() => onProgress?.(), RESTART_PROGRESS_HEARTBEAT_MS).unref();
 			try {
 				await loadRootComponents();
+				// isolated applications added or removed by the reload get their dedicated worker started or
+				// stopped; a crash-looping newcomer can take a while, so the heartbeat runs through this too
+				try {
+					for (const application of (await isolatedWorkerReconciler?.()) ?? []) freshlyStarted.add(application);
+				} catch (error) {
+					harperLogger.error('Could not reconcile isolated application workers', error);
+				}
 			} finally {
 				clearInterval(loading);
 			}
@@ -580,6 +707,8 @@ async function restartWorkers(
 			// Terminal shutdown: stop replacing workers mid-loop — the guard for every replacement start below.
 			if (processShuttingDown && startReplacementThreads) break;
 			if ((name && worker.name !== name) || worker.wasShutdown) continue; // filter by type, if specified
+			if (application !== '*' && worker.application !== application) continue; // and by isolated application
+			if (worker.application && freshlyStarted.has(worker.application)) continue;
 			const overlapping = OVERLAPPING_RESTART_TYPES.indexOf(worker.name) > -1;
 			if (overlapping && startReplacementThreads && canPreStartReplacement) {
 				// Overlapping restart: start the replacement and wait until it is accepting connections
@@ -761,6 +890,7 @@ async function restartWorkers(
 		parentPort.postMessage({
 			type: RESTART_TYPE,
 			workerType: name,
+			scope: encodeRestartScope(application),
 		});
 	}
 }
@@ -810,7 +940,7 @@ function whenWorkerStarted(newWorker) {
 	});
 }
 function shutdownWorkers(name) {
-	return restartWorkers(name, Infinity, false);
+	return restartWorkers(name, Infinity, false, null, '*');
 }
 function beginProcessShutdown() {
 	processShuttingDown = true;
@@ -828,6 +958,24 @@ async function shutdownWorkersNow(name) {
 	} else {
 		await Promise.all(workers.map((worker) => worker.terminate()));
 	}
+}
+
+/**
+ * The restart scope on the wire: a worker cannot post `undefined` and have it mean "the pool" (a
+ * message with no scope at all means "everything", as every pre-existing sender intends).
+ */
+function encodeRestartScope(application) {
+	return application === undefined ? '' : application; // '' is not a legal application name
+}
+function decodeRestartScope(message) {
+	if (message.scope === undefined) return '*';
+	return message.scope === '' ? undefined : message.scope;
+}
+
+let isolatedWorkerReconciler = null;
+/** Registered by socketRouter: starts and stops dedicated workers to match the root config's isolated applications. */
+function setIsolatedWorkerReconciler(reconcile) {
+	isolatedWorkerReconciler = reconcile;
 }
 
 const messageListeners = [];
@@ -1096,6 +1244,7 @@ function getChildWorkerInfo() {
 	return workers.map((worker) => ({
 		threadId: worker.threadId,
 		name: worker.name,
+		application: worker.application,
 		heapTotal: worker.resources?.heapTotal,
 		heapUsed: worker.resources?.heapUsed,
 		externalMemory: worker.resources?.external,
@@ -1727,7 +1876,7 @@ if (isMainThread) {
 					if (queuedRestart) clearTimeout(queuedRestart);
 					queuedRestart = setTimeout(async () => {
 						if (beforeRestart) await beforeRestart();
-						await restartWorkers();
+						await restartWorkers(undefined, undefined, true, null, '*');
 						console.log('Reloaded Harper components, changed files:', Array.from(changedFiles));
 						changedFiles.clear();
 					}, 100);

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -668,15 +668,16 @@ async function restartWorkers(
 		const freshlyStarted = new Set(); // dedicated workers the reconcile just started: already on the new code
 		// problematic cyclic dependency, bind late
 		const { resetRestartNeeded } = require('../../components/requestRestart.ts');
-		// One process-wide bit cannot say which application is pending, so it is cleared only by a restart
-		// that replaces the pool: that is the one scope guaranteed to load everything the bit could stand
-		// for. Clearing it on a restart scoped to a single dedicated worker would report
-		// restartRequired: false while every pool worker is still on the old code — a silent 404 with no
-		// signal. The cost is the opposite error in one case: a deploy of an already-isolated application
-		// without a restart sets the bit, and a later app-scoped restart of that same application brings
-		// it live without clearing it, so restartRequired stays true until some pool restart happens. A
-		// needless pool restart is recoverable and self-clearing; an un-live component with no signal is not.
-		if (application === undefined || application === '*') resetRestartNeeded();
+		// One process-wide bit cannot say WHICH application is pending, so it may only be cleared by a
+		// restart that demonstrably covers every worker the bit could stand for. A restart scoped to one
+		// application leaves the whole pool on its old code; a pool restart replaces every pool worker and
+		// reconciles dedicated slots, but leaves an already-running dedicated worker on its old modules.
+		// Clearing from either would report restartRequired: false while a deployed component is still
+		// loaded nowhere. So: all workers always, the pool only while no dedicated worker is running --
+		// which is every node that uses no isolated application, i.e. the historic behavior unchanged.
+		const coversEveryWorker =
+			application === '*' || (application === undefined && !workers.some((worker) => worker.application));
+		if (coversEveryWorker) resetRestartNeeded();
 		// This is here to prevent circular dependencies
 		if (startReplacementThreads) {
 			const { loadRootComponents } = require('../loadRootComponents.js');

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -719,7 +719,7 @@ async function restartWorkers(
 		// replacement — an unavoidable brief gap, but only for worker-owned listeners, since the main
 		// thread keeps serving the HTTP ports throughout. This ordering is also what lets
 		// listenOnPorts() treat a dedicated listener's EADDRINUSE as an external conflict.
-		const canPreStartReplacement = process.platform !== 'win32' && process.platform !== 'darwin' && !isBun;
+		const platformCanPreStartReplacement = process.platform !== 'win32' && process.platform !== 'darwin' && !isBun;
 		const restarting = workers.slice(0);
 		for (let index = 0; index < restarting.length; index++) {
 			const worker = restarting[index];
@@ -729,6 +729,7 @@ async function restartWorkers(
 			if (application !== '*' && worker.application !== application) continue; // and by isolated application
 			if (worker.application && freshlyStarted.has(worker.application)) continue;
 			const overlapping = OVERLAPPING_RESTART_TYPES.indexOf(worker.name) > -1;
+			const canPreStartReplacement = platformCanPreStartReplacement && !worker.application;
 			if (overlapping && startReplacementThreads && canPreStartReplacement) {
 				// Overlapping restart: start the replacement and wait until it is accepting connections
 				// *before* shutting down the worker it replaces. The replacement joins the (SO_REUSEPORT)

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -64,10 +64,12 @@ let threadTerminationTimeout = process.env.DEV_MODE === 'true' || process.env.DE
 const RESTART_TYPE = 'restart';
 const RESTART_PROGRESS_HEARTBEAT_MS = 15000;
 const REQUEST_THREAD_INFO = 'request_thread_info';
+const REQUEST_RUNNING_ISOLATED_APPLICATIONS = 'request-running-isolated-applications';
 const RESOURCE_REPORT = 'resource_report';
 const OS_THREAD_ID = 'os-thread-id';
 const STUCK_WORKER_REPORT = 'stuck-worker-report';
 const THREAD_INFO = 'thread_info';
+const RUNNING_ISOLATED_APPLICATIONS = 'running-isolated-applications';
 const ADDED_PORT = 'added-port';
 const ACKNOWLEDGEMENT = 'ack';
 const REMOVE_PORT = 'remove-port';
@@ -85,6 +87,7 @@ const AWAIT_PROCESS_GROUP_TERMINATION = 'await-process-group-termination';
 const PROCESS_GROUP_TERMINATION_CONFIRMED = 'process-group-termination-confirmed';
 const THREAD_INFO_REQUEST_TIMEOUT_MS = 1000;
 let getThreadInfo;
+let getRunningIsolatedApplications;
 let awaitProcessGroupTermination;
 // Worker-side backstop that force-exits if the graceful shutdown sequence doesn't finish in time.
 let selfExitTimer;
@@ -152,6 +155,7 @@ module.exports = {
 	setMonitorListener,
 	onMessageFromWorkers,
 	setIsolatedWorkerReconciler,
+	setRunningIsolatedApplicationsGetter,
 	isApplicationPrimaryWorker,
 	applicationWorkerIndex,
 	runsApplicationCodeSingletons,
@@ -425,6 +429,14 @@ if (!parentPort) {
 	onMessageByType(REQUEST_THREAD_INFO, (message, worker) => {
 		if (worker) sendThreadInfo(worker);
 	});
+	onMessageByType(REQUEST_RUNNING_ISOLATED_APPLICATIONS, (message, worker) => {
+		if (worker)
+			worker.postMessage({
+				type: RUNNING_ISOLATED_APPLICATIONS,
+				requestId: message.requestId,
+				applications: runningIsolatedApplicationsGetter(),
+			});
+	});
 	onMessageByType(RESOURCE_REPORT, (message, worker) => {
 		if (worker) recordResourceReport(worker, message);
 	});
@@ -459,11 +471,12 @@ listenersByType.set(hdbTerms.ITC_EVENT_TYPES.MIDDLEWARE_CHAINS_RESPONSE, null);
 listenersByType.set(hdbTerms.ITC_EVENT_TYPES.OPERATION_REGISTERED, null);
 listenersByType.set(hdbTerms.ITC_EVENT_TYPES.OPERATION_EXECUTE_REQUEST, null);
 listenersByType.set(hdbTerms.ITC_EVENT_TYPES.OPERATION_EXECUTE_RESPONSE, null);
-// getThreadInfo/awaitProcessGroupTermination register their own one-shot parentPort listener per
+// These request/response functions register their own one-shot parentPort listener per
 // call rather than going through onMessageByType, so without this, every reply would also reach
 // addPort's permanent dispatcher as an "unregistered" type: notifyMessageListeners would warn and
 // queue each one in messagesQueuedByType forever, and a lock-wait polls every 50ms.
 listenersByType.set(THREAD_INFO, null);
+listenersByType.set(RUNNING_ISOLATED_APPLICATIONS, null);
 listenersByType.set(PROCESS_GROUP_TERMINATION_CONFIRMED, null);
 
 function startWorker(path, options = {}) {
@@ -973,9 +986,13 @@ function decodeRestartScope(message) {
 }
 
 let isolatedWorkerReconciler = null;
+let runningIsolatedApplicationsGetter = () => [];
 /** Registered by socketRouter: starts and stops dedicated workers to match the root config's isolated applications. */
 function setIsolatedWorkerReconciler(reconcile) {
 	isolatedWorkerReconciler = reconcile;
+}
+function setRunningIsolatedApplicationsGetter(getter) {
+	runningIsolatedApplicationsGetter = getter;
 }
 
 const messageListeners = [];
@@ -1354,6 +1371,38 @@ if (parentPort && workerData?.addPorts) {
 				}, timeoutMs);
 			}
 		});
+	let nextRunningIsolatedApplicationsRequestId = 0;
+	getRunningIsolatedApplications = (timeoutMs) =>
+		new Promise((resolve, reject) => {
+			const requestId = ++nextRunningIsolatedApplicationsRequestId;
+			let timeout;
+			parentPort.on('message', receiveApplications);
+			try {
+				parentPort.postMessage({ type: REQUEST_RUNNING_ISOLATED_APPLICATIONS, requestId });
+			} catch (error) {
+				cleanup();
+				reject(error);
+				return;
+			}
+			function receiveApplications(message) {
+				if (message.type === RUNNING_ISOLATED_APPLICATIONS && message.requestId === requestId) {
+					cleanup();
+					resolve(message.applications);
+				}
+			}
+			function cleanup() {
+				if (timeout) clearTimeout(timeout);
+				parentPort.off('message', receiveApplications);
+			}
+			if (timeoutMs != null) {
+				timeout = setTimeout(() => {
+					cleanup();
+					const error = new Error(`Timed out waiting for isolated application topology after ${timeoutMs}ms`);
+					error.code = 'ERR_ISOLATED_APPLICATIONS_TIMEOUT';
+					reject(error);
+				}, timeoutMs);
+			}
+		});
 	let awaitTerminationRequestId = 0;
 	awaitProcessGroupTermination = (ownerThreadId, signal) =>
 		new Promise((resolve) => {
@@ -1378,10 +1427,12 @@ if (parentPort && workerData?.addPorts) {
 		});
 } else {
 	getThreadInfo = getChildWorkerInfo;
+	getRunningIsolatedApplications = () => runningIsolatedApplicationsGetter();
 	awaitProcessGroupTermination = (ownerThreadId) =>
 		pendingProcessGroupTerminations.get(ownerThreadId) ?? Promise.resolve();
 }
 module.exports.getThreadInfo = getThreadInfo;
+module.exports.getRunningIsolatedApplications = getRunningIsolatedApplications;
 
 // Listeners notified when a connected thread's port closes (worker exit/restart), so
 // modules holding per-thread state (e.g. registeredOperations' registry and in-flight

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -668,7 +668,11 @@ async function restartWorkers(
 		const freshlyStarted = new Set(); // dedicated workers the reconcile just started: already on the new code
 		// problematic cyclic dependency, bind late
 		const { resetRestartNeeded } = require('../../components/requestRestart.ts');
-		resetRestartNeeded();
+		// The flag stands for pool-loaded code that a deploy left un-live, so only a restart that
+		// replaces the pool can clear it. A restart scoped to one application's dedicated worker leaves
+		// every pool worker on the old code, and clearing it there would report restartRequired: false
+		// while the pending component is still not loaded anywhere.
+		if (application === undefined || application === '*') resetRestartNeeded();
 		// This is here to prevent circular dependencies
 		if (startReplacementThreads) {
 			const { loadRootComponents } = require('../loadRootComponents.js');

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -1,11 +1,28 @@
-import { startWorker, setMonitorListener, setMainIsWorker, threadsHaveStarted } from './manageThreads.js';
+import {
+	startWorker,
+	setMonitorListener,
+	setMainIsWorker,
+	threadsHaveStarted,
+	setIsolatedWorkerReconciler,
+	workersForApplication,
+	stopWorker,
+} from './manageThreads.js';
+import {
+	isolatedApplicationNames,
+	maxIsolatedApplications,
+	isolatedApplicationRefusal,
+} from './isolatedApplications.ts';
+import { getConfigPath } from '../../config/configUtils.ts';
+import { lifecycle as componentLifecycle } from '../../components/status/index.ts';
+import { existsSync } from 'node:fs';
+import * as env from '../../utility/environment/environmentManager.ts';
 import * as hdbTerms from '../../utility/hdbTerms.ts';
 import * as harperLogger from '../../utility/logging/harper_logger.ts';
 import { recordHostname } from '../../resources/analytics/write.ts';
 import { startTransactionLogCooling } from '../transactionLogCooling.ts';
 import { startLongLivedTransactionReporting } from '../../resources/longLivedTransactions.ts';
 import { isMainThread } from 'worker_threads';
-import { join } from 'path';
+import { join, basename } from 'path';
 
 const workers = [];
 const HTTP_WORKER_STARTUP_DIAGNOSTIC_MS = 60000;
@@ -78,17 +95,160 @@ export async function startHTTPThreads(threadCount = 2, dynamicThreads?: boolean
 			// Windows does not support SO_REUSEPORT, so only a single HTTP worker is supported.
 			if (process.platform === 'win32') threadCount = 1;
 		}
+		poolSize = threadCount;
+		nextIsolatedIndex = threadCount; // past the pool: worker 0 and the last pool worker carry node-wide duties
+		const isolated = admittedIsolatedApplications([]);
+		const heapShareCount = threadCount + isolated.length;
 		for (let i = 0; i < threadCount; i++) {
-			workerSlots.push(startHTTPWorker(i, threadCount));
+			workerSlots.push(startHTTPWorker(i, threadCount, undefined, heapShareCount));
 		}
-		await Promise.all(workerSlots.map((slot) => slot.ready));
+		// One dedicated worker per isolated application, numbered past the pool so no pool-only duty
+		// (worker 0's startup log, the last worker's cleanup) ever lands on it.
+		const dedicatedStarts = [];
+		for (const application of isolated) {
+			const slot = startHTTPWorker(nextIsolatedIndex++, threadCount, application, heapShareCount);
+			isolatedSlots.set(application, slot);
+			workerSlots.push(slot);
+			// with a backstop, like a later reconcile: one application's hung boot must not hold up the instance
+			dedicatedStarts.push(watchDedicatedStart(application, slot));
+		}
+		await Promise.all([
+			...workerSlots.filter((slot) => !slot.application).map((slot) => slot.ready),
+			...dedicatedStarts,
+		]);
 	} finally {
 		for (const slot of workerSlots) slot.finishStartup();
 		threadsHaveStarted(undefined as any);
 	}
 }
 
-function startHTTPWorker(index, threadCount = 1) {
+let poolSize = 0;
+const refusedIsolated = new Set<string>(); // reported once, not on every reconcile
+const ISOLATED_WORKER_READY_TIMEOUT_MS = 60_000; // the pool replacement path's backstop
+let nextIsolatedIndex = 0;
+type IsolatedSlot = {
+	ready: Promise<void>;
+	finishStartup: () => void;
+	shutdown: () => Promise<void>;
+	application?: string;
+};
+const isolatedSlots = new Map<string, IsolatedSlot>();
+
+/**
+ * The isolated applications that get a dedicated worker. Ones already running keep their place; new
+ * ones are admitted up to `threads.maxIsolated`, and only while a dedicated worker would be reachable
+ * at all. Everything refused is refused loudly and loaded nowhere -- never downgraded to the pool.
+ */
+function admittedIsolatedApplications(running: string[]): string[] {
+	const names = isolatedApplicationNames();
+	const max = maxIsolatedApplications();
+	const admitted = running.filter((name) => names.includes(name));
+	for (const name of names) {
+		if (admitted.includes(name)) continue;
+		const refusal =
+			isolatedApplicationRefusal(name) ??
+			(admitted.length >= max
+				? `the instance already runs ${max} isolated application(s) (threads.maxIsolated)`
+				: undefined);
+		if (refusal) {
+			if (!refusedIsolated.has(name)) {
+				refusedIsolated.add(name);
+				const error = new Error(
+					`Application '${name}' is isolated but gets no dedicated worker: ${refusal}; it is not loaded anywhere`
+				);
+				harperLogger.error(error.message);
+				componentLifecycle.failed(name, error, `Component '${name}' failed to load`);
+			}
+			continue;
+		}
+		refusedIsolated.delete(name);
+		admitted.push(name);
+	}
+	return admitted;
+}
+
+/**
+ * Wait for a dedicated worker to become ready, with the pool replacement path's backstop. A worker that
+ * fails, or stays alive without ever reporting ready, is recorded as a failed component, stopped, and
+ * its slot freed so the next reconcile retries. Resolves whether it became ready.
+ */
+function watchDedicatedStart(application: string, slot: IsolatedSlot): Promise<boolean> {
+	return Promise.race([
+		slot.ready,
+		new Promise<never>((_, reject) =>
+			setTimeout(
+				() => reject(new Error(`Dedicated worker for '${application}' did not become ready in time`)),
+				ISOLATED_WORKER_READY_TIMEOUT_MS
+			).unref()
+		),
+	])
+		.then(() => true)
+		.catch((error) => {
+			harperLogger.error(`Dedicated worker for isolated application '${application}' failed to start`, error);
+			componentLifecycle.failed(application, error, `Component '${application}' failed to load`);
+			isolatedSlots.delete(application);
+			void slot.shutdown();
+			return false;
+		})
+		.finally(() => slot.finishStartup());
+}
+
+/** The isolated applications that currently hold a dedicated worker. */
+export function runningIsolatedApplications(): string[] {
+	return [...isolatedSlots.keys()];
+}
+
+/**
+ * Bring the dedicated workers in line with the root config: start one for each isolated application
+ * that has none, stop the one of an application that is no longer isolated or no longer configured.
+ * Runs on the main thread after every root-component reload (deploy, drop, restart).
+ */
+let reconciling: Promise<string[]> = Promise.resolve([]);
+export function reconcileIsolatedWorkers(): Promise<string[]> {
+	// serialized: two reloads in flight must not compute `wanted` against each other's half-done work
+	reconciling = reconciling.then(reconcileIsolatedWorkersNow, reconcileIsolatedWorkersNow);
+	return reconciling;
+}
+
+async function reconcileIsolatedWorkersNow(): Promise<string[]> {
+	if (!isMainThread || poolSize === 0) return [];
+	// An isolated entry whose component directory is gone has nothing to run: its worker stops even if
+	// the config entry outlives the drop (an environment-supplied entry, say).
+	const componentsRoot = getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT) as string;
+	// a directory application lives under componentsRoot, a root-config `package:` one under
+	// <rootPath>/components (see the root pass in componentLoader)
+	const installedRoot = join(env.get(hdbTerms.CONFIG_PARAMS.ROOTPATH), 'components');
+	const present = (application: string) =>
+		existsSync(join(componentsRoot, application)) ||
+		existsSync(join(installedRoot, application)) ||
+		(process.env.RUN_HDB_APP && basename(process.env.RUN_HDB_APP) === application);
+	const wanted = new Set(admittedIsolatedApplications([...isolatedSlots.keys()]).filter(present));
+	const stopping = [];
+	for (const [application, slot] of isolatedSlots) {
+		if (wanted.has(application)) continue;
+		isolatedSlots.delete(application);
+		// awaited: a caller that goes on to remove the application's storage must see its worker gone
+		stopping.push(slot.shutdown());
+	}
+	await Promise.all(stopping);
+	const starting = [];
+	const started: string[] = [];
+	for (const application of wanted) {
+		if (isolatedSlots.has(application)) continue;
+		const slot = startHTTPWorker(nextIsolatedIndex++, poolSize, application, poolSize + isolatedSlots.size + 1);
+		isolatedSlots.set(application, slot);
+		starting.push(
+			watchDedicatedStart(application, slot).then((ready) => {
+				if (ready) started.push(application);
+			})
+		);
+	}
+	await Promise.all(starting);
+	return started;
+}
+if (isMainThread) setIsolatedWorkerReconciler(reconcileIsolatedWorkers);
+
+function startHTTPWorker(index, threadCount = 1, application?: string, heapShareCount?: number) {
 	const { promise: ready, resolve: resolveReady, reject: rejectReady } = Promise.withResolvers<void>();
 	let waitingForInitialReady = true;
 	let finishCurrentStartup = () => {};
@@ -110,6 +270,8 @@ function startHTTPWorker(index, threadCount = 1) {
 		name: hdbTerms.THREAD_TYPES.HTTP,
 		workerIndex: index,
 		threadCount,
+		application,
+		heapShareCount,
 		onStarted(worker) {
 			const attempt = ++startupAttempts;
 			const threadId = (lastThreadId = worker.threadId);
@@ -125,7 +287,7 @@ function startHTTPWorker(index, threadCount = 1) {
 				worker.off('message', onMessage);
 			};
 			const describeStartup = (event) =>
-				`HTTP worker slot ${index} ${event} before ready (thread ${threadId}, attempt ${attempt}, phase ${startupPhase})`;
+				`HTTP worker slot ${index}${application ? ` (isolated application '${application}')` : ''} ${event} before ready (thread ${threadId}, attempt ${attempt}, phase ${startupPhase})`;
 			const onMessage = (message) => {
 				if (message.type === hdbTerms.ITC_EVENT_TYPES.CHILD_STARTUP_PHASE) {
 					startupPhase = message.phase;
@@ -160,11 +322,21 @@ function startHTTPWorker(index, threadCount = 1) {
 			}
 		},
 		onRestartExhausted() {
+			// a dead dedicated worker leaves its slot, so the next reconcile (a deploy of the fix) starts a new one
+			if (application) isolatedSlots.delete(application);
 			failStartup(new Error(`HTTP worker slot ${index} exhausted restarts before ready (thread ${lastThreadId})`));
 		},
 	};
 	startWorker(join(__dirname, './threadServer.js'), workerOptions);
-	return { ready, finishStartup };
+	// Stop of a dedicated worker whose application is gone: every worker carrying the application,
+	// a crashed one's replacement still booting included, so none is left running the removed app.
+	const shutdown = async (): Promise<void> => {
+		if (!application) return;
+		// a slot still booting must settle its readiness, or the reconcile awaiting it hangs
+		failStartup(new Error(`Dedicated worker for '${application}' was stopped before it became ready`));
+		await Promise.all(workersForApplication(application).map((worker) => stopWorker(worker)));
+	};
+	return { ready, finishStartup, shutdown, application };
 }
 
 // basically, the amount of additional idleness to expect based on previous idleness (some work will continue, some

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -177,7 +177,8 @@ function reportIsolatedRefusal(name: string, refusal: string) {
 /**
  * Wait for a dedicated worker to become ready, with the pool replacement path's backstop. A worker that
  * fails, or stays alive without ever reporting ready, is recorded as a failed component, stopped, and
- * its slot freed so the next reconcile retries. Resolves whether it became ready.
+ * only then has its slot freed, so the next reconcile retries against a worker that has exited.
+ * Resolves whether it became ready.
  */
 function watchDedicatedStart(application: string, slot: IsolatedSlot): Promise<boolean> {
 	return Promise.race([
@@ -193,13 +194,15 @@ function watchDedicatedStart(application: string, slot: IsolatedSlot): Promise<b
 		.catch(async (error) => {
 			harperLogger.error(`Dedicated worker for isolated application '${application}' failed to start`, error);
 			componentLifecycle.failed(application, error, `Component '${application}' failed to load`);
-			const withdrewLease = isolatedSlots.get(application) === slot;
-			if (withdrewLease) isolatedSlots.delete(application);
+			// The slot IS the lease: holding it until the failed worker has actually exited is what stops a
+			// reconcile from starting a replacement over its still-bound UDS mirror and still-open stores,
+			// and what makes a concurrent drop's `await slot.shutdown()` cover this worker too.
 			await slot.shutdown();
-			if (withdrewLease && !isolatedSlots.has(application)) {
-				const { cleanupApplicationSockets } = await import('../http.ts');
-				cleanupApplicationSockets(application);
-			}
+			if (isolatedSlots.get(application) !== slot) return false; // a drop already withdrew this lease
+			isolatedSlots.delete(application);
+			const { cleanupApplicationSockets } = await import('../http.ts');
+			// A reconcile may have installed a replacement while that import resolved. Never unlink its mirror.
+			if (!isolatedSlots.has(application)) cleanupApplicationSockets(application);
 			return false;
 		})
 		.finally(() => slot.finishStartup());

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -274,6 +274,9 @@ function startHTTPWorker(index, threadCount = 1, application?: string, heapShare
 		threadCount,
 		application,
 		heapShareCount,
+		shouldAutoRestart: application
+			? () => isolatedSlot !== undefined && isolatedSlots.get(application) === isolatedSlot
+			: undefined,
 		onStarted(worker) {
 			const attempt = ++startupAttempts;
 			const threadId = (lastThreadId = worker.threadId);
@@ -349,11 +352,15 @@ function startHTTPWorker(index, threadCount = 1, application?: string, heapShare
 	startWorker(join(__dirname, './threadServer.js'), workerOptions);
 	// Stop of a dedicated worker whose application is gone: every worker carrying the application,
 	// a crashed one's replacement still booting included, so none is left running the removed app.
-	const shutdown = async (): Promise<void> => {
-		if (!application) return;
-		// a slot still booting must settle its readiness, or the reconcile awaiting it hangs
+	let shutdownPromise: Promise<void> | undefined;
+	const shutdown = (): Promise<void> => {
+		if (!application) return Promise.resolve();
+		if (shutdownPromise) return shutdownPromise;
+		shutdownPromise = Promise.all(workersForApplication(application).map((worker) => stopWorker(worker))).then(
+			() => undefined
+		);
 		failStartup(new Error(`Dedicated worker for '${application}' was stopped before it became ready`));
-		await Promise.all(workersForApplication(application).map((worker) => stopWorker(worker)));
+		return shutdownPromise;
 	};
 	const setHeapShareCount = (count: number) => {
 		workerOptions.heapShareCount = count;

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -75,7 +75,9 @@ export async function startHTTPThreads(threadCount = 2, dynamicThreads?: boolean
 			// does not bind ports in this mode, so on platforms without SO_REUSEPORT (macOS/Windows)
 			// worker 0's exclusive HTTP bind would silently swallow an external EADDRINUSE — the
 			// external-conflict detection in listenOnPorts() assumes the main thread binds first.
-			workerSlots.push(startHTTPWorker(0, 1));
+			const slot = startHTTPWorker(0, 1);
+			workerSlots.push(slot);
+			poolSlots.push(slot);
 		} else {
 			const { loadRootComponents } = require('../loadRootComponents.js');
 			if (threadCount === 0) {
@@ -98,7 +100,9 @@ export async function startHTTPThreads(threadCount = 2, dynamicThreads?: boolean
 		const isolated = admittedIsolatedApplications([...isolatedSlots.keys()]);
 		const heapShareCount = threadCount + isolated.length;
 		for (let i = 0; i < threadCount; i++) {
-			workerSlots.push(startHTTPWorker(i, threadCount, undefined, heapShareCount));
+			const slot = startHTTPWorker(i, threadCount, undefined, heapShareCount);
+			workerSlots.push(slot);
+			poolSlots.push(slot);
 		}
 		// One dedicated worker per isolated application, numbered past the pool so no pool-only duty
 		// (worker 0's startup log, the last worker's cleanup) ever lands on it.
@@ -124,9 +128,11 @@ type IsolatedSlot = {
 	ready: Promise<void>;
 	finishStartup: () => void;
 	shutdown: () => Promise<void>;
+	setHeapShareCount: (count: number) => void;
 	application?: string;
 };
 const isolatedSlots = new Map<string, IsolatedSlot>();
+const poolSlots: IsolatedSlot[] = [];
 
 /**
  * The isolated applications that get a dedicated worker. Ones already running keep their place; new
@@ -176,7 +182,11 @@ function watchDedicatedStart(application: string, slot: IsolatedSlot): Promise<b
 			harperLogger.error(`Dedicated worker for isolated application '${application}' failed to start`, error);
 			componentLifecycle.failed(application, error, `Component '${application}' failed to load`);
 			await slot.shutdown();
-			if (isolatedSlots.get(application) === slot) isolatedSlots.delete(application);
+			if (isolatedSlots.get(application) === slot) {
+				isolatedSlots.delete(application);
+				const { cleanupApplicationSockets } = await import('../http.ts');
+				cleanupApplicationSockets(application);
+			}
 			return false;
 		})
 		.finally(() => slot.finishStartup());
@@ -211,6 +221,8 @@ async function reconcileIsolatedWorkersNow(): Promise<string[]> {
 	}
 	const started: string[] = [];
 	const heapShareCount = poolSize + wanted.size;
+	for (const slot of poolSlots) slot.setHeapShareCount(heapShareCount);
+	for (const slot of isolatedSlots.values()) slot.setHeapShareCount(heapShareCount);
 	for (const application of wanted) {
 		if (isolatedSlots.has(application)) continue;
 		const slot = startHTTPWorker(nextIsolatedIndex++, poolSize, application, heapShareCount);
@@ -315,7 +327,10 @@ function startHTTPWorker(index, threadCount = 1, application?: string, heapShare
 		failStartup(new Error(`Dedicated worker for '${application}' was stopped before it became ready`));
 		await Promise.all(workersForApplication(application).map((worker) => stopWorker(worker)));
 	};
-	isolatedSlot = { ready, finishStartup, shutdown, application };
+	const setHeapShareCount = (count: number) => {
+		workerOptions.heapShareCount = count;
+	};
+	isolatedSlot = { ready, finishStartup, shutdown, setHeapShareCount, application };
 	return isolatedSlot;
 }
 

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -9,21 +9,19 @@ import {
 	stopWorker,
 } from './manageThreads.js';
 import {
-	isolatedApplicationNames,
+	presentIsolatedApplicationNames,
+	isolatedWorkerHeapShareCount,
 	isolatedApplicationRefusal,
 	isolatedApplicationCapacityRefusal,
 } from './isolatedApplications.ts';
-import { getConfigPath } from '../../config/configUtils.ts';
 import { lifecycle as componentLifecycle } from '../../components/status/index.ts';
-import { existsSync } from 'node:fs';
-import * as env from '../../utility/environment/environmentManager.ts';
 import * as hdbTerms from '../../utility/hdbTerms.ts';
 import * as harperLogger from '../../utility/logging/harper_logger.ts';
 import { recordHostname } from '../../resources/analytics/write.ts';
 import { startTransactionLogCooling } from '../transactionLogCooling.ts';
 import { startLongLivedTransactionReporting } from '../../resources/longLivedTransactions.ts';
 import { isMainThread } from 'node:worker_threads';
-import { join, basename } from 'node:path';
+import { join } from 'node:path';
 
 const workers = [];
 const HTTP_WORKER_STARTUP_DIAGNOSTIC_MS = 60000;
@@ -99,27 +97,22 @@ export async function startHTTPThreads(threadCount = 2, dynamicThreads?: boolean
 		poolSize = threadCount;
 		nextIsolatedIndex = Math.max(nextIsolatedIndex, threadCount);
 		const isolated = admittedIsolatedApplications([...isolatedSlots.keys()]);
-		const heapShareCount = threadCount + isolated.length;
+		const heapShareCount = isolatedWorkerHeapShareCount(threadCount);
 		for (let i = 0; i < threadCount; i++) {
 			workerSlots.push(startHTTPWorker(i, threadCount, undefined, heapShareCount));
 		}
 		// One dedicated worker per isolated application, numbered past the pool so no pool-only duty
 		// (worker 0's startup log, the last worker's cleanup) ever lands on it.
-		const dedicatedStarts = [];
 		for (const application of isolated) {
 			if (isolatedSlots.has(application)) continue;
 			const slot = startHTTPWorker(nextIsolatedIndex++, threadCount, application, heapShareCount);
 			isolatedSlots.set(application, slot);
 			workerSlots.push(slot);
-			// with a backstop, like a later reconcile: one application's hung boot must not hold up the instance
-			dedicatedStarts.push(watchDedicatedStart(application, slot));
+			void watchDedicatedStart(application, slot);
 		}
-		await Promise.all([
-			...workerSlots.filter((slot) => !slot.application).map((slot) => slot.ready),
-			...dedicatedStarts,
-		]);
+		await Promise.all(workerSlots.filter((slot) => !slot.application).map((slot) => slot.ready));
 	} finally {
-		for (const slot of workerSlots) slot.finishStartup();
+		for (const slot of workerSlots) if (!slot.application) slot.finishStartup();
 		threadsHaveStarted(undefined as any);
 	}
 }
@@ -162,17 +155,6 @@ function admittedIsolatedApplications(running: string[]): string[] {
 		admitted.push(name);
 	}
 	return admitted;
-}
-
-function presentIsolatedApplicationNames(): string[] {
-	const componentsRoot = getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT) as string;
-	const installedRoot = join(env.get(hdbTerms.CONFIG_PARAMS.ROOTPATH), 'components');
-	return isolatedApplicationNames().filter(
-		(application) =>
-			existsSync(join(componentsRoot, application)) ||
-			existsSync(join(installedRoot, application)) ||
-			(process.env.RUN_HDB_APP && basename(process.env.RUN_HDB_APP) === application)
-	);
 }
 
 /**
@@ -224,20 +206,15 @@ async function reconcileIsolatedWorkersNow(): Promise<string[]> {
 		stopping.push(slot.shutdown());
 	}
 	await Promise.all(stopping);
-	const starting = [];
 	const started: string[] = [];
-	const heapShareCount = poolSize + wanted.size;
+	const heapShareCount = isolatedWorkerHeapShareCount(poolSize);
 	for (const application of wanted) {
 		if (isolatedSlots.has(application)) continue;
 		const slot = startHTTPWorker(nextIsolatedIndex++, poolSize, application, heapShareCount);
 		isolatedSlots.set(application, slot);
-		starting.push(
-			watchDedicatedStart(application, slot).then((ready) => {
-				if (ready) started.push(application);
-			})
-		);
+		started.push(application);
+		void watchDedicatedStart(application, slot);
 	}
-	await Promise.all(starting);
 	return started;
 }
 if (isMainThread) {

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -4,13 +4,14 @@ import {
 	setMainIsWorker,
 	threadsHaveStarted,
 	setIsolatedWorkerReconciler,
+	setRunningIsolatedApplicationsGetter,
 	workersForApplication,
 	stopWorker,
 } from './manageThreads.js';
 import {
 	isolatedApplicationNames,
-	maxIsolatedApplications,
 	isolatedApplicationRefusal,
+	isolatedApplicationCapacityRefusal,
 } from './isolatedApplications.ts';
 import { getConfigPath } from '../../config/configUtils.ts';
 import { lifecycle as componentLifecycle } from '../../components/status/index.ts';
@@ -21,8 +22,8 @@ import * as harperLogger from '../../utility/logging/harper_logger.ts';
 import { recordHostname } from '../../resources/analytics/write.ts';
 import { startTransactionLogCooling } from '../transactionLogCooling.ts';
 import { startLongLivedTransactionReporting } from '../../resources/longLivedTransactions.ts';
-import { isMainThread } from 'worker_threads';
-import { join, basename } from 'path';
+import { isMainThread } from 'node:worker_threads';
+import { join, basename } from 'node:path';
 
 const workers = [];
 const HTTP_WORKER_STARTUP_DIAGNOSTIC_MS = 60000;
@@ -96,8 +97,8 @@ export async function startHTTPThreads(threadCount = 2, dynamicThreads?: boolean
 			if (process.platform === 'win32') threadCount = 1;
 		}
 		poolSize = threadCount;
-		nextIsolatedIndex = threadCount; // past the pool: worker 0 and the last pool worker carry node-wide duties
-		const isolated = admittedIsolatedApplications([]);
+		nextIsolatedIndex = Math.max(nextIsolatedIndex, threadCount);
+		const isolated = admittedIsolatedApplications([...isolatedSlots.keys()]);
 		const heapShareCount = threadCount + isolated.length;
 		for (let i = 0; i < threadCount; i++) {
 			workerSlots.push(startHTTPWorker(i, threadCount, undefined, heapShareCount));
@@ -106,6 +107,7 @@ export async function startHTTPThreads(threadCount = 2, dynamicThreads?: boolean
 		// (worker 0's startup log, the last worker's cleanup) ever lands on it.
 		const dedicatedStarts = [];
 		for (const application of isolated) {
+			if (isolatedSlots.has(application)) continue;
 			const slot = startHTTPWorker(nextIsolatedIndex++, threadCount, application, heapShareCount);
 			isolatedSlots.set(application, slot);
 			workerSlots.push(slot);
@@ -140,16 +142,11 @@ const isolatedSlots = new Map<string, IsolatedSlot>();
  * at all. Everything refused is refused loudly and loaded nowhere -- never downgraded to the pool.
  */
 function admittedIsolatedApplications(running: string[]): string[] {
-	const names = isolatedApplicationNames();
-	const max = maxIsolatedApplications();
+	const names = presentIsolatedApplicationNames();
 	const admitted = running.filter((name) => names.includes(name));
 	for (const name of names) {
 		if (admitted.includes(name)) continue;
-		const refusal =
-			isolatedApplicationRefusal(name) ??
-			(admitted.length >= max
-				? `the instance already runs ${max} isolated application(s) (threads.maxIsolated)`
-				: undefined);
+		const refusal = isolatedApplicationRefusal(name) ?? isolatedApplicationCapacityRefusal(name, admitted);
 		if (refusal) {
 			if (!refusedIsolated.has(name)) {
 				refusedIsolated.add(name);
@@ -165,6 +162,17 @@ function admittedIsolatedApplications(running: string[]): string[] {
 		admitted.push(name);
 	}
 	return admitted;
+}
+
+function presentIsolatedApplicationNames(): string[] {
+	const componentsRoot = getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT) as string;
+	const installedRoot = join(env.get(hdbTerms.CONFIG_PARAMS.ROOTPATH), 'components');
+	return isolatedApplicationNames().filter(
+		(application) =>
+			existsSync(join(componentsRoot, application)) ||
+			existsSync(join(installedRoot, application)) ||
+			(process.env.RUN_HDB_APP && basename(process.env.RUN_HDB_APP) === application)
+	);
 }
 
 /**
@@ -183,19 +191,14 @@ function watchDedicatedStart(application: string, slot: IsolatedSlot): Promise<b
 		),
 	])
 		.then(() => true)
-		.catch((error) => {
+		.catch(async (error) => {
 			harperLogger.error(`Dedicated worker for isolated application '${application}' failed to start`, error);
 			componentLifecycle.failed(application, error, `Component '${application}' failed to load`);
-			isolatedSlots.delete(application);
-			void slot.shutdown();
+			await slot.shutdown();
+			if (isolatedSlots.get(application) === slot) isolatedSlots.delete(application);
 			return false;
 		})
 		.finally(() => slot.finishStartup());
-}
-
-/** The isolated applications that currently hold a dedicated worker. */
-export function runningIsolatedApplications(): string[] {
-	return [...isolatedSlots.keys()];
 }
 
 /**
@@ -212,17 +215,7 @@ export function reconcileIsolatedWorkers(): Promise<string[]> {
 
 async function reconcileIsolatedWorkersNow(): Promise<string[]> {
 	if (!isMainThread || poolSize === 0) return [];
-	// An isolated entry whose component directory is gone has nothing to run: its worker stops even if
-	// the config entry outlives the drop (an environment-supplied entry, say).
-	const componentsRoot = getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT) as string;
-	// a directory application lives under componentsRoot, a root-config `package:` one under
-	// <rootPath>/components (see the root pass in componentLoader)
-	const installedRoot = join(env.get(hdbTerms.CONFIG_PARAMS.ROOTPATH), 'components');
-	const present = (application: string) =>
-		existsSync(join(componentsRoot, application)) ||
-		existsSync(join(installedRoot, application)) ||
-		(process.env.RUN_HDB_APP && basename(process.env.RUN_HDB_APP) === application);
-	const wanted = new Set(admittedIsolatedApplications([...isolatedSlots.keys()]).filter(present));
+	const wanted = new Set(admittedIsolatedApplications([...isolatedSlots.keys()]));
 	const stopping = [];
 	for (const [application, slot] of isolatedSlots) {
 		if (wanted.has(application)) continue;
@@ -233,9 +226,10 @@ async function reconcileIsolatedWorkersNow(): Promise<string[]> {
 	await Promise.all(stopping);
 	const starting = [];
 	const started: string[] = [];
+	const heapShareCount = poolSize + wanted.size;
 	for (const application of wanted) {
 		if (isolatedSlots.has(application)) continue;
-		const slot = startHTTPWorker(nextIsolatedIndex++, poolSize, application, poolSize + isolatedSlots.size + 1);
+		const slot = startHTTPWorker(nextIsolatedIndex++, poolSize, application, heapShareCount);
 		isolatedSlots.set(application, slot);
 		starting.push(
 			watchDedicatedStart(application, slot).then((ready) => {
@@ -246,7 +240,10 @@ async function reconcileIsolatedWorkersNow(): Promise<string[]> {
 	await Promise.all(starting);
 	return started;
 }
-if (isMainThread) setIsolatedWorkerReconciler(reconcileIsolatedWorkers);
+if (isMainThread) {
+	setIsolatedWorkerReconciler(reconcileIsolatedWorkers);
+	setRunningIsolatedApplicationsGetter(() => [...isolatedSlots.keys()]);
+}
 
 function startHTTPWorker(index, threadCount = 1, application?: string, heapShareCount?: number) {
 	const { promise: ready, resolve: resolveReady, reject: rejectReady } = Promise.withResolvers<void>();
@@ -256,6 +253,7 @@ function startHTTPWorker(index, threadCount = 1, application?: string, heapShare
 	// A Worker's threadId reads back as -1 once it has exited, which is exactly when the diagnostics
 	// below run, so each attempt records its id while the worker is still alive.
 	let lastThreadId = -1;
+	let isolatedSlot: IsolatedSlot | undefined;
 	const finishStartup = () => {
 		waitingForInitialReady = false;
 		finishCurrentStartup();
@@ -322,9 +320,10 @@ function startHTTPWorker(index, threadCount = 1, application?: string, heapShare
 			}
 		},
 		onRestartExhausted() {
-			// a dead dedicated worker leaves its slot, so the next reconcile (a deploy of the fix) starts a new one
-			if (application) isolatedSlots.delete(application);
-			failStartup(new Error(`HTTP worker slot ${index} exhausted restarts before ready (thread ${lastThreadId})`));
+			const error = new Error(`HTTP worker slot ${index} exhausted restarts (thread ${lastThreadId})`);
+			if (waitingForInitialReady) failStartup(error);
+			else if (application && isolatedSlot && isolatedSlots.get(application) === isolatedSlot)
+				isolatedSlots.delete(application);
 		},
 	};
 	startWorker(join(__dirname, './threadServer.js'), workerOptions);
@@ -336,7 +335,8 @@ function startHTTPWorker(index, threadCount = 1, application?: string, heapShare
 		failStartup(new Error(`Dedicated worker for '${application}' was stopped before it became ready`));
 		await Promise.all(workersForApplication(application).map((worker) => stopWorker(worker)));
 	};
-	return { ready, finishStartup, shutdown, application };
+	isolatedSlot = { ready, finishStartup, shutdown, application };
+	return isolatedSlot;
 }
 
 // basically, the amount of additional idleness to expect based on previous idleness (some work will continue, some

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -331,20 +331,20 @@ function startHTTPWorker(index, threadCount = 1, application?: string, heapShare
 			const error = new Error(`HTTP worker slot ${index} exhausted restarts (thread ${lastThreadId})`);
 			if (waitingForInitialReady) failStartup(error);
 			else if (application && isolatedSlot && isolatedSlots.get(application) === isolatedSlot) {
-				const exhaustedSlot = isolatedSlot;
+				isolatedSlots.delete(application);
 				componentLifecycle.failed(application, error, `Component '${application}' worker failed`);
 				void import('../http.ts').then(
 					({ cleanupApplicationSockets }) => {
-						if (isolatedSlots.get(application) !== exhaustedSlot) return;
+						// A config reconciliation may already have installed a replacement after the
+						// exhausted slot released its lease. Never unlink that replacement's mirror.
+						if (isolatedSlots.has(application)) return;
 						cleanupApplicationSockets(application);
-						isolatedSlots.delete(application);
 					},
 					(cleanupError) => {
 						harperLogger.error(
 							`Could not clean sockets for failed isolated application '${application}'`,
 							cleanupError
 						);
-						if (isolatedSlots.get(application) === exhaustedSlot) isolatedSlots.delete(application);
 					}
 				);
 			}

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -10,7 +10,6 @@ import {
 } from './manageThreads.js';
 import {
 	presentIsolatedApplicationNames,
-	isolatedWorkerHeapShareCount,
 	isolatedApplicationRefusal,
 	isolatedApplicationCapacityRefusal,
 } from './isolatedApplications.ts';
@@ -97,7 +96,7 @@ export async function startHTTPThreads(threadCount = 2, dynamicThreads?: boolean
 		poolSize = threadCount;
 		nextIsolatedIndex = Math.max(nextIsolatedIndex, threadCount);
 		const isolated = admittedIsolatedApplications([...isolatedSlots.keys()]);
-		const heapShareCount = isolatedWorkerHeapShareCount(threadCount);
+		const heapShareCount = threadCount + isolated.length;
 		for (let i = 0; i < threadCount; i++) {
 			workerSlots.push(startHTTPWorker(i, threadCount, undefined, heapShareCount));
 		}
@@ -203,11 +202,15 @@ async function reconcileIsolatedWorkersNow(): Promise<string[]> {
 		if (wanted.has(application)) continue;
 		isolatedSlots.delete(application);
 		// awaited: a caller that goes on to remove the application's storage must see its worker gone
-		stopping.push(slot.shutdown());
+		stopping.push(slot.shutdown().then(() => application));
 	}
-	await Promise.all(stopping);
+	const stoppedApplications = await Promise.all(stopping);
+	if (stoppedApplications.length > 0) {
+		const { cleanupApplicationSockets } = await import('../http.ts');
+		for (const application of stoppedApplications) cleanupApplicationSockets(application);
+	}
 	const started: string[] = [];
-	const heapShareCount = isolatedWorkerHeapShareCount(poolSize);
+	const heapShareCount = poolSize + wanted.size;
 	for (const application of wanted) {
 		if (isolatedSlots.has(application)) continue;
 		const slot = startHTTPWorker(nextIsolatedIndex++, poolSize, application, heapShareCount);

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -141,25 +141,37 @@ const poolSlots: IsolatedSlot[] = [];
  */
 function admittedIsolatedApplications(running: string[]): string[] {
 	const names = presentIsolatedApplicationNames();
-	const admitted = running.filter((name) => names.includes(name));
+	const admitted = [];
+	for (const name of running) {
+		if (!names.includes(name)) continue;
+		const refusal = isolatedApplicationRefusal(name);
+		if (refusal) {
+			reportIsolatedRefusal(name, refusal);
+			continue;
+		}
+		admitted.push(name);
+	}
 	for (const name of names) {
 		if (admitted.includes(name)) continue;
 		const refusal = isolatedApplicationRefusal(name) ?? isolatedApplicationCapacityRefusal(name, admitted);
 		if (refusal) {
-			if (!refusedIsolated.has(name)) {
-				refusedIsolated.add(name);
-				const error = new Error(
-					`Application '${name}' is isolated but gets no dedicated worker: ${refusal}; it is not loaded anywhere`
-				);
-				harperLogger.error(error.message);
-				componentLifecycle.failed(name, error, `Component '${name}' failed to load`);
-			}
+			reportIsolatedRefusal(name, refusal);
 			continue;
 		}
 		refusedIsolated.delete(name);
 		admitted.push(name);
 	}
 	return admitted;
+}
+
+function reportIsolatedRefusal(name: string, refusal: string) {
+	if (refusedIsolated.has(name)) return;
+	refusedIsolated.add(name);
+	const error = new Error(
+		`Application '${name}' is isolated but gets no dedicated worker: ${refusal}; it is not loaded anywhere`
+	);
+	harperLogger.error(error.message);
+	componentLifecycle.failed(name, error, `Component '${name}' failed to load`);
 }
 
 /**
@@ -314,8 +326,24 @@ function startHTTPWorker(index, threadCount = 1, application?: string, heapShare
 		onRestartExhausted() {
 			const error = new Error(`HTTP worker slot ${index} exhausted restarts (thread ${lastThreadId})`);
 			if (waitingForInitialReady) failStartup(error);
-			else if (application && isolatedSlot && isolatedSlots.get(application) === isolatedSlot)
-				isolatedSlots.delete(application);
+			else if (application && isolatedSlot && isolatedSlots.get(application) === isolatedSlot) {
+				const exhaustedSlot = isolatedSlot;
+				componentLifecycle.failed(application, error, `Component '${application}' worker failed`);
+				void import('../http.ts').then(
+					({ cleanupApplicationSockets }) => {
+						if (isolatedSlots.get(application) !== exhaustedSlot) return;
+						cleanupApplicationSockets(application);
+						isolatedSlots.delete(application);
+					},
+					(cleanupError) => {
+						harperLogger.error(
+							`Could not clean sockets for failed isolated application '${application}'`,
+							cleanupError
+						);
+						if (isolatedSlots.get(application) === exhaustedSlot) isolatedSlots.delete(application);
+					}
+				);
+			}
 		},
 	};
 	startWorker(join(__dirname, './threadServer.js'), workerOptions);

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -193,9 +193,10 @@ function watchDedicatedStart(application: string, slot: IsolatedSlot): Promise<b
 		.catch(async (error) => {
 			harperLogger.error(`Dedicated worker for isolated application '${application}' failed to start`, error);
 			componentLifecycle.failed(application, error, `Component '${application}' failed to load`);
+			const withdrewLease = isolatedSlots.get(application) === slot;
+			if (withdrewLease) isolatedSlots.delete(application);
 			await slot.shutdown();
-			if (isolatedSlots.get(application) === slot) {
-				isolatedSlots.delete(application);
+			if (withdrewLease && !isolatedSlots.has(application)) {
 				const { cleanupApplicationSockets } = await import('../http.ts');
 				cleanupApplicationSockets(application);
 			}

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -101,6 +101,11 @@ exports.listenOnDomainSocket = listenOnDomainSocket;
 exports.listenOnPorts = listenOnPorts;
 exports.startServers = startServers;
 exports.closeServers = closeServers;
+exports.shouldStartGlobalUwsServers = shouldStartGlobalUwsServers;
+
+function shouldStartGlobalUwsServers(isolatedApplication = thisThreadsIsolatedApplication()) {
+	return isolatedApplication === undefined;
+}
 
 function closeServers() {
 	if (isBun) {
@@ -409,10 +414,9 @@ function listenOnPorts() {
 	// These replace the Node http UDS mirror; createUwsServer binds the unix socket and bridges each
 	// request through httpChain[port] via UwsRequest.
 	const uwsServeConfigs = httpComponent.uwsServeConfigs;
-	if (uwsServeConfigs) {
+	if (uwsServeConfigs && shouldStartGlobalUwsServers()) {
 		for (const key in uwsServeConfigs) {
 			const cfg = uwsServeConfigs[key];
-			if (thisThreadsIsolatedApplication() && !cfg.socketPath) continue; // dedicated worker: mirrors only
 			if (cfg.socketPath && existsSync(cfg.socketPath)) unlinkSync(cfg.socketPath);
 			const { createUwsServer } = require('../serverHelpers/uwsServer.ts');
 			listening.push(

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -577,6 +577,7 @@ async function listenOnPortsBun() {
 			}
 		} catch (error) {
 			harperLogger.error(`Unable to start Bun server on port ${port}`, error);
+			if (thisThreadsIsolatedApplication()) throw error;
 		}
 	}
 	// Also start any non-HTTP servers (raw socket servers) that were registered in SERVERS

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -26,7 +26,11 @@ const {
 	getShutdownDrainCeilingMs,
 } = require('../../components/shutdownDrain.ts');
 const { realExit } = require('./workerProcessGuard.ts');
-const { thisThreadsIsolatedApplication, applicationSocketName } = require('./isolatedApplications.ts');
+const {
+	thisThreadsIsolatedApplication,
+	applicationSocketName,
+	shouldStartUwsListenerHere,
+} = require('./isolatedApplications.ts');
 const { isBun } = require('../serverHelpers/Request.ts');
 const { getDomainSocketPathMaxBytes, isDomainSocketPathTooLong } = require('../../utility/domainSocket.ts');
 const { createTLSSelector, getEffectiveTlsCiphers } = require('../../security/keys.ts');
@@ -412,7 +416,7 @@ function listenOnPorts() {
 	if (uwsServeConfigs) {
 		for (const key in uwsServeConfigs) {
 			const cfg = uwsServeConfigs[key];
-			if (thisThreadsIsolatedApplication() && !cfg.socketPath) continue; // dedicated worker: mirrors only
+			if (!shouldStartUwsListenerHere(cfg)) continue; // dedicated worker: its own mirrors only
 			if (cfg.socketPath && existsSync(cfg.socketPath)) unlinkSync(cfg.socketPath);
 			const { createUwsServer } = require('../serverHelpers/uwsServer.ts');
 			listening.push(

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -539,8 +539,9 @@ async function listenOnPortsBun() {
 				delete serveOptions.port;
 			}
 			if (isNaN(serveOptions.port)) continue;
-			// a dedicated worker binds no public port (see listenOnPorts); its UDS mirror below is its only surface
-			if (!(thisThreadsIsolatedApplication() && !String(port).includes('/'))) {
+			// Keep ownership independent of address syntax: adding a Bun UDS route later must not widen
+			// a dedicated worker's ingress beyond its application-addressed mirror below.
+			if (!thisThreadsIsolatedApplication()) {
 				const bunServer = Bun.serve(serveOptions);
 				SERVERS[port] = bunServer;
 				harperLogger.trace('Bun listening on port ' + port, threadId);

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -26,6 +26,7 @@ const {
 	getShutdownDrainCeilingMs,
 } = require('../../components/shutdownDrain.ts');
 const { realExit } = require('./workerProcessGuard.ts');
+const { thisThreadsIsolatedApplication, applicationSocketName } = require('./isolatedApplications.ts');
 const { isBun } = require('../serverHelpers/Request.ts');
 const { getDomainSocketPathMaxBytes, isDomainSocketPathTooLong } = require('../../utility/domainSocket.ts');
 const { createTLSSelector, getEffectiveTlsCiphers } = require('../../security/keys.ts');
@@ -330,10 +331,15 @@ function listenOnPorts() {
 		const server = SERVERS[port];
 
 		// If server is unix domain socket
+		// A worker dedicated to an isolated application binds only its own per-thread mirrors: not the shared
+		// ports (the kernel would hand it every application's connections) and not a global domain socket
+		// such as the operations API's, which it would take from the main thread.
 		if (port.includes?.('/')) {
-			listening.push(listenOnDomainSocket(port, server));
+			if (!thisThreadsIsolatedApplication() || server.isPerThreadSocket)
+				listening.push(listenOnDomainSocket(port, server));
 			continue;
 		}
+		if (thisThreadsIsolatedApplication()) continue;
 		let listen_on;
 		let ownerWorkerIndex = 0; // lowest eligible worker index for this port
 		const threadRange = env.get(terms.CONFIG_PARAMS.HTTP_THREADRANGE);
@@ -406,6 +412,7 @@ function listenOnPorts() {
 	if (uwsServeConfigs) {
 		for (const key in uwsServeConfigs) {
 			const cfg = uwsServeConfigs[key];
+			if (thisThreadsIsolatedApplication() && !cfg.socketPath) continue; // dedicated worker: mirrors only
 			if (cfg.socketPath && existsSync(cfg.socketPath)) unlinkSync(cfg.socketPath);
 			const { createUwsServer } = require('../serverHelpers/uwsServer.ts');
 			listening.push(
@@ -455,7 +462,7 @@ async function listenOnPortsBun() {
 	for (let port in bunServeConfigs) {
 		const config = bunServeConfigs[port];
 		const threadRange = env.get(terms.CONFIG_PARAMS.HTTP_THREADRANGE);
-		if (threadRange) {
+		if (threadRange && !thisThreadsIsolatedApplication()) {
 			let threadRangeArray = typeof threadRange === 'string' ? threadRange.split('-') : threadRange;
 			let threadIndex = getWorkerIndex();
 			if (threadIndex < threadRangeArray[0] || threadIndex > threadRangeArray[1]) {
@@ -532,15 +539,21 @@ async function listenOnPortsBun() {
 				delete serveOptions.port;
 			}
 			if (isNaN(serveOptions.port)) continue;
-			const bunServer = Bun.serve(serveOptions);
-			SERVERS[port] = bunServer;
-			harperLogger.trace('Bun listening on port ' + port, threadId);
+			// a dedicated worker binds no public port (see listenOnPorts); its UDS mirror below is its only surface
+			if (!(thisThreadsIsolatedApplication() && !String(port).includes('/'))) {
+				const bunServer = Bun.serve(serveOptions);
+				SERVERS[port] = bunServer;
+				harperLogger.trace('Bun listening on port ' + port, threadId);
+			}
 
 			// Create a corresponding Unix Domain Socket mirror for secure ports
 			if (config.isSecure && env.get(terms.CONFIG_PARAMS.TLS_UNIXDOMAINSOCKETS)) {
 				const socketsDir = join(env.getHdbBasePath(), 'sockets');
 				mkdirSync(socketsDir, { recursive: true });
-				const socketName = `${getWorkerIndex()}-${port}`;
+				const isolatedApplication = thisThreadsIsolatedApplication();
+				const socketName = isolatedApplication
+					? applicationSocketName(isolatedApplication, port)
+					: `${getWorkerIndex()}-${port}`;
 				const udsPath = join(socketsDir, `${socketName}.sock`);
 				const yamlPath = join(socketsDir, `${socketName}.yaml`);
 				if (existsSync(udsPath)) unlinkSync(udsPath);
@@ -574,6 +587,7 @@ async function listenOnPortsBun() {
 		if (server?.stop || bunServeConfigs[port]) continue;
 		if (server?.listen) {
 			if (port.includes?.('/')) {
+				if (thisThreadsIsolatedApplication() && !server.isPerThreadSocket) continue; // as in listenOnPorts
 				listening.push(listenOnDomainSocket(port, server));
 			} else {
 				const lastColon = String(port).lastIndexOf(':');
@@ -673,7 +687,10 @@ function onSocket(listener, options) {
 		if (env.get(terms.CONFIG_PARAMS.TLS_UNIXDOMAINSOCKETS)) {
 			const socketsDir = join(env.getHdbBasePath(), 'sockets');
 			mkdirSync(socketsDir, { recursive: true });
-			const socketName = `${getWorkerIndex()}-${options.securePort}`;
+			const isolatedApplication = thisThreadsIsolatedApplication();
+			const socketName = isolatedApplication
+				? applicationSocketName(isolatedApplication, options.securePort)
+				: `${getWorkerIndex()}-${options.securePort}`;
 			const udsPath = join(socketsDir, `${socketName}.sock`);
 			const yamlPath = join(socketsDir, `${socketName}.yaml`);
 

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -101,11 +101,6 @@ exports.listenOnDomainSocket = listenOnDomainSocket;
 exports.listenOnPorts = listenOnPorts;
 exports.startServers = startServers;
 exports.closeServers = closeServers;
-exports.shouldStartGlobalUwsServers = shouldStartGlobalUwsServers;
-
-function shouldStartGlobalUwsServers(isolatedApplication = thisThreadsIsolatedApplication()) {
-	return isolatedApplication === undefined;
-}
 
 function closeServers() {
 	if (isBun) {
@@ -414,9 +409,10 @@ function listenOnPorts() {
 	// These replace the Node http UDS mirror; createUwsServer binds the unix socket and bridges each
 	// request through httpChain[port] via UwsRequest.
 	const uwsServeConfigs = httpComponent.uwsServeConfigs;
-	if (uwsServeConfigs && shouldStartGlobalUwsServers()) {
+	if (uwsServeConfigs) {
 		for (const key in uwsServeConfigs) {
 			const cfg = uwsServeConfigs[key];
+			if (thisThreadsIsolatedApplication() && !cfg.socketPath) continue; // dedicated worker: mirrors only
 			if (cfg.socketPath && existsSync(cfg.socketPath)) unlinkSync(cfg.socketPath);
 			const { createUwsServer } = require('../serverHelpers/uwsServer.ts');
 			listening.push(

--- a/unitTests/components/componentLoader.test.js
+++ b/unitTests/components/componentLoader.test.js
@@ -409,6 +409,20 @@ describe('ComponentLoader Status Integration', function () {
 			assert.ok(failure, 'reported as a failed load');
 			assert.match(failure.args[1].message, /threads\.count is 0/);
 		});
+
+		it('fails a malformed isolation setting closed instead of loading it in the pool', async function () {
+			configUtils.getConfigObj.returns({ [isoName]: { isolated: 'true' } });
+			setMainIsWorker(false);
+			try {
+				await componentLoader.loadComponentDirectories(new Map(), { isWorker: true, set() {} }, new WeakMap());
+			} finally {
+				setMainIsWorker(mainWasWorker);
+			}
+			assert.strictEqual(isoStarts, 0);
+			const failure = lifecycle.failed.getCalls().find((call) => call.args[0] === isoName);
+			assert.ok(failure, 'reported as a failed load');
+			assert.match(failure.args[1].message, /expected a boolean/);
+		});
 	});
 
 	describe('deploy lifecycle listener lifecycle (#1462)', function () {

--- a/unitTests/components/componentLoader.test.js
+++ b/unitTests/components/componentLoader.test.js
@@ -355,6 +355,62 @@ describe('ComponentLoader Status Integration', function () {
 		}
 	});
 
+	describe('isolated applications (harper#642 tier 2)', function () {
+		const { setMainIsWorker, getWorkerIndex } = require('#src/server/threads/manageThreads');
+		let mainWasWorker;
+		beforeEach(() => (mainWasWorker = getWorkerIndex() === 0));
+		const configUtils = require('#src/config/configUtils');
+		const isoName = 'isolated-probe';
+		const sharedName = 'shared-probe';
+		let isoStarts = 0;
+		let sharedStarts = 0;
+
+		beforeEach(async () => {
+			isoStarts = sharedStarts = 0;
+			for (const [name, plugin] of [
+				[isoName, 'isolatedProbePlugin'],
+				[sharedName, 'sharedProbePlugin'],
+			]) {
+				await fs.mkdir(path.join(tempDir, name), { recursive: true });
+				await fs.writeFile(path.join(tempDir, name, 'config.yaml'), `${plugin}: {}\n`);
+			}
+			componentLoader.TRUSTED_RESOURCE_PLUGINS.isolatedProbePlugin = { start: () => isoStarts++ };
+			componentLoader.TRUSTED_RESOURCE_PLUGINS.sharedProbePlugin = { start: () => sharedStarts++ };
+			configUtils.getConfigObj.returns({ [isoName]: { isolated: true } });
+		});
+		afterEach(async () => {
+			delete componentLoader.TRUSTED_RESOURCE_PLUGINS.isolatedProbePlugin;
+			delete componentLoader.TRUSTED_RESOURCE_PLUGINS.sharedProbePlugin;
+			componentLoader.loadedPaths.clear();
+			for (const name of [isoName, sharedName]) await fs.rm(path.join(tempDir, name), { recursive: true, force: true });
+		});
+
+		it('a thread that is not the dedicated worker never imports an isolated application', async function () {
+			setMainIsWorker(false); // the main thread of a multi-worker instance
+			try {
+				await componentLoader.loadComponentDirectories(new Map(), { isWorker: true, set() {} }, new WeakMap());
+			} finally {
+				setMainIsWorker(mainWasWorker); // other suites in this process rely on the previous mode
+			}
+			assert.strictEqual(sharedStarts, 1, 'the shared application loads here');
+			assert.strictEqual(isoStarts, 0, 'the isolated one is left to its own thread');
+			assert.ok(!lifecycle.failed.getCalls().some((call) => call.args[0] === isoName), 'and is not a failure');
+		});
+
+		it('fails an isolated application closed when the main thread is the only worker', async function () {
+			setMainIsWorker(true); // threads.count: 0
+			try {
+				await componentLoader.loadComponentDirectories(new Map(), { isWorker: true, set() {} }, new WeakMap());
+			} finally {
+				setMainIsWorker(mainWasWorker); // other suites in this process rely on the previous mode
+			}
+			assert.strictEqual(isoStarts, 0, 'never downgraded onto the shared thread');
+			const failure = lifecycle.failed.getCalls().find((call) => call.args[0] === isoName);
+			assert.ok(failure, 'reported as a failed load');
+			assert.match(failure.args[1].message, /threads\.count is 0/);
+		});
+	});
+
 	describe('deploy lifecycle listener lifecycle (#1462)', function () {
 		const { deployLifecycle } = require('#src/components/deployLifecycle');
 

--- a/unitTests/components/prepareApplicationSerialization.test.js
+++ b/unitTests/components/prepareApplicationSerialization.test.js
@@ -164,16 +164,27 @@ describe('prepareApplication serialization', () => {
 		});
 		firstApplication.dirPath = componentDirPath;
 		secondApplication.dirPath = componentDirPath;
+		let firstBeforePrepare = false;
+		let secondBeforePrepare = false;
 
 		try {
-			const firstPreparation = prepareApplication(firstApplication);
+			const firstPreparation = prepareApplication(firstApplication, {
+				beforePrepare: async () => {
+					firstBeforePrepare = true;
+				},
+			});
 			await waitFor(() =>
 				access(firstStartedPath).then(
 					() => true,
 					() => false
 				)
 			);
-			const secondPreparation = prepareApplication(secondApplication);
+			assert.strictEqual(firstBeforePrepare, true);
+			const secondPreparation = prepareApplication(secondApplication, {
+				beforePrepare: async () => {
+					secondBeforePrepare = true;
+				},
+			});
 
 			// Tolerates the live path not existing yet, which is the new invariant: the first deploy's
 			// candidate is still installing, so nothing has been published to the component path at all.
@@ -189,9 +200,11 @@ describe('prepareApplication serialization', () => {
 				/second extraction started before the first install completed/
 			);
 			await assert.rejects(access(secondStartedPath));
+			assert.strictEqual(secondBeforePrepare, false, 'preparation hooks share the component lock');
 
 			await writeFile(releaseFirstPath, 'release');
 			await Promise.all([firstPreparation, secondPreparation]);
+			assert.strictEqual(secondBeforePrepare, true);
 			assert.equal(JSON.parse(await readFile(join(componentDirPath, 'package.json'), 'utf8')).version, '2.0.0');
 			assert.equal(await readFile(secondStartedPath, 'utf8'), 'started');
 		} finally {

--- a/unitTests/components/requestRestart.test.js
+++ b/unitTests/components/requestRestart.test.js
@@ -1,4 +1,9 @@
-const { requestRestart, restartNeeded, resetRestartNeeded } = require('#src/components/requestRestart');
+const {
+	requestRestart,
+	requestRestartAfterDeploy,
+	restartNeeded,
+	resetRestartNeeded,
+} = require('#src/components/requestRestart');
 const assert = require('node:assert');
 
 describe('requestRestart', () => {
@@ -16,5 +21,23 @@ describe('requestRestart', () => {
 		assert.strictEqual(restartNeeded(), false);
 		requestRestart();
 		assert.strictEqual(restartNeeded(), true);
+	});
+
+	it('requests a restart when a deploy changes application isolation', () => {
+		assert.strictEqual(requestRestartAfterDeploy(false, false, false, true), true);
+		assert.strictEqual(restartNeeded(), true);
+
+		resetRestartNeeded();
+		assert.strictEqual(requestRestartAfterDeploy(false, false, true, false), true);
+		assert.strictEqual(restartNeeded(), true);
+	});
+
+	it('keeps the existing new-component and package-metadata rules', () => {
+		assert.strictEqual(requestRestartAfterDeploy(false, false, true, true), false);
+		assert.strictEqual(restartNeeded(), false);
+		assert.strictEqual(requestRestartAfterDeploy(true, false, false, false), true);
+
+		resetRestartNeeded();
+		assert.strictEqual(requestRestartAfterDeploy(false, true, false, false), true);
 	});
 });

--- a/unitTests/resources/dataLoader.test.js
+++ b/unitTests/resources/dataLoader.test.js
@@ -982,7 +982,7 @@ records:
 
 		beforeEach(function () {
 			// Save original function
-			originalGetWorkerIndex = manageThreads.getWorkerIndex;
+			originalGetWorkerIndex = manageThreads.isApplicationPrimaryWorker;
 
 			// Clear any previous stub calls to the logger
 			loggerStub.info.resetHistory();
@@ -992,12 +992,12 @@ records:
 
 		afterEach(function () {
 			// Restore original functions
-			manageThreads.getWorkerIndex = originalGetWorkerIndex;
+			manageThreads.isApplicationPrimaryWorker = originalGetWorkerIndex;
 		});
 
 		it('should set up file handler on primary worker', function () {
-			// Mock getWorkerIndex to return zero
-			manageThreads.getWorkerIndex = sinon.stub().returns(0);
+			// the data loader runs only on the application's primary worker
+			manageThreads.isApplicationPrimaryWorker = sinon.stub().returns(true);
 
 			const mockScope = {
 				handleEntry: sinon.stub(),
@@ -1010,7 +1010,7 @@ records:
 		});
 
 		it('should skip non-file entries', async function () {
-			manageThreads.getWorkerIndex = sinon.stub().returns(0);
+			manageThreads.isApplicationPrimaryWorker = sinon.stub().returns(true);
 
 			const mockScope = {
 				handleEntry: sinon.stub(),
@@ -1031,7 +1031,7 @@ records:
 		});
 
 		it('should skip unlink events', async function () {
-			manageThreads.getWorkerIndex = sinon.stub().returns(0);
+			manageThreads.isApplicationPrimaryWorker = sinon.stub().returns(true);
 
 			const mockScope = {
 				handleEntry: sinon.stub(),

--- a/unitTests/resources/expiresAtAttribute.test.js
+++ b/unitTests/resources/expiresAtAttribute.test.js
@@ -2,6 +2,7 @@ require('../testUtils');
 const assert = require('assert');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
+const { makeTable: makeTableResource } = require('#src/resources/Table');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 
 // A schema @expiresAt attribute must be authoritative over the table-level expiration default, in both
@@ -136,6 +137,54 @@ describe('@expiresAt attribute is authoritative over the table default', () => {
 		await Redeclared.put(1, { id: 1, expiresAt });
 		assert.strictEqual(await storedExpiresAt(Redeclared, 1), expiresAt);
 		assert.strictEqual(await Redeclared.get(1), null);
+	});
+
+	// A worker that only hydrated a table from the catalog has no cleanup scan armed: setTTLExpiration
+	// runs at construction only when an expiration is set, and an eviction-only table persists
+	// expiration 0. When an isolated application then redeclares that table with just an @expiresAt
+	// attribute, the declaration preserves the loaded configuration -- so the loaded eviction is the
+	// only thing left that can arm the scan, and without it those records are never physically evicted.
+	it('arms a preserved eviction cleanup on an ownership-only redeclaration', () => {
+		const Declared = table({
+			table: 'EvictionOnlyDeclared',
+			database: 'test',
+			eviction: 40,
+			attributes: [{ name: 'id', isPrimaryKey: true }],
+		});
+		assert.strictEqual(Declared.evictionMS, 40_000);
+		// the same table as a worker that only hydrated it sees it: eviction from the persisted
+		// metadata, and no setTTLExpiration call of its own
+		const hydrated = (evictionMS) =>
+			makeTableResource({
+				primaryStore: Declared.primaryStore,
+				auditStore: Declared.auditStore,
+				audit: false,
+				evictionMS,
+				tableName: `EvictionOnlyHydrated-${evictionMS}`,
+				tableId: Declared.primaryStore.tableId,
+				primaryKey: 'id',
+				databasePath: 'test',
+				databaseName: 'test',
+				indices: {},
+				attributes: [{ name: 'id', isPrimaryKey: true }],
+				dbisDB: Declared.dbisDB,
+			});
+		const cleanupTimersArmedBy = (Table) => {
+			const originalSetTimeout = global.setTimeout;
+			let timers = 0;
+			global.setTimeout = (callback, delay, ...args) => {
+				timers++;
+				return originalSetTimeout(callback, delay, ...args);
+			};
+			try {
+				Table.setTTLExpiration({ fromSchema: true, isolatedApplicationOwner: true });
+			} finally {
+				global.setTimeout = originalSetTimeout;
+			}
+			return timers;
+		};
+		assert.strictEqual(cleanupTimersArmedBy(hydrated(40_000)), 1, 'the preserved eviction arms the cleanup scan');
+		assert.strictEqual(cleanupTimersArmedBy(hydrated(0)), 0, 'with nothing loaded to clean up, none is armed');
 	});
 
 	it('arms one @expiresAt interval initially and when a live table gains the attribute', async () => {

--- a/unitTests/resources/expiresAtAttribute.test.js
+++ b/unitTests/resources/expiresAtAttribute.test.js
@@ -140,10 +140,16 @@ describe('@expiresAt attribute is authoritative over the table default', () => {
 
 	it('arms one @expiresAt interval initially and when a live table gains the attribute', async () => {
 		const originalSetInterval = global.setInterval;
+		const originalSetTimeout = global.setTimeout;
 		let expirationIntervals = 0;
+		let cleanupTimers = 0;
 		global.setInterval = (callback, delay, ...args) => {
 			if (delay === 60_000) expirationIntervals++;
 			return originalSetInterval(callback, delay, ...args);
+		};
+		global.setTimeout = (callback, delay, ...args) => {
+			cleanupTimers++;
+			return originalSetTimeout(callback, delay, ...args);
 		};
 		try {
 			const beforeInitialDeclaration = expirationIntervals;
@@ -186,6 +192,7 @@ describe('@expiresAt attribute is authoritative over the table default', () => {
 				`unexpected retained default expiry ${storedDefaultExpiry}`
 			);
 
+			const beforeSharedDeclarationTimers = cleanupTimers;
 			table({
 				table: 'ExpiresAtAddedToSharedTable',
 				database: 'test',
@@ -201,8 +208,14 @@ describe('@expiresAt attribute is authoritative over the table default', () => {
 				],
 			});
 			assert.strictEqual(expirationIntervals, beforeSharedRedeclaration + 1);
+			assert.strictEqual(
+				cleanupTimers,
+				beforeSharedDeclarationTimers,
+				'field-only declarations do not create a default table cleanup timer'
+			);
 		} finally {
 			global.setInterval = originalSetInterval;
+			global.setTimeout = originalSetTimeout;
 		}
 	});
 });

--- a/unitTests/resources/expiresAtAttribute.test.js
+++ b/unitTests/resources/expiresAtAttribute.test.js
@@ -138,7 +138,7 @@ describe('@expiresAt attribute is authoritative over the table default', () => {
 		assert.strictEqual(await Redeclared.get(1), null);
 	});
 
-	it('arms one @expiresAt interval initially and when a live isolated table already owns TTL', () => {
+	it('arms one @expiresAt interval initially and when a live table gains the attribute', () => {
 		const originalSetInterval = global.setInterval;
 		let expirationIntervals = 0;
 		global.setInterval = (callback, delay, ...args) => {
@@ -178,6 +178,22 @@ describe('@expiresAt attribute is authoritative over the table default', () => {
 				],
 			});
 			assert.strictEqual(expirationIntervals, before + 1);
+
+			table({
+				table: 'ExpiresAtAddedToSharedTable',
+				database: 'test',
+				attributes: [{ name: 'id', isPrimaryKey: true }],
+			});
+			const beforeSharedRedeclaration = expirationIntervals;
+			table({
+				table: 'ExpiresAtAddedToSharedTable',
+				database: 'test',
+				attributes: [
+					{ name: 'id', isPrimaryKey: true },
+					{ name: 'expiresAt', expiresAt: true, indexed: true },
+				],
+			});
+			assert.strictEqual(expirationIntervals, beforeSharedRedeclaration + 1);
 		} finally {
 			global.setInterval = originalSetInterval;
 		}

--- a/unitTests/resources/expiresAtAttribute.test.js
+++ b/unitTests/resources/expiresAtAttribute.test.js
@@ -137,4 +137,49 @@ describe('@expiresAt attribute is authoritative over the table default', () => {
 		assert.strictEqual(await storedExpiresAt(Redeclared, 1), expiresAt);
 		assert.strictEqual(await Redeclared.get(1), null);
 	});
+
+	it('arms one @expiresAt interval initially and when a live isolated table already owns TTL', () => {
+		const originalSetInterval = global.setInterval;
+		let expirationIntervals = 0;
+		global.setInterval = (callback, delay, ...args) => {
+			if (delay === 60_000) expirationIntervals++;
+			return originalSetInterval(callback, delay, ...args);
+		};
+		try {
+			const beforeInitialDeclaration = expirationIntervals;
+			table({
+				table: 'ExpiresAtInitialInterval',
+				database: 'test',
+				expiration: 60,
+				isolatedApplicationOwner: true,
+				attributes: [
+					{ name: 'id', isPrimaryKey: true },
+					{ name: 'expiresAt', expiresAt: true, indexed: true },
+				],
+			});
+			assert.strictEqual(expirationIntervals, beforeInitialDeclaration + 1);
+
+			table({
+				table: 'ExpiresAtAddedAfterTtl',
+				database: 'test',
+				expiration: 60,
+				isolatedApplicationOwner: true,
+				attributes: [{ name: 'id', isPrimaryKey: true }],
+			});
+			const before = expirationIntervals;
+			table({
+				table: 'ExpiresAtAddedAfterTtl',
+				database: 'test',
+				expiration: 60,
+				isolatedApplicationOwner: true,
+				attributes: [
+					{ name: 'id', isPrimaryKey: true },
+					{ name: 'expiresAt', expiresAt: true, indexed: true },
+				],
+			});
+			assert.strictEqual(expirationIntervals, before + 1);
+		} finally {
+			global.setInterval = originalSetInterval;
+		}
+	});
 });

--- a/unitTests/resources/expiresAtAttribute.test.js
+++ b/unitTests/resources/expiresAtAttribute.test.js
@@ -138,7 +138,7 @@ describe('@expiresAt attribute is authoritative over the table default', () => {
 		assert.strictEqual(await Redeclared.get(1), null);
 	});
 
-	it('arms one @expiresAt interval initially and when a live table gains the attribute', () => {
+	it('arms one @expiresAt interval initially and when a live table gains the attribute', async () => {
 		const originalSetInterval = global.setInterval;
 		let expirationIntervals = 0;
 		global.setInterval = (callback, delay, ...args) => {
@@ -167,10 +167,9 @@ describe('@expiresAt attribute is authoritative over the table default', () => {
 				attributes: [{ name: 'id', isPrimaryKey: true }],
 			});
 			const before = expirationIntervals;
-			table({
+			const AddedAfterTtl = table({
 				table: 'ExpiresAtAddedAfterTtl',
 				database: 'test',
-				expiration: 60,
 				isolatedApplicationOwner: true,
 				attributes: [
 					{ name: 'id', isPrimaryKey: true },
@@ -178,6 +177,14 @@ describe('@expiresAt attribute is authoritative over the table default', () => {
 				],
 			});
 			assert.strictEqual(expirationIntervals, before + 1);
+			assert.strictEqual(AddedAfterTtl.expirationMS, 60_000, 'ownership-only redeclaration preserves loaded TTL');
+			const beforeDefaultExpiry = Date.now();
+			await AddedAfterTtl.put(1, { id: 1 });
+			const storedDefaultExpiry = await storedExpiresAt(AddedAfterTtl, 1);
+			assert(
+				storedDefaultExpiry >= beforeDefaultExpiry + 60_000 && storedDefaultExpiry <= Date.now() + 60_000,
+				`unexpected retained default expiry ${storedDefaultExpiry}`
+			);
 
 			table({
 				table: 'ExpiresAtAddedToSharedTable',

--- a/unitTests/resources/expiresAtAttribute.test.js
+++ b/unitTests/resources/expiresAtAttribute.test.js
@@ -115,4 +115,26 @@ describe('@expiresAt attribute is authoritative over the table default', () => {
 		await Table.primaryStore.committed;
 		assert.strictEqual(await Table.get(1), null);
 	});
+
+	it('refreshes @expiresAt behavior when a live table is redeclared', async function () {
+		const Table = table({
+			table: 'ExpiresAtRedeclared',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }],
+		});
+		const Redeclared = table({
+			table: 'ExpiresAtRedeclared',
+			database: 'test',
+			isolatedApplicationOwner: true,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'expiresAt', expiresAt: true, indexed: true },
+			],
+		});
+		assert.strictEqual(Redeclared, Table);
+		const expiresAt = Date.now() - 1_000;
+		await Redeclared.put(1, { id: 1, expiresAt });
+		assert.strictEqual(await storedExpiresAt(Redeclared, 1), expiresAt);
+		assert.strictEqual(await Redeclared.get(1), null);
+	});
 });

--- a/unitTests/server/fastifyRoutes/operations.test.js
+++ b/unitTests/server/fastifyRoutes/operations.test.js
@@ -522,7 +522,7 @@ describe('Test custom functions operations', () => {
 			const addConfigStub = sandbox.stub(configUtils, 'addConfig').resolves();
 
 			// Mock prepareApplication to prevent actual installation
-			const prepareApplicationStub = sandbox.stub();
+			const prepareApplicationStub = sandbox.stub().callsFake((_application, options) => options.beforePrepare());
 			operations.__set__('prepareApplication', prepareApplicationStub);
 
 			// This should work - user components can be overwritten without force
@@ -548,7 +548,7 @@ describe('Test custom functions operations', () => {
 			const addConfigStub = sandbox.stub(configUtils, 'addConfig').resolves();
 
 			// Mock prepareApplication to prevent actual installation
-			const prepareApplicationStub = sandbox.stub();
+			const prepareApplicationStub = sandbox.stub().callsFake((_application, options) => options.beforePrepare());
 			operations.__set__('prepareApplication', prepareApplicationStub);
 
 			// This should work fine - no component exists yet
@@ -591,7 +591,7 @@ describe('Test custom functions operations', () => {
 			const addConfigStub = sandbox.stub(configUtils, 'addConfig').resolves();
 
 			// Mock prepareApplication to prevent actual installation
-			const prepareApplicationStub = sandbox.stub();
+			const prepareApplicationStub = sandbox.stub().callsFake((_application, options) => options.beforePrepare());
 			operations.__set__('prepareApplication', prepareApplicationStub);
 
 			// This should NOT throw an error because force is true

--- a/unitTests/server/storageReclamation.test.js
+++ b/unitTests/server/storageReclamation.test.js
@@ -17,6 +17,7 @@ describe('storageReclamation module', function () {
 	let storageReclamation;
 	let getWorkerIndexStub;
 	let getWorkerCountStub;
+	let ownsStoreMaintenanceStub;
 
 	before(() => {
 		env.initTestEnvironment();
@@ -33,6 +34,8 @@ describe('storageReclamation module', function () {
 		const manageThreads = require('#js/server/threads/manageThreads');
 		getWorkerIndexStub = sandbox.stub(manageThreads, 'getWorkerIndex').returns(0);
 		getWorkerCountStub = sandbox.stub(manageThreads, 'getWorkerCount').returns(1);
+		// the module gates on the per-store predicate, which reads the raw getters internally (unstubbable)
+		ownsStoreMaintenanceStub = sandbox.stub(manageThreads, 'ownsStoreMaintenance').returns(true);
 
 		storageReclamation = rewire(STORAGE_RECLAMATION_PATH);
 	});
@@ -71,6 +74,7 @@ describe('storageReclamation module', function () {
 			// Worker index 0, worker count 1 means this is the last worker (0 === 1-1)
 			getWorkerIndexStub.returns(0);
 			getWorkerCountStub.returns(1);
+			ownsStoreMaintenanceStub.returns(true);
 
 			const handler = sandbox.stub();
 			storageReclamation.onStorageReclamation('/test/path', handler);
@@ -83,6 +87,7 @@ describe('storageReclamation module', function () {
 			// Worker index 0, worker count 2 means this is NOT the last worker
 			getWorkerIndexStub.returns(0);
 			getWorkerCountStub.returns(2);
+			ownsStoreMaintenanceStub.returns(false);
 
 			// Need to reload module with new stub values
 			delete require.cache[require.resolve(STORAGE_RECLAMATION_PATH)];

--- a/unitTests/server/threads/fixtures/exitImmediately.cjs
+++ b/unitTests/server/threads/fixtures/exitImmediately.cjs
@@ -1,0 +1,1 @@
+setImmediate(() => process.exit(0));

--- a/unitTests/server/threads/isolatedApplications.test.js
+++ b/unitTests/server/threads/isolatedApplications.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert');
 const path = require('node:path');
 const fs = require('node:fs');
 const os = require('node:os');
+const { once } = require('node:events');
 // Required lazily, inside the tests: loading these module graphs at file load time would install real
 // loggers before sibling suites in the same mocha process (dataLoader) stub theirs.
 const iso = () => require('#src/server/threads/isolatedApplications');
@@ -159,6 +160,24 @@ describe('isolated applications (harper#642 tier 2)', () => {
 				() => restart().restartService({ service: 'http', scope: 'iso-one', scopeFallback: 'iso-two' }),
 				/Invalid HTTP worker restart scope fallback/
 			);
+		});
+	});
+
+	describe('worker slot lifetime', () => {
+		it('does not auto-restart a worker after its owner withdraws the slot lease', async () => {
+			let starts = 0;
+			let restartChecks = 0;
+			const worker = threads().startWorker(require.resolve('./fixtures/exitImmediately.cjs'), {
+				onStarted: () => starts++,
+				shouldAutoRestart: () => {
+					restartChecks++;
+					return false;
+				},
+			});
+			await once(worker, 'exit');
+			await new Promise(setImmediate);
+			assert.strictEqual(restartChecks, 1);
+			assert.strictEqual(starts, 1, 'the withdrawn slot did not create a replacement');
 		});
 	});
 

--- a/unitTests/server/threads/isolatedApplications.test.js
+++ b/unitTests/server/threads/isolatedApplications.test.js
@@ -163,8 +163,9 @@ describe('isolated applications (harper#642 tier 2)', () => {
 			const { requestRestart, restartNeeded, resetRestartNeeded } = require('#src/components/requestRestart');
 			const restartScoped = (scope) => threads().restartWorkers('http', Infinity, false, null, scope);
 			// already marked shut down, so the restart loop skips it: this stands in for the live topology
-			// the gate reads, not for a worker to replace
-			const dedicated = { name: 'http', application: 'iso-one', wasShutdown: true };
+			// the gate reads, not for a worker to replace. `recentELU` so the entry is complete on its own
+			// rather than relying on the monitor tick to backfill it.
+			const dedicated = { name: 'http', application: 'iso-one', wasShutdown: true, recentELU: { idle: 0 } };
 			try {
 				requestRestart();
 				await restartScoped('iso-one');

--- a/unitTests/server/threads/isolatedApplications.test.js
+++ b/unitTests/server/threads/isolatedApplications.test.js
@@ -165,19 +165,28 @@ describe('isolated applications (harper#642 tier 2)', () => {
 
 	describe('worker slot lifetime', () => {
 		it('does not auto-restart a worker after its owner withdraws the slot lease', async () => {
+			// This lifecycle-only worker must not become the process's first preload resolver: the
+			// preload suite configures its fixtures later and intentionally verifies the production cache.
+			const originalSafeMode = process.env.HARPER_SAFE_MODE;
+			process.env.HARPER_SAFE_MODE = '1';
 			let starts = 0;
 			let restartChecks = 0;
-			const worker = threads().startWorker(require.resolve('./fixtures/exitImmediately.cjs'), {
-				onStarted: () => starts++,
-				shouldAutoRestart: () => {
-					restartChecks++;
-					return false;
-				},
-			});
-			await once(worker, 'exit');
-			await new Promise(setImmediate);
-			assert.strictEqual(restartChecks, 1);
-			assert.strictEqual(starts, 1, 'the withdrawn slot did not create a replacement');
+			try {
+				const worker = threads().startWorker(require.resolve('./fixtures/exitImmediately.cjs'), {
+					onStarted: () => starts++,
+					shouldAutoRestart: () => {
+						restartChecks++;
+						return false;
+					},
+				});
+				await once(worker, 'exit');
+				await new Promise(setImmediate);
+				assert.strictEqual(restartChecks, 1);
+				assert.strictEqual(starts, 1, 'the withdrawn slot did not create a replacement');
+			} finally {
+				if (originalSafeMode === undefined) delete process.env.HARPER_SAFE_MODE;
+				else process.env.HARPER_SAFE_MODE = originalSafeMode;
+			}
 		});
 	});
 

--- a/unitTests/server/threads/isolatedApplications.test.js
+++ b/unitTests/server/threads/isolatedApplications.test.js
@@ -82,7 +82,6 @@ describe('isolated applications (harper#642 tier 2)', () => {
 
 		it('defaults the admission budget when none is configured', () => {
 			assert.strictEqual(iso().maxIsolatedApplications(), iso().DEFAULT_MAX_ISOLATED_APPLICATIONS);
-			assert.strictEqual(iso().isolatedWorkerHeapShareCount(2, 8), 10);
 		});
 
 		it('refuses Windows where per-application UDS mirrors are unavailable', () => {

--- a/unitTests/server/threads/isolatedApplications.test.js
+++ b/unitTests/server/threads/isolatedApplications.test.js
@@ -109,6 +109,10 @@ describe('isolated applications (harper#642 tier 2)', () => {
 			// a pool socket is `<index>-<port>`; an application literally named like one still cannot alias it
 			assert.notStrictEqual(iso().applicationSocketName('1', 9926), '1-9926');
 			assert.strictEqual(iso().applicationSocketName('my app', 9926), 'app-my%20app-9926');
+			assert.ok(
+				!iso().applicationSocketName('foo-bar', 9927).startsWith(iso().applicationSocketName('foo', '')),
+				'application cleanup prefixes cannot match a longer name'
+			);
 			// fixed-width per UTF-8 byte: variable-width code-point hex would let these two collide
 			assert.notStrictEqual(iso().applicationSocketName('\u01D83', 9926), iso().applicationSocketName('\u1D83', 9926));
 			assert.notStrictEqual(iso().applicationSocketName('\u00E9A', 9926), iso().applicationSocketName('\u0E9A', 9926));

--- a/unitTests/server/threads/isolatedApplications.test.js
+++ b/unitTests/server/threads/isolatedApplications.test.js
@@ -159,6 +159,24 @@ describe('isolated applications (harper#642 tier 2)', () => {
 			);
 		});
 
+		it('clears the restart-required flag only when the pool is in scope', async () => {
+			const { requestRestart, restartNeeded, resetRestartNeeded } = require('#src/components/requestRestart');
+			const restartPool = (scope) => threads().restartWorkers('http', Infinity, false, null, scope);
+			try {
+				requestRestart();
+				await restartPool('iso-one');
+				assert.strictEqual(restartNeeded(), true, 'one dedicated worker leaves the pool on the old code');
+				await restartPool(undefined);
+				assert.strictEqual(restartNeeded(), false, 'the pool restart makes the pending component live');
+
+				requestRestart();
+				await restartPool('*');
+				assert.strictEqual(restartNeeded(), false, 'so does restarting everything');
+			} finally {
+				resetRestartNeeded();
+			}
+		});
+
 		it('rejects a malformed scope before selecting workers', async () => {
 			await assert.rejects(
 				() => restart().restartService({ service: 'http', scope: null }),

--- a/unitTests/server/threads/isolatedApplications.test.js
+++ b/unitTests/server/threads/isolatedApplications.test.js
@@ -1,0 +1,148 @@
+'use strict';
+const testUtils = require('../../testUtils.js');
+testUtils.preTestPrep();
+const assert = require('node:assert');
+const path = require('node:path');
+const fs = require('node:fs');
+// Required lazily, inside the tests: loading these module graphs at file load time would install real
+// loggers before sibling suites in the same mocha process (dataLoader) stub theirs.
+const iso = () => require('#src/server/threads/isolatedApplications');
+const application = () => require('#src/components/Application');
+const http = () => require('#src/server/http');
+const threads = () => require('#src/server/threads/manageThreads');
+
+const CONFIG = {
+	'shared': { package: 'x' },
+	'iso-one': { package: 'x', isolated: true, host: 'one.qa.example' },
+	'iso-two': { package: 'x', isolated: true },
+	'notIsolated': { package: 'x', isolated: false },
+	'http': { port: 9926 }, // a non-application entry
+};
+
+describe('isolated applications (harper#642 tier 2)', () => {
+	describe('placement', () => {
+		it('lists exactly the applications marked isolated', () => {
+			assert.deepStrictEqual(iso().isolatedApplicationNames(CONFIG), ['iso-one', 'iso-two']);
+			assert.strictEqual(iso().isIsolatedApplication('shared', CONFIG), false);
+			assert.strictEqual(iso().isIsolatedApplication('http', CONFIG), false);
+			assert.deepStrictEqual(iso().isolatedApplicationNames(undefined), []);
+		});
+
+		it('a thread with no application of its own loads only the non-isolated applications', () => {
+			assert.strictEqual(iso().shouldLoadApplicationHere('shared', undefined, CONFIG), true);
+			assert.strictEqual(iso().shouldLoadApplicationHere('notIsolated', undefined, CONFIG), true);
+			assert.strictEqual(iso().shouldLoadApplicationHere('iso-one', undefined, CONFIG), false);
+			assert.strictEqual(iso().shouldLoadApplicationHere('iso-two', undefined, CONFIG), false);
+		});
+
+		it('a dedicated worker loads its own application and nothing else', () => {
+			assert.strictEqual(iso().shouldLoadApplicationHere('iso-one', 'iso-one', CONFIG), true);
+			assert.strictEqual(iso().shouldLoadApplicationHere('iso-two', 'iso-one', CONFIG), false);
+			assert.strictEqual(
+				iso().shouldLoadApplicationHere('shared', 'iso-one', CONFIG),
+				false,
+				'not even the shared ones'
+			);
+		});
+
+		it('publishes the application and its host as the route', () => {
+			assert.deepStrictEqual(iso().isolatedApplicationRoute('iso-one', CONFIG), {
+				application: 'iso-one',
+				hosts: ['one.qa.example'],
+			});
+			assert.deepStrictEqual(iso().isolatedApplicationRoute('iso-two', CONFIG), { application: 'iso-two', hosts: [] });
+			assert.strictEqual(iso().isolatedApplicationRoute(undefined, CONFIG), undefined);
+		});
+
+		it('refuses a dedicated worker that nothing could reach', () => {
+			// this test environment configures no secure port, so a mirror would never be bound
+			assert.match(String(iso().isolatedApplicationRefusal('iso-one')), /unreachable/);
+		});
+
+		it('defaults the admission budget when none is configured', () => {
+			assert.strictEqual(iso().maxIsolatedApplications(), iso().DEFAULT_MAX_ISOLATED_APPLICATIONS);
+		});
+	});
+
+	describe('socket naming', () => {
+		it('is injective and filesystem-safe, and cannot collide with a pool socket', () => {
+			const names = ['my-app', 'my_app', 'my app', 'my/app', 'my%app', 'app-1', 'App', '1-9926'];
+			const sockets = names.map((name) => iso().applicationSocketName(name, 9926));
+			assert.strictEqual(new Set(sockets).size, names.length, 'two names never share a socket');
+			for (const socket of sockets) {
+				assert.match(socket, /^app-[A-Za-z0-9._%-]+-9926$/, socket);
+				assert.ok(!socket.includes('/'), 'never a path separator');
+			}
+			// a pool socket is `<index>-<port>`; an application literally named like one still cannot alias it
+			assert.notStrictEqual(iso().applicationSocketName('1', 9926), '1-9926');
+			assert.strictEqual(iso().applicationSocketName('my app', 9926), 'app-my%20app-9926');
+			// fixed-width per UTF-8 byte: variable-width code-point hex would let these two collide
+			assert.notStrictEqual(iso().applicationSocketName('\u01D83', 9926), iso().applicationSocketName('\u1D83', 9926));
+			assert.notStrictEqual(iso().applicationSocketName('\u00E9A', 9926), iso().applicationSocketName('\u0E9A', 9926));
+		});
+	});
+
+	describe('restart scope on the wire', () => {
+		it('round-trips pool, one application and everything, and cannot be spoofed by an application named pool', () => {
+			assert.strictEqual(
+				threads().decodeRestartScope({ scope: threads().encodeRestartScope(undefined) }),
+				undefined,
+				'the pool'
+			);
+			assert.strictEqual(threads().decodeRestartScope({ scope: threads().encodeRestartScope('iso-one') }), 'iso-one');
+			assert.strictEqual(
+				threads().decodeRestartScope({ scope: threads().encodeRestartScope('pool') }),
+				'pool',
+				'a legal application name'
+			);
+			assert.strictEqual(
+				threads().decodeRestartScope({}),
+				'*',
+				'a message with no scope, as every pre-existing sender, means all'
+			);
+		});
+	});
+
+	describe('root config', () => {
+		it('accepts isolated as a boolean and refuses anything else', () => {
+			application().assertApplicationConfig('ok', { package: 'x', isolated: true });
+			application().assertApplicationConfig('ok', { package: 'x', isolated: false });
+			application().assertApplicationConfig('ok', { package: 'x' });
+			assert.throws(
+				() => application().assertApplicationConfig('bad', { package: 'x', isolated: 'yes' }),
+				/Invalid 'isolated'/
+			);
+		});
+	});
+
+	describe('mirror metadata', () => {
+		const dir = path.join(testUtils.ENV_DIR_PATH, 'sockets');
+		const secureServer = { secureContexts: new Map() };
+		before(() => fs.mkdirSync(dir, { recursive: true }));
+
+		it('names the application and its hosts, separately from certificate coverage', () => {
+			const yamlPath = path.join(dir, 'app-iso-9926.yaml');
+			http().writeUdsMetadata(yamlPath, 9926, secureServer, undefined, true, {
+				application: 'iso one',
+				hosts: ['one.qa.example', 'alt.qa.example'],
+			});
+			const yaml = fs.readFileSync(yamlPath, 'utf8');
+			assert.match(yaml, /^application: "iso one"$/m);
+			assert.match(yaml, /^applicationHosts:\n {2}- "one\.qa\.example"\n {2}- "alt\.qa\.example"$/m);
+			assert.match(yaml, /^certificates:$/m, 'certificate coverage is still published');
+		});
+
+		it('publishes an empty host list as a list, not as nothing', () => {
+			const yamlPath = path.join(dir, 'app-nohost-9926.yaml');
+			http().writeUdsMetadata(yamlPath, 9926, secureServer, undefined, true, { application: 'nohost', hosts: [] });
+			assert.match(fs.readFileSync(yamlPath, 'utf8'), /^applicationHosts: \[\]$/m);
+		});
+
+		it('publishes no route for a pool worker', () => {
+			const yamlPath = path.join(dir, '0-9926.yaml');
+			http().writeUdsMetadata(yamlPath, 9926, secureServer, undefined, true, undefined);
+			const yaml = fs.readFileSync(yamlPath, 'utf8');
+			assert.doesNotMatch(yaml, /application/);
+		});
+	});
+});

--- a/unitTests/server/threads/isolatedApplications.test.js
+++ b/unitTests/server/threads/isolatedApplications.test.js
@@ -66,6 +66,12 @@ describe('isolated applications (harper#642 tier 2)', () => {
 			);
 		});
 
+		it('identifies only a named application owned by a dedicated worker', () => {
+			assert.strictEqual(iso().thisThreadOwnsApplication('iso-one', 'iso-one'), true);
+			assert.strictEqual(iso().thisThreadOwnsApplication('iso-two', 'iso-one'), false);
+			assert.strictEqual(iso().thisThreadOwnsApplication(undefined, undefined), false);
+		});
+
 		it('publishes the application and its host as the route', () => {
 			assert.deepStrictEqual(iso().isolatedApplicationRoute('iso-one', CONFIG), {
 				application: 'iso-one',

--- a/unitTests/server/threads/isolatedApplications.test.js
+++ b/unitTests/server/threads/isolatedApplications.test.js
@@ -4,6 +4,7 @@ testUtils.preTestPrep();
 const assert = require('node:assert');
 const path = require('node:path');
 const fs = require('node:fs');
+const os = require('node:os');
 // Required lazily, inside the tests: loading these module graphs at file load time would install real
 // loggers before sibling suites in the same mocha process (dataLoader) stub theirs.
 const iso = () => require('#src/server/threads/isolatedApplications');
@@ -26,6 +27,26 @@ describe('isolated applications (harper#642 tier 2)', () => {
 			assert.strictEqual(iso().isIsolatedApplication('shared', CONFIG), false);
 			assert.strictEqual(iso().isIsolatedApplication('http', CONFIG), false);
 			assert.deepStrictEqual(iso().isolatedApplicationNames(undefined), []);
+		});
+
+		it('counts only installed isolated applications as desired capacity', () => {
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), 'harper-isolated-presence-'));
+			const componentsRoot = path.join(root, 'components');
+			const installedRoot = path.join(root, 'installed');
+			fs.mkdirSync(path.join(componentsRoot, 'iso-one'), { recursive: true });
+			try {
+				assert.deepStrictEqual(
+					iso().presentIsolatedApplicationNames(
+						{ ...CONFIG, stale: { package: 'x', isolated: true } },
+						componentsRoot,
+						installedRoot,
+						path.join(root, 'iso-two')
+					),
+					['iso-one', 'iso-two']
+				);
+			} finally {
+				fs.rmSync(root, { recursive: true, force: true });
+			}
 		});
 
 		it('a thread with no application of its own loads only the non-isolated applications', () => {
@@ -61,6 +82,11 @@ describe('isolated applications (harper#642 tier 2)', () => {
 
 		it('defaults the admission budget when none is configured', () => {
 			assert.strictEqual(iso().maxIsolatedApplications(), iso().DEFAULT_MAX_ISOLATED_APPLICATIONS);
+			assert.strictEqual(iso().isolatedWorkerHeapShareCount(2, 8), 10);
+		});
+
+		it('refuses Windows where per-application UDS mirrors are unavailable', () => {
+			assert.match(iso().isolatedApplicationsUnreachableReason('win32'), /Windows/);
 		});
 
 		it('counts actual dedicated applications when enforcing the admission budget', () => {

--- a/unitTests/server/threads/isolatedApplications.test.js
+++ b/unitTests/server/threads/isolatedApplications.test.js
@@ -62,6 +62,14 @@ describe('isolated applications (harper#642 tier 2)', () => {
 		it('defaults the admission budget when none is configured', () => {
 			assert.strictEqual(iso().maxIsolatedApplications(), iso().DEFAULT_MAX_ISOLATED_APPLICATIONS);
 		});
+
+		it('counts actual dedicated applications when enforcing the admission budget', () => {
+			assert.strictEqual(iso().isolatedApplicationCapacityRefusal('iso-one', ['iso-one', 'iso-two'], 2), undefined);
+			assert.match(
+				iso().isolatedApplicationCapacityRefusal('configured-but-not-running', ['iso-one', 'iso-two'], 2),
+				/threads\.maxIsolated/
+			);
+		});
 	});
 
 	describe('socket naming', () => {

--- a/unitTests/server/threads/isolatedApplications.test.js
+++ b/unitTests/server/threads/isolatedApplications.test.js
@@ -68,6 +68,18 @@ describe('isolated applications (harper#642 tier 2)', () => {
 			);
 		});
 
+		it("starts a dedicated worker's own uWS mirror but never a global port listener", () => {
+			// The regression this guards: skipping every uWS entry on a dedicated worker (not just the
+			// global-port ones) leaves the isolated application with no ingress at all under HARPER_UWS_UDS.
+			assert.strictEqual(
+				iso().shouldStartUwsListenerHere({ socketPath: '/tmp/app-iso%2Done-9926.sock' }, 'iso-one'),
+				true
+			);
+			assert.strictEqual(iso().shouldStartUwsListenerHere({ port: 9926 }, 'iso-one'), false);
+			assert.strictEqual(iso().shouldStartUwsListenerHere({ port: 9926 }, undefined), true, 'a pool worker binds it');
+			assert.strictEqual(iso().shouldStartUwsListenerHere({ socketPath: '/tmp/0-9926.sock' }, undefined), true);
+		});
+
 		it('identifies only a named application owned by a dedicated worker', () => {
 			assert.strictEqual(iso().thisThreadOwnsApplication('iso-one', 'iso-one'), true);
 			assert.strictEqual(iso().thisThreadOwnsApplication('iso-two', 'iso-one'), false);

--- a/unitTests/server/threads/isolatedApplications.test.js
+++ b/unitTests/server/threads/isolatedApplications.test.js
@@ -151,6 +151,14 @@ describe('isolated applications (harper#642 tier 2)', () => {
 				() => restart().restartService({ service: 'http', scope: null }),
 				/Invalid HTTP worker restart scope/
 			);
+			await assert.rejects(
+				() => restart().restartService({ service: 'http', scope: 'iso-one', scopeFallback: null }),
+				/Invalid HTTP worker restart scope fallback/
+			);
+			await assert.rejects(
+				() => restart().restartService({ service: 'http', scope: 'iso-one', scopeFallback: 'iso-two' }),
+				/Invalid HTTP worker restart scope fallback/
+			);
 		});
 	});
 

--- a/unitTests/server/threads/isolatedApplications.test.js
+++ b/unitTests/server/threads/isolatedApplications.test.js
@@ -11,6 +11,7 @@ const iso = () => require('#src/server/threads/isolatedApplications');
 const application = () => require('#src/components/Application');
 const http = () => require('#src/server/http');
 const threads = () => require('#src/server/threads/manageThreads');
+const restart = () => require('#src/bin/restart');
 
 const CONFIG = {
 	'shared': { package: 'x' },
@@ -142,6 +143,13 @@ describe('isolated applications (harper#642 tier 2)', () => {
 				threads().decodeRestartScope({}),
 				'*',
 				'a message with no scope, as every pre-existing sender, means all'
+			);
+		});
+
+		it('rejects a malformed scope before selecting workers', async () => {
+			await assert.rejects(
+				() => restart().restartService({ service: 'http', scope: null }),
+				/Invalid HTTP worker restart scope/
 			);
 		});
 	});

--- a/unitTests/server/threads/isolatedApplications.test.js
+++ b/unitTests/server/threads/isolatedApplications.test.js
@@ -159,20 +159,28 @@ describe('isolated applications (harper#642 tier 2)', () => {
 			);
 		});
 
-		it('clears the restart-required flag only when the pool is in scope', async () => {
+		it('clears the restart-required flag only from a restart that covers every worker', async () => {
 			const { requestRestart, restartNeeded, resetRestartNeeded } = require('#src/components/requestRestart');
-			const restartPool = (scope) => threads().restartWorkers('http', Infinity, false, null, scope);
+			const restartScoped = (scope) => threads().restartWorkers('http', Infinity, false, null, scope);
+			// already marked shut down, so the restart loop skips it: this stands in for the live topology
+			// the gate reads, not for a worker to replace
+			const dedicated = { name: 'http', application: 'iso-one', wasShutdown: true };
 			try {
 				requestRestart();
-				await restartPool('iso-one');
-				assert.strictEqual(restartNeeded(), true, 'one dedicated worker leaves the pool on the old code');
-				await restartPool(undefined);
-				assert.strictEqual(restartNeeded(), false, 'the pool restart makes the pending component live');
+				await restartScoped('iso-one');
+				assert.strictEqual(restartNeeded(), true, 'one dedicated worker leaves the whole pool on the old code');
+				await restartScoped(undefined);
+				assert.strictEqual(restartNeeded(), false, 'with no dedicated worker running, the pool IS every worker');
 
+				threads().workers.push(dedicated);
 				requestRestart();
-				await restartPool('*');
-				assert.strictEqual(restartNeeded(), false, 'so does restarting everything');
+				await restartScoped(undefined);
+				assert.strictEqual(restartNeeded(), true, 'a running dedicated worker keeps its old modules through it');
+				await restartScoped('*');
+				assert.strictEqual(restartNeeded(), false, 'only restarting every worker covers that');
 			} finally {
+				const at = threads().workers.indexOf(dedicated);
+				if (at > -1) threads().workers.splice(at, 1);
 				resetRestartNeeded();
 			}
 		});

--- a/unitTests/server/threads/threadInfoTimeout.test.js
+++ b/unitTests/server/threads/threadInfoTimeout.test.js
@@ -30,6 +30,31 @@ function startThreadInfoWorker(timeoutMs) {
 	);
 }
 
+function startIsolatedApplicationsWorker(timeoutMs) {
+	const manageThreadsPath = require.resolve('#src/server/threads/manageThreads');
+	return new Worker(
+		`const { parentPort, workerData } = require('node:worker_threads');
+		const { getRunningIsolatedApplications } = require(workerData.manageThreadsPath);
+		const baselineListeners = parentPort.listenerCount('message');
+		getRunningIsolatedApplications(workerData.timeoutMs).then(
+			(applications) => parentPort.postMessage({
+				applications,
+				listenerCount: parentPort.listenerCount('message'),
+				baselineListeners,
+			}),
+			(error) => parentPort.postMessage({
+				code: error.code,
+				listenerCount: parentPort.listenerCount('message'),
+				baselineListeners,
+			})
+		);`,
+		{
+			eval: true,
+			workerData: { addPorts: [], addThreadIds: [], manageThreadsPath, timeoutMs },
+		}
+	);
+}
+
 describe('thread information liveness timeout', () => {
 	it('rejects and removes its response listener when the main thread does not reply', async () => {
 		const worker = startThreadInfoWorker(50);
@@ -58,6 +83,45 @@ describe('thread information liveness timeout', () => {
 			await waitFor(() => messages.some((message) => 'isRunning' in message));
 			const result = messages.find((message) => 'isRunning' in message);
 			assert.equal(result.isRunning, true);
+			assert.equal(result.listenerCount, result.baselineListeners);
+		} finally {
+			await worker.terminate();
+		}
+	});
+});
+
+describe('isolated application topology request', () => {
+	it('rejects and removes its response listener when the main thread does not reply', async () => {
+		const worker = startIsolatedApplicationsWorker(50);
+		const messages = [];
+		worker.on('message', (message) => messages.push(message));
+		try {
+			await waitFor(() => messages.some((message) => message.code));
+			const result = messages.find((message) => message.code);
+			assert.equal(result.code, 'ERR_ISOLATED_APPLICATIONS_TIMEOUT');
+			assert.equal(result.listenerCount, result.baselineListeners);
+		} finally {
+			await worker.terminate();
+		}
+	});
+
+	it('returns the slot registry response and removes its response listener', async () => {
+		const worker = startIsolatedApplicationsWorker(500);
+		const messages = [];
+		worker.on('message', (message) => {
+			messages.push(message);
+			if (message.type === 'request-running-isolated-applications') {
+				worker.postMessage({
+					type: 'running-isolated-applications',
+					requestId: message.requestId,
+					applications: ['iso-one', 'iso-two'],
+				});
+			}
+		});
+		try {
+			await waitFor(() => messages.some((message) => message.applications));
+			const result = messages.find((message) => message.applications);
+			assert.deepStrictEqual(result.applications, ['iso-one', 'iso-two']);
 			assert.equal(result.listenerCount, result.baselineListeners);
 		} finally {
 			await worker.terminate();

--- a/unitTests/server/threads/threadInfoTimeout.test.js
+++ b/unitTests/server/threads/threadInfoTimeout.test.js
@@ -55,6 +55,16 @@ function startIsolatedApplicationsWorker(timeoutMs) {
 	);
 }
 
+function startUnavailableIsolatedApplicationsWorker() {
+	const manageThreadsPath = require.resolve('#src/server/threads/manageThreads');
+	return new Worker(
+		`const { parentPort, workerData } = require('node:worker_threads');
+		const { getRunningIsolatedApplications } = require(workerData.manageThreadsPath);
+		getRunningIsolatedApplications().catch((error) => parentPort.postMessage({ code: error.code }));`,
+		{ eval: true, workerData: { manageThreadsPath } }
+	);
+}
+
 describe('thread information liveness timeout', () => {
 	it('rejects and removes its response listener when the main thread does not reply', async () => {
 		const worker = startThreadInfoWorker(50);
@@ -123,6 +133,18 @@ describe('isolated application topology request', () => {
 			const result = messages.find((message) => message.applications);
 			assert.deepStrictEqual(result.applications, ['iso-one', 'iso-two']);
 			assert.equal(result.listenerCount, result.baselineListeners);
+		} finally {
+			await worker.terminate();
+		}
+	});
+
+	it('fails closed when a worker has no channel to the main thread', async () => {
+		const worker = startUnavailableIsolatedApplicationsWorker();
+		const messages = [];
+		worker.on('message', (message) => messages.push(message));
+		try {
+			await waitFor(() => messages.length > 0);
+			assert.equal(messages[0].code, 'ERR_ISOLATED_APPLICATIONS_UNAVAILABLE');
 		} finally {
 			await worker.terminate();
 		}

--- a/unitTests/server/threads/threadServerListenOnPorts.test.js
+++ b/unitTests/server/threads/threadServerListenOnPorts.test.js
@@ -5,7 +5,11 @@ const net = require('node:net');
 const os = require('node:os');
 const path = require('node:path');
 const { SERVERS } = require('#src/server/serverRegistry');
-const { listenOnDomainSocket, listenOnPorts } = require('#src/server/threads/threadServer');
+const {
+	listenOnDomainSocket,
+	listenOnPorts,
+	shouldStartGlobalUwsServers,
+} = require('#src/server/threads/threadServer');
 const { getDomainSocketPathMaxBytes } = require('#src/utility/domainSocket');
 
 /**
@@ -50,5 +54,10 @@ describe('threadServer listenOnPorts — domain socket fail-soft', () => {
 		failingServer = net.createServer();
 		SERVERS[failingSocketPath] = failingServer;
 		await assert.rejects(listenOnPorts());
+	});
+
+	it('reserves global uWS listeners for the pool', () => {
+		assert.strictEqual(shouldStartGlobalUwsServers(undefined), true);
+		assert.strictEqual(shouldStartGlobalUwsServers('isolated-app'), false);
 	});
 });

--- a/unitTests/server/threads/threadServerListenOnPorts.test.js
+++ b/unitTests/server/threads/threadServerListenOnPorts.test.js
@@ -5,11 +5,7 @@ const net = require('node:net');
 const os = require('node:os');
 const path = require('node:path');
 const { SERVERS } = require('#src/server/serverRegistry');
-const {
-	listenOnDomainSocket,
-	listenOnPorts,
-	shouldStartGlobalUwsServers,
-} = require('#src/server/threads/threadServer');
+const { listenOnDomainSocket, listenOnPorts } = require('#src/server/threads/threadServer');
 const { getDomainSocketPathMaxBytes } = require('#src/utility/domainSocket');
 
 /**
@@ -54,10 +50,5 @@ describe('threadServer listenOnPorts — domain socket fail-soft', () => {
 		failingServer = net.createServer();
 		SERVERS[failingSocketPath] = failingServer;
 		await assert.rejects(listenOnPorts());
-	});
-
-	it('reserves global uWS listeners for the pool', () => {
-		assert.strictEqual(shouldStartGlobalUwsServers(undefined), true);
-		assert.strictEqual(shouldStartGlobalUwsServers('isolated-app'), false);
 	});
 });

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -526,6 +526,7 @@ export const CONFIG_PARAMS = {
 	THREADS_DEBUG_HOST: 'threads_debug_host',
 	THREADS_DEBUG_WAITFORDEBUGGER: 'threads_debug_waitForDebugger',
 	THREADS_MAXHEAPMEMORY: 'threads_maxHeapMemory',
+	THREADS_MAXISOLATED: 'threads_maxIsolated',
 	THREADS_HEAPSNAPSHOTNEARLIMIT: 'threads_heapSnapshotNearLimit',
 	THREADS_PRELOAD: 'threads_preload',
 	THREADS_PRELOADREQUIRE: 'threads_preloadRequire',

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -435,6 +435,7 @@ export function configValidator(configJson, skipFsValidation = false) {
 					})
 				),
 				maxHeapMemory: number.min(0).optional(),
+				maxIsolated: number.integer().min(0).optional(),
 				preload: Joi.alternatives([string, array.items(string)])
 					.allow(null)
 					.optional(),


### PR DESCRIPTION
An application declared with `isolated: true` now runs in one dedicated HTTP worker that loads no other application, exposes an application-addressed secure UDS mirror, and can be restarted without rotating unrelated workers. Admission, placement, restart, expiration, and cleanup paths fail closed so an unsupported, over-budget, malformed, or exhausted application is reported instead of silently appearing on the shared listener.

## For the human reviewer

1. **UDS-only ingress.** Dedicated workers expose only application-named secure UDS mirrors. The metadata includes the application identity and optional hosts; a host is intentionally not required because application-ID routing and direct socket consumers are supported. Joining public listeners would change the proxy and security boundary.
2. **Asynchronous readiness.** Pool readiness still marks the node started while dedicated applications boot, so one application cannot delay the node. A deploy can therefore finish before the dedicated UDS appears; the integration test waits on the socket itself. Making a deploy success mean “dedicated route is serving” requires a product decision about whether one app may stall a pool restart.
3. **Shared-store TTL ownership.** Schema and runtime TTL declared by an isolated application run where that application code runs, even for a shared store already maintained by a pool owner. This guarantees eventual cleanup when only the isolated app declares the schema, but can duplicate version-guarded scans. Central ownership needs IPC for application-defined functions/configuration. The same locality means a shared `sourcedFrom` cache has no dedicated low-disk reclamation owner.
4. **Node-local admission.** The origin rejects unreachable or over-budget isolation, while replicated peers persist desired config and may refuse locally. Concurrent deployments of different applications can both observe the final free slot; reconciliation admits one and reports the other failed. Atomic admission requires a main-thread reservation spanning configuration, installation, replication, and rollback.
5. **Configuration semantics.** Omitting `isolated` preserves an existing true value, and isolation intent is persisted before package preparation so a failed install leaves desired topology for recovery. Reads, admission, persistence, and activation for one application are now serialized by the component preparation lock. Changing failed-deploy rollback or sticky isolation is a separate API decision.
6. **Restart and drop policy.** Restart scope uses absent/`*` for all workers, empty string for the pool, and an application name for one dedicated worker; `scopeFallback` accepts only the pool sentinel. A drop queries live topology under the component lock and returns 503 before mutation if topology is unavailable. The core managed-worker path is covered; whether an external replication executor can invoke this without a topology channel needs validation in the enterprise wrapper.
7. **Package boundary.** Ordinary package entries are applications and obey isolation placement. Trusted built-ins still load everywhere, including a forced package replacement using a protected name. If forced protected-name deployment must support isolation, the loader needs a distinct built-in-versus-application contract.
8. **Lifecycle fencing.** The slot registry is the authoritative lease: removing a slot prevents every old generation from auto-restarting, shutdown is idempotent, and dedicated UDS replacements do not pre-start over a live fixed socket path. A start that fails or never reports ready now [awaits `slot.shutdown()` before withdrawing the lease](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-545704b0f9ebb0c229b5f127dc8c710d5061aedb1e01e00514a96385babb1196R197), so the application is never registered-as-absent while its worker is still draining; the earlier ordering let a reconcile start a replacement over the live mirror and let a drop's `removeBranchesForApplication()` run past a worker still holding the stores. Unlinking application sockets on every worker exit was rejected because an outgoing rolling-restart worker can share the path with its replacement and would delete the replacement's live endpoint. Cleanup therefore runs on deliberate retirement or final restart exhaustion, guarded by slot identity.

9. **Restart-required is one bit, so only a restart that covers every worker clears it.** `restartWorkers()` cleared the node's restart-required flag on every call, which was correct while every restart replaced every worker. Restart scopes broke that in two ways: an application-scoped restart leaves the whole pool on its old code, and a pool-scoped restart leaves an already-running dedicated worker on its old modules. Either one clearing the bit reports `restartRequired: false` while a deployed component is loaded nowhere. It is now cleared [for all workers always, and for the pool only while no dedicated worker is running](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-02c28577c2ca63129ed10809ce3db1469c70bef080e04fd273f8cbd510b6521bR675) — which is every node that uses no isolated application, leaving the historic behavior unchanged there. The rejected alternative, clearing only on the all-workers sentinel, would stop an ordinary shared `deploy_component` with `restart: true` from ever clearing the bit (that path passes the pool scope), leaving the flag permanently on for every node. The one remaining conservative case: a dedicated worker the reconcile is about to stop is still counted, because the check reads topology before the reconcile runs. A precise answer needs a per-application signal rather than one process-wide bit.

10. **Where to look hardest.** The lease ordering above has no direct unit coverage: `watchDedicatedStart` and `isolatedSlots` are module-private, and asserting the ordering would mean exporting both purely for a test. The integration suite exercises the happy path and the drop paths, not a hung start racing a reconcile. The two coverage threads that were open on the last head are now closed by unit tests: the dedicated worker's uWS entry rule is named as [`shouldStartUwsListenerHere()`](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-a4c07ca2de2e257a7771e724b5dea2ce0bc48711a113e092ffb9350e75f57881R101) and pinned across all four quadrants, and the preserved-eviction gate has a differential case. One honest limit on the latter: it reaches `scheduleCleanup()` through the `ownsStoreMaintenance()` leg, not the `ttlConfiguredByApplication && isDedicatedWorker()` leg a real dedicated worker takes, so it pins the scheduling gate rather than the ownership path. The per-thread rulings for every review finding on this PR are now published as [a single comment](https://github.com/HarperFast/harper/pull/2524#issuecomment-5644943407) rather than as review threads: the author's pending review (`pullrequestreview-5184029425`, 19 comments) anchors on outdated commits, so submitting it would open 19 new threads on lines that have since moved.

## Implementation

- Configuration validates `isolated` as a boolean and `threads.maxIsolated` as a bounded count. Malformed values fail placement before any application import.
- The main thread owns a serialized slot registry, admits only installed and reachable applications, preserves incumbents when capacity is lowered, adjusts heap shares, reports lifecycle failures, and removes stale UDS and metadata on retirement or restart exhaustion.
- Pool workers skip isolated applications; a dedicated worker loads only its named application and presents application-relative worker identity `0/1`. Scheduler, data-loader, cache-source, audit, reclamation, branch, and expiration ownership follow the defining application or store.
- Restart messages preserve historical all-worker behavior while supporting pool-only and application-only scopes. Dedicated UDS workers use shutdown-before-replacement; shared HTTP workers retain overlap where the platform supports it.
- Deploy and drop derive restart scope from live topology, serialize config/topology decisions with preparation, preserve root config and package linkage for file-only drops, and keep isolated applications off the public port through reloads.
- Isolated GraphQL and programmatic schema declarations tag their owning application. Live table redeclarations refresh derived `@expiresAt` state, and the isolated schema integration fixture proves physical eviction from the shared store.

## Verification

- `npm run build` — passed on the final head.
- Prettier, `oxlint`, and `git diff --check` over every changed source/test file — passed. Repository-wide `npm run lint` still reports 15 warnings in files unchanged from `origin/main`.
- The final focused Mocha set covering activation, serialized preparation, TTL, placement, topology timeouts, UDS binding, safe-mode preloads, and deploy operations — 115 passing, 1 platform-dependent pending.
- `npm run test:integration -- integrationTests/components/isolated-application.test.ts` — 7 passing: placement, capacity refusal, public-port exclusion, UDS routing, shared drop, file-only isolated drop, and full isolated drop. The same 7 pass with `HARPER_UWS_UDS=1`, including the application-named uWS mirror.
- The schema-TTL integration assertion failed before the TTL ownership fix (`rawTtlRecords` remained 1) and passed after it. The stale-config capacity assertion likewise failed on the rebased pre-fix head because the second real isolated worker was absent.
- `npm run test:unit:main` reached 5,515 passing and 197 pending; 32 failures were baseline/environment failures from ancestor-checkout dependency resolution plus existing credential/path-length cases. The Windows/API baseline issues and the six current API assertions reproduce on `main`.
- Four full independent reviews and exact remediation deltas ran across Claude, Gemini, Cursor Grok/Composer, and Harper domain adjudication. A required round-9 framing recheck compared global serialization, universal generations, config checks, and slot-owned leases; Gemini certified the slot-lease approach. On the latest whole-branch pass Gemini completed, Claude hit its weekly usage limit, and the Harper domain pass timed out; the one reported major was falsified by the unconditional `restart !== true` early return. Two subsequent Claude/Gemini deltas accepted the TTL-preservation fix and its eviction-only hardening with no surviving new finding. Human-Review-Need remains 4 for the policy choices above.
- Review-adjudication pass over all 14 threads at `da5de6772`: 12 rulings verified against source, 2 (`codex`/`cb1kenobi` on the failed dedicated start) found not to hold and fixed here. `unitTests/server/threads/isolatedApplications.test.js`, `threadInfoTimeout.test.js`, `expiresAtAttribute.test.js`, `requestRestart.test.js` — 38 passing; `integrationTests/components/isolated-application.test.ts` — 7 passing; `npm run build`, Prettier and `oxlint` clean on the changed files.
- `npm run test:unit:resources` — 2486 passing, 33 pending, 3 failing. The 3 are `crud.test.js` "publishes and subscribes" (`2 == 1`), and they **reproduce on this branch's merge base** `bba808e74` with every PR source file swapped out, so they are inherited from `main`, not from this change. The same file passes at `6d725818c` (Sep 8), which bounds the regression to `6d725818c..bba808e74`.
- Round 19 (delta, Claude graded + Gemini, `8e74b1b5e6a8`): **no new finding survived.** Gemini's `blocker` — a late `slot.ready` rejection crashing the process — is wrong on JS semantics: `Promise.race` subscribes a rejection reaction to every input at call time, so the losing input's late rejection is handled, not unhandled. Verified by running the exact shape (race loses to a timeout, the input rejects 50 ms later, `process.on('unhandledRejection')` never fires, exit 0). The graded leg re-raised its `major` on `drop_component` with `restart: false` for the third round; refuted again by exact count — `components/operations.js` has exactly one `req.restart !== true` guard (line 1418) with an unconditional `return`, and exactly one `manageThreads.restartWorkers(...)` call (line 1441) after it, so `restartScope` is unreachable on that path and `branched` only affects the message text and post-restart branch removal. Both legs' comment-narration `nit` is declined: it targets comments already on the branch, not this delta, and the graded leg itself exempts the delta's comments as rationale rather than narration.

- Round 20 (delta, Claude graded + Gemini, `1d79483c1177`): **no new finding.** Both legs traced the predicate extraction as behaviour-preserving and the eviction case as a true differential. The graded leg re-raised its `major` on `drop_component` with `restart: false` for the fourth time, this round on a new premise — that a *branched* application bypasses the `!req.restart` early return. It does not: `components/operations.js` has exactly one `req.restart !== true` guard (line 1418) whose `return` (line 1422) is unconditional, the only `restartWorkers(...)` in that function is at line 1441 after it, and `branched` only appends `BRANCH_STORAGE_RETAINED` to the message — text that says the branch storage is *kept*, the opposite of the claimed lock-clearing bypass. Both legs' comment-narration `nit` is declined again: it names lines already on the branch, and the graded leg itself exempts the delta's comments as rationale.
- Test-coverage follow-up at `1d79483c1`: `unitTests/resources/expiresAtAttribute.test.js` 13 passing, `unitTests/server/threads/isolatedApplications.test.js` 19 passing; `npm run test:unit:resources` 2487 passing / 33 pending / 3 failing (the same 3 `crud.test.js` "publishes and subscribes" cases inherited from `main`); `unitTests/server/**/*test.*js` 931 passing / 0 failing; `integrationTests/components/isolated-application.test.ts` 7/7 with `HARPER_UWS_UDS=1`. Both new tests were verified differentially — removing `|| evictionMs` fails the eviction case.

- Review-adjudication pass over all 17 threads at `1d79483c1` → `74fb011cc`: every thread on the PR was already resolved, so each ruling was re-verified against source rather than trusted. **Fifteen hold as written**; one (`cb1kenobi`'s schema-TTL finding, first ruled no-change) had already been overturned and fixed in-PR; `cb1kenobi`'s `dynamicThreads` counter-read was re-checked independently and is correct (`poolSize = threadCount` at `server/threads/socketRouter.ts:98` is a sibling of the `if/else` closing at `:97`, `origin/main` carries the same fall-through, and neither `bin/run.ts:225` nor `bin/lite.ts:2` passes the flag). The per-thread rulings are in [this comment](https://github.com/HarperFast/harper/pull/2524#issuecomment-5644943407).
- One defect nobody had raised turned up beside them and is fixed here: `restartWorkers()`'s unconditional `resetRestartNeeded()` under the new restart scopes (item 9 above). Verified differentially — removing the gate fails the new case's first assertion.
- At `74fb011cc`: `npm run build` passed; Prettier and `git diff --check` clean on both changed files; `unitTests/server/**/*test*.js` **932 passing / 0 failing**; `unitTests/components/**/*test*.js` 1641 passing / 2 pending / 1 failing (`gitCredentials.test.js` credential-scoping, a known local-environment failure unrelated to this diff); the focused isolation/TTL/restart set 41 passing.
- Rounds 21 and 22 (delta, Claude graded + Gemini). Round 21 raised one finding against the new gate's *comment* rather than its behaviour — the comment claimed the flag only ever stands for pool-loaded code, which the isolated case contradicts. The comment was rewritten to state the trade instead. Round 22 on `74fb011cc`: **no findings.**
- @cb1kenobi then raised the symmetric case on the pushed head — a pool-scoped restart also leaves a running dedicated worker on its old modules — and it holds. `6868c4eba` replaces the gate with the covers-every-worker rule in item 9 rather than the suggested all-workers-only rule; [the thread](https://github.com/HarperFast/harper/pull/2524#discussion_r3995886844) has the four-cell comparison. Verified differentially: removing the `workers.some(...)` clause fails the running-dedicated-worker assertion.
- Rounds 23–25. Round 23 flagged the test's topology stand-in as a possible monitor-tick flake; round 24 **self-corrected that finding** (`manageThreads.js:1328` backfills `recentELU` in the same tick, before the listener reads it), so the property was kept for self-containment and only its comment was corrected. Round 25 on `b1d5cbc5c` ran a **full** whole-branch review: Gemini and Cursor Grok both completed with **no surviving finding**; the Claude graded leg failed on its review profile (`exit 1`) and the domain adjudication timed out, so that round's coverage is the two outside legs rather than three.
- `unitTests/server/**/*test*.js` — **932 passing / 0 failing** at each of `74fb011cc`, `6868c4eba` and `b1d5cbc5c`.
- CI on `b1d5cbc5c`: **45 pass, 3 skipping, 1 failure** — every required check is green (validate, runLinter, Format Check, Unit Test v24, all six Integration Tests shards), plus the non-required v22/v26/Windows/Bun/uWS matrices, Build Harper, Docker smoke and the Next.js downstream suite. The one failure is the non-required `review / review` job, which ran 25 minutes and then exited on `SDK execution error: Claude Code returned an error result: Prompt is too long` — a capacity failure of the review agent's own transcript on a 43-file diff at `--effort max` / `--max-turns 96`, not a finding about this code. No comment was posted because the run never reached one.
 `unitTests/components/**/*test*.js` — 1641 passing / 2 pending / 1 failing (`gitCredentials.test.js` credential-scoping, a known local-environment failure unrelated to this diff).

Complexity: complicated

## Changed files

- Core lifecycle/config: [DESIGN.md](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-3dc5dd454e080eb849ee5efaf79df2585fbe0a06804d69249b4c81da05a63875R1958), [bin/restart.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-79b2936f95589c02e1c11589c45b5496220455fbcdd94fc29181cccdcb2f55a4R13), [components/Application.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R87), [components/Scope.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-3ad922b5eb54262456b7e046c62a2a69bfaa4e377953ba616fea6e4a8258d24fR23), [components/componentLoader.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-1e3a919bf3d6ba479113144854f95e5126e6926774ef0af6770ea9feaff170b7R35), [components/operations.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-99fa57601c9a33cdc212f18a0b2b88cbe1d2e4e2cd5ad8d7dd627e529c3df899R51), [components/operationsValidation.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-074ccf6833fa41042cf09889ef2c061ad132cff07e79c68f06c13da82eaeb277R537), [components/requestRestart.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-cf5e6b61abfe14ff9c6ad77e4bfb4733b0ec451a4a9aa86f61cae100d7e8fac1R27), [config-root.schema.json](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-ef8a93bd2922e0b6e460e611904dc32a3004c803c9450c87cd5a0a0144069b68R175), [utility/hdbTerms.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-85897aa30843afee9a67fc30b41713bbc7f2e3a3e1e9fa1a0437ecac46a698f9R529), [validation/configValidator.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-aeee467d8401b59eaffd099dd61547bbf4a63b0198e2be2dc0fe55d06c284cb0R438).
- Runtime/storage: [resources/Table.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R93), [resources/auditStore.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-db526bfa2603e0ee94ab17a9ea8c2b8bd02e1f626dd6907624cfe8508ad356baR5), [resources/dataLoader.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-713ad9d6eaa54785a87bc28f52d6fb3c5e168dcd97ec17da7546f6a24f398a4dR5), [resources/databases.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R6), [resources/graphql.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-72e8b09df8fa4bd777558edfcb08b247ac3965b75d83c9c8c6c7f81cbe2374c8R5), [resources/scheduler/scheduler.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-40192d5f1e5f644f8f63513b5ca59aca30b6d7d8222217724cfa1dab0ef9f2f7R2), [security/jsLoader.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-017d60e3f7f4b41769872ae398a2c11a80a5c783da018b471d1c0d2b0cb7dddcR35), [server/http.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-df0a865ce41dd6dd95036d1be97cc57d8f0a22d83eec5619914f0b34274b09c3R15), [server/storageReclamation.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-ee5cbdbf9eab77a1979df5c68479453f25f6a492681285525992125842ae6848R4), [server/threads/isolatedApplications.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-a4c07ca2de2e257a7771e724b5dea2ce0bc48711a113e092ffb9350e75f57881R1), [server/threads/manageThreads.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-02c28577c2ca63129ed10809ce3db1469c70bef080e04fd273f8cbd510b6521bR67), [server/threads/socketRouter.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-545704b0f9ebb0c229b5f127dc8c710d5061aedb1e01e00514a96385babb1196R1), [server/threads/threadServer.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-203cc9c9c5531f3f084fdd3b3f51473caef679476c20f7db9328d12ecd334269R29).
- Integration: [integrationTests/components/isolated-application.test.ts](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-760e9ae965143630d2d3d41430681906a6317a5429cfffbe845af6932afb6dc1R1), [isolated-app/config.yaml](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-e8d88433adf97aa662a8f4466104b3cd3465661d092faa703653e83811eda858R1), [isolated-app/resources.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-204e8d11f2e7be3a8021e967cebfcca79d906e99736937b3439545c86ddb322fR1), [isolated-app/schema.graphql](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-fbf8276a04eb75d5f0813dbfaef7cd0e568c78584378d4ea7ffb039c99e830daR1), [isolated-app/drop-me.txt](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-7bedd27c56c156b53f1beb58358b074f80f3aef919004b7b2e881452d88fb6c3R1), [isolated-app-two/config.yaml](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-f38e65049f35c8c9223a4052413ca132322e4225f05cea1591b6dbbaf3f14e4aR1), [isolated-app-two/resources.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-d9d6d318c76e62ea870d59b9f83a1560019e694e9cc516e05b00020a7ac483cfR1), [shared-sibling/config.yaml](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-4b12c0bb38cef8741d9365f7618de2b08ae0e315c1bdb039b22b24eb9c3d53c9R1), [shared-sibling/resources.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-2422ad4e05b62a321cede9fb328f45e8f3812f88f1e528c9ed40db02a4b27d7fR1).
- Unit coverage: [unitTests/components/componentLoader.test.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-3202bc18b91bc840299bbf5c3e774e16f4eb2825fdbbf081a1280df599de311eR358), [unitTests/components/prepareApplicationSerialization.test.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-a67ae2a0b61daaca0f83e493e4e43f6a8f35efd189570c42ccd75c94123e5a5bR167), [unitTests/components/requestRestart.test.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-161091da09d3825d4ba88b14a701406be3d5dbd7db394383f915ef1bb2127ba6R1), [unitTests/resources/dataLoader.test.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-edb80184488258ba362e0ef4e13ed99f119eb822772cba97bae1f163b47f0a5bR985), [unitTests/resources/expiresAtAttribute.test.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-f88440fd541a8c6e5427bd531d00a8d23ec17bd294408ca56e6d6ff1fb5a7759R118), [unitTests/server/fastifyRoutes/operations.test.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-711b18abba07f6b7e9147ac6ebd7eecff081215115d1cc323aa6c0ab56871117R525), [unitTests/server/storageReclamation.test.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-ecaf6585f6dec942f94d1450d03a0048d5bda3720381401551348b0990b9b726R20), [unitTests/server/threads/fixtures/exitImmediately.cjs](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-cd8e540f4203e3f1bf2135a31162af50579f8f2c8fc215ef02342a9d94fe7085R1), [unitTests/server/threads/isolatedApplications.test.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-f8db4800083d3a4807591f632644d9948e8e11cc2631277de3ebd239e9d0d5dcR1), [unitTests/server/threads/threadInfoTimeout.test.js](https://github.com/HarperFast/harper/pull/2524/changes?w=1#diff-1157b1bf97155a91fa4562200fe5ab354ff461b4685c67707bb521f517100d2eR33).

<sub>Review-Coverage: authored=codex; ran=gemini,cursor-grok; blocked=claude(exit-1),domain(timeout); declined=cursor-composer; rounds=25; full=4 @ b1d5cbc5c11e</sub>

<sub>Human-Review-Need: 4 @ b1d5cbc5c11e</sub>
