### PR TITLE
Guard transaction-log space reclamation after restart

### DIFF
--- a/integrationTests/database/txnlog-restart-reclaim.test.ts
+++ b/integrationTests/database/txnlog-restart-reclaim.test.ts
@@ -1,12 +1,9 @@
 /**
  * A RocksDB restart must return purged transaction-log blocks to the filesystem, not merely
- * remove their directory entries. The test rotates a real log, stops Harper before retention can
- * purge it, lets it age while no cleanup scheduler is running, and checks the startup purge with
- * both the visible files and `statfs`. The filesystem delta is reconciled with every visible
- * allocation change under the data root during boot, then must account for at least 75% of the
- * purged blocks; the remainder is tolerance for metadata and unrelated activity on the shared
- * filesystem. This promotes only P-643's restart-reclaim leg; continuous retention re-arming is
- * covered separately by audit-retention-rocks.test.ts.
+ * remove their directory entries. The test retires steady-state cleanup, rotates and flushes a
+ * real log, lets it age while Harper is stopped, and checks the one restart purge with both the
+ * visible files and `statfs`. The filesystem delta is reconciled with every visible allocation
+ * change under the data root during boot, then must account for at least 75% of the purged blocks.
  *
  * Refs harper#2337.
  */
@@ -25,9 +22,9 @@ import {
 } from '@harperfast/integration-testing';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'txnlog-restart-reclaim');
-const AUDIT_RETENTION_SECONDS = 30;
+const AUDIT_RETENTION_SECONDS = 2;
 const AUDIT_RETENTION_MS = AUDIT_RETENTION_SECONDS * 1000;
-const RETENTION_MARGIN_MS = 1000;
+const RETENTION_MARGIN_MS = 500;
 const MIN_RECLAIM_BYTES = 64 * 1024 * 1024;
 const MIN_RECLAIM_RATIO = 0.75;
 const VOLUME_RECORDS = 14_000;
@@ -42,6 +39,13 @@ const ENV = {
 };
 
 type FileAllocation = { path: string; bytes: number; allocatedBytes: number };
+type ReclaimState = {
+	engineGuess: string;
+	oldestSequenceNumber: number;
+	currentSequenceNumber: number;
+	lastFlushedSequence: number;
+	purgeRuns: number;
+};
 
 function authHeader(ctx: ContextWithHarper): string {
 	const { username, password } = ctx.harper.admin;
@@ -89,18 +93,27 @@ async function freeBytes(root: string): Promise<number> {
 	return stats.bavail * stats.bsize;
 }
 
-async function pollReadiness(ctx: ContextWithHarper): Promise<void> {
+async function waitForReclaimState(ctx: ContextWithHarper): Promise<ReclaimState> {
 	const deadline = Date.now() + 60_000;
 	while (Date.now() < deadline) {
+		let response: Response;
 		try {
-			const response = await fetch(`${ctx.harper.httpURL}/Telemetry/`, {
+			response = await fetch(`${ctx.harper.httpURL}/ReclaimState/`, {
 				headers: { Authorization: authHeader(ctx) },
 			});
-			if (response.status !== 404) return;
-		} catch {}
-		await sleep(250);
+		} catch {
+			await sleep(250);
+			continue;
+		}
+		const responseBody = await response.text();
+		if (response.status === 404) {
+			await sleep(250);
+			continue;
+		}
+		strictEqual(response.status, 200, `ReclaimState failed: ${responseBody.slice(0, 300)}`);
+		return JSON.parse(responseBody);
 	}
-	throw new Error('Telemetry route did not become ready within 60 seconds');
+	throw new Error('ReclaimState route did not become ready within 60 seconds');
 }
 
 async function createLogVolume(ctx: ContextWithHarper): Promise<void> {
@@ -122,13 +135,33 @@ async function flush(ctx: ContextWithHarper): Promise<void> {
 	strictEqual(response.status, 200, `Flush failed: ${(await response.text()).slice(0, 300)}`);
 }
 
+async function flushUntilPurgeable(ctx: ContextWithHarper): Promise<ReclaimState> {
+	const deadline = Date.now() + 30_000;
+	let state: ReclaimState;
+	do {
+		await flush(ctx);
+		state = await waitForReclaimState(ctx);
+		if (
+			state.oldestSequenceNumber < state.currentSequenceNumber &&
+			state.lastFlushedSequence > state.oldestSequenceNumber
+		)
+			return state;
+		await sleep(250);
+	} while (Date.now() < deadline);
+	throw new Error(
+		`transaction log did not become purgeable: oldest=${state.oldestSequenceNumber}, ` +
+			`current=${state.currentSequenceNumber}, lastFlushed=${state.lastFlushedSequence}`
+	);
+}
+
 suite(
 	'RocksDB restart returns purged transaction-log blocks to the filesystem (#2337)',
 	{ skip: process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun' },
 	(ctx: ContextWithHarper) => {
 		before(async () => {
 			await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: CONFIG, env: ENV });
-			await pollReadiness(ctx);
+			const initialState = await waitForReclaimState(ctx);
+			strictEqual(initialState.engineGuess, 'rocksdb');
 		});
 
 		after(async () => {
@@ -136,26 +169,14 @@ suite(
 		});
 
 		test('startup purge reclaims visible and filesystem-allocated bytes together', { timeout: 180_000 }, async () => {
-			const engineResponse = await fetch(`${ctx.harper.httpURL}/StorageEngineInfo/`, {
-				headers: { Authorization: authHeader(ctx) },
-			});
-			strictEqual(engineResponse.status, 200);
-			strictEqual((await engineResponse.json()).engineGuess, 'rocksdb');
-
-			const seedStartedAt = Date.now();
 			await createLogVolume(ctx);
-			await flush(ctx);
+			await flushUntilPurgeable(ctx);
 			const liveLogs = transactionLogsUnder(ctx.harper.dataRootDir);
 			ok(liveLogs.length > 1, `expected transaction-log rotation, found ${liveLogs.length} file(s)`);
 			ok(
 				liveLogs.reduce((total, file) => total + file.bytes, 0) > MIN_RECLAIM_BYTES,
 				`expected more than ${MIN_RECLAIM_BYTES} transaction-log bytes before restart`
 			);
-			ok(
-				Date.now() - seedStartedAt < AUDIT_RETENTION_MS,
-				'test setup exceeded the retention window, so live cleanup could have purged the target log'
-			);
-
 			await killHarper(ctx);
 			const stoppedLogs = transactionLogsUnder(ctx.harper.dataRootDir);
 			const stoppedPaths = new Set(stoppedLogs.map((file) => file.path));
@@ -175,7 +196,8 @@ suite(
 			const preBootFree = await freeBytes(ctx.harper.dataRootDir);
 
 			await startHarper(ctx, { config: CONFIG, env: ENV });
-			await pollReadiness(ctx);
+			const restartState = await waitForReclaimState(ctx);
+			strictEqual(restartState.purgeRuns, 1, 'expected the restart purge to be the only cleanup pass');
 
 			const postBootLogs = transactionLogsUnder(ctx.harper.dataRootDir);
 			const postBootPaths = new Set(postBootLogs.map((file) => file.path));

--- a/integrationTests/database/txnlog-restart-reclaim.test.ts
+++ b/integrationTests/database/txnlog-restart-reclaim.test.ts
@@ -1,0 +1,205 @@
+/**
+ * A RocksDB restart must return purged transaction-log blocks to the filesystem, not merely
+ * remove their directory entries. The test rotates a real log, stops Harper before retention can
+ * purge it, lets it age while no cleanup scheduler is running, and checks the startup purge with
+ * both the visible files and `statfs`. The filesystem delta is reconciled with every visible
+ * allocation change under the data root during boot, then must account for at least 75% of the
+ * purged blocks; the remainder is tolerance for metadata and unrelated activity on the shared
+ * filesystem. This promotes only P-643's restart-reclaim leg; continuous retention re-arming is
+ * covered separately by audit-retention-rocks.test.ts.
+ *
+ * Refs harper#2337.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { statfs } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+	setupHarperWithFixture,
+	startHarper,
+	killHarper,
+	teardownHarper,
+	type ContextWithHarper,
+} from '@harperfast/integration-testing';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'txnlog-restart-reclaim');
+const AUDIT_RETENTION_SECONDS = 30;
+const AUDIT_RETENTION_MS = AUDIT_RETENTION_SECONDS * 1000;
+const RETENTION_MARGIN_MS = 1000;
+const MIN_RECLAIM_BYTES = 64 * 1024 * 1024;
+const MIN_RECLAIM_RATIO = 0.75;
+const VOLUME_RECORDS = 14_000;
+const PAYLOAD = 'p'.repeat(5000);
+const CONFIG = {
+	threads: { count: 1 },
+	logging: { auditLog: true, auditRetention: AUDIT_RETENTION_SECONDS, level: 'error' as const },
+};
+const ENV = {
+	HARPER_STORAGE_ENGINE: 'rocksdb',
+	STORAGE_RECLAMATION_THRESHOLD: 0,
+};
+
+type FileAllocation = { path: string; bytes: number; allocatedBytes: number };
+
+function authHeader(ctx: ContextWithHarper): string {
+	const { username, password } = ctx.harper.admin;
+	return 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
+}
+
+function filesUnder(root: string, matcher: (path: string) => boolean): FileAllocation[] {
+	const files: FileAllocation[] = [];
+	function walk(directory: string): void {
+		let entries: import('node:fs').Dirent[];
+		try {
+			entries = readdirSync(directory, { withFileTypes: true });
+		} catch (error: any) {
+			if (error?.code === 'ENOENT') return;
+			throw error;
+		}
+		for (const entry of entries) {
+			const path = join(directory, entry.name);
+			if (entry.isDirectory()) {
+				walk(path);
+			} else if (matcher(path)) {
+				try {
+					const stats = statSync(path);
+					files.push({ path, bytes: stats.size, allocatedBytes: stats.blocks * 512 });
+				} catch (error: any) {
+					if (error?.code !== 'ENOENT') throw error;
+				}
+			}
+		}
+	}
+	if (existsSync(root)) walk(root);
+	return files;
+}
+
+function allocatedBytesUnder(root: string): number {
+	return filesUnder(root, () => true).reduce((total, file) => total + file.allocatedBytes, 0);
+}
+
+function transactionLogsUnder(root: string): FileAllocation[] {
+	return filesUnder(root, (path) => path.endsWith('.txnlog'));
+}
+
+async function freeBytes(root: string): Promise<number> {
+	const stats = await statfs(root);
+	return stats.bavail * stats.bsize;
+}
+
+async function pollReadiness(ctx: ContextWithHarper): Promise<void> {
+	const deadline = Date.now() + 60_000;
+	while (Date.now() < deadline) {
+		try {
+			const response = await fetch(`${ctx.harper.httpURL}/Telemetry/`, {
+				headers: { Authorization: authHeader(ctx) },
+			});
+			if (response.status !== 404) return;
+		} catch {}
+		await sleep(250);
+	}
+	throw new Error('Telemetry route did not become ready within 60 seconds');
+}
+
+async function createLogVolume(ctx: ContextWithHarper): Promise<void> {
+	const response = await fetch(`${ctx.harper.httpURL}/Churn/`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', 'Authorization': authHeader(ctx) },
+		body: JSON.stringify({ count: VOLUME_RECORDS, payload: PAYLOAD }),
+		signal: AbortSignal.timeout(120_000),
+	});
+	const responseBody = await response.text();
+	strictEqual(response.status, 200, `transaction-log churn failed: ${responseBody.slice(0, 300)}`);
+}
+
+async function flush(ctx: ContextWithHarper): Promise<void> {
+	const response = await fetch(`${ctx.harper.httpURL}/Flush/`, {
+		method: 'POST',
+		headers: { Authorization: authHeader(ctx) },
+	});
+	strictEqual(response.status, 200, `Flush failed: ${(await response.text()).slice(0, 300)}`);
+}
+
+suite(
+	'RocksDB restart returns purged transaction-log blocks to the filesystem (#2337)',
+	{ skip: process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun' },
+	(ctx: ContextWithHarper) => {
+		before(async () => {
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: CONFIG, env: ENV });
+			await pollReadiness(ctx);
+		});
+
+		after(async () => {
+			await teardownHarper(ctx);
+		});
+
+		test('startup purge reclaims visible and filesystem-allocated bytes together', { timeout: 180_000 }, async () => {
+			const engineResponse = await fetch(`${ctx.harper.httpURL}/StorageEngineInfo/`, {
+				headers: { Authorization: authHeader(ctx) },
+			});
+			strictEqual(engineResponse.status, 200);
+			strictEqual((await engineResponse.json()).engineGuess, 'rocksdb');
+
+			const seedStartedAt = Date.now();
+			await createLogVolume(ctx);
+			await flush(ctx);
+			const liveLogs = transactionLogsUnder(ctx.harper.dataRootDir);
+			ok(liveLogs.length > 1, `expected transaction-log rotation, found ${liveLogs.length} file(s)`);
+			ok(
+				liveLogs.reduce((total, file) => total + file.bytes, 0) > MIN_RECLAIM_BYTES,
+				`expected more than ${MIN_RECLAIM_BYTES} transaction-log bytes before restart`
+			);
+			ok(
+				Date.now() - seedStartedAt < AUDIT_RETENTION_MS,
+				'test setup exceeded the retention window, so live cleanup could have purged the target log'
+			);
+
+			await killHarper(ctx);
+			const stoppedLogs = transactionLogsUnder(ctx.harper.dataRootDir);
+			const stoppedPaths = new Set(stoppedLogs.map((file) => file.path));
+			ok(
+				liveLogs.every((file) => stoppedPaths.has(file.path)),
+				'a transaction log disappeared during shutdown instead of the startup purge under test'
+			);
+			await sleep(AUDIT_RETENTION_MS + RETENTION_MARGIN_MS);
+
+			const preBootLogs = transactionLogsUnder(ctx.harper.dataRootDir);
+			const preBootPaths = new Set(preBootLogs.map((file) => file.path));
+			ok(
+				stoppedLogs.every((file) => preBootPaths.has(file.path)),
+				'a transaction log disappeared while Harper was stopped'
+			);
+			const preBootAllocated = allocatedBytesUnder(ctx.harper.dataRootDir);
+			const preBootFree = await freeBytes(ctx.harper.dataRootDir);
+
+			await startHarper(ctx, { config: CONFIG, env: ENV });
+			await pollReadiness(ctx);
+
+			const postBootLogs = transactionLogsUnder(ctx.harper.dataRootDir);
+			const postBootPaths = new Set(postBootLogs.map((file) => file.path));
+			const removedLogs = preBootLogs.filter((file) => !postBootPaths.has(file.path));
+			const removedAllocated = removedLogs.reduce((total, file) => total + file.allocatedBytes, 0);
+			ok(
+				removedAllocated >= MIN_RECLAIM_BYTES,
+				`startup purge removed only ${removedAllocated} allocated transaction-log bytes; expected at least ${MIN_RECLAIM_BYTES}`
+			);
+
+			const postBootAllocated = allocatedBytesUnder(ctx.harper.dataRootDir);
+			const dataRootAllocatedDelta = postBootAllocated - preBootAllocated;
+			const filesystemFreeDelta = (await freeBytes(ctx.harper.dataRootDir)) - preBootFree;
+			const filesystemReclaim = filesystemFreeDelta + dataRootAllocatedDelta + removedAllocated;
+			console.log(
+				`restart reclaim: removed txnlogs=${removedAllocated} bytes, data-root allocated delta=${dataRootAllocatedDelta} bytes, ` +
+					`filesystem free delta=${filesystemFreeDelta} bytes, reconciled txnlog reclaim=${filesystemReclaim} bytes`
+			);
+			ok(
+				filesystemReclaim >= removedAllocated * MIN_RECLAIM_RATIO,
+				`startup removed ${removedAllocated} allocated transaction-log bytes, but statfs reported a free-space delta of ` +
+					`${filesystemFreeDelta} bytes after accounting for a ${dataRootAllocatedDelta}-byte change under the data root; ` +
+					`only ${filesystemReclaim} bytes (${((filesystemReclaim / removedAllocated) * 100).toFixed(1)}%) were actually reclaimed`
+			);
+		});
+	}
+);

--- a/integrationTests/database/txnlog-restart-reclaim.test.ts
+++ b/integrationTests/database/txnlog-restart-reclaim.test.ts
@@ -1,9 +1,7 @@
 /**
  * A RocksDB restart must return purged transaction-log blocks to the filesystem, not merely
- * remove their directory entries. The test retires steady-state cleanup, rotates and flushes a
- * real log, lets it age while Harper is stopped, and checks the one restart purge with both the
- * visible files and `statfs`. The filesystem delta is reconciled with every visible allocation
- * change under the data root during boot, then must account for at least 75% of the purged blocks.
+ * remove their directory entries. The `statfs` delta is reconciled with every visible allocation
+ * change under the isolated data root and must account for at least 75% of the purged blocks.
  *
  * Refs harper#2337.
  */
@@ -27,8 +25,11 @@ const AUDIT_RETENTION_MS = AUDIT_RETENTION_SECONDS * 1000;
 const RETENTION_MARGIN_MS = 500;
 const MIN_RECLAIM_BYTES = 64 * 1024 * 1024;
 const MIN_RECLAIM_RATIO = 0.75;
-const VOLUME_RECORDS = 14_000;
+const VOLUME_RECORDS = 20_000;
+const CHURN_BATCH_RECORDS = 500;
 const PAYLOAD = 'p'.repeat(5000);
+const RECLAIM_FILESYSTEM_ROOT = '/dev/shm';
+const TMPFS_MAGIC = 0x01021994;
 const CONFIG = {
 	threads: { count: 1 },
 	logging: { auditLog: true, auditRetention: AUDIT_RETENTION_SECONDS, level: 'error' as const },
@@ -117,14 +118,16 @@ async function waitForReclaimState(ctx: ContextWithHarper): Promise<ReclaimState
 }
 
 async function createLogVolume(ctx: ContextWithHarper): Promise<void> {
-	const response = await fetch(`${ctx.harper.httpURL}/Churn/`, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json', 'Authorization': authHeader(ctx) },
-		body: JSON.stringify({ count: VOLUME_RECORDS, payload: PAYLOAD }),
-		signal: AbortSignal.timeout(120_000),
-	});
-	const responseBody = await response.text();
-	strictEqual(response.status, 200, `transaction-log churn failed: ${responseBody.slice(0, 300)}`);
+	for (let start = 0; start < VOLUME_RECORDS; start += CHURN_BATCH_RECORDS) {
+		const response = await fetch(`${ctx.harper.httpURL}/Churn/`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', 'Authorization': authHeader(ctx) },
+			body: JSON.stringify({ start, count: Math.min(CHURN_BATCH_RECORDS, VOLUME_RECORDS - start), payload: PAYLOAD }),
+			signal: AbortSignal.timeout(120_000),
+		});
+		const responseBody = await response.text();
+		strictEqual(response.status, 200, `transaction-log churn at ${start} failed: ${responseBody.slice(0, 300)}`);
+	}
 }
 
 async function flush(ctx: ContextWithHarper): Promise<void> {
@@ -156,10 +159,20 @@ async function flushUntilPurgeable(ctx: ContextWithHarper): Promise<ReclaimState
 
 suite(
 	'RocksDB restart returns purged transaction-log blocks to the filesystem (#2337)',
-	{ skip: process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun' },
+	{
+		skip: process.platform !== 'linux' || process.env.HARPER_RUNTIME === 'bun' || !existsSync(RECLAIM_FILESYSTEM_ROOT),
+	},
 	(ctx: ContextWithHarper) => {
 		before(async () => {
-			await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: CONFIG, env: ENV });
+			const previousInstallParent = process.env.HARPER_INTEGRATION_TEST_INSTALL_PARENT_DIR;
+			process.env.HARPER_INTEGRATION_TEST_INSTALL_PARENT_DIR = RECLAIM_FILESYSTEM_ROOT;
+			try {
+				await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: CONFIG, env: ENV });
+			} finally {
+				if (previousInstallParent === undefined) delete process.env.HARPER_INTEGRATION_TEST_INSTALL_PARENT_DIR;
+				else process.env.HARPER_INTEGRATION_TEST_INSTALL_PARENT_DIR = previousInstallParent;
+			}
+			strictEqual((await statfs(ctx.harper.dataRootDir)).type, TMPFS_MAGIC, 'reclaim test requires a tmpfs data root');
 			const initialState = await waitForReclaimState(ctx);
 			strictEqual(initialState.engineGuess, 'rocksdb');
 		});

--- a/integrationTests/database/txnlog-restart-reclaim.test.ts
+++ b/integrationTests/database/txnlog-restart-reclaim.test.ts
@@ -1,13 +1,12 @@
 /**
  * A RocksDB restart must return purged transaction-log blocks to the filesystem, not merely
- * remove their directory entries. The `statfs` delta is reconciled with every visible allocation
- * change under the isolated data root and must account for at least 75% of the purged blocks.
+ * remove their directory entries.
  *
  * Refs harper#2337.
  */
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual } from 'node:assert';
-import { existsSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, statfsSync, statSync } from 'node:fs';
 import { statfs } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -30,6 +29,7 @@ const CHURN_BATCH_RECORDS = 500;
 const PAYLOAD = 'p'.repeat(5000);
 const RECLAIM_FILESYSTEM_ROOT = '/dev/shm';
 const TMPFS_MAGIC = 0x01021994;
+const MIN_FILESYSTEM_FREE_BYTES = 512 * 1024 * 1024;
 const CONFIG = {
 	threads: { count: 1 },
 	logging: { auditLog: true, auditRetention: AUDIT_RETENTION_SECONDS, level: 'error' as const },
@@ -47,6 +47,21 @@ type ReclaimState = {
 	lastFlushedSequence: number;
 	purgeRuns: number;
 };
+
+function reclaimSkipReason(): string | false {
+	if (process.platform !== 'linux') return 'requires Linux tmpfs semantics';
+	if (process.env.HARPER_RUNTIME === 'bun') return 'requires the Node.js RocksDB runtime';
+	if (!existsSync(RECLAIM_FILESYSTEM_ROOT)) return `${RECLAIM_FILESYSTEM_ROOT} is unavailable`;
+	try {
+		const filesystem = statfsSync(RECLAIM_FILESYSTEM_ROOT);
+		if (filesystem.type !== TMPFS_MAGIC) return `${RECLAIM_FILESYSTEM_ROOT} is not tmpfs`;
+		const freeBytes = filesystem.bavail * filesystem.bsize;
+		if (freeBytes < MIN_FILESYSTEM_FREE_BYTES) return `${RECLAIM_FILESYSTEM_ROOT} has only ${freeBytes} free bytes`;
+	} catch (error) {
+		return `cannot inspect ${RECLAIM_FILESYSTEM_ROOT}: ${(error as Error).message}`;
+	}
+	return false;
+}
 
 function authHeader(ctx: ContextWithHarper): string {
 	const { username, password } = ctx.harper.admin;
@@ -159,9 +174,7 @@ async function flushUntilPurgeable(ctx: ContextWithHarper): Promise<ReclaimState
 
 suite(
 	'RocksDB restart returns purged transaction-log blocks to the filesystem (#2337)',
-	{
-		skip: process.platform !== 'linux' || process.env.HARPER_RUNTIME === 'bun' || !existsSync(RECLAIM_FILESYSTEM_ROOT),
-	},
+	{ skip: reclaimSkipReason() },
 	(ctx: ContextWithHarper) => {
 		before(async () => {
 			const previousInstallParent = process.env.HARPER_INTEGRATION_TEST_INSTALL_PARENT_DIR;

--- a/integrationTests/database/txnlog-restart-reclaim/config.yaml
+++ b/integrationTests/database/txnlog-restart-reclaim/config.yaml
@@ -1,0 +1,5 @@
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/database/txnlog-restart-reclaim/resources.js
+++ b/integrationTests/database/txnlog-restart-reclaim/resources.js
@@ -23,7 +23,7 @@ export class Flush extends Resource {
 	}
 }
 
-export class StorageEngineInfo extends Resource {
+export class ReclaimState extends Resource {
 	static loadAsInstance = false;
 	async get() {
 		const table = tables.Telemetry;
@@ -31,6 +31,17 @@ export class StorageEngineInfo extends Resource {
 		const primaryPath = table.primaryStore?.path || table.primaryStore?.rootStore?.path || null;
 		const looksLikeLmdbPath = typeof primaryPath === 'string' && primaryPath.endsWith('.mdb');
 		const hasPurgeLogs = typeof table.primaryStore?.rootStore?.purgeLogs === 'function';
-		return { engineGuess: looksLikeLmdbPath ? 'lmdb' : hasPurgeLogs ? 'rocksdb' : 'unknown' };
+		const stats = table.auditStore?.log?.getStats?.();
+		if (!stats) throw new Error('Telemetry transaction-log statistics are unavailable');
+		return {
+			engineGuess: looksLikeLmdbPath ? 'lmdb' : hasPurgeLogs ? 'rocksdb' : 'unknown',
+			oldestSequenceNumber: stats.oldestSequenceNumber,
+			currentSequenceNumber: stats.currentSequenceNumber,
+			lastFlushedSequence: stats.lastFlushedPosition?.sequence,
+			purgeRuns: stats.totals?.purgeRuns,
+		};
 	}
 }
+
+// Retire background cleanup during component load so any later purge is attributable to restart replay.
+tables.Telemetry.auditStore.stopAuditCleanup();

--- a/integrationTests/database/txnlog-restart-reclaim/resources.js
+++ b/integrationTests/database/txnlog-restart-reclaim/resources.js
@@ -1,0 +1,36 @@
+export class Churn extends Resource {
+	static loadAsInstance = false;
+	async post(_query, body) {
+		const count = Number(body?.count);
+		const payload = String(body?.payload || '');
+		if (!Number.isSafeInteger(count) || count < 1) throw new Error('count must be a positive integer');
+		for (let sequence = 0; sequence < count; sequence++) {
+			await tables.Telemetry.put({ id: 'hot-record', sequence, payload });
+		}
+		return { count };
+	}
+}
+
+export class Flush extends Resource {
+	static loadAsInstance = false;
+	async post() {
+		const table = tables.Telemetry;
+		if (!table || typeof table.primaryStore.flush !== 'function') {
+			throw new Error('Telemetry primaryStore.flush() is unavailable');
+		}
+		await table.primaryStore.flush();
+		return { flushed: true };
+	}
+}
+
+export class StorageEngineInfo extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		const table = tables.Telemetry;
+		if (!table) throw new Error('Telemetry table is unavailable');
+		const primaryPath = table.primaryStore?.path || table.primaryStore?.rootStore?.path || null;
+		const looksLikeLmdbPath = typeof primaryPath === 'string' && primaryPath.endsWith('.mdb');
+		const hasPurgeLogs = typeof table.primaryStore?.rootStore?.purgeLogs === 'function';
+		return { engineGuess: looksLikeLmdbPath ? 'lmdb' : hasPurgeLogs ? 'rocksdb' : 'unknown' };
+	}
+}

--- a/integrationTests/database/txnlog-restart-reclaim/resources.js
+++ b/integrationTests/database/txnlog-restart-reclaim/resources.js
@@ -1,10 +1,12 @@
 export class Churn extends Resource {
 	static loadAsInstance = false;
 	async post(_query, body) {
+		const start = Number(body?.start);
 		const count = Number(body?.count);
 		const payload = String(body?.payload || '');
+		if (!Number.isSafeInteger(start) || start < 0) throw new Error('start must be a non-negative integer');
 		if (!Number.isSafeInteger(count) || count < 1) throw new Error('count must be a positive integer');
-		for (let sequence = 0; sequence < count; sequence++) {
+		for (let sequence = start; sequence < start + count; sequence++) {
 			await tables.Telemetry.put({ id: 'hot-record', sequence, payload });
 		}
 		return { count };
@@ -43,5 +45,4 @@ export class ReclaimState extends Resource {
 	}
 }
 
-// Retire background cleanup during component load so any later purge is attributable to restart replay.
 tables.Telemetry.auditStore.stopAuditCleanup();

--- a/integrationTests/database/txnlog-restart-reclaim/schema.graphql
+++ b/integrationTests/database/txnlog-restart-reclaim/schema.graphql
@@ -1,0 +1,5 @@
+type Telemetry @table(audit: true) @export {
+	id: ID @primaryKey
+	sequence: Int
+	payload: String
+}


### PR DESCRIPTION
Adds a Linux/RocksDB integration regression that creates more than 100 MB of purgeable transaction logs, waits past retention while Harper is stopped, restarts, and [reconciles removed file blocks against `statfs` free space](https://github.com/HarperFast/harper/pull/2529/changes?w=1#diff-5738c738737622df461e3bc8494e23c5cbb00450893792150d5dcda5ff7ce068R239). This guards physical block release rather than directory-entry removal and intentionally leaves passive audit-retention rearming to its existing coverage. Refs #2337.

## For the human reviewer

1. The test uses a flushed graceful restart with [passive cleanup disabled by the fixture](https://github.com/HarperFast/harper/pull/2529/changes?w=1#diff-83254f9397f22b06b9b7fbd17cbe56e6c8a86de3adf68e75ceb99ccde602b991R48) so removed logs are attributable to the startup purge. A hard-crash/unflushed-tail variant would broaden recovery coverage but is independent of the physical-reclamation invariant; adding it later only changes the fixture. One residual false-red edge remains: component initialization taking more than the cleanup timer's first 10 seconds could let a passive purge run before the fixture cancels it; eliminating that edge would require a product-level pre-arm suppression seam in this otherwise test-only change.
2. The [runtime and tmpfs capability gate](https://github.com/HarperFast/harper/pull/2529/changes?w=1#diff-5738c738737622df461e3bc8494e23c5cbb00450893792150d5dcda5ff7ce068R51) requires Linux, Node, and at least 512 MB free on `/dev/shm`, skipping otherwise. A designated CI capability requirement would prevent infrastructure drift from silently removing coverage, but it would make runner policy part of this PR. `/dev/shm` is still host-shared, so unrelated allocation can perturb `statfs`; the approximately 100 MB signal and 25% tolerance reduce but cannot fully eliminate that noise without a privileged private mount. This is where to look hardest.
3. The [reclamation assertion](https://github.com/HarperFast/harper/pull/2529/changes?w=1#diff-5738c738737622df461e3bc8494e23c5cbb00450893792150d5dcda5ff7ce068R246) accepts at least 75% of the removed transaction-log allocation as reconciled filesystem reclamation. Requiring 100% would be stricter but brittle to boot-time filesystem noise; tightening the constant later is a local, reversible calibration change.

## Verification

- `npm run build` — passed.
- `npm run lint:required` — passed.
- `npx harper-integration-test-run integrationTests/database/txnlog-restart-reclaim.test.ts` — 1 passed; 101,453,824 transaction-log bytes removed and 101,453,824 bytes reconciled as filesystem reclaim.
- Negative control using a temporary local build that retained file descriptors for unlinked transaction logs — failed the new assertion as intended: 101,453,824 bytes removed, 0 bytes reconciled (0.0%); the temporary product patch was reverted before commit.
- `npm run test:unit:main` — 5,418 passed, 196 pending under a short bind-mounted worktree path with dispatch-injected Git variables removed.
- `npm run test:unit:resources` — 2,190 passed, 30 pending.
- `npm run test:integration:all` — the promoted test passed, then the sweep exited nonzero in the unrelated existing `OllamaBackend` suite because Node 26 rejected `json/systemSchema.json` without an import attribute; the Ollama failure reproduces by itself.

Comment generated by kAIle (GPT-5.6)

Complexity: medium

<sub>Review-Coverage: authored=codex; ran=gemini,claude; adjudicated=domain; declined=cursor-grok,cursor-composer; rounds=4 @ d561b82d1071</sub>

<sub>Human-Review-Need: 3 (decisions: restart-coverage-scope, tmpfs-coverage-policy, reclaim-tolerance) @ d561b82d1071</sub>
