### PR TITLE
Give the dual-clock audit suite a monotonic allocator for fabricated origin log keys, fixing the shared-key lookup flake

### DIFF
--- a/unitTests/resources/dualClockAuditRecord.test.js
+++ b/unitTests/resources/dualClockAuditRecord.test.js
@@ -22,6 +22,15 @@ describe('Dual-clock audit records (harper#2412)', () => {
 	let Plain, Filled, auditStore;
 	let reportedVersion;
 
+	// Origin log keys for applied writes. Each must be unique on the local log: auditStore.get reads
+	// only the contiguous run of entries at a key, so a second transaction at the same key hides
+	// whatever was written after it. Anchors are 100 s apart so the offsets tests subtract from one
+	// (at most 60 s) never reach the previous anchor.
+	let lastAnchor = Date.now() - 3 * 3_600_000;
+	function originClock() {
+		return (lastAnchor += 100_000);
+	}
+
 	// Every audit entry this suite's tables produced, newest last.
 	function auditEntriesFor(TableClass, id) {
 		const entries = [];
@@ -149,7 +158,7 @@ describe('Dual-clock audit records (harper#2412)', () => {
 	it('an applied write keeps the origin version and takes the origin log key', async function () {
 		if (isLMDB) return this.skip();
 		const id = 'applied-1';
-		const logKey = Date.now();
+		const logKey = originClock();
 		const version = logKey - 30_000;
 		await applyFromOrigin(Plain, id, { id, name: 'from-origin' }, { logKey, version });
 		assert.equal(Plain.primaryStore.getEntry(id).version, version, 'the peer stores the origin record version');
@@ -161,7 +170,7 @@ describe('Dual-clock audit records (harper#2412)', () => {
 	it('keeps a log-key pointer to the audit head when the stored version differs', async function () {
 		if (isLMDB) return this.skip();
 		const id = 'applied-head-1';
-		const baseVersion = Date.now() - 60_000;
+		const baseVersion = originClock() - 60_000;
 		await applyFromOrigin(
 			Plain,
 			id,
@@ -206,9 +215,9 @@ describe('Dual-clock audit records (harper#2412)', () => {
 	it('distinguishes equal record versions from distinct log-key writes', async function () {
 		if (isLMDB) return this.skip();
 		const id = 'equal-version-distinct-log-key-1';
-		const version = Date.now() - 30_000;
+		const version = originClock() - 30_000;
 		await applyFromOrigin(Plain, id, { id, name: 'base', count: 0 }, { logKey: version, version, nodeId: 0 });
-		const logKey = Date.now();
+		const logKey = originClock();
 		await applyFromOrigin(
 			Plain,
 			id,
@@ -226,7 +235,7 @@ describe('Dual-clock audit records (harper#2412)', () => {
 	it('keeps a log-key pointer to an applied delete whose version differs', async function () {
 		if (isLMDB) return this.skip();
 		const id = 'applied-delete-head-1';
-		const writeLogKey = Date.now() - 10_000;
+		const writeLogKey = originClock() - 10_000;
 		const writeVersion = writeLogKey - 30_000;
 		await applyFromOrigin(
 			Plain,
@@ -257,14 +266,14 @@ describe('Dual-clock audit records (harper#2412)', () => {
 	it('keeps a log-key pointer to an applied invalidation whose version differs', async function () {
 		if (isLMDB) return this.skip();
 		const id = 'applied-invalidate-head-1';
-		const baseVersion = Date.now() - 30_000;
+		const baseVersion = originClock() - 30_000;
 		await applyFromOrigin(
 			Plain,
 			id,
 			{ id, name: 'present' },
 			{ logKey: baseVersion, version: baseVersion, nodeId: 0, isCopyApply: true }
 		);
-		const logKey = Date.now() + 20;
+		const logKey = originClock();
 		const version = baseVersion;
 		await invalidateFromOrigin(Plain, id, { id, name: 'present' }, { logKey, version, nodeId: 0 });
 		const invalidated = Plain.primaryStore.getEntry(id);
@@ -283,14 +292,14 @@ describe('Dual-clock audit records (harper#2412)', () => {
 	it('keeps a log-key pointer to an applied relocation whose version differs', async function () {
 		if (isLMDB) return this.skip();
 		const id = 'applied-relocate-head-1';
-		const baseVersion = Date.now() - 30_000;
+		const baseVersion = originClock() - 30_000;
 		await applyFromOrigin(
 			Plain,
 			id,
 			{ id, name: 'present' },
 			{ logKey: baseVersion, version: baseVersion, nodeId: 0, isCopyApply: true }
 		);
-		const logKey = Date.now() + 21;
+		const logKey = originClock();
 		const version = baseVersion;
 		await relocateFromOrigin(Plain, id, { logKey, version, nodeId: 0 });
 		const relocated = Plain.primaryStore.getEntry(id);
@@ -309,7 +318,7 @@ describe('Dual-clock audit records (harper#2412)', () => {
 	it('does not point a copy-applied record at an audit entry that was never written', async function () {
 		if (isLMDB) return this.skip();
 		const id = 'copy-head-1';
-		const logKey = Date.now() + 11;
+		const logKey = originClock();
 		await applyFromOrigin(
 			Plain,
 			id,
@@ -328,7 +337,7 @@ describe('Dual-clock audit records (harper#2412)', () => {
 	it('does not let an audit-only fold displace an ordinary audit head', async function () {
 		if (isLMDB) return this.skip();
 		const id = 'ordinary-fold-head-1';
-		const head = Date.now() - 10_000;
+		const head = originClock() - 10_000;
 		await applyFromOrigin(Plain, id, { id, name: 'newer' }, { logKey: head, version: head, nodeId: 0 });
 		await applyFromOrigin(
 			Plain,
@@ -345,7 +354,7 @@ describe('Dual-clock audit records (harper#2412)', () => {
 	it('bounds an applied record version by the originating transaction-log key', async function () {
 		if (isLMDB) return this.skip();
 		const id = 'applied-out-of-order-1';
-		const logKey = Date.now();
+		const logKey = originClock();
 		const survivingVersion = logKey + 30_000;
 		await applyFromOrigin(Plain, id, { id, name: 'from-origin' }, { logKey, version: survivingVersion });
 		assert.equal(Plain.primaryStore.getEntry(id).version, logKey);
@@ -358,7 +367,7 @@ describe('Dual-clock audit records (harper#2412)', () => {
 		if (isLMDB) return this.skip();
 		// A sender frames by log key, so entries committed together — a fill and an ordinary write —
 		// reach the receiver in one transaction with different record versions. Each has to keep its own.
-		const logKey = Date.now() + 1;
+		const logKey = originClock();
 		const olderVersion = logKey - 45_000;
 		const context = { source: {}, sourceApply: true, timestamp: logKey };
 		await transaction(context, async () => {
@@ -399,11 +408,13 @@ describe('Dual-clock audit records (harper#2412)', () => {
 	it('delivers a subscriber event whose version is the record version and localTime the log position', async function () {
 		if (isLMDB) return this.skip();
 		const id = 'transport-1';
-		const subscription = await Plain.subscribe({});
+		// omitCurrent skips the replay that would otherwise raise the subscription's high-water mark
+		// above every fabricated key; live forwarding then accepts any key.
+		const subscription = await Plain.subscribe({ omitCurrent: true });
 		const events = [];
 		subscription.on('data', (event) => events.push(event));
 		try {
-			const logKey = Date.now() + 2;
+			const logKey = originClock();
 			const version = logKey - 90_000;
 			await applyFromOrigin(Plain, id, { id, name: 'delivered' }, { logKey, version });
 			await waitFor(() => events.some((event) => event.id === id), {
@@ -440,8 +451,8 @@ describe('Dual-clock audit records (harper#2412)', () => {
 		// auditStore.get(key, ...) walks the entries at one log key; a fill's entry sits at its commit
 		// key while the record itself stores the source version, so keying by version must not find it.
 		const id = 'lookup-1';
-		const logKey = Date.now() + 1_000;
-		const version = logKey - 120_000;
+		const logKey = originClock();
+		const version = logKey - 30_000;
 		// nodeId 0 so the entry lands in — and is read back from — the one log a single-node test has
 		await applyFromOrigin(Plain, id, { id, name: 'lookup' }, { logKey, version, nodeId: 0 });
 		const found = auditStore.get(logKey, Plain.tableId, id, 0);


### PR DESCRIPTION
`one applied transaction can carry writes at different record versions` in `unitTests/resources/dualClockAuditRecord.test.js` failed on the Node 26 leg of the Unit Test run for #2526 with `lookup scans every entry sharing the transaction log key`, passed on rerun, and reproduces locally at about 1 in 20 runs pinned to two cores with CPU burners. **Test-only change; no product code.**

## Mechanism

Every test in the suite fabricated its origin log keys as `Date.now() ± n`. Under load, an earlier test's key can equal a later test's: on the failing run the invalidate test's `Date.now() + 20` landed on the same millisecond as this test's `Date.now() + 1`, nineteen milliseconds later. `RocksTransactionLogStore.getSync` reads only the contiguous run of entries at a key, which is correct for a real log, where one key names one transaction. Here that run was the invalidate test's transaction, and [`batched-new`](https://github.com/HarperFast/harper/pull/2530/changes?w=1#diff-3fd3d9dcea51dd2168022cbf6366b233d1ae7f1979cbddbb818b7a4e24a8e0aeR417) sat further down the log under the same key, never reached.

The fix mirrors the production property the lookup relies on. All fabricated keys come from [one suite-level allocator, `originClock`](https://github.com/HarperFast/harper/pull/2530/changes?w=1#diff-3fd3d9dcea51dd2168022cbf6366b233d1ae7f1979cbddbb818b7a4e24a8e0aeR30), stepping 100 s per call from three hours in the past, so no two tests can share a key and the offsets a test subtracts (at most 60 s) never cross the previous anchor. The subscriber-delivery test now [subscribes with `omitCurrent`](https://github.com/HarperFast/harper/pull/2530/changes?w=1#diff-3fd3d9dcea51dd2168022cbf6366b233d1ae7f1979cbddbb818b7a4e24a8e0aeR413), which leaves the subscription's high-water mark at zero, so it takes an allocator key like every other test and the suite writes no future-dated record.

## For the human reviewer

1. **Fixed in the fixture, not the store.** The contiguous-run read in `getSync` assumes an origin log never holds two transactions at one key. Origin keys come from a per-node monotonic clock, so that holds in production; this suite was the only place two transactions shared a key. If you read it as a production lookup gap worth hardening, that is a product change and a different PR.
2. **Anchors are past-dated, not future-dated.** Past keys stay below every real-time write, so nothing outlives the run and no later subscription on the table is gated. The costs: the suite's local log is appended out of key order (a state production never reaches), keys older than the retention window skip the RocksDB write-time dedup scan (none of these tests assert on dedup), and the subscriber test needs `omitCurrent`. Reversible in one line.
3. **The subscriber test no longer covers the replay-to-live handoff.** With `omitCurrent` it proves `event.version` and `event.localTime` on a live event only. The default-subscribe form needed a key ahead of the wall clock, which the earlier rounds of this PR tried at +1 s and +1 h and rejected as a landmine for later subscribers.
4. **Uniqueness is a convention, not an asserted invariant.** The allocator does not record keys and fail on reuse, and a future test that fabricates its own `Date.now()` key re-arms the flake. Declined an assertion in `auditEntriesFor` to keep the diff to the flake; cheap to add later.

## Verification

| check | result |
|---|---|
| suite on base, 2 cores + 2 CPU burners | 3 failures in 52 runs, all `lookup scans every entry sharing the transaction log key` |
| instrumented failing run | the exact-start scan yielded `applied-invalidate-head-1` at the colliding key, then an entry at a different key, then stopped; `batched-old` and `batched-new` were later in the log |
| suite with fix, same contention | 0 failures in 160 runs across four rounds |
| suite with fix, uncontended | 20 of 20 pass |
| `test:unit:resources`, RocksDB | 2190 passing, 30 pending |
| LMDB pass of the file | 1 passing, 16 pending, as before |
| `lint:required`, `format:check` | clean |

Fails-on-base is the contended-loop row: the test asserts the same things as before, only its keys changed.

Five pre-push review rounds (codex + gemini, cursor-composer on rounds 1 and 2, Harper domain adjudication on each). Round 1 widened the anchor budget and corrected the comment's claimed invariant. Round 2 pulled the subscriber key back from an hour ahead after Gemini pointed out a far-future record gates any later subscription on the table. Round 3 fixed the comment's description of the scan and a 120 s version offset. Round 4 converged and proposed `omitCurrent`, adopted in round 5, which converged again.

Complexity: easy

<sub>Review-Coverage: authored=claude; ran=gemini,codex; adjudicated=domain; declined=cursor-grok,cursor-composer; rounds=5 @ 8f653028a515</sub>

<sub>Human-Review-Need: 3 (decisions: anchor-direction-past-vs-future, omit-current-vs-default-subscribe, shared-allocator-vs-per-test-constants, flake-fix-layer) @ 8f653028a515</sub>
