### PR TITLE
Bound dormant staged builds per component with deployment.stagingRetention.maxCount

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -665,14 +665,17 @@ Everything else journal-less — a partial tree, a directory whose tree already 
 window between `.complete` and the journal; #2315 step 6 (deploy from an existing aside) is the producer this
 bound exists for.
 
-The classification is meaningful **only under the owner's preparation lock**: activation writes `.complete`
-moments before its journal while holding that lock, so an unlocked read of "complete, no journal" may be a
-swap in progress. Boot recovery therefore classifies inside the same locked pass that removes residue, prunes
-per owner afterwards under the lock again, and treats a lock it cannot get as the same deferral the residue
-branch records — "do not delete" is not "safe to load". The deploy path prunes inside the settlement scan it
-already runs under the lock, before building, so a deploy pays one traversal of the staging root. Each
-eviction re-checks for a journal first, since the catalog may predate a deploy that ran between the scan
-and the prune. Only ENOENT is absence; any other read error keeps the entry and moves on. Pruning is disk
+Removal is decided **only under the owner's preparation lock**: activation writes `.complete` moments
+before its journal while holding that lock, so an unlocked read of "complete, no journal" is a candidate, not
+a verdict. Boot recovery catalogues dormant builds unlocked and leaves them alone; only an owner over its
+bound takes the lock, once, and every eviction is re-derived under it (still dormant, still no journal).
+It used to take the lock per journal-less directory, which was one-shot because the directory was removed —
+doing that for retained builds on every pass made a healthy component lose the 250 ms probe to its sibling
+threads at boot and be deferred with nothing in progress. A lock a live deploy holds is still recorded as
+that same deferral: "do not delete" is not "safe to load". The deploy path prunes inside the settlement scan
+it already runs under the lock, before building, so a deploy pays one traversal of the staging root.
+`dropComponentDirectory` reclaims the dropped component's dormant builds, since no later deploy of that
+name will. Only ENOENT is absence; any other read error keeps the entry and moves on. Pruning is disk
 hygiene: it never fails a component closed and never replaces a deploy's own error, so the bound is
 best-effort under filesystem failure and is not a storage quota — journaled, unsettled and unowned
 directories are preserved by design and can still fill a volume.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -668,10 +668,10 @@ bound exists for.
 Removal is decided **only under the owner's preparation lock**: activation writes `.complete` moments
 before its journal while holding that lock, so an unlocked read of "complete, no journal" is a candidate, not
 a verdict. Boot recovery catalogues dormant builds unlocked and leaves them alone; only an owner over its
-bound takes the lock, once, and every eviction is re-derived under it (still dormant, still no journal).
-It used to take the lock per journal-less directory, which was one-shot because the directory was removed —
-doing that for retained builds on every pass made a healthy component lose the 250 ms probe to its sibling
-threads at boot and be deferred with nothing in progress. A lock a live deploy holds is still recorded as
+bound takes the lock, once, re-catalogues under it, and re-derives every eviction (still dormant, still no
+journal). It used to take the lock per journal-less directory, which was one-shot because the directory was
+removed — doing that for retained builds on every pass made a healthy component lose the 250 ms probe to its
+sibling threads at boot and be deferred with nothing in progress. A lock a live deploy holds is still recorded as
 that same deferral: "do not delete" is not "safe to load". The deploy path prunes inside the settlement scan
 it already runs under the lock, before building, so a deploy pays one traversal of the staging root.
 `dropComponentDirectory` reclaims the dropped component's dormant builds, since no later deploy of that

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -654,6 +654,29 @@ briefly absent (in-memory resources are unaffected, but a component that opens i
 request can still see a gap); validation does not run on the main-thread deploy path; and config
 publication is not yet an effect of this transaction, as above.
 
+### Retention of dormant staged builds
+
+A journal-less deployment directory holding `.complete` and the owner's tree is a **dormant build**: built
+and validated, activated by nobody. Recovery used to remove every owned journal-less directory; it now keeps
+dormant builds and bounds them per component to `deployment_stagingRetention_maxCount` (default 5, 0 keeps
+none), newest by `.complete` mtime, ties broken by deployment id so concurrent passes pick the same victims.
+Everything else journal-less — a partial tree, a directory whose tree already moved live, a stale
+`.unsettled` — is still residue and still removed. Nothing here produces a dormant build yet beyond the crash
+window between `.complete` and the journal; #2315 step 6 (deploy from an existing aside) is the producer this
+bound exists for.
+
+The classification is meaningful **only under the owner's preparation lock**: activation writes `.complete`
+moments before its journal while holding that lock, so an unlocked read of "complete, no journal" may be a
+swap in progress. Boot recovery therefore classifies inside the same locked pass that removes residue, prunes
+per owner afterwards under the lock again, and treats a lock it cannot get as the same deferral the residue
+branch records — "do not delete" is not "safe to load". The deploy path prunes inside the settlement scan it
+already runs under the lock, before building, so a deploy pays one traversal of the staging root. Each
+eviction re-checks for a journal first, since the catalog may predate a deploy that ran between the scan
+and the prune. Only ENOENT is absence; any other read error keeps the entry and moves on. Pruning is disk
+hygiene: it never fails a component closed and never replaces a deploy's own error, so the bound is
+best-effort under filesystem failure and is not a storage quota — journaled, unsettled and unowned
+directories are preserved by design and can still fill a volume.
+
 ## Component preparation is serialized across worker threads
 
 `prepareApplication()` performs one transaction per component: build the replacement, validate it, then swap it in (see "A deploy builds off to the side" below). Deploy operations can execute on worker threads as well as main, so a module-local promise queue is insufficient—each worker has its own module registry. `withComponentPreparationLock()` (`components/componentPreparationLock.ts`) instead acquires an atomic filesystem lock keyed by the absolute component path. The deprecated `install_node_modules` operation uses the same lock, so it cannot run npm concurrently with a deploy.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -667,10 +667,13 @@ bound exists for.
 
 Removal is decided **only under the owner's preparation lock**: activation writes `.complete` moments
 before its journal while holding that lock, so an unlocked read of "complete, no journal" is a candidate, not
-a verdict. Boot recovery catalogues dormant builds unlocked and leaves them alone; only an owner over its
-bound takes the lock, once, and re-derives its catalogued directories under it — never the whole staging
-root, which sibling threads are probing — before choosing the kept set; a build created after the scan waits
-for the next pass. It used to take the lock per journal-less directory, which was one-shot because the directory was
+a verdict. Boot recovery catalogues dormant builds unlocked, then reconciles each owner once: if any
+catalogued directory has acquired a journal since the scan, or the owner is over its bound, it takes the lock
+and re-reads only that owner's catalogued directories — never the whole staging root, which sibling threads
+are probing — settling any journal that appeared (a deploy that published one and died mid-swap would
+otherwise leave the component unloadable until the next start) and bounding what is still dormant. The
+residue branch re-classifies under its lock too, since the `.complete` a deploy wrote before dying can land
+while the scan waits for the lock. A build created after the scan waits for the next pass. It used to take the lock per journal-less directory, which was one-shot because the directory was
 removed — doing that for retained builds on every pass made a healthy component lose the 250 ms probe to its
 sibling threads at boot and be deferred with nothing in progress. A lock a live deploy holds is still recorded as
 that same deferral: "do not delete" is not "safe to load". The deploy path prunes inside the settlement scan

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -668,8 +668,9 @@ bound exists for.
 Removal is decided **only under the owner's preparation lock**: activation writes `.complete` moments
 before its journal while holding that lock, so an unlocked read of "complete, no journal" is a candidate, not
 a verdict. Boot recovery catalogues dormant builds unlocked and leaves them alone; only an owner over its
-bound takes the lock, once, re-catalogues under it, and re-derives every eviction (still dormant, still no
-journal). It used to take the lock per journal-less directory, which was one-shot because the directory was
+bound takes the lock, once, and re-derives its catalogued directories under it — never the whole staging
+root, which sibling threads are probing — before choosing the kept set; a build created after the scan waits
+for the next pass. It used to take the lock per journal-less directory, which was one-shot because the directory was
 removed — doing that for retained builds on every pass made a healthy component lose the 250 ms probe to its
 sibling threads at boot and be deferred with nothing in progress. A lock a live deploy holds is still recorded as
 that same deferral: "do not delete" is not "safe to load". The deploy path prunes inside the settlement scan

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -1709,30 +1709,17 @@ export async function recoverInterruptedActivations(componentsRootDirPath: strin
 		throw error;
 	}
 	const dormant = new Map<string, DormantBuild[]>();
+	const catalogue = (owner: string, build: DormantBuild) => {
+		const builds = dormant.get(owner);
+		if (builds) builds.push(build);
+		else dormant.set(owner, [build]);
+	};
 
 	for (const deployment of deployments) {
 		if (!deployment.isDirectory()) continue;
 		const deploymentDirPath = join(stagingRoot, deployment.name);
 		const journalPath = join(deploymentDirPath, ACTIVATION_JOURNAL);
-		const fail = async (component: string, error: unknown) => {
-			const failure = error instanceof Error ? error : new Error(String(error));
-			if (!failures.has(component)) failures.set(component, failure);
-			logger.error(`Could not settle the interrupted activation of ${component}:`, errorForLog(failure));
-			// A DEFERRAL is not a verdict, and only verdicts go on disk. A held lock means a live deploy, which
-			// settles its own journal; a marker written here would outlive that deploy and have
-			// `unsettleableComponentsFromDisk` read it as an authoritative "cannot be settled", failing a
-			// healthy component closed on every worker. The failure is already recorded above, so this thread
-			// still defers — it just leaves nothing behind.
-			if (failure instanceof ComponentPreparationLockTimeoutError) return;
-			// Everything else IS a verdict, recorded so workers reach the same one. An unreadable journal is
-			// self-evident, but a well-formed journal this pass could not settle looks exactly like a deploy
-			// in flight, and a worker would otherwise load the component over state nobody reconciled.
-			// Best-effort: the alternative to a missing marker is today's behavior, not a worse one.
-			await writeFile(join(deploymentDirPath, UNSETTLED_MARKER), failure.message, { mode: 0o600 }).catch(
-				(markerError) =>
-					logger.warn(`Could not record the unsettled activation of ${component}: ${errorMessage(markerError)}`)
-			);
-		};
+		const fail = (component: string, error: unknown) => recordUnsettled(failures, component, error, deploymentDirPath);
 
 		let journal: ActivationJournal | undefined;
 		try {
@@ -1792,6 +1779,13 @@ export async function recoverInterruptedActivations(componentsRootDirPath: strin
 					activationToFail = undefined;
 					return;
 				}
+				// Re-classified UNDER the lock: the unlocked read that routed this here can predate the `.complete`
+				// a deploy wrote before dying, and that is a retainable build, not residue.
+				const build = await dormantBuildAt(deploymentDirPath, owner!);
+				if (build) {
+					catalogue(owner!, build);
+					return;
+				}
 				// Cleanup, not settlement. There was no activation here — this is most often the residue a
 				// SUCCESSFUL settlement leaves when its own sweep failed — so a sweep that fails again cannot
 				// make anything unsettled, and recording it would refuse a live component on every worker
@@ -1830,9 +1824,7 @@ export async function recoverInterruptedActivations(componentsRootDirPath: strin
 					continue;
 				}
 				if (build) {
-					const builds = dormant.get(owner);
-					if (builds) builds.push(build);
-					else dormant.set(owner, [build]);
+					catalogue(owner, build);
 					continue;
 				}
 			}
@@ -1905,29 +1897,105 @@ export async function recoverInterruptedActivations(componentsRootDirPath: strin
 
 	const maxCount = getStagingRetentionMaxCount();
 	for (const [owner, builds] of dormant) {
-		if (builds.length <= maxCount) continue;
-		try {
-			await withComponentPreparationLock(
-				join(componentsRootDirPath, owner),
-				// Only this owner's catalogued directories are re-read under the lock, never the whole staging
-				// root: sibling threads probe these locks for 250 ms.
-				() => pruneDormantBuilds(owner, builds, maxCount),
-				{
-					purpose: 'activation-recovery',
-					...RECOVERY_LOCK_WAIT,
-					isOwnerAlive: (lockOwner) => lockOwner.pid !== process.pid || isThreadRunning(lockOwner.threadId),
+		for (const [component, error] of await reconcileDormantBuilds(componentsRootDirPath, owner, builds, maxCount)) {
+			if (!failures.has(component)) failures.set(component, error);
+		}
+	}
+	return failures;
+}
+
+/**
+ * Record a settlement failure against a component. A lock TIMEOUT is a deferral, not a verdict, and only
+ * verdicts go on disk: a held lock means a live deploy, which settles its own journal, and a marker written
+ * here would outlive it and have `unsettleableComponentsFromDisk` fail a healthy component closed on every
+ * worker. Everything else is written so workers reach the same verdict — a well-formed journal this pass
+ * could not settle looks exactly like a deploy in flight otherwise. Marker write is best-effort.
+ */
+async function recordUnsettled(
+	failures: Map<string, Error>,
+	component: string,
+	error: unknown,
+	deploymentDirPath: string
+): Promise<void> {
+	const failure = error instanceof Error ? error : new Error(String(error));
+	if (!failures.has(component)) failures.set(component, failure);
+	logger.error(`Could not settle the interrupted activation of ${component}:`, errorForLog(failure));
+	if (failure instanceof ComponentPreparationLockTimeoutError) return;
+	await writeFile(join(deploymentDirPath, UNSETTLED_MARKER), failure.message, { mode: 0o600 }).catch((markerError) =>
+		logger.warn(`Could not record the unsettled activation of ${component}: ${errorMessage(markerError)}`)
+	);
+}
+
+/**
+ * Finish one owner's catalogued dormant builds after the scan. The catalog was read without the lock, so a
+ * deploy may have published a journal into one of these directories since — and if it then died mid-swap,
+ * only settlement brings the component back. So: settle any journal that appeared, then bound what is still
+ * dormant. The lock is taken only when there is something to do; a lock a live deploy holds is the same
+ * deferral the residue branch records.
+ */
+export async function reconcileDormantBuilds(
+	componentsRootDirPath: string,
+	owner: string,
+	builds: DormantBuild[],
+	maxCount: number
+): Promise<Map<string, Error>> {
+	const failures = new Map<string, Error>();
+	let journalAppeared = false;
+	for (const build of builds) {
+		// Anything but a clean ENOENT means "read it properly, under the lock".
+		journalAppeared = await presentOrAbsent(join(build.deploymentDirPath, ACTIVATION_JOURNAL)).then(
+			(stats) => stats !== undefined,
+			() => true
+		);
+		if (journalAppeared) break;
+	}
+	if (!journalAppeared && builds.length <= maxCount) return failures;
+	try {
+		await withComponentPreparationLock(
+			join(componentsRootDirPath, owner),
+			async () => {
+				const stillDormant: DormantBuild[] = [];
+				for (const build of builds) {
+					let journal: ActivationJournal | undefined;
+					try {
+						journal = await readActivationJournal(join(build.deploymentDirPath, ACTIVATION_JOURNAL));
+					} catch (error) {
+						await recordUnsettled(failures, owner, error, build.deploymentDirPath);
+						continue;
+					}
+					if (!journal) {
+						stillDormant.push(build);
+						continue;
+					}
+					// The lock held here is the SIDECAR owner's, as in the residue branch: a journal naming someone
+					// else is not settled under it, and both names are failed.
+					const splitNames = splitAttributionOwners(journal.component, owner);
+					if (splitNames) {
+						const split = splitAttributionError(build.deploymentDirPath, journal.component, splitNames[0]);
+						for (const name of splitNames) await recordUnsettled(failures, name, split, build.deploymentDirPath);
+						continue;
+					}
+					try {
+						await settleInterruptedActivation(componentsRootDirPath, build.deploymentDirPath, journal);
+					} catch (error) {
+						await recordUnsettled(failures, journal.component, error, build.deploymentDirPath);
+					}
 				}
-			);
-		} catch (error) {
-			// A held lock is a live deploy of this component: the same deferral the residue branch records.
-			// Anything else is hygiene that could not run, not a verdict.
-			const failure = error instanceof Error ? error : new Error(String(error));
-			if (failure instanceof ComponentPreparationLockTimeoutError) {
-				if (!failures.has(owner)) failures.set(owner, failure);
-				logger.info?.(`Deferred pruning the dormant staged builds of ${owner}: a deploy holds its lock`);
-			} else {
-				logger.warn(`Could not prune the dormant staged builds of ${owner}:`, errorForLog(failure));
+				if (stillDormant.length > maxCount) await pruneDormantBuilds(owner, stillDormant, maxCount);
+			},
+			{
+				purpose: 'activation-recovery',
+				...RECOVERY_LOCK_WAIT,
+				isOwnerAlive: (lockOwner) => lockOwner.pid !== process.pid || isThreadRunning(lockOwner.threadId),
 			}
+		);
+	} catch (error) {
+		const failure = error instanceof Error ? error : new Error(String(error));
+		if (failure instanceof ComponentPreparationLockTimeoutError) {
+			if (!failures.has(owner)) failures.set(owner, failure);
+			logger.info?.(`Deferred reconciling the dormant staged builds of ${owner}: a deploy holds its lock`);
+		} else {
+			logger.warn(`Could not reconcile the dormant staged builds of ${owner}:`, errorForLog(failure));
 		}
 	}
 	return failures;

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -1940,16 +1940,19 @@ export async function reconcileDormantBuilds(
 	maxCount: number
 ): Promise<Map<string, Error>> {
 	const failures = new Map<string, Error>();
-	let journalAppeared = false;
+	let journaled: DormantBuild | undefined;
 	for (const build of builds) {
 		// Anything but a clean ENOENT means "read it properly, under the lock".
-		journalAppeared = await presentOrAbsent(join(build.deploymentDirPath, ACTIVATION_JOURNAL)).then(
+		const appeared = await presentOrAbsent(join(build.deploymentDirPath, ACTIVATION_JOURNAL)).then(
 			(stats) => stats !== undefined,
 			() => true
 		);
-		if (journalAppeared) break;
+		if (appeared) {
+			journaled = build;
+			break;
+		}
 	}
-	if (!journalAppeared && builds.length <= maxCount) return failures;
+	if (!journaled && builds.length <= maxCount) return failures;
 	try {
 		await withComponentPreparationLock(
 			join(componentsRootDirPath, owner),
@@ -1990,12 +1993,19 @@ export async function reconcileDormantBuilds(
 			}
 		);
 	} catch (error) {
+		// With a journal in view this is an activation that could not be settled — recorded exactly as the
+		// scan records one it saw directly (a timeout defers, anything else is a verdict). Without one it is
+		// hygiene that could not run, unless a live deploy holds the lock, which defers as everywhere else.
+		if (journaled) {
+			await recordUnsettled(failures, owner, error, journaled.deploymentDirPath);
+			return failures;
+		}
 		const failure = error instanceof Error ? error : new Error(String(error));
 		if (failure instanceof ComponentPreparationLockTimeoutError) {
 			if (!failures.has(owner)) failures.set(owner, failure);
-			logger.info?.(`Deferred reconciling the dormant staged builds of ${owner}: a deploy holds its lock`);
+			logger.info?.(`Deferred pruning the dormant staged builds of ${owner}: a deploy holds its lock`);
 		} else {
-			logger.warn(`Could not reconcile the dormant staged builds of ${owner}:`, errorForLog(failure));
+			logger.warn(`Could not prune the dormant staged builds of ${owner}:`, errorForLog(failure));
 		}
 	}
 	return failures;

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -1036,10 +1036,9 @@ const ACTIVATION_JOURNAL_VERSION = 1;
 const DEFAULT_STAGING_RETENTION_MAX_COUNT = 5;
 
 /**
- * How many dormant staged builds (`.complete`, tree present, no journal) may survive per component under
- * `.deploy-staging`. `deployment_stagingRetention_maxCount`; 0 keeps none. Same coercion as
- * `getPayloadRetentionMaxSize`: only a number or numeric string counts, so `true`/`[]`/blank cannot become
- * an accidental "keep nothing".
+ * How many dormant staged builds may survive per component under `.deploy-staging`
+ * (`deployment_stagingRetention_maxCount`; 0 keeps none). Only a number or numeric string counts, so
+ * `true`/`[]`/blank cannot become an accidental "keep nothing".
  */
 export function getStagingRetentionMaxCount(): number {
 	const configured = getConfigValue(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT);
@@ -1063,11 +1062,11 @@ async function presentOrAbsent(path: string): Promise<import('node:fs').Stats | 
 }
 
 /**
- * A journal-less deployment directory that holds a complete, validated tree nobody is activating — the only
- * kind retention may count or remove. Meaningful ONLY under the owner's preparation lock: activation writes
- * `.complete` moments before its journal while holding that lock, so without it a complete-and-journal-less
- * directory may be mid-swap. Anything else journal-less is residue. A stale `.unsettled` also makes it
- * residue, since workers read that marker as a verdict and only removing the directory clears it.
+ * A journal-less deployment directory holding a complete, validated tree nobody is activating — the only
+ * kind retention may count or remove. Activation writes `.complete` moments before its journal, both under
+ * the owner's preparation lock, so an unlocked read is a candidate for retention and a read under that lock
+ * is the verdict. A stale `.unsettled` makes it residue instead: workers read that marker as a verdict, and
+ * only removing the directory clears it.
  *
  * Only ENOENT is absence; any other read error propagates so the caller preserves the entry.
  */
@@ -1082,9 +1081,9 @@ async function dormantBuildAt(deploymentDirPath: string, owner: string): Promise
 
 /**
  * Remove the oldest dormant builds beyond `maxCount`, newest by `.complete` mtime surviving. Assumes the
- * caller holds the component's preparation lock. Each candidate is re-checked for a journal first: the
- * catalog may predate a deploy that ran between the scan and this lock. Never throws — the bound is disk
- * hygiene, and a failure here must neither fail a component closed at boot nor replace a deploy's own error.
+ * caller holds the component's preparation lock. Each eviction is re-derived under that lock — still
+ * dormant, still no journal — because the catalog may have been read unlocked or before a deploy ran. Never
+ * throws: a failure here must neither fail a component closed at boot nor replace a deploy's own error.
  */
 export async function pruneDormantBuilds(
 	componentName: string,
@@ -1097,6 +1096,7 @@ export async function pruneDormantBuilds(
 		.slice(Math.max(0, maxCount));
 	for (const build of evictions) {
 		try {
+			if (!(await dormantBuildAt(build.deploymentDirPath, componentName))) continue;
 			if (await presentOrAbsent(join(build.deploymentDirPath, ACTIVATION_JOURNAL))) continue;
 			await rm(build.deploymentDirPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 			logger.debug?.(
@@ -1110,6 +1110,35 @@ export async function pruneDormantBuilds(
 			);
 		}
 	}
+}
+
+/** Every dormant build a component owns. A directory that cannot be read is left out and logged. */
+async function dormantBuildsOf(componentsRootDirPath: string, componentName: string): Promise<DormantBuild[]> {
+	const stagingRoot = join(componentsRootDirPath, DEPLOY_STAGING_DIR);
+	let deployments;
+	try {
+		deployments = await readdir(stagingRoot, { withFileTypes: true });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+		throw error;
+	}
+	const builds: DormantBuild[] = [];
+	for (const deployment of deployments) {
+		if (!deployment.isDirectory()) continue;
+		const deploymentDirPath = join(stagingRoot, deployment.name);
+		try {
+			if ((await candidateComponentName(deploymentDirPath)) !== componentName) continue;
+			if (await presentOrAbsent(join(deploymentDirPath, ACTIVATION_JOURNAL))) continue;
+			const build = await dormantBuildAt(deploymentDirPath, componentName);
+			if (build) builds.push(build);
+		} catch (error) {
+			logger.warn(
+				`Leaving deploy staging ${deploymentDirPath} out of retention; it could not be read:`,
+				errorForLog(error)
+			);
+		}
+	}
+	return builds;
 }
 
 /**
@@ -1501,8 +1530,6 @@ async function inProgressAsideRecords(asideStagingDir: string): Promise<string[]
  * still names the DISPLACED tree, so restoring it would put the old version back over the new one. That
  * pass refuses to restore against a surviving journal, but refusing is a stalled component; settling first
  * is what lets the deploy proceed.
- *
- * Retention rides the same scan so a deploy pays one traversal of the staging root, not two.
  */
 async function settleStagingForComponent(componentsRootDirPath: string, componentName: string): Promise<void> {
 	const stagingRoot = join(componentsRootDirPath, DEPLOY_STAGING_DIR);
@@ -1759,14 +1786,6 @@ export async function recoverInterruptedActivations(componentsRootDirPath: strin
 					activationToFail = undefined;
 					return;
 				}
-				// A complete, validated tree with no activation is a dormant build, kept for retention to bound
-				// after the scan rather than removed. Classified here, under the owner's lock, because that is
-				// what rules out "complete but about to be journaled".
-				const build = await dormantBuildAt(deploymentDirPath, owner!);
-				if (build) {
-					dormant.set(owner!, [...(dormant.get(owner!) ?? []), build]);
-					return;
-				}
 				// Cleanup, not settlement. There was no activation here — this is most often the residue a
 				// SUCCESSFUL settlement leaves when its own sweep failed — so a sweep that fails again cannot
 				// make anything unsettled, and recording it would refuse a live component on every worker
@@ -1790,6 +1809,28 @@ export async function recoverInterruptedActivations(componentsRootDirPath: strin
 						`ownership cannot be read: ${errorMessage(error)}`
 				);
 				continue;
+			}
+			// A dormant build — complete, tree present, nobody activating it — is catalogued WITHOUT the lock and
+			// left alone; only an owner over its retention bound takes the lock, once, below. Locking here per
+			// directory on every pass, forever, is what made a healthy component with retained builds lose the
+			// 250 ms probe to its sibling threads at boot and be deferred with nothing in progress.
+			if (owner) {
+				let build: DormantBuild | undefined;
+				try {
+					build = await dormantBuildAt(deploymentDirPath, owner);
+				} catch (error) {
+					logger.warn(
+						`Leaving deploy staging ${deploymentDirPath} in place; it could not be read:`,
+						errorForLog(error)
+					);
+					continue;
+				}
+				if (build) {
+					const builds = dormant.get(owner);
+					if (builds) builds.push(build);
+					else dormant.set(owner, [build]);
+					continue;
+				}
 			}
 			// Scoped to THIS deployment, like the journaled branch below: a lock timeout or an EIO here used to
 			// abort the entire scan, leaving every later deployment unsettled and unmarked.
@@ -1872,8 +1913,7 @@ export async function recoverInterruptedActivations(componentsRootDirPath: strin
 				}
 			);
 		} catch (error) {
-			// A held lock is a deploy of this component that started after its directories were classified,
-			// which is exactly the signal the journal-less branch defers a load on; the same deferral applies.
+			// A held lock is a live deploy of this component: the same deferral the residue branch records.
 			// Anything else is hygiene that could not run, not a verdict.
 			const failure = error instanceof Error ? error : new Error(String(error));
 			if (failure instanceof ComponentPreparationLockTimeoutError) {
@@ -2722,6 +2762,16 @@ export async function dropComponentDirectory(
 		asideStagingDir,
 		new Set([droppedPath])
 	);
+	// Retention only runs on the component's next deploy, and a dropped component has none — the drop is
+	// what reclaims its dormant builds.
+	try {
+		await pruneDormantBuilds(componentName, await dormantBuildsOf(dirname(componentDirPath), componentName), 0);
+	} catch (error) {
+		componentLogger.warn(
+			`Dropped ${componentName} but could not reclaim its dormant staged builds:`,
+			errorForLog(error)
+		);
+	}
 }
 
 async function cleanupExtractionPaths(

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -1033,6 +1033,84 @@ const CANDIDATE_COMPONENT_FILE = '.component';
 // to a deploy in flight, so without a record they would treat an unsettled component as healthy and load it.
 const UNSETTLED_MARKER = '.unsettled';
 const ACTIVATION_JOURNAL_VERSION = 1;
+const DEFAULT_STAGING_RETENTION_MAX_COUNT = 5;
+
+/**
+ * How many dormant staged builds (`.complete`, tree present, no journal) may survive per component under
+ * `.deploy-staging`. `deployment_stagingRetention_maxCount`; 0 keeps none. Same coercion as
+ * `getPayloadRetentionMaxSize`: only a number or numeric string counts, so `true`/`[]`/blank cannot become
+ * an accidental "keep nothing".
+ */
+export function getStagingRetentionMaxCount(): number {
+	const configured = getConfigValue(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT);
+	if (typeof configured !== 'number' && typeof configured !== 'string') return DEFAULT_STAGING_RETENTION_MAX_COUNT;
+	if (typeof configured === 'string' && configured.trim() === '') return DEFAULT_STAGING_RETENTION_MAX_COUNT;
+	const parsed = Number(configured);
+	return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : DEFAULT_STAGING_RETENTION_MAX_COUNT;
+}
+
+type DormantBuild = {
+	deploymentDirPath: string;
+	deploymentId: string;
+	completedAt: number;
+};
+
+async function presentOrAbsent(path: string): Promise<import('node:fs').Stats | undefined> {
+	return lstat(path).catch((error: NodeJS.ErrnoException) => {
+		if (error?.code === 'ENOENT') return undefined;
+		throw error;
+	});
+}
+
+/**
+ * A journal-less deployment directory that holds a complete, validated tree nobody is activating — the only
+ * kind retention may count or remove. Meaningful ONLY under the owner's preparation lock: activation writes
+ * `.complete` moments before its journal while holding that lock, so without it a complete-and-journal-less
+ * directory may be mid-swap. Anything else journal-less is residue. A stale `.unsettled` also makes it
+ * residue, since workers read that marker as a verdict and only removing the directory clears it.
+ *
+ * Only ENOENT is absence; any other read error propagates so the caller preserves the entry.
+ */
+async function dormantBuildAt(deploymentDirPath: string, owner: string): Promise<DormantBuild | undefined> {
+	const complete = await presentOrAbsent(join(deploymentDirPath, CANDIDATE_COMPLETE_MARKER));
+	if (!complete) return undefined;
+	if (await presentOrAbsent(join(deploymentDirPath, UNSETTLED_MARKER))) return undefined;
+	const tree = await presentOrAbsent(join(deploymentDirPath, owner));
+	if (!tree || !(tree.isDirectory() || tree.isSymbolicLink())) return undefined;
+	return { deploymentDirPath, deploymentId: basename(deploymentDirPath), completedAt: complete.mtimeMs };
+}
+
+/**
+ * Remove the oldest dormant builds beyond `maxCount`, newest by `.complete` mtime surviving. Assumes the
+ * caller holds the component's preparation lock. Each candidate is re-checked for a journal first: the
+ * catalog may predate a deploy that ran between the scan and this lock. Never throws — the bound is disk
+ * hygiene, and a failure here must neither fail a component closed at boot nor replace a deploy's own error.
+ */
+export async function pruneDormantBuilds(
+	componentName: string,
+	builds: DormantBuild[],
+	maxCount: number
+): Promise<void> {
+	const evictions = builds
+		.slice()
+		.sort((left, right) => right.completedAt - left.completedAt || left.deploymentId.localeCompare(right.deploymentId))
+		.slice(Math.max(0, maxCount));
+	for (const build of evictions) {
+		try {
+			if (await presentOrAbsent(join(build.deploymentDirPath, ACTIVATION_JOURNAL))) continue;
+			await rm(build.deploymentDirPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+			logger.debug?.(
+				`Pruned dormant staged build ${build.deploymentId} of ${componentName} beyond deployment_stagingRetention_maxCount=${maxCount}`
+			);
+		} catch (error) {
+			logger.warn(
+				`Could not prune dormant staged build ${build.deploymentDirPath} of ${componentName}; it remains beyond ` +
+					`deployment_stagingRetention_maxCount=${maxCount}:`,
+				errorForLog(error)
+			);
+		}
+	}
+}
 
 /**
  * Best-effort fsync of a directory. Best-effort by necessity — Node cannot fsync a directory on Windows —
@@ -1415,18 +1493,18 @@ async function inProgressAsideRecords(asideStagingDir: string): Promise<string[]
 }
 
 /**
- * Settle journaled activations for ONE component, assuming the caller already holds its preparation lock.
+ * Settle journaled activations for ONE component, and bound its dormant staged builds, assuming the caller
+ * already holds its preparation lock.
  *
  * Exists because the journal-first rule has to hold at every entry point, not just startup. A deploy runs
  * `recoverOrCleanupStaleExtractionPaths` first. After an activation whose retirement failed, the aside
  * still names the DISPLACED tree, so restoring it would put the old version back over the new one. That
  * pass refuses to restore against a surviving journal, but refusing is a stalled component; settling first
  * is what lets the deploy proceed.
+ *
+ * Retention rides the same scan so a deploy pays one traversal of the staging root, not two.
  */
-async function settleJournaledActivationsForComponent(
-	componentsRootDirPath: string,
-	componentName: string
-): Promise<void> {
+async function settleStagingForComponent(componentsRootDirPath: string, componentName: string): Promise<void> {
 	const stagingRoot = join(componentsRootDirPath, DEPLOY_STAGING_DIR);
 	let deployments;
 	try {
@@ -1435,6 +1513,7 @@ async function settleJournaledActivationsForComponent(
 		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
 		throw error;
 	}
+	const dormant: DormantBuild[] = [];
 	for (const deployment of deployments) {
 		if (!deployment.isDirectory()) continue;
 		const deploymentDirPath = join(stagingRoot, deployment.name);
@@ -1464,13 +1543,27 @@ async function settleJournaledActivationsForComponent(
 		// A journal-less directory is what a SUCCESSFUL settlement leaves when its best-effort sweep fails, so
 		// this must not fail closed. An unattributable *activation* still does: `readActivationJournal` throws
 		// on a journal that exists but cannot be read.
-		if (!journal) continue;
+		if (!journal) {
+			if (ownerUnreadable) continue;
+			try {
+				const build = await dormantBuildAt(deploymentDirPath, componentName);
+				if (build) dormant.push(build);
+			} catch (error) {
+				logger.warn(
+					`Leaving staged ${componentName} build ${deploymentDirPath} out of retention; it could not be read:`,
+					errorForLog(error)
+				);
+			}
+			continue;
+		}
 		// The journal decides, not the sidecar. Skipping on an unreadable sidecar alone would leave this
 		// component's own unsettled activation in place while a new deploy proceeded over it, and an
 		// activation interrupted before B1 has no rollback record for the restore gate to catch.
 		if (journal.component !== componentName) continue;
 		await settleInterruptedActivation(componentsRootDirPath, deploymentDirPath, journal);
 	}
+	const maxCount = getStagingRetentionMaxCount();
+	if (dormant.length > maxCount) await pruneDormantBuilds(componentName, dormant, maxCount);
 }
 
 /**
@@ -1582,6 +1675,7 @@ export async function recoverInterruptedActivations(componentsRootDirPath: strin
 		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return failures;
 		throw error;
 	}
+	const dormant = new Map<string, DormantBuild[]>();
 
 	for (const deployment of deployments) {
 		if (!deployment.isDirectory()) continue;
@@ -1663,6 +1757,14 @@ export async function recoverInterruptedActivations(componentsRootDirPath: strin
 					// Settled. Anything that fails after this — releasing the lock, say — is not this
 					// activation's, and attributing it here would fail a correctly settled component closed.
 					activationToFail = undefined;
+					return;
+				}
+				// A complete, validated tree with no activation is a dormant build, kept for retention to bound
+				// after the scan rather than removed. Classified here, under the owner's lock, because that is
+				// what rules out "complete but about to be journaled".
+				const build = await dormantBuildAt(deploymentDirPath, owner!);
+				if (build) {
+					dormant.set(owner!, [...(dormant.get(owner!) ?? []), build]);
 					return;
 				}
 				// Cleanup, not settlement. There was no activation here — this is most often the residue a
@@ -1753,6 +1855,33 @@ export async function recoverInterruptedActivations(componentsRootDirPath: strin
 		} catch (error) {
 			// The journal named its component, so attribution is exact however the settle failed.
 			await fail(journal.component, error);
+		}
+	}
+
+	const maxCount = getStagingRetentionMaxCount();
+	for (const [owner, builds] of dormant) {
+		if (builds.length <= maxCount) continue;
+		try {
+			await withComponentPreparationLock(
+				join(componentsRootDirPath, owner),
+				() => pruneDormantBuilds(owner, builds, maxCount),
+				{
+					purpose: 'activation-recovery',
+					...RECOVERY_LOCK_WAIT,
+					isOwnerAlive: (lockOwner) => lockOwner.pid !== process.pid || isThreadRunning(lockOwner.threadId),
+				}
+			);
+		} catch (error) {
+			// A held lock is a deploy of this component that started after its directories were classified,
+			// which is exactly the signal the journal-less branch defers a load on; the same deferral applies.
+			// Anything else is hygiene that could not run, not a verdict.
+			const failure = error instanceof Error ? error : new Error(String(error));
+			if (failure instanceof ComponentPreparationLockTimeoutError) {
+				if (!failures.has(owner)) failures.set(owner, failure);
+				logger.info?.(`Deferred pruning the dormant staged builds of ${owner}: a deploy holds its lock`);
+			} else {
+				logger.warn(`Could not prune the dormant staged builds of ${owner}:`, errorForLog(failure));
+			}
 		}
 	}
 	return failures;
@@ -3385,7 +3514,7 @@ export async function prepareApplication(application: Application, options: Prep
 				}
 				// BEFORE the legacy pass. That pass refuses to restore while a journal survives, so skipping
 				// this would not lose data — it would just stall the deploy behind its own unsettled state.
-				await settleJournaledActivationsForComponent(dirname(application.dirPath), application.name);
+				await settleStagingForComponent(dirname(application.dirPath), application.name);
 				if (recoveryPending) {
 					await ensureExtractionStagingDirectory(asideStagingDir);
 					await recoverOrCleanupStaleExtractionPaths(application, asideStagingDir);

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -1074,16 +1074,28 @@ async function dormantBuildAt(deploymentDirPath: string, owner: string): Promise
 
 /**
  * Remove the oldest dormant builds beyond `maxCount`. The caller must hold the component's preparation lock;
- * each eviction is re-derived under it. Never throws: a failure must neither fail a component closed nor
- * replace a deploy's own error.
+ * every catalogued build is re-derived under it before the kept set is chosen, so a catalog read unlocked
+ * cannot hold or miss a slot. Never throws: a failure must neither fail a component closed nor replace a
+ * deploy's own error.
  */
 export async function pruneDormantBuilds(
 	componentName: string,
 	builds: DormantBuild[],
 	maxCount: number
 ): Promise<void> {
-	const evictions = builds
-		.slice()
+	const current: DormantBuild[] = [];
+	for (const build of builds) {
+		try {
+			const fresh = await dormantBuildAt(build.deploymentDirPath, componentName);
+			if (fresh && !(await presentOrAbsent(join(build.deploymentDirPath, ACTIVATION_JOURNAL)))) current.push(fresh);
+		} catch (error) {
+			logger.warn(
+				`Leaving deploy staging ${build.deploymentDirPath} out of retention; it could not be read:`,
+				errorForLog(error)
+			);
+		}
+	}
+	const evictions = current
 		.sort(
 			(left, right) =>
 				right.completedAt - left.completedAt ||
@@ -1092,8 +1104,6 @@ export async function pruneDormantBuilds(
 		.slice(Math.max(0, maxCount));
 	for (const build of evictions) {
 		try {
-			if (!(await dormantBuildAt(build.deploymentDirPath, componentName))) continue;
-			if (await presentOrAbsent(join(build.deploymentDirPath, ACTIVATION_JOURNAL))) continue;
 			await rm(build.deploymentDirPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 			logger.debug?.(
 				`Pruned dormant staged build ${build.deploymentId} of ${componentName} beyond deployment_stagingRetention_maxCount=${maxCount}`
@@ -1899,9 +1909,9 @@ export async function recoverInterruptedActivations(componentsRootDirPath: strin
 		try {
 			await withComponentPreparationLock(
 				join(componentsRootDirPath, owner),
-				// Re-catalogued under the lock: a build activated or staged since the unlocked scan would otherwise
-				// hold or miss a kept slot.
-				async () => pruneDormantBuilds(owner, await dormantBuildsOf(componentsRootDirPath, owner), maxCount),
+				// Only this owner's catalogued directories are re-read under the lock, never the whole staging
+				// root: sibling threads probe these locks for 250 ms.
+				() => pruneDormantBuilds(owner, builds, maxCount),
 				{
 					purpose: 'activation-recovery',
 					...RECOVERY_LOCK_WAIT,

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -1035,11 +1035,7 @@ const UNSETTLED_MARKER = '.unsettled';
 const ACTIVATION_JOURNAL_VERSION = 1;
 const DEFAULT_STAGING_RETENTION_MAX_COUNT = 5;
 
-/**
- * How many dormant staged builds may survive per component under `.deploy-staging`
- * (`deployment_stagingRetention_maxCount`; 0 keeps none). Only a number or numeric string counts, so
- * `true`/`[]`/blank cannot become an accidental "keep nothing".
- */
+/** `deployment_stagingRetention_maxCount`; 0 keeps none. Only a number or numeric string counts, so `true`/`[]`/blank cannot become "keep nothing". */
 export function getStagingRetentionMaxCount(): number {
 	const configured = getConfigValue(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT);
 	if (typeof configured !== 'number' && typeof configured !== 'string') return DEFAULT_STAGING_RETENTION_MAX_COUNT;
@@ -1062,12 +1058,9 @@ async function presentOrAbsent(path: string): Promise<import('node:fs').Stats | 
 }
 
 /**
- * A journal-less deployment directory holding a complete, validated tree nobody is activating — the only
- * kind retention may count or remove. Activation writes `.complete` moments before its journal, both under
- * the owner's preparation lock, so an unlocked read is a candidate for retention and a read under that lock
- * is the verdict. A stale `.unsettled` makes it residue instead: workers read that marker as a verdict, and
- * only removing the directory clears it.
- *
+ * A dormant build: complete, tree present, no journal. Activation writes `.complete` moments before its
+ * journal under the owner's preparation lock, so only a read under that lock is a verdict. A stale
+ * `.unsettled` makes it residue instead, since only removing the directory clears that marker for workers.
  * Only ENOENT is absence; any other read error propagates so the caller preserves the entry.
  */
 async function dormantBuildAt(deploymentDirPath: string, owner: string): Promise<DormantBuild | undefined> {
@@ -1080,10 +1073,9 @@ async function dormantBuildAt(deploymentDirPath: string, owner: string): Promise
 }
 
 /**
- * Remove the oldest dormant builds beyond `maxCount`, newest by `.complete` mtime surviving. Assumes the
- * caller holds the component's preparation lock. Each eviction is re-derived under that lock — still
- * dormant, still no journal — because the catalog may have been read unlocked or before a deploy ran. Never
- * throws: a failure here must neither fail a component closed at boot nor replace a deploy's own error.
+ * Remove the oldest dormant builds beyond `maxCount`. The caller must hold the component's preparation lock;
+ * each eviction is re-derived under it. Never throws: a failure must neither fail a component closed nor
+ * replace a deploy's own error.
  */
 export async function pruneDormantBuilds(
 	componentName: string,
@@ -1092,7 +1084,11 @@ export async function pruneDormantBuilds(
 ): Promise<void> {
 	const evictions = builds
 		.slice()
-		.sort((left, right) => right.completedAt - left.completedAt || left.deploymentId.localeCompare(right.deploymentId))
+		.sort(
+			(left, right) =>
+				right.completedAt - left.completedAt ||
+				(left.deploymentId < right.deploymentId ? -1 : left.deploymentId > right.deploymentId ? 1 : 0)
+		)
 		.slice(Math.max(0, maxCount));
 	for (const build of evictions) {
 		try {
@@ -1112,7 +1108,7 @@ export async function pruneDormantBuilds(
 	}
 }
 
-/** Every dormant build a component owns. A directory that cannot be read is left out and logged. */
+/** Every dormant build a component owns; an unreadable directory is left out and logged. */
 async function dormantBuildsOf(componentsRootDirPath: string, componentName: string): Promise<DormantBuild[]> {
 	const stagingRoot = join(componentsRootDirPath, DEPLOY_STAGING_DIR);
 	let deployments;
@@ -1810,10 +1806,8 @@ export async function recoverInterruptedActivations(componentsRootDirPath: strin
 				);
 				continue;
 			}
-			// A dormant build — complete, tree present, nobody activating it — is catalogued WITHOUT the lock and
-			// left alone; only an owner over its retention bound takes the lock, once, below. Locking here per
-			// directory on every pass, forever, is what made a healthy component with retained builds lose the
-			// 250 ms probe to its sibling threads at boot and be deferred with nothing in progress.
+			// Catalogued WITHOUT the lock and left alone: a retained build is never removed here, so a per-directory
+			// lock would recur on every pass and contend with sibling threads for a component nothing is deploying.
 			if (owner) {
 				let build: DormantBuild | undefined;
 				try {
@@ -1905,7 +1899,9 @@ export async function recoverInterruptedActivations(componentsRootDirPath: strin
 		try {
 			await withComponentPreparationLock(
 				join(componentsRootDirPath, owner),
-				() => pruneDormantBuilds(owner, builds, maxCount),
+				// Re-catalogued under the lock: a build activated or staged since the unlocked scan would otherwise
+				// hold or miss a kept slot.
+				async () => pruneDormantBuilds(owner, await dormantBuildsOf(componentsRootDirPath, owner), maxCount),
 				{
 					purpose: 'activation-recovery',
 					...RECOVERY_LOCK_WAIT,
@@ -2762,8 +2758,7 @@ export async function dropComponentDirectory(
 		asideStagingDir,
 		new Set([droppedPath])
 	);
-	// Retention only runs on the component's next deploy, and a dropped component has none — the drop is
-	// what reclaims its dormant builds.
+	// A dropped component has no next deploy to bound its dormant builds.
 	try {
 		await pruneDormantBuilds(componentName, await dormantBuildsOf(dirname(componentDirPath), componentName), 0);
 	} catch (error) {

--- a/integrationTests/deploy/staging-retention.test.ts
+++ b/integrationTests/deploy/staging-retention.test.ts
@@ -1,0 +1,75 @@
+/**
+ * `deployment.stagingRetention.maxCount` bounds how many complete, unactivated builds survive under
+ * `.deploy-staging` per component (#2315 step 4). The bound is enforced at the start of that component's
+ * next deploy, under its preparation lock, so this plants dormant builds beside a running instance and
+ * deploys once through the real operations API — proving the knob reaches the prune through real config
+ * loading, and that the deploy itself is untouched by the pruning.
+ *
+ * Scope: the build state is planted, not produced — nothing on `main` stages without activating yet.
+ */
+import { suite, test, before, after } from 'node:test';
+import { deepStrictEqual, strictEqual } from 'node:assert';
+import { join } from 'node:path';
+import { mkdir, mkdtemp, readdir, readFile, rm, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+import { startHarper, teardownHarper, targz, type ContextWithHarper } from '@harperfast/integration-testing';
+import { operation } from './redeploy-restart-flag-helpers.ts';
+
+const PROJECT = 'staging-retention';
+
+async function buildPayload(version: number): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), 'staging-retention-fixture-'));
+	try {
+		await writeFile(join(dir, 'package.json'), JSON.stringify({ name: PROJECT, version: `${version}.0.0` }));
+		await writeFile(join(dir, 'version.txt'), String(version));
+		await writeFile(join(dir, 'config.yaml'), 'rest: true\n');
+		return await targz(dir);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+}
+
+/** A complete, validated build nobody activated: `.complete`, the sidecar, the tree, and no journal. */
+async function plantDormantBuild(componentsRoot: string, id: string, completedAt: number): Promise<void> {
+	const deploymentDir = join(componentsRoot, '.deploy-staging', id);
+	await mkdir(join(deploymentDir, PROJECT), { recursive: true });
+	await writeFile(join(deploymentDir, PROJECT, 'version.txt'), id);
+	await writeFile(join(deploymentDir, '.component'), PROJECT);
+	await writeFile(join(deploymentDir, '.complete'), '');
+	await utimes(join(deploymentDir, '.complete'), completedAt, completedAt);
+}
+
+suite(
+	'deploy_component bounds dormant staged builds to deployment.stagingRetention.maxCount',
+	(ctx: ContextWithHarper) => {
+		before(async () => {
+			await startHarper(ctx, { config: { deployment: { stagingRetention: { maxCount: 1 } } }, env: {} });
+		});
+
+		after(async () => {
+			await teardownHarper(ctx);
+		});
+
+		test('the next deploy of the component keeps only its newest dormant build', async () => {
+			const componentsRoot = join(ctx.harper.dataRootDir, 'components');
+			await plantDormantBuild(componentsRoot, 'd-older', 1_000);
+			await plantDormantBuild(componentsRoot, 'd-newer', 2_000);
+			deepStrictEqual((await readdir(join(componentsRoot, '.deploy-staging'))).sort(), ['d-newer', 'd-older']);
+
+			await operation(ctx, {
+				operation: 'deploy_component',
+				project: PROJECT,
+				payload: await buildPayload(1),
+				restart: false,
+			});
+
+			strictEqual(await readFile(join(componentsRoot, PROJECT, 'version.txt'), 'utf8'), '1', 'the deploy landed');
+			deepStrictEqual(
+				await readdir(join(componentsRoot, '.deploy-staging')),
+				['d-newer'],
+				'the older dormant build was pruned, the newest kept, and the deploy left no candidate of its own'
+			);
+		});
+	}
+);

--- a/unitTests/components/deployStagingRetention.test.js
+++ b/unitTests/components/deployStagingRetention.test.js
@@ -25,8 +25,10 @@ const {
 } = require('#src/components/Application');
 const {
 	withComponentPreparationLock,
+	componentPreparationLockPaths,
 	ComponentPreparationLockTimeoutError,
 } = require('#src/components/componentPreparationLock');
+const { waitFor } = require('../waitFor.js');
 const env = require('#src/utility/environment/environmentManager');
 const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
 
@@ -77,6 +79,19 @@ async function publishJournalAndMoveLiveAside(root, component, id) {
 	const asideDir = path.join(root, ASIDE_STAGING_DIR, component);
 	await fs.mkdir(asideDir, { recursive: true });
 	await fs.rename(path.join(root, component), path.join(asideDir, '.in-progress-1-1-aaa'));
+}
+
+/** Resolves once a second contender has published a ticket for the component's lock: the scan is parked on it. */
+async function waitForLockWaiter(root, component) {
+	const { lockRoot, lockName } = componentPreparationLockPaths(path.join(root, component));
+	await waitFor(
+		async () => {
+			const entries = await fs.readdir(lockRoot).catch(() => []);
+			return entries.filter((name) => name.startsWith(`${lockName}.ticket.`)).length >= 2;
+		},
+		5000,
+		5
+	);
 }
 
 async function stagedIds(root) {
@@ -298,9 +313,11 @@ describe('staged build retention', () => {
 
 		it('recovers a swap interrupted between the scan reading no journal and the end of the pass', async function () {
 			this.timeout(10000);
+			// Over the bound on purpose, so the only lock this pass takes is the reconcile's — the catalogued
+			// build is read unlocked first, and the deploy's journal lands while that lock is awaited.
+			env.setProperty(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT, 0);
 			const root = await newRoot('interleaved-journal');
 			await plant(root, 'web', 'd-a', { completedAt: 1_000 });
-			await plant(root, 'web', 'd-z', { complete: false }); // residue: the scan parks on this owner's lock
 			await fs.mkdir(path.join(root, 'web'), { recursive: true });
 			await fs.writeFile(path.join(root, 'web', 'index.js'), 'LIVE\n');
 
@@ -309,9 +326,7 @@ describe('staged build retention', () => {
 				path.join(root, 'web'),
 				async () => {
 					const recovery = recoverInterruptedActivations(root);
-					// The scan has read d-a's (absent) journal and is now blocked on this lock for d-z; the deploy
-					// publishes its journal, moves live aside, and dies before B2.
-					await sleep(50);
+					await waitForLockWaiter(root, 'web');
 					await publishJournalAndMoveLiveAside(root, 'web', 'd-a');
 					// Released by the lock callback returning; the scan then acquires it.
 					void recovery.then((result) => (failures = result));
@@ -338,7 +353,7 @@ describe('staged build retention', () => {
 				path.join(root, 'web'),
 				async () => {
 					const recovery = recoverInterruptedActivations(root);
-					await sleep(50);
+					await waitForLockWaiter(root, 'web');
 					await fs.writeFile(path.join(root, DEPLOY_STAGING_DIR, 'd-finishing', '.complete'), '');
 					void recovery.then((result) => (failures = result));
 				},

--- a/unitTests/components/deployStagingRetention.test.js
+++ b/unitTests/components/deployStagingRetention.test.js
@@ -161,6 +161,20 @@ describe('staged build retention', () => {
 			await fs.rm(root, { recursive: true, force: true });
 		});
 
+		it('settles a journaled activation rather than retaining it, however dormant it looks', async () => {
+			const root = await newRoot('journaled');
+			await plant(root, 'web', 'd-activating', { journal: true });
+			await fs.mkdir(path.join(root, 'web'), { recursive: true });
+			await fs.writeFile(path.join(root, 'web', 'index.js'), 'LIVE\n');
+
+			const failures = await recoverInterruptedActivations(root);
+
+			assert.strictEqual(failures.size, 0);
+			assert.strictEqual(await fs.readFile(path.join(root, 'web', 'index.js'), 'utf8'), 'LIVE\n');
+			assert.deepStrictEqual(await stagedIds(root), [], 'live present with a candidate: the journal path discards it');
+			await fs.rm(root, { recursive: true, force: true });
+		});
+
 		it('removes a complete build carrying a stale unsettled verdict, so workers stop refusing it', async () => {
 			const root = await newRoot('stale-verdict');
 			await plant(root, 'web', 'd-verdict', { unsettled: true });

--- a/unitTests/components/deployStagingRetention.test.js
+++ b/unitTests/components/deployStagingRetention.test.js
@@ -10,12 +10,16 @@ const { Readable } = require('node:stream');
 const testUtils = require('../testUtils.js');
 testUtils.preTestPrep();
 
+const { setTimeout: sleep } = require('node:timers/promises');
+
 const {
 	dropComponentDirectory,
 	getStagingRetentionMaxCount,
 	prepareApplication,
 	pruneDormantBuilds,
+	reconcileDormantBuilds,
 	recoverInterruptedActivations,
+	ASIDE_STAGING_DIR,
 	DEPLOY_STAGING_DIR,
 	Application,
 } = require('#src/components/Application');
@@ -62,6 +66,17 @@ async function plant(root, component, id, state = {}) {
 	}
 	if (state.unsettled) await fs.writeFile(path.join(deploymentDir, '.unsettled'), 'stale verdict');
 	return deploymentDir;
+}
+
+/** What a deploy that died between B1 and B2 leaves: journal written, live tree moved aside, candidate still staged. */
+async function publishJournalAndMoveLiveAside(root, component, id) {
+	await fs.writeFile(
+		path.join(root, DEPLOY_STAGING_DIR, id, '.activation.json'),
+		JSON.stringify({ v: 1, component, candidateId: id })
+	);
+	const asideDir = path.join(root, ASIDE_STAGING_DIR, component);
+	await fs.mkdir(asideDir, { recursive: true });
+	await fs.rename(path.join(root, component), path.join(asideDir, '.in-progress-1-1-aaa'));
 }
 
 async function stagedIds(root) {
@@ -226,6 +241,115 @@ describe('staged build retention', () => {
 			assert.ok(failures.get('web') instanceof ComponentPreparationLockTimeoutError, 'deferred, not failed');
 			assert.deepStrictEqual(await stagedIds(root), ['d-1', 'd-2'], 'nothing was removed behind the lock');
 			assert.ok(!existsSync(path.join(root, DEPLOY_STAGING_DIR, 'd-1', '.unsettled')), 'and no verdict was written');
+			await fs.rm(root, { recursive: true, force: true });
+		});
+	});
+
+	describe('journals published after the unlocked scan', () => {
+		it('settles a journal that appeared on a catalogued build instead of leaving the component broken', async () => {
+			const root = await newRoot('late-journal');
+			const deploymentDirPath = await plant(root, 'web', 'd-late', { completedAt: 1_000 });
+			await fs.mkdir(path.join(root, 'web'), { recursive: true });
+			await fs.writeFile(path.join(root, 'web', 'index.js'), 'LIVE\n');
+			// Catalogued as dormant by the scan, then the deploy published its journal, moved live aside, and died.
+			const catalogued = [{ deploymentDirPath, deploymentId: 'd-late', completedAt: 1_000 }];
+			await publishJournalAndMoveLiveAside(root, 'web', 'd-late');
+
+			const failures = await reconcileDormantBuilds(root, 'web', catalogued, 5);
+
+			assert.strictEqual(failures.size, 0);
+			assert.strictEqual(
+				await fs.readFile(path.join(root, 'web', 'index.js'), 'utf8'),
+				'// d-late\n',
+				'rolled forward'
+			);
+			assert.deepStrictEqual(await stagedIds(root), [], 'and the settled deployment directory is gone');
+			await fs.rm(root, { recursive: true, force: true });
+		});
+
+		it('defers the component when the journal that appeared belongs to a deploy still holding the lock', async function () {
+			this.timeout(10000);
+			const root = await newRoot('late-journal-held');
+			const deploymentDirPath = await plant(root, 'web', 'd-late', { completedAt: 1_000 });
+			await fs.writeFile(
+				path.join(deploymentDirPath, '.activation.json'),
+				JSON.stringify({ v: 1, component: 'web', candidateId: 'd-late' })
+			);
+
+			let failures;
+			await withComponentPreparationLock(
+				path.join(root, 'web'),
+				async () => {
+					failures = await reconcileDormantBuilds(
+						root,
+						'web',
+						[{ deploymentDirPath, deploymentId: 'd-late', completedAt: 1 }],
+						5
+					);
+				},
+				{ purpose: 'test-deploy' }
+			);
+
+			assert.ok(failures.get('web') instanceof ComponentPreparationLockTimeoutError);
+			assert.ok(!existsSync(path.join(deploymentDirPath, '.unsettled')), 'a deferral writes no verdict');
+			assert.deepStrictEqual(await stagedIds(root), ['d-late']);
+			await fs.rm(root, { recursive: true, force: true });
+		});
+
+		it('recovers a swap interrupted between the scan reading no journal and the end of the pass', async function () {
+			this.timeout(10000);
+			const root = await newRoot('interleaved-journal');
+			await plant(root, 'web', 'd-a', { completedAt: 1_000 });
+			await plant(root, 'web', 'd-z', { complete: false }); // residue: the scan parks on this owner's lock
+			await fs.mkdir(path.join(root, 'web'), { recursive: true });
+			await fs.writeFile(path.join(root, 'web', 'index.js'), 'LIVE\n');
+
+			let failures;
+			await withComponentPreparationLock(
+				path.join(root, 'web'),
+				async () => {
+					const recovery = recoverInterruptedActivations(root);
+					// The scan has read d-a's (absent) journal and is now blocked on this lock for d-z; the deploy
+					// publishes its journal, moves live aside, and dies before B2.
+					await sleep(50);
+					await publishJournalAndMoveLiveAside(root, 'web', 'd-a');
+					// Released by the lock callback returning; the scan then acquires it.
+					void recovery.then((result) => (failures = result));
+				},
+				{ purpose: 'test-deploy' }
+			);
+			const deadline = Date.now() + 5000;
+			while (!failures && Date.now() < deadline) await sleep(10);
+
+			assert.ok(failures, 'recovery completed');
+			assert.strictEqual(failures.size, 0);
+			assert.strictEqual(await fs.readFile(path.join(root, 'web', 'index.js'), 'utf8'), '// d-a\n', 'rolled forward');
+			assert.deepStrictEqual(await stagedIds(root), []);
+			await fs.rm(root, { recursive: true, force: true });
+		});
+
+		it('retains a build whose .complete landed while the scan waited for the lock', async function () {
+			this.timeout(10000);
+			const root = await newRoot('interleaved-complete');
+			await plant(root, 'web', 'd-finishing', { complete: false }); // looks like residue unlocked
+
+			let failures;
+			await withComponentPreparationLock(
+				path.join(root, 'web'),
+				async () => {
+					const recovery = recoverInterruptedActivations(root);
+					await sleep(50);
+					await fs.writeFile(path.join(root, DEPLOY_STAGING_DIR, 'd-finishing', '.complete'), '');
+					void recovery.then((result) => (failures = result));
+				},
+				{ purpose: 'test-deploy' }
+			);
+			const deadline = Date.now() + 5000;
+			while (!failures && Date.now() < deadline) await sleep(10);
+
+			assert.ok(failures, 'recovery completed');
+			assert.strictEqual(failures.size, 0, 'the lock was released within the probe budget, so nothing deferred');
+			assert.deepStrictEqual(await stagedIds(root), ['d-finishing'], 'reclassified under the lock and kept');
 			await fs.rm(root, { recursive: true, force: true });
 		});
 	});

--- a/unitTests/components/deployStagingRetention.test.js
+++ b/unitTests/components/deployStagingRetention.test.js
@@ -11,6 +11,7 @@ const testUtils = require('../testUtils.js');
 testUtils.preTestPrep();
 
 const {
+	dropComponentDirectory,
 	getStagingRetentionMaxCount,
 	prepareApplication,
 	pruneDormantBuilds,
@@ -171,6 +172,27 @@ describe('staged build retention', () => {
 			await fs.rm(root, { recursive: true, force: true });
 		});
 
+		it('takes no lock for a component within its bound, so a held lock does not defer it', async function () {
+			this.timeout(10000);
+			env.setProperty(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT, 2);
+			const root = await newRoot('steady-state');
+			await plant(root, 'web', 'd-1', { completedAt: 1_000 });
+			await plant(root, 'web', 'd-2', { completedAt: 2_000 });
+
+			let failures;
+			await withComponentPreparationLock(
+				path.join(root, 'web'),
+				async () => {
+					failures = await recoverInterruptedActivations(root);
+				},
+				{ purpose: 'test-deploy' }
+			);
+
+			assert.strictEqual(failures.size, 0, 'a component with nothing to prune is never deferred by retention');
+			assert.deepStrictEqual(await stagedIds(root), ['d-1', 'd-2']);
+			await fs.rm(root, { recursive: true, force: true });
+		});
+
 		it('defers the component instead of pruning while a deploy holds its lock, and deletes nothing', async function () {
 			this.timeout(10000);
 			env.setProperty(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT, 1);
@@ -230,6 +252,22 @@ describe('staged build retention', () => {
 				await fs.chmod(staging, 0o700);
 			}
 			assert.deepStrictEqual(await stagedIds(root), ['d-stuck']);
+			await fs.rm(root, { recursive: true, force: true });
+		});
+	});
+
+	describe('on drop', () => {
+		it("reclaims the dropped component's dormant builds and leaves its neighbour's alone", async () => {
+			const root = await newRoot('drop');
+			await plant(root, 'web', 'd-web-1');
+			await plant(root, 'web', 'd-web-2');
+			await plant(root, 'api', 'd-api');
+			await fs.mkdir(path.join(root, 'web'), { recursive: true });
+
+			await dropComponentDirectory(path.join(root, 'web'), 'web');
+
+			assert.ok(!existsSync(path.join(root, 'web')));
+			assert.deepStrictEqual(await stagedIds(root), ['d-api']);
 			await fs.rm(root, { recursive: true, force: true });
 		});
 	});

--- a/unitTests/components/deployStagingRetention.test.js
+++ b/unitTests/components/deployStagingRetention.test.js
@@ -1,0 +1,258 @@
+'use strict';
+
+const assert = require('node:assert');
+const path = require('node:path');
+const fs = require('node:fs/promises');
+const { existsSync } = require('node:fs');
+const os = require('node:os');
+const { Readable } = require('node:stream');
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const {
+	getStagingRetentionMaxCount,
+	prepareApplication,
+	pruneDormantBuilds,
+	recoverInterruptedActivations,
+	DEPLOY_STAGING_DIR,
+	Application,
+} = require('#src/components/Application');
+const {
+	withComponentPreparationLock,
+	ComponentPreparationLockTimeoutError,
+} = require('#src/components/componentPreparationLock');
+const env = require('#src/utility/environment/environmentManager');
+const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+
+async function newRoot(label) {
+	return fs.mkdtemp(path.join(os.tmpdir(), `staging-retention-${label}-`));
+}
+
+/**
+ * Plant one `.deploy-staging/<id>` directory. By default it is a DORMANT build: `.complete`, the owner's
+ * tree, the sidecar, and no journal. `completedAt` sets the `.complete` mtime, which is what retention
+ * orders by.
+ */
+async function plant(root, component, id, state = {}) {
+	const deploymentDir = path.join(root, DEPLOY_STAGING_DIR, id);
+	await fs.mkdir(deploymentDir, { recursive: true });
+	if (state.tree !== false) {
+		if (state.tree === 'symlink') {
+			const target = path.join(root, `${id}-source`);
+			await fs.mkdir(target, { recursive: true });
+			await fs.symlink(target, path.join(deploymentDir, component), 'dir');
+		} else {
+			await fs.mkdir(path.join(deploymentDir, component), { recursive: true });
+			await fs.writeFile(path.join(deploymentDir, component, 'index.js'), `// ${id}\n`);
+		}
+	}
+	if (state.sidecar !== false) await fs.writeFile(path.join(deploymentDir, '.component'), component);
+	if (state.complete !== false) {
+		const marker = path.join(deploymentDir, '.complete');
+		await fs.writeFile(marker, '');
+		if (state.completedAt !== undefined) await fs.utimes(marker, state.completedAt, state.completedAt);
+	}
+	if (state.journal) {
+		await fs.writeFile(
+			path.join(deploymentDir, '.activation.json'),
+			JSON.stringify({ v: 1, component, candidateId: id })
+		);
+	}
+	if (state.unsettled) await fs.writeFile(path.join(deploymentDir, '.unsettled'), 'stale verdict');
+	return deploymentDir;
+}
+
+async function stagedIds(root) {
+	return (await fs.readdir(path.join(root, DEPLOY_STAGING_DIR)).catch(() => [])).sort();
+}
+
+function failingDeployOf(root, component) {
+	const app = new Application({
+		name: component,
+		payload: Readable.from(
+			(async function* () {
+				yield Buffer.from('not a tarball');
+				throw new Error('payload delivery failed');
+			})()
+		),
+	});
+	app.dirPath = path.join(root, component);
+	return app;
+}
+
+describe('staged build retention', () => {
+	afterEach(() => env.setProperty(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT, undefined));
+
+	describe('getStagingRetentionMaxCount', () => {
+		it('defaults to 5 when unset, null, blank, or not a number', () => {
+			for (const value of [undefined, null, '', '   ', true, false, [], {}, 'five', NaN, Infinity, -1, '-3']) {
+				env.setProperty(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT, value);
+				assert.strictEqual(getStagingRetentionMaxCount(), 5, `for ${JSON.stringify(value)}`);
+			}
+		});
+
+		it('accepts a number or numeric string, floors fractions, and lets 0 mean keep none', () => {
+			env.setProperty(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT, 2);
+			assert.strictEqual(getStagingRetentionMaxCount(), 2);
+			env.setProperty(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT, '3');
+			assert.strictEqual(getStagingRetentionMaxCount(), 3);
+			env.setProperty(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT, 2.9);
+			assert.strictEqual(getStagingRetentionMaxCount(), 2);
+			env.setProperty(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT, 0);
+			assert.strictEqual(getStagingRetentionMaxCount(), 0);
+			env.setProperty(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT, '0');
+			assert.strictEqual(getStagingRetentionMaxCount(), 0);
+		});
+	});
+
+	describe('at boot', () => {
+		it('keeps a complete build nobody activated and still removes an incomplete one', async () => {
+			const root = await newRoot('keep-complete');
+			await plant(root, 'web', 'd-complete');
+			await plant(root, 'web', 'd-linked', { tree: 'symlink' });
+			await plant(root, 'web', 'd-partial', { complete: false });
+			await plant(root, 'web', 'd-swept', { tree: false }); // what a settled sweep that failed leaves
+
+			const failures = await recoverInterruptedActivations(root);
+
+			assert.strictEqual(failures.size, 0);
+			assert.deepStrictEqual(await stagedIds(root), ['d-complete', 'd-linked']);
+			await fs.rm(root, { recursive: true, force: true });
+		});
+
+		it('bounds each component to the newest maxCount builds without counting its neighbours', async () => {
+			env.setProperty(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT, 2);
+			const root = await newRoot('bound');
+			await plant(root, 'web', 'd-oldest', { completedAt: 1_000 });
+			await plant(root, 'web', 'd-middle', { completedAt: 2_000 });
+			await plant(root, 'web', 'd-newest', { completedAt: 3_000 });
+			await plant(root, 'api', 'd-api', { completedAt: 500 });
+
+			const failures = await recoverInterruptedActivations(root);
+
+			assert.strictEqual(failures.size, 0);
+			assert.deepStrictEqual(await stagedIds(root), ['d-api', 'd-middle', 'd-newest']);
+			await fs.rm(root, { recursive: true, force: true });
+		});
+
+		it('breaks a completion-time tie by deployment id so concurrent passes evict the same build', async () => {
+			env.setProperty(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT, 1);
+			const root = await newRoot('tie');
+			await plant(root, 'web', 'd-b', { completedAt: 1_000 });
+			await plant(root, 'web', 'd-a', { completedAt: 1_000 });
+
+			await recoverInterruptedActivations(root);
+
+			assert.deepStrictEqual(await stagedIds(root), ['d-a']);
+			await fs.rm(root, { recursive: true, force: true });
+		});
+
+		it('keeps none when maxCount is 0', async () => {
+			env.setProperty(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT, 0);
+			const root = await newRoot('zero');
+			await plant(root, 'web', 'd-1');
+			await plant(root, 'web', 'd-2');
+
+			await recoverInterruptedActivations(root);
+
+			assert.deepStrictEqual(await stagedIds(root), []);
+			await fs.rm(root, { recursive: true, force: true });
+		});
+
+		it('removes a complete build carrying a stale unsettled verdict, so workers stop refusing it', async () => {
+			const root = await newRoot('stale-verdict');
+			await plant(root, 'web', 'd-verdict', { unsettled: true });
+
+			const failures = await recoverInterruptedActivations(root);
+
+			assert.strictEqual(failures.size, 0);
+			assert.deepStrictEqual(await stagedIds(root), []);
+			await fs.rm(root, { recursive: true, force: true });
+		});
+
+		it('defers the component instead of pruning while a deploy holds its lock, and deletes nothing', async function () {
+			this.timeout(10000);
+			env.setProperty(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT, 1);
+			const root = await newRoot('held-lock');
+			await plant(root, 'web', 'd-1', { completedAt: 1_000 });
+			await plant(root, 'web', 'd-2', { completedAt: 2_000 });
+
+			let failures;
+			await withComponentPreparationLock(
+				path.join(root, 'web'),
+				async () => {
+					failures = await recoverInterruptedActivations(root);
+				},
+				{ purpose: 'test-deploy' }
+			);
+
+			assert.ok(failures.get('web') instanceof ComponentPreparationLockTimeoutError, 'deferred, not failed');
+			assert.deepStrictEqual(await stagedIds(root), ['d-1', 'd-2'], 'nothing was removed behind the lock');
+			assert.ok(!existsSync(path.join(root, DEPLOY_STAGING_DIR, 'd-1', '.unsettled')), 'and no verdict was written');
+			await fs.rm(root, { recursive: true, force: true });
+		});
+	});
+
+	describe('pruneDormantBuilds', () => {
+		it('re-checks for a journal before removing, so a build activated since the scan survives', async () => {
+			const root = await newRoot('recheck');
+			const builds = [];
+			for (const [id, completedAt] of [
+				['d-old', 1_000],
+				['d-mid', 2_000],
+				['d-new', 3_000],
+			]) {
+				const deploymentDirPath = await plant(root, 'web', id, { completedAt });
+				builds.push({ deploymentDirPath, deploymentId: id, completedAt });
+			}
+			// The scan saw no journal here; a deploy since then is activating this very build.
+			await fs.writeFile(
+				path.join(root, DEPLOY_STAGING_DIR, 'd-old', '.activation.json'),
+				JSON.stringify({ v: 1, component: 'web', candidateId: 'd-old' })
+			);
+
+			await pruneDormantBuilds('web', builds, 1);
+
+			assert.deepStrictEqual(await stagedIds(root), ['d-new', 'd-old']);
+			await fs.rm(root, { recursive: true, force: true });
+		});
+
+		it('does not throw when a build cannot be removed', async function () {
+			if (process.platform === 'win32' || process.getuid?.() === 0) return this.skip();
+			const root = await newRoot('unremovable');
+			const staging = path.join(root, DEPLOY_STAGING_DIR);
+			const deploymentDirPath = await plant(root, 'web', 'd-stuck');
+			await fs.chmod(staging, 0o500);
+			try {
+				await pruneDormantBuilds('web', [{ deploymentDirPath, deploymentId: 'd-stuck', completedAt: 1 }], 0);
+			} finally {
+				await fs.chmod(staging, 0o700);
+			}
+			assert.deepStrictEqual(await stagedIds(root), ['d-stuck']);
+			await fs.rm(root, { recursive: true, force: true });
+		});
+	});
+
+	describe('on the deploy path', () => {
+		it('bounds this component before building, protects its neighbours, and surfaces the deploy error', async () => {
+			env.setProperty(CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT, 1);
+			const root = await newRoot('deploy-path');
+			await plant(root, 'web', 'd-old', { completedAt: 1_000 });
+			await plant(root, 'web', 'd-new', { completedAt: 2_000 });
+			await plant(root, 'web', 'd-partial', { complete: false, completedAt: 3_000 });
+			await plant(root, 'api', 'd-api-old', { completedAt: 1 });
+			await plant(root, 'api', 'd-api-new', { completedAt: 2 });
+			await fs.mkdir(path.join(root, 'web'), { recursive: true });
+			await fs.writeFile(path.join(root, 'web', 'index.js'), 'LIVE\n');
+
+			await assert.rejects(() => prepareApplication(failingDeployOf(root, 'web')), /payload delivery failed/);
+
+			assert.strictEqual(await fs.readFile(path.join(root, 'web', 'index.js'), 'utf8'), 'LIVE\n');
+			// `web` is bounded to its newest; residue on the deploy path is left to boot, as before; `api` is
+			// not this deploy's business.
+			assert.deepStrictEqual(await stagedIds(root), ['d-api-new', 'd-api-old', 'd-new', 'd-partial']);
+			await fs.rm(root, { recursive: true, force: true });
+		});
+	});
+});

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -595,6 +595,7 @@ export const CONFIG_PARAMS = {
 	OPERATIONSAPI_NETWORK_MAXREQUESTBODYSIZE: 'operationsApi_network_maxRequestBodySize',
 	OPERATIONSAPI_COMPONENTFILE_MAXSIZE: 'operationsApi_componentFile_maxSize',
 	DEPLOYMENT_PAYLOADRETENTION_MAXSIZE: 'deployment_payloadRetention_maxSize',
+	DEPLOYMENT_STAGINGRETENTION_MAXCOUNT: 'deployment_stagingRetention_maxCount',
 	OPERATIONSAPI_TLS: 'operationsApi_tls',
 	OPERATIONSAPI_TLS_CERTIFICATE: 'operationsApi_tls_certificate',
 	OPERATIONSAPI_TLS_PRIVATEKEY: 'operationsApi_tls_privateKey',


### PR DESCRIPTION
Step 4 of #2315. Adds [`deployment.stagingRetention.maxCount`](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-85897aa30843afee9a67fc30b41713bbc7f2e3a3e1e9fa1a0437ecac46a698f9R598) (default `5`, `0` keeps none, [coerced like its sibling](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R1039)) and bounds, per component, how many **dormant** staged builds survive under `<componentsRoot>/.deploy-staging` — a [dormant build](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R1066) being a journal-less deployment directory that holds `.complete` and the owner's tree: built and validated, activated by nobody.

The premise this step was planned on moved during step 1's review: `main` discards a rejected or failed candidate immediately, and boot recovery removed *every* owned, journal-less staging directory. So nothing intentionally leaves a dormant build behind today — only the crash window between `.complete` and the journal write does. Step 6 (deploy from an existing aside) is the producer this bound exists for; this PR lands the bound and the knob so that step has a contract to build on, and makes recovery stop destroying the state step 6 will rely on.

What changes on disk: boot recovery [keeps dormant builds instead of removing them](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R1813), and [bounds them per owner](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R1936) to the newest `maxCount` by `.complete` mtime (ties broken by deployment id, so concurrent worker passes evict the same build). Residue — a partial tree, a tree already moved live, a directory carrying a stale `.unsettled` — is still removed exactly as before. The deploy path applies the same bound at the start of a deploy, [inside the settlement scan](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R1582) `prepareApplication` already runs under the component lock, so a deploy pays one traversal of the staging root rather than two. [`drop_component` reclaims the dropped component's dormant builds](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R2849), since no later deploy of that name will.

## For the human reviewer

1. **Dormant is `.complete` + tree + no journal, with removal decided under the owner's lock — not a new marker.** The planning review proposed an explicit "staged/dormant" marker written by a stage-only operation, arguing `.complete` proves durability but not dormancy because activation writes it moments before the journal. That is true of an *unlocked* read, which is why an unlocked read is only a candidate here and nothing is removed without re-deriving it under the owner's preparation lock, where a complete, journal-less directory cannot be mid-activation: activation holds that lock from `.complete` through the swap. A marker would duplicate `.complete` for the one producer step 6 adds. Reversible at zero migration cost: no dormant builds exist in the wild yet, so step 6 can introduce a marker if its stage-only mode wants one. Cost of a "no" here: step 6 writes and retention reads one more control file.
2. **Dormant builds are catalogued without the lock; only an over-quota owner takes it, once.** Round 1 classified each retained build under the owner's lock on every recovery pass — a lock per directory, forever, since a retained build is never removed — and the domain review showed a healthy component losing the 250 ms probe to its sibling threads at boot and being deferred with nothing in progress. Now an unlocked read is a candidate, the lock is taken once per owner over its bound, and each owner is then [reconciled once](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R1936): if a journal appeared on any catalogued directory since the scan, or the owner is over its bound, the lock is taken and only its catalogued directories — never the whole staging root, which sibling threads are probing — are re-read under it. A journal that appeared is [settled there](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R1982) — kriszyp's finding: a deploy that published one and died mid-swap would otherwise leave the component unloadable until the next start, since workers accept a well-formed journal while the legacy pass refuses to restore against it — and what is still dormant is [re-derived before the kept set is chosen](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R1086). The residue branch [re-classifies under its lock](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R1782) too, his second finding: a `.complete` written while the scan waited for the lock is a retainable build, not residue. A lock a live deploy holds on such an owner is still [recorded as the deferral](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R1999) `componentLoader` already acts on, and no `.unsettled` is written: "do not delete" is not "safe to load". The alternative — skip and log on timeout — is the more available reading; the conservative one was kept because it only arises while an owner is over quota, which the same pass then clears.
3. **Default is 5, not 0.** `0` would preserve today's on-disk behaviour exactly but make step 6's default useless and force a later default change. `5` is the reviewed #1849 default. The only behaviour visible today: a `.complete` build whose journal was never written (crash in that window) is retained up to the bound at boot instead of removed. Cost of a "no": one line and the docs.
4. **The deploy path prunes before building, not after.** It rides the settlement scan that already runs under the lock before the candidate is built, so the guarantee is "at most N dormant builds when a deploy of X starts", not "when it returns" — today the deploy's own candidate never survives, so the two are the same; step 6's stage-only mode decides whether to prune again after staging.
5. **Count, not size; `.complete` mtime as the order; no pin for a build a deploy is about to read.** The domain review's ledger raised all three. Count is what the issue specifies and matches #1849; disk is the constraint that bites, so a `maxSize` sibling may be worth adding once step 6 produces real trees — cheap to add beside this knob, awkward to replace it. `.complete` mtime does not survive a timestamp-normalising restore; a monotonic id or a recorded stamp can replace it before any retained build is something an operator rolls back to. Pruning before the build has nothing to pin today because no deploy reads a retained build; step 6 must pin its source or prune after.
6. **Unowned residue is deliberately out of scope.** A crash while resolving or packing leaves an empty `.deploy-staging/<id>`; nothing names it, so it cannot be told from a build that has not reached extraction yet. The fix — writing the sidecar at the start of the build — would make every respawning worker defer that component for the whole `npm install`, a step-1 decision this step does not reopen. Documented in [DESIGN.md](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-3dc5dd454e080eb849ee5efaf79df2585fbe0a06804d69249b4c81da05a63875R657) rather than fixed.

## Verification

- **Unit** — `unitTests/components/deployStagingRetention.test.js` (18 tests): a complete build and a `file:` symlink build survive boot while a partial tree and a swept-but-not-removed directory are removed; per-component bound to the newest N with a neighbour's builds not counted; completion-time tie broken by id; `maxCount: 0` keeps none; a stale `.unsettled` on a journal-less directory is removed so workers stop refusing it; [a journaled activation is settled rather than retained](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-d07055ed56251c81bb86a1506708541c9747138c0623b03a7a4f0bc966af9039R194) however dormant it looks; [a component within its bound takes no lock](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-d07055ed56251c81bb86a1506708541c9747138c0623b03a7a4f0bc966af9039R219), so a held lock does not defer it; [an over-quota owner whose lock is held is deferred](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-d07055ed56251c81bb86a1506708541c9747138c0623b03a7a4f0bc966af9039R240), with nothing deleted and no verdict written; [`dropComponentDirectory` reclaims the dropped component's dormant builds](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-d07055ed56251c81bb86a1506708541c9747138c0623b03a7a4f0bc966af9039R413) and leaves a neighbour's alone; [the eviction re-check keeps a build that acquired a journal since the scan](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-d07055ed56251c81bb86a1506708541c9747138c0623b03a7a4f0bc966af9039R373); [a journal published after the scan on a catalogued build is settled and rolls forward](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-d07055ed56251c81bb86a1506708541c9747138c0623b03a7a4f0bc966af9039R264), or defers the component while a live deploy holds the lock; two held-lock interleavings, each waiting on the scan's lock ticket rather than a timer — [a journal published plus live moved aside between the scan and the end of the pass](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-d07055ed56251c81bb86a1506708541c9747138c0623b03a7a4f0bc966af9039R314), and [a `.complete` landing while the scan waits for the lock](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-d07055ed56251c81bb86a1506708541c9747138c0623b03a7a4f0bc966af9039R346) — recover and retain respectively; an unremovable build is logged, not thrown; the deploy path bounds its own component, leaves its neighbours alone, and still surfaces the deploy's own error; getter coercion (unset/blank/boolean/array/NaN/negative → 5; numeric string, float floor, explicit 0). The 43 existing `deployActivation` tests still pass unchanged.
- **Mutation-checked**: removing the dormant branch fails 3 tests, removing the journal re-check fails exactly the re-check test, removing the bound fails 5 tests, removing the under-lock residue re-classification fails exactly the `.complete`-landed test, and making reconciliation ignore late journals fails exactly the two late-journal tests.
- **End-to-end, route (b)** — [new `integrationTests/deploy/staging-retention.test.ts`](https://github.com/HarperFast/harper/pull/2531/changes?w=1#diff-bc5dd1fd687e402423c9a294e548eefe01d09f5f5264d79f6cecca23ea1153d1R54) starts Harper with `deployment.stagingRetention.maxCount: 1` through the harness's config override, plants two dormant builds beside the running instance, deploys the component once through the operations API, and asserts the deploy landed and only the newest planted build survives. Passes locally. The whole `integrationTests/deploy/` folder also passes locally.
- **Suites**: `unitTests/components/*.test.js` run as one suite locally: 829 pass; the 7 failures (`applicationSpawn` process-group timing, `RuntimeModuleTracker` macOS `/private/var` realpath) reproduce identically on a clean `origin/main` worktree and touch nothing in this diff. `tsc --noEmit`, `oxlint`, `prettier --check` clean on the touched files; the full unit and integration matrix is CI's.
- **Docs**: companion PR HarperFast/documentation#668 adds a `deployment` section to the configuration reference (this knob plus the previously undocumented `payloadRetention.maxSize`) and a 5.3 release note.

Complexity: medium

<sub>Review-Coverage: authored=claude; ran=codex,gemini; adjudicated=domain; declined=cursor-grok,cursor-composer; rounds=6 @ c941cb60854e</sub>

<sub>Human-Review-Need: 3 (decisions: lock-tickets-as-test-oracle) @ c941cb60854e</sub>
