### PR TITLE
Implement the shared derived-index transaction-log runtime

### DIFF
--- a/docs/derived-index-runtime-stage-1.md
+++ b/docs/derived-index-runtime-stage-1.md
@@ -123,6 +123,9 @@ Stage 1 adds an opt-in `includeLogName` value to `RocksTransactionLogStore.getRa
 reuses its existing aggregate iterator, per-log corrupt-frame tracking, new-log discovery, and
 timestamp merge. `AuditRecord.logName` is initialized to `undefined` on both decoded and sentinel
 entries so existing hot consumers keep one stable object shape; it is assigned only when requested.
+The returned iterable also exposes `failedLogs`, naming any physical iterator that ended on an
+unexpected non-corruption error; a derived-index runner treats either that signal or the existing
+corrupt-frame signal as an availability failure and never advances its cursor through it.
 A runner starts the aggregate with its backend's `startByLog` vector and preserves the physical log
 name on every result. Entries from one physical log are assembled through `endTxn`; a drain budget
 is checked only between complete transactions, never in the middle of one.

--- a/docs/derived-index-runtime-stage-1.md
+++ b/docs/derived-index-runtime-stage-1.md
@@ -30,9 +30,9 @@ API, blob extraction, generation activation, or HNSW migration.
 - Conflict retries can re-resolve a record after its transaction-log payload was first staged. The
   audit entry therefore provides durable mutation identity and version evidence, but its embedded
   record is not authoritative for derived-index projection.
-- `Table.evict()` removes the primary row and its transactional custom indexes without writing an
-  audit entry. A derived index cannot mirror cache eviction until Harper adds a local-only eviction
-  marker to the same RocksDB transaction, limited to tables with derived-index registrations.
+- `Table.evict()` ordinarily removes the primary row and its transactional custom indexes without
+  writing an audit entry. A registered derived index adds a local-only eviction marker to that same
+  RocksDB transaction so asynchronous indexing can mirror the removal.
 - Transaction-log retention removes whole files. `TransactionLog.getStats()` exposes the oldest
   retained file sequence, while `exactStart` proves whether a saved transaction boundary remains
   readable.
@@ -231,14 +231,14 @@ in the existing physical transaction log before removing the primary row. It use
 transaction as the version-guarded removal and is `LOCAL_ONLY`: cache residency is local and must not
 replicate. If the transaction conflicts or aborts, neither removal nor marker commits.
 
-The internal action is a no-op in boot replay and does not increment replayed-record counts. Audit
-and transaction-log read APIs filter it from customer output, and replication continues to reject it
-through `LOCAL_ONLY`. The runtime consumes it before those presentation filters.
+The internal action is a no-op in boot replay and does not increment replayed-record counts.
+Customer-facing history and subscription replay filter it, while raw transaction-log readers retain
+it for the derived runtime. Replication continues to reject it through `LOCAL_ONLY`.
 
 This is the only Stage 1 producer change. It is necessary because HNSW and ordinary secondary
 indexes are currently removed synchronously by `updateIndices`, while an asynchronous derived
 index otherwise has no durable evidence that the cached row disappeared. Tables without a derived
-backend keep the current eviction path and cost.
+backend pay only an O(1) registration guard and retain the existing storage writes.
 
 ### Cursor validation and retention gaps
 
@@ -468,8 +468,8 @@ the cursor and batch contracts do not prevent adding cohorts after comparative b
   presenting a clean end-of-log.
 - Prove direct, expires-at sweep, and `createEvictionBatcher` eviction while delivery is deferred all
   remove the document, while a failed eviction transaction emits neither removal nor marker.
-- Prove internal eviction entries are hidden from audit/log read APIs, ignored and uncounted by boot
-  replay, and never sent to a peer.
+- Prove internal eviction entries are hidden from customer history and subscription APIs, ignored
+  and uncounted by boot replay, and never sent to a peer.
 - Prove an out-of-band reload marker triggers rebuild rather than cursor advancement.
 - Reopen after an unclean shutdown and prove the installed rocksdb-js exposes recovered durable
   entries to the ordinary committed reader; never substitute `readUncommitted` in the runtime.

--- a/docs/derived-index-runtime-stage-1.md
+++ b/docs/derived-index-runtime-stage-1.md
@@ -108,6 +108,12 @@ registrations. Each registered backend/index has its own process-wide lock, curs
 runner; multiple full-text indexes can therefore be owned by different workers and enqueue into
 different Tantivy writers in parallel.
 
+Registration is distinct from runner ownership. Schema activation must install the same table
+registrations in every worker before that worker can accept table operations or run eviction; only
+the derived-index drain is lock-elected. This makes the worker-local O(1) eviction guard reliable
+even when another worker owns the backend runner. Schema deactivation removes those registrations
+only after the worker can no longer evict for the old schema.
+
 The runtime listens to the root store's existing `committed` event. The listener only marks a drain
 scheduled and uses `setImmediate`, so commit bursts coalesce. A scheduled runner attempts the
 backend's process-wide lock. A failed `tryLock(key, onUnlocked)` call does not confer ownership when

--- a/docs/derived-index-runtime-stage-1.md
+++ b/docs/derived-index-runtime-stage-1.md
@@ -1,0 +1,480 @@
+# Derived-index runtime: committed log delivery and exact replay foundation
+
+## Goal
+
+Implement the Harper-owned portion of the `DerivedIndexBackend` protocol from
+[HarperFast/harper#2489](https://github.com/HarperFast/harper/issues/2489) before connecting
+Tantivy. Stage 1 must prove that a fake backend receives the authoritative state produced by
+committed mutations, preserves physical transaction-log boundaries, and resumes without skipping
+retained work.
+
+The transaction log is the data path in steady state and after restart. Commit notifications only
+wake bounded index runners. This keeps ordinary delivery off the record transaction, gives live
+delivery and recovery identical semantics, and avoids assigning all work to worker 0.
+
+This stage is internal. It does not add schema directives, query syntax, Tantivy, a customer-visible
+API, blob extraction, generation activation, or HNSW migration.
+
+## Source-grounded constraints
+
+- A RocksDB database has one set of transaction logs partitioned by origin. Every Harper worker can
+  append to the same physical `local` log, while each worker has its own JavaScript
+  `RocksTransactionLogStore` instance.
+- `RocksTransactionLogStore.getRange()` can query one physical log with `start`, `exactStart`, and
+  `exclusiveStart`. Entries carry a transaction timestamp and `endTxn`; ordinary queries exclude
+  uncommitted entries.
+- `RocksDatabase.tryLock()` and `getUserSharedBuffer()` already coordinate work across Harper worker
+  threads. The subscription path uses these primitives where one worker must drain shared state.
+- The root store's `committed` event is a cross-thread notification. It is a wake-up, not proof of
+  which entries a particular worker observed.
+- Conflict retries can re-resolve a record after its transaction-log payload was first staged. The
+  audit entry therefore provides durable mutation identity and version evidence, but its embedded
+  record is not authoritative for derived-index projection.
+- `Table.evict()` removes the primary row and its transactional custom indexes without writing an
+  audit entry. A derived index cannot mirror cache eviction until Harper adds a local-only eviction
+  marker to the same RocksDB transaction, limited to tables with derived-index registrations.
+- Transaction-log retention removes whole files. `TransactionLog.getStats()` exposes the oldest
+  retained file sequence, while `exactStart` proves whether a saved transaction boundary remains
+  readable.
+- An `exactStart` miss can scan to the end of a physical log. Harper already avoids this cost in an
+  audit dedup path by reading the first retained entry before attempting an exact lookup.
+- `RocksTransactionLogStore.getRange()` converts native framing failures into
+  `corruptFrameStop`; a decode failure yields a sentinel with no table or type. A derived reader
+  must consume both signals rather than treating them as end-of-log or an irrelevant entry.
+- The aggregate iterator's `safeNext()` also converts a non-framing iterator failure to
+  `{ done: true }` without updating `corruptFrameStop`. Stage 1 adds a stable failed-log signal to
+  the iterable so derived readers cannot confuse an I/O failure with a clean drain.
+- A peer log can append a transaction key lower than an earlier physical entry. Resumption must use
+  `exactStart` together with `exclusiveStart`: after locating the exact physical boundary,
+  rocksdb-js returns every following transaction regardless of timestamp order.
+- The installed rocksdb-js crash-recovery contract restores durable committed entries to ordinary
+  committed queries on reopen, including entries written after the last RocksDB flush. Stage 1
+  verifies that behavior through Harper instead of using `readUncommitted`.
+- Current HNSW mutation remains synchronous and transactional. Stage 1 establishes the shared
+  post-commit runtime without changing HNSW behavior.
+
+## Invariants
+
+1. Only committed transaction-log entries are delivered. The runtime never enables
+   `readUncommitted`.
+2. At most one worker runs a given backend/index for a database at a time. The elected runner merges
+   that backend's physical logs into one serial delivery stream while keeping a cursor per log.
+3. A backend's cursor is a versioned vector of `log name -> completed transaction timestamp`.
+   Progress advances only at `endTxn` and only after that backend's durability barrier covers the
+   complete transaction.
+4. The live path and restart path use the same cursor validation, aggregate iterator, and dispatch
+   code. Losing a wake-up or filling a backend queue can delay indexing but cannot skip durable log
+   work.
+5. Resume first proves every saved transaction with `exactStart`. A missing, corrupt, truncated, or
+   ambiguous boundary moves the affected backend to `needs-rebuild`; approximate resume is not
+   permitted.
+6. The runtime resolves the current committed primary entry once per changed record in a runner
+   batch and projects only the attributes registered for that backend. Backends never receive the
+   full record or the log entry's potentially stale body.
+7. No exception from log iteration, primary reads, projection, backend delivery, or native unlock
+   callbacks can escape the scheduled drain, block another backend, or interfere with subscriptions
+   and replication.
+8. Ordinary commit-time work is limited to emitting the transaction log and coalescing a wake-up.
+   Registration adds no `aftercommit` listener, retains no `AuditRecord` objects, does not hook
+   `recordUpdater`, and never awaits index work. The only new write-path fact is a local-only eviction
+   marker when a registered caching table removes a row without an existing audit event.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    W1[Harper worker A] -->|commit| L[(physical transaction log)]
+    W2[Harper worker B] -->|commit| L
+    L -->|committed wake-up| R1[worker runtimes]
+    R1 -->|tryLock per backend| D[sticky elected index runner]
+    D -->|merged query with log identity| L
+    D -->|record id and version| P[(authoritative primary store)]
+    P -->|backend projection only| B[one derived backend]
+    B -->|durable cursor vector| C[(backend state)]
+    R1 -. independent lock and runner .-> B2[another derived backend]
+```
+
+### Runtime ownership and wake-up
+
+Each worker creates one `DerivedIndexRuntime` for a RocksDB root store when that database has at
+least one registered derived backend. Worker-local runtimes have the same schema-derived
+registrations. Each registered backend/index has its own process-wide lock, cursor vector, and
+runner; multiple full-text indexes can therefore be owned by different workers and enqueue into
+different Tantivy writers in parallel.
+
+The runtime listens to the root store's existing `committed` event. The listener only marks a drain
+scheduled and uses `setImmediate`, so commit bursts coalesce. A scheduled runner attempts the
+backend's process-wide lock. A failed `tryLock(key, onUnlocked)` call does not confer ownership when
+`onUnlocked` fires; the callback schedules a fresh acquisition attempt, matching the documented
+rocksdb-js contract.
+
+The winner keeps a reusable aggregate iterator and retains this derived-only lock while work is
+active. It drains for bounded count, bytes, and wall time, then yields with `setImmediate`. The lock
+is not taken by record writers, so retaining it across these turns cannot delay commits. After an
+idle grace period—and only after durable progress has caught offered progress—it releases ownership
+and discards the iterator. Cleanup, backend failure, and runtime shutdown release in `finally`;
+another worker can then acquire and exact-resume. Native unlock callbacks are guarded and only
+schedule a fresh `tryLock` attempt. This sticky-but-recoverable ownership avoids rebuilding and
+seeking an iterator for every commit without permanently assigning worker 0.
+
+### Per-backend scan and transaction assembly
+
+Stage 1 adds an opt-in `includeLogName` value to `RocksTransactionLogStore.getRange()` and otherwise
+reuses its existing aggregate iterator, per-log corrupt-frame tracking, new-log discovery, and
+timestamp merge. `AuditRecord.logName` is initialized to `undefined` on both decoded and sentinel
+entries so existing hot consumers keep one stable object shape; it is assigned only when requested.
+A runner starts the aggregate with its backend's `startByLog` vector and preserves the physical log
+name on every result. Entries from one physical log are assembled through `endTxn`; a drain budget
+is checked only between complete transactions, never in the middle of one.
+
+Before constructing or reconstructing an aggregate iterator, the runner validates every saved log
+cursor independently. The aggregate query retains both `exactStart: true` and
+`exclusiveStart: true` for each `startByLog` value. This locates the saved physical transaction,
+excludes it, and still returns a subsequently appended lower timestamp. One runner serializes all
+logs for one backend, so two logs cannot apply competing states for the same primary key
+concurrently.
+
+A bounded drain produces one backend batch, not one call per source transaction. Relevant
+transactions retain their log name and boundary; the batch's `through` vector also records the last
+complete transaction read from every log. A batch containing no relevant mutation can therefore
+advance cursor-only progress with one delivery call instead of allocating an empty transaction for
+every unrelated commit.
+
+Each backend has an independent runner, iterator, progress vector, and backpressure state. If one
+returns `deferred`, only that runner stops. Other indexes continue from their own positions without
+re-reading a lagging backend's history. This deliberately accepts one log decode per index rather
+than a shared scan whose start is pinned to the slowest cursor. Sharing may be added later only for a
+cohort whose cursor distance is bounded and whose independent fallback is preserved.
+
+Within a runner batch, repeated mutations for one `(tableId, recordId)` share one authoritative
+primary read and one backend projection. The runtime never calls the resource `get()` path: a cache
+miss must not fetch from an origin inside the drain. The configured projection runs in Harper and
+returns only declared derived-index attributes; record bodies, credentials, and unrelated fields do
+not cross the backend boundary or enter diagnostic logs.
+
+### Offered progress versus durable progress
+
+Native backends may accept several transactions before their next durability barrier. The runtime
+therefore distinguishes:
+
+- **offered progress**: a process-local, cross-worker watermark recording the last transaction a
+  backend accepted into its queue; and
+- **durable progress**: the backend-owned cursor included in its durable index state.
+
+Offered progress uses one fixed-size `getUserSharedBuffer()` per `(backend id, log name)` and is read
+or changed only while holding the backend runner lock. A separate shared owner epoch is minted from
+an atomic process-wide counter for each worker-local runner instance. When a new epoch acquires the
+lock— including an individual Harper worker restart—it resets offered progress to the backend's
+durable cursor before constructing its iterator. Replaying work that survived in a native queue is
+safe; trusting the dead worker's non-durable position is not.
+
+A backend state-change notification wakes the runner after capacity returns or a barrier advances.
+If the current owner reports that accepted work was lost, it also resets offered progress to durable
+progress and reconstructs the iterator. A full process crash discards all offered progress and
+replays from the durable cursor.
+
+The fake Stage 1 backend acknowledges each complete transaction durably before returning
+`accepted`. This proves the cursor and cross-worker mechanics without pretending to implement the
+later Tantivy queue and barrier.
+
+### Authoritative record resolution
+
+The transaction log decides what must be revisited; the primary store decides what should be in the
+index now. Before delivery, the runtime loads the current committed entry with raw
+`primaryStore.getEntry()` for every unique record id referenced by a relevant mutation:
+
+- a present, locally valid entry yields its current version and projected indexed attributes;
+- a missing, deleted, evicted, or invalidated entry yields absence only because every supported
+  removal now has a durable `delete`, `invalidate`, `relocate`, or local-only `evict` fact;
+- a record newer than the log mutation is delivered at its current version; later log entries for
+  that version are harmless overlap; and
+- `message`, `publish`, and structure-only entries advance progress without becoming indexed
+  documents; a `reload` marker makes affected backends rebuild because its base-copy rows have no
+  per-record log entries.
+
+This is deliberately a latest-state protocol rather than an event-history protocol. Full-text and
+HNSW are materialized views, and backend mutations replace state idempotently by primary key. Reading
+the primary store costs more than passing the in-memory write object, but it avoids indexing an
+attempt that lost a retry and keeps live and replay payloads identical. Drain batching and shared
+resolution amortize that cost outside the commit path.
+
+### Cache eviction marker
+
+For a caching table with a registered derived backend, both `Table.evict()` and
+`createEvictionBatcher().stageInto()` call one helper that stages a bodyless internal eviction entry
+in the existing physical transaction log before removing the primary row. It uses the same RocksDB
+transaction as the version-guarded removal and is `LOCAL_ONLY`: cache residency is local and must not
+replicate. If the transaction conflicts or aborts, neither removal nor marker commits.
+
+The internal action is a no-op in boot replay and does not increment replayed-record counts. Audit
+and transaction-log read APIs filter it from customer output, and replication continues to reject it
+through `LOCAL_ONLY`. The runtime consumes it before those presentation filters.
+
+This is the only Stage 1 producer change. It is necessary because HNSW and ordinary secondary
+indexes are currently removed synchronously by `updateIndices`, while an asynchronous derived
+index otherwise has no durable evidence that the cached row disappeared. Tables without a derived
+backend keep the current eviction path and cost.
+
+### Cursor validation and retention gaps
+
+The cursor format is canonical and versioned. It records a completed transaction timestamp for
+every known physical log, including logs whose transactions had no entries relevant to a backend;
+otherwise a quiet index could retain an old cursor until normal log retention forced an unnecessary
+rebuild.
+
+Before validation, the runtime checks `rootStore.listLogs()` so querying a removed cursor name does
+not recreate an empty log through `useLog()`. It then reads and caches the first retained transaction
+for each log, invalidating the cache when `oldestSequenceNumber` changes. A cursor older than this
+floor goes directly to `needs-rebuild`, avoiding the known full-log cost of an `exactStart` miss.
+
+Every new iterator—startup, owner handoff, or recovery after lost accepted work—anchors each saved
+log with `exactStart`. The first transaction must match the saved timestamp exactly and close exactly
+once before the aggregate starts exclusively after it. An incomplete transaction, two transaction
+boundaries with the same timestamp, a missing saved log, or an exact-start miss produces
+`needs-rebuild` for that backend.
+
+After every bounded iterator pass, the runner inspects `corruptFrameStop` and the new failed-log set.
+Any frame break, terminated per-log iterator, audit decode sentinel, primary read failure, or
+projection failure is fail-closed: the runtime cannot prove the transaction's state, so the backend
+transitions to rebuild rather than treating it as absence or advancing through it. Other backend
+runners encounter the same durable fault independently. This rule is intentionally stricter than
+subscription delivery.
+
+Activation must persist the complete set of log names and a boundary for each log before a base
+scan begins. A subsequently discovered log may start at its first retained transaction only when
+`TransactionLog.getStats().oldestSequenceNumber === 1`; otherwise its unknown prefix requires a
+rebuild. Generation activation and the scan-to-replay handoff are later work, but Stage 1 keeps the
+cursor shape compatible with that requirement.
+
+Supported retention and purge operations are covered by these proofs. Transaction-log mappings can
+continue reading a file after it was purged from disk, so an in-process test cannot prove the
+retention-gap branch. Qualification closes and reopens the database in a child process before
+asserting the exact-anchor miss and rebuild transition. Out-of-band deletion and
+recreation of a log directory with the same name and no surviving cursor boundary cannot be
+distinguished with the supported rocksdb-js API. Harper will not claim detection for that
+unsupported filesystem mutation. A saved boundary normally makes recreation fail `exactStart` and
+therefore rebuild.
+
+Harper does not pin transaction-log retention in Stage 1. A backend lagging past retention rebuilds
+when its next exact anchor fails. Runtime status records cursor age and log-floor distance, and emits
+one error and one metric per transition to `needs-rebuild`, so this availability loss is visible.
+
+### Backend boundary
+
+The runtime-facing contract remains storage-engine-neutral:
+
+```ts
+type DerivedIndexCursor = {
+	format: 1;
+	logs: Record<string, number>;
+};
+
+type DerivedIndexTransaction = {
+	logName: string;
+	timestamp: number;
+	mutations: DerivedIndexMutation[];
+};
+
+type DerivedIndexBatch = {
+	transactions: DerivedIndexTransaction[];
+	through: DerivedIndexCursor;
+};
+
+type DerivedIndexMutation = {
+	tableId: number;
+	recordId: Id;
+	logVersion: number;
+	state: { kind: 'record'; version: number; projection: unknown } | { kind: 'absent' };
+};
+
+interface DerivedIndexBackend {
+	readonly id: string;
+	getDurableCursor(): DerivedIndexCursor | undefined;
+	deliver(batch: DerivedIndexBatch): DerivedIndexDeliveryResult;
+	onStateChange(wake: () => void): () => void;
+}
+
+type DerivedIndexRegistration = {
+	backend: DerivedIndexBackend;
+	projections: ReadonlyMap<number, (record: unknown) => unknown>;
+};
+```
+
+`DerivedIndexRegistration` belongs to Harper. Its projection functions are compiled from schema
+attributes and execute before `deliver()`, so the backend receives only its declared materialized
+view. They are not customer callbacks.
+
+`DerivedIndexDeliveryResult` uses exported numeric constants rather than allocating result objects
+on the drain path. A `deliver()` call is included in the runner's wall-time budget and may not wait
+on a writer mutex or merge. `accepted` means the backend owns the batch; it does not authorize durable
+cursor advancement until the backend's barrier includes its `through` vector. `deferred` preserves the
+cursor and requires a later state-change wake. A permanent failure transitions the backend to
+`needs-rebuild` and emits one contextual error outside the write path.
+
+The cursor remains backend-owned because its atomic durability mechanism differs by engine:
+Tantivy includes it in published index state, while a future HNSW implementation stores it with the
+plane generation. Harper owns validation, iteration, coordination, and rebuild transitions.
+
+## Failure and recovery flow
+
+```mermaid
+flowchart TD
+    A[load backend cursor] --> B{all saved logs and boundaries exact?}
+    B -->|no| R[mark needs-rebuild and report once]
+    B -->|yes| W[wait for commit or backend wake]
+    W --> L{acquire backend runner lock?}
+    L -->|no| W
+    L -->|yes| Q[exact-anchor each log and merge]
+    Q --> T[assemble bounded complete transactions]
+    T --> P[resolve and project current state]
+    P --> O{backend outcome}
+    O -->|accepted| N[advance offered progress]
+    O -->|deferred| H[hold backend at cursor]
+    O -->|failed| R
+    N --> D{backend barrier durable?}
+    D -->|later| C[persist durable cursor and wake]
+    D -->|not yet| T
+    C --> T
+    H --> W
+```
+
+## Approaches considered
+
+**Invariant:** every committed mutation relevant to a derived index is eventually reflected in the
+index, or that index is explicitly unavailable pending rebuild; cursor advancement can never hide
+unapplied work.
+
+### Different layer
+
+The transaction-log reader in the resource layer owns delivery. Extending `transactionBroadcast`
+with full-database subscriptions and a durable cursor would reuse its wake-up and batching, but its
+state is one scalar per subscription set, its active-count lifecycle is customer-facing, and its
+aggregate results omit the log identity required by a cursor vector. Stage 1 reuses the aggregate
+iterator and scheduling patterns without coupling index availability or backpressure to customer
+subscriptions. Putting the reader in each backend would duplicate Harper's corruption, retention,
+and replay rules.
+
+### Deeper cause
+
+Running derived-index mutation inside the primary write transaction would prevent divergence and is
+how current HNSW custom-index updates behave. It is rejected for this protocol because neither
+Tantivy nor the native HNSW plane shares RocksDB transaction rollback: pre-commit application can
+leave phantoms after abort, adds index latency to record writes, and cannot atomically commit the two
+stores.
+
+A transactional intent outbox would instead write `(tableId, recordId, version)` into a separate
+column family in the same RocksDB transaction and drain that durable queue. It avoids transaction-log
+retention, but adds another write, compaction stream, cleanup protocol, and recovery store to every
+indexed mutation even though the existing transaction log already records the same identity. The
+design rejects that hot-path write amplification and second source of mutation truth.
+
+### Do less
+
+Rebuilding every derived index from the primary table on every process start avoids cursors and
+replay. It is correct but not operationally viable for catalogs containing hundreds of millions of
+records, and it turns an ordinary restart into a long period without search. Rebuild remains the
+fail-closed recovery path when retained log continuity cannot be proved.
+
+Pinning log reclamation to the slowest derived cursor would reduce rebuilds. Current rocksdb-js has
+no protected-position registration: `purgeLogs()` accepts time/name filters and its configured
+retention still applies independently. Harper will not introduce a rocksdb-js primitive for this
+stage. Instead it exposes lag, exact-checks every reconstructed reader, and rebuilds when retention
+wins. A later availability improvement may add a Harper-controlled maximum-lag policy, but cannot
+silently weaken the exactness rule.
+
+Keeping evicted documents in the derived index and filtering search candidates against the primary
+store would avoid an eviction marker. Harper's transactional indexes, including current HNSW, remove
+their entries during both direct and batched eviction. Retaining full-text documents would make this
+index the exception and add a primary point read to result filtering, directly consuming the search
+latency budget. The design instead mirrors Harper's existing index lifecycle.
+
+### Chosen
+
+A bounded, lock-elected runner per backend uses the transaction log for both live and restart
+delivery. Compared with same-thread `aftercommit` dispatch, it gives one serial backend stream and a
+well-defined cursor vector for logs shared by all workers, avoids retaining every audit object in a
+database transaction, and resolves the authoritative post-retry record. Compared with a permanent
+worker-0 drainer, different indexes can elect different workers and run in parallel. Compared with a
+single shared scan, a lagging index cannot force healthy indexes to rescan its backlog or starve at
+the head.
+
+A later optimization may run one shared head reader for indexes whose cursors remain within a
+bounded cohort and move a lagging member to its own catch-up runner. That avoids N decodes in the
+common aligned case without pinning healthy indexes to the slowest cursor. Stage 1 has one fake
+backend and no measured N-scan bottleneck, so it establishes the independent runner fallback first;
+the cursor and batch contracts do not prevent adding cohorts after comparative benchmarks.
+
+## Verification
+
+### Correctness
+
+- Real audited RocksDB writes: put, patch, delete, eviction/invalidation, multi-record transaction,
+  aborted transaction, and replicated/source-timestamp transaction.
+- Prove ordinary queries exclude a failed commit's staged log entries.
+- Force coordinated and `ERR_BUSY` retry paths; compare delivered state with the committed primary
+  state.
+- Interleave two workers writing the same `local` log and prove one complete, ordered delivery per
+  transaction with no cursor leap.
+- Interleave local and replicated writes to the same record across two physical logs; prove one
+  backend runner preserves enqueue order and converges to current primary state.
+- Append a lower origin transaction key after a higher key in one physical peer log, resume from
+  the higher boundary, and prove `exactStart + exclusiveStart` still delivers the later physical
+  entry.
+- Prove one backend's throw, malformed result, deferral, and recovery do not affect another backend
+  or the existing subscription and replication listeners.
+- Force primary-read and projection throws inside a scheduled drain; prove the backend rebuilds,
+  the lock releases, and the worker remains healthy.
+- Compare an uninterrupted fake index with one rebuilt by exact replay from every possible durable
+  transaction boundary.
+- Prove exact resume, missing saved log, exact-start miss, new-log discovery, retention gap,
+  corrupt/truncated transaction, and duplicate transaction timestamp behavior.
+- Prove a corrupt-frame stop and undecodable sentinel transition to rebuild without advancing any
+  affected cursor.
+- Inject a non-framing per-log iterator failure and prove the failed-log signal rebuilds rather than
+  presenting a clean end-of-log.
+- Prove direct, expires-at sweep, and `createEvictionBatcher` eviction while delivery is deferred all
+  remove the document, while a failed eviction transaction emits neither removal nor marker.
+- Prove internal eviction entries are hidden from audit/log read APIs, ignored and uncounted by boot
+  replay, and never sent to a peer.
+- Prove an out-of-band reload marker triggers rebuild rather than cursor advancement.
+- Reopen after an unclean shutdown and prove the installed rocksdb-js exposes recovered durable
+  entries to the ordinary committed reader; never substitute `readUncommitted` in the runtime.
+- Queue behind an occupied backend lock and prove its unlock callback retries `tryLock` before
+  running and that every acquired path releases on stop or failure.
+- Terminate the elected worker with accepted but non-durable work; prove the new owner epoch resets
+  offered progress to the durable cursor and redelivers it.
+- Use an asynchronous fake durability barrier and bounded queue, not only the immediate-durable fake,
+  for backpressure, handoff, and crash tests.
+- Assert the runtime-observed eligible mutation identity multiset against the committed workload in
+  addition to comparing final index state, so convergence cannot hide a skipped transaction.
+- Saturate the fake backend, drop live wake-ups, then release capacity and prove it catches up from
+  its durable cursor without missing a mutation.
+
+### Performance and bounds
+
+- Assert that backend registration does not add an `aftercommit` listener or cause
+  `transaction.logEntries` retention solely for derived indexing, including while an unrelated
+  same-thread subscription is active.
+- Assert one backend call per bounded drain batch, including cursor-only batches, rather than one
+  empty delivery per unrelated transaction.
+- Verify `AuditRecord` keeps a stable `logName` field shape with and without `includeLogName` and run
+  the existing subscription/replication performance coverage against the default iterator.
+- Apply count, byte, and wall-time budgets between complete transactions; a single oversized
+  transaction is handled as an explicit bounded exception rather than silently split.
+- Benchmark write throughput and event-loop delay with no backend, an idle backend on an unrelated
+  table, and an active backend.
+- Benchmark one versus several derived indexes to measure per-index log decoding and seeks, sticky
+  iterator reuse, native enqueue throughput, deferred recovery, and independent runner parallelism.
+- Benchmark aligned and intentionally divergent index cursors before considering a shared scan
+  cohort; no cohort optimization is part of Stage 1.
+- Exercise a large transaction to prove memory is bounded by the configured drain batch plus one
+  complete transaction, not by all writes retained until commit.
+
+### Repository gates
+
+- Add focused resource unit coverage and the existing cross-worker harness coverage.
+- Run the resource unit gate and the repository's full required unit and integration gates before
+  PR promotion.
+- End-to-end verification for Stage 1 is a real audited RocksDB table feeding the fake backend
+  through commit, bounded drain, cursor persistence, restart, and replay. Tantivy equivalence is a
+  later integration gate.

--- a/docs/derived-index-runtime-stage-1.md
+++ b/docs/derived-index-runtime-stage-1.md
@@ -36,8 +36,10 @@ API, blob extraction, generation activation, or HNSW migration.
 - Transaction-log retention removes whole files. `TransactionLog.getStats()` exposes the oldest
   retained file sequence, while `exactStart` proves whether a saved transaction boundary remains
   readable.
-- An `exactStart` miss can scan to the end of a physical log. Harper already avoids this cost in an
-  audit dedup path by reading the first retained entry before attempting an exact lookup.
+- An `exactStart` miss can scan to the end of a physical log. Because transaction timestamps can
+  move backward, neither the first retained timestamp nor `oldestSequenceNumber` can prove that a
+  timestamp cursor was purged. Stage 1 accepts this reconstruction-time scan rather than making an
+  unsafe timestamp comparison.
 - `RocksTransactionLogStore.getRange()` converts native framing failures into
   `corruptFrameStop`; a decode failure yields a sentinel with no table or type. A derived reader
   must consume both signals rather than treating them as end-of-log or an irrelevant entry.
@@ -45,8 +47,12 @@ API, blob extraction, generation activation, or HNSW migration.
   `{ done: true }` without updating `corruptFrameStop`. Stage 1 adds a stable failed-log signal to
   the iterable so derived readers cannot confuse an I/O failure with a clean drain.
 - A peer log can append a transaction key lower than an earlier physical entry. Resumption must use
-  `exactStart` together with `exclusiveStart`: after locating the exact physical boundary,
-  rocksdb-js returns every following transaction regardless of timestamp order.
+  `exactStart` and consume its anchor from the same iterator: after locating the exact physical
+  boundary, rocksdb-js returns every following transaction regardless of timestamp order.
+- Harper replay and rocksdb-js `exactStart` already treat a transaction timestamp as the identity of
+  one transaction within a physical log. Stage 1 keeps that existing invariant rather than adding a
+  second log identity. If the runner observes the same timestamp closing twice in one physical log,
+  it fails the backend closed and requires a rebuild.
 - The installed rocksdb-js crash-recovery contract restores durable committed entries to ordinary
   committed queries on reopen, including entries written after the last RocksDB flush. Stage 1
   verifies that behavior through Harper instead of using `readUncommitted`.
@@ -130,12 +136,15 @@ A runner starts the aggregate with its backend's `startByLog` vector and preserv
 name on every result. Entries from one physical log are assembled through `endTxn`; a drain budget
 is checked only between complete transactions, never in the middle of one.
 
-Before constructing or reconstructing an aggregate iterator, the runner validates every saved log
-cursor independently. The aggregate query retains both `exactStart: true` and
-`exclusiveStart: true` for each `startByLog` value. This locates the saved physical transaction,
-excludes it, and still returns a subsequently appended lower timestamp. One runner serializes all
-logs for one backend, so two logs cannot apply competing states for the same primary key
-concurrently.
+On construction or reconstruction, the aggregate reader exact-seeks each saved log cursor, validates
+and consumes exactly one complete anchor transaction per saved log, then merges from those same
+per-log iterators. It reports a missing or incomplete anchor and a second transaction boundary with
+the same timestamp. Keeping validation and continuation in one iterator closes the race in which an
+independently validated duplicate timestamp could commit before an exclusive resume and then be
+skipped. A later physical transaction with a lower timestamp still follows the anchor and is
+delivered. A newly discovered log without a saved cursor scans from its beginning only when its
+oldest retained sequence is `1`; otherwise it forces a rebuild. One runner serializes all logs for
+one backend, so two logs cannot apply competing states for the same primary key concurrently.
 
 A bounded drain produces one backend batch, not one call per source transaction. Relevant
 transactions retain their log name and boundary; the batch's `through` vector also records the last
@@ -160,21 +169,34 @@ not cross the backend boundary or enter diagnostic logs.
 Native backends may accept several transactions before their next durability barrier. The runtime
 therefore distinguishes:
 
-- **offered progress**: a process-local, cross-worker watermark recording the last transaction a
-  backend accepted into its queue; and
+- **offered progress**: the current owner's in-memory record of complete cursor vectors the backend
+  accepted into its queue; and
 - **durable progress**: the backend-owned cursor included in its durable index state.
 
-Offered progress uses one fixed-size `getUserSharedBuffer()` per `(backend id, log name)` and is read
-or changed only while holding the backend runner lock. A separate shared owner epoch is minted from
-an atomic process-wide counter for each worker-local runner instance. When a new epoch acquires the
-lock— including an individual Harper worker restart—it resets offered progress to the backend's
-durable cursor before constructing its iterator. Replaying work that survived in a native queue is
-safe; trusting the dead worker's non-durable position is not.
+Offered progress is read or changed only while holding the backend runner lock. A shared owner epoch
+is minted from an atomic process-wide counter for each ownership acquisition and included in every
+batch, allowing a backend to distinguish callbacks or queued work from different owners. When a new
+epoch acquires the lock—including after an individual Harper worker restart—it resets offered
+progress to the backend's durable cursor before constructing its iterator. Replaying work that
+survived in a native queue is safe; trusting the dead worker's non-durable position is not.
 
 A backend state-change notification wakes the runner after capacity returns or a barrier advances.
 If the current owner reports that accepted work was lost, it also resets offered progress to durable
 progress and reconstructs the iterator. A full process crash discards all offered progress and
 replays from the durable cursor.
+
+The owner retains the complete cursor vector for each accepted batch until the backend advances its
+durable barrier. A reported durable cursor must exactly equal one of those vectors; validating each
+log independently would allow a backend to assemble a cursor from different batch boundaries and
+hide work. Once a full vector becomes durable, older offered vectors and their duplicate-detection
+window are discarded. The backend must therefore publish the `through` vector atomically with the
+index state made durable by that barrier.
+
+Accepted-but-not-durable progress is capped at 64 batches by default. At the cap, the runner retains
+ownership but stops reading and enters `waiting-durable`; database commit wakes do not retry it. A
+backend state-change wake reconciles its cursor and resumes only after a complete offered vector has
+become durable. Backend-returned `deferred` batches follow the same wake discipline, preventing an
+unrelated database write stream from repeatedly probing a saturated native queue.
 
 The fake Stage 1 backend acknowledges each complete transaction durably before returning
 `accepted`. This proves the cursor and cross-worker mechanics without pretending to implement the
@@ -225,16 +247,21 @@ every known physical log, including logs whose transactions had no entries relev
 otherwise a quiet index could retain an old cursor until normal log retention forced an unnecessary
 rebuild.
 
-Before validation, the runtime checks `rootStore.listLogs()` so querying a removed cursor name does
-not recreate an empty log through `useLog()`. It then reads and caches the first retained transaction
-for each log, invalidating the cache when `oldestSequenceNumber` changes. A cursor older than this
-floor goes directly to `needs-rebuild`, avoiding the known full-log cost of an `exactStart` miss.
-
-Every new iterator—startup, owner handoff, or recovery after lost accepted work—anchors each saved
-log with `exactStart`. The first transaction must match the saved timestamp exactly and close exactly
-once before the aggregate starts exclusively after it. An incomplete transaction, two transaction
-boundaries with the same timestamp, a missing saved log, or an exact-start miss produces
+Before opening an iterator, the runtime checks `rootStore.listLogs()` so querying a removed cursor
+name does not recreate an empty log through `useLog()`. Every new iterator—startup, owner handoff, or
+recovery after lost accepted work—uses `exactStart` for saved logs and asks the aggregate reader to
+resume after one physical transaction rather than applying a value-based exclusive filter. Its
+in-stream anchor phase requires the first matching transaction to close exactly once before any
+following transaction is eligible for delivery. The range's `exactStartFailures` map distinguishes a
+missing, incomplete, or duplicate boundary. Any such failure or a missing saved log produces
 `needs-rebuild` for that backend.
+
+`oldestSequenceNumber` remains useful for lag telemetry and for deciding whether a newly discovered
+log can safely start at its beginning, but it is not compared with a timestamp cursor. The current
+rocksdb-js iterator does not expose the physical sequence and offset of yielded entries, and a lower
+timestamp can be appended in a later sequence. Stage 1 therefore pays a possible full-log scan only
+when reconstructing an owner whose exact cursor has been lost to retention; sticky ownership keeps
+that work off steady-state drains.
 
 After every bounded iterator pass, the runner inspects `corruptFrameStop` and the new failed-log set.
 Any frame break, terminated per-log iterator, audit decode sentinel, primary read failure, or
@@ -279,6 +306,7 @@ type DerivedIndexTransaction = {
 };
 
 type DerivedIndexBatch = {
+	ownerEpoch: bigint;
 	transactions: DerivedIndexTransaction[];
 	through: DerivedIndexCursor;
 };
@@ -294,7 +322,7 @@ interface DerivedIndexBackend {
 	readonly id: string;
 	getDurableCursor(): DerivedIndexCursor | undefined;
 	deliver(batch: DerivedIndexBatch): DerivedIndexDeliveryResult;
-	onStateChange(wake: () => void): () => void;
+	onStateChange(wake: (change?: 'changed' | 'accepted-work-lost' | 'failed') => void): () => void;
 }
 
 type DerivedIndexRegistration = {
@@ -307,12 +335,15 @@ type DerivedIndexRegistration = {
 attributes and execute before `deliver()`, so the backend receives only its declared materialized
 view. They are not customer callbacks.
 
-`DerivedIndexDeliveryResult` uses exported numeric constants rather than allocating result objects
-on the drain path. A `deliver()` call is included in the runner's wall-time budget and may not wait
-on a writer mutex or merge. `accepted` means the backend owns the batch; it does not authorize durable
-cursor advancement until the backend's barrier includes its `through` vector. `deferred` preserves the
-cursor and requires a later state-change wake. A permanent failure transitions the backend to
-`needs-rebuild` and emits one contextual error outside the write path.
+`DerivedIndexDeliveryResult` uses the exported numeric constants `DERIVED_INDEX_ACCEPTED`,
+`DERIVED_INDEX_DEFERRED`, and `DERIVED_INDEX_FAILED` rather than allocating result objects on the
+drain path. A `deliver()` call is included in the runner's wall-time budget and may not wait on a
+writer mutex or merge. `accepted` means the backend owns the batch; it does not authorize durable
+cursor advancement until the backend's barrier includes its `through` vector. `deferred` preserves
+the batch and requires a later state-change wake. A backend reports discarded accepted-but-not-
+durable queue contents as `accepted-work-lost`, causing the current owner to reconstruct from the
+durable cursor. A permanent failure transitions the backend to `needs-rebuild` and emits one
+contextual error outside the write path.
 
 The cursor remains backend-owned because its atomic durability mechanism differs by engine:
 Tantivy includes it in published index state, while a future HNSW implementation stores it with the
@@ -327,8 +358,8 @@ flowchart TD
     B -->|yes| W[wait for commit or backend wake]
     W --> L{acquire backend runner lock?}
     L -->|no| W
-    L -->|yes| Q[exact-anchor each log and merge]
-    Q --> T[assemble bounded complete transactions]
+    L -->|yes| Q[merge and validate exact anchors in-stream]
+    Q --> T[discard anchors, assemble bounded complete transactions]
     T --> P[resolve and project current state]
     P --> O{backend outcome}
     O -->|accepted| N[advance offered progress]
@@ -421,7 +452,7 @@ the cursor and batch contracts do not prevent adding cohorts after comparative b
 - Interleave local and replicated writes to the same record across two physical logs; prove one
   backend runner preserves enqueue order and converges to current primary state.
 - Append a lower origin transaction key after a higher key in one physical peer log, resume from
-  the higher boundary, and prove `exactStart + exclusiveStart` still delivers the later physical
+  the higher boundary, and prove same-iterator anchor consumption still delivers the later physical
   entry.
 - Prove one backend's throw, malformed result, deferral, and recovery do not affect another backend
   or the existing subscription and replication listeners.

--- a/resources/DESIGN.md
+++ b/resources/DESIGN.md
@@ -12,24 +12,26 @@ See also: `../DESIGN.md` for cross-cutting non-obvious internals (RecordObject p
 
 ## File overview
 
-| File                    | Purpose                                                                                                                                      |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Resource.ts`           | Base class; `transactional()` wrapper; method routing                                                                                        |
-| `Table.ts`              | Table-as-Resource implementation. Factory `makeTable()` returns a `TableResource` subclass per table. **See section markers below.**         |
-| `Resources.ts`          | Registry mapping URL paths → Resource classes                                                                                                |
-| `RequestTarget.ts`      | Parses path/query into a structured target                                                                                                   |
-| `ResourceInterface.ts`  | Type definitions (`Context`, `Record`, etc.)                                                                                                 |
-| `RecordEncoder.ts`      | msgpack encoding + `entryMap` (record → storage entry)                                                                                       |
-| `IterableEventQueue.ts` | Async iterable used for subscriptions and streaming responses                                                                                |
-| `transaction.ts`        | Per-request transaction object stored in `contextStorage`                                                                                    |
-| `auditStore.ts`         | Append-only audit log records                                                                                                                |
-| `recordLock.ts`         | Exclusive record locks (harper#483): option contract, native key lock primitives (`lockAttemptKey`, `makeKeyLockHandle`, `acquireRecordKey`) |
-| `nodeIdMapping.ts`      | Maps node IDs ↔ timestamps for replication ordering                                                                                          |
-| `openApi.ts`            | Generates OpenAPI/JSON Schema from `@export` schemas                                                                                         |
-| `defineTable.ts`        | Code-first table authoring (`defineTable` + `types`) — a TS front-end to the canonical `table()` model                                       |
-| `defineResource.ts`     | Per-method request contract (`defineResource` / `Resource.withSchema`, `t`, `schemaOf`) — typed handlers + edge validation                   |
-| `jsonSchemaTypes.ts`    | Shared `JsonSchemaFragment` IR + `attributeToFragment` projector (one vocabulary for validation/OpenAPI/MCP)                                 |
-| `analytics/`            | Telemetry recording (separate from monitoring)                                                                                               |
+| File                      | Purpose                                                                                                                                      |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Resource.ts`             | Base class; `transactional()` wrapper; method routing                                                                                        |
+| `Table.ts`                | Table-as-Resource implementation. Factory `makeTable()` returns a `TableResource` subclass per table. **See section markers below.**         |
+| `Resources.ts`            | Registry mapping URL paths → Resource classes                                                                                                |
+| `RequestTarget.ts`        | Parses path/query into a structured target                                                                                                   |
+| `ResourceInterface.ts`    | Type definitions (`Context`, `Record`, etc.)                                                                                                 |
+| `RecordEncoder.ts`        | msgpack encoding + `entryMap` (record → storage entry)                                                                                       |
+| `IterableEventQueue.ts`   | Async iterable used for subscriptions and streaming responses                                                                                |
+| `transaction.ts`          | Per-request transaction object stored in `contextStorage`                                                                                    |
+| `auditStore.ts`           | Append-only audit log records                                                                                                                |
+| `derivedIndexRuntime.ts`  | Lock-elected, cursor-based delivery of committed RocksDB log mutations to derived-index backends                                             |
+| `derivedIndexRegistry.ts` | Worker-local registration counts used to emit cache-eviction markers only for tables with derived indexes                                    |
+| `recordLock.ts`           | Exclusive record locks (harper#483): option contract, native key lock primitives (`lockAttemptKey`, `makeKeyLockHandle`, `acquireRecordKey`) |
+| `nodeIdMapping.ts`        | Maps node IDs ↔ timestamps for replication ordering                                                                                          |
+| `openApi.ts`              | Generates OpenAPI/JSON Schema from `@export` schemas                                                                                         |
+| `defineTable.ts`          | Code-first table authoring (`defineTable` + `types`) — a TS front-end to the canonical `table()` model                                       |
+| `defineResource.ts`       | Per-method request contract (`defineResource` / `Resource.withSchema`, `t`, `schemaOf`) — typed handlers + edge validation                   |
+| `jsonSchemaTypes.ts`      | Shared `JsonSchemaFragment` IR + `attributeToFragment` projector (one vocabulary for validation/OpenAPI/MCP)                                 |
+| `analytics/`              | Telemetry recording (separate from monitoring)                                                                                               |
 
 ---
 

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -30,12 +30,15 @@ type TransactionLogIterator = Iterator<TransactionEntry | number> & {
 
 type TrackedIterator = IterableIterator<TransactionEntry> & { lastVersion?: number; lastEndTxn?: boolean };
 type NamedTransactionEntry = TransactionEntry & { logName?: string };
+export type ExactStartFailure = 'missing' | 'incomplete' | 'duplicate';
 
 export type TransactionLogIterable = Iterable<AuditRecord> & {
 	/** Corrupt frames that ended a log's iteration during this range. */
 	corruptFrameStop: CorruptFrameStop;
 	/** Physical logs whose iterators ended with an unexpected, non-corruption error. */
 	failedLogs: Set<string>;
+	/** Physical logs whose requested exact transaction could not form one unambiguous resume boundary. */
+	exactStartFailures: Map<string, ExactStartFailure>;
 };
 
 const reportCorruptFrame = createCorruptFrameReporter(harperLogger);
@@ -255,6 +258,8 @@ export class RocksTransactionLogStore extends EventEmitter {
 		readUncommitted?: boolean;
 		/** Include the source transaction-log name on each returned audit record. */
 		includeLogName?: boolean;
+		/** Validate and consume one complete exact-start transaction per entry in `startByLog`. */
+		resumeAfterExactStart?: boolean;
 		/**
 		 * Track which version a break truncated, in `corruptFrameStop.truncatedVersions`. Costs two
 		 * property stores per yielded entry (see below), so it defaults off: only boot replay reads
@@ -269,6 +274,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 		const attributeCorruption = options.trackCorruptTransactions === true;
 		const corruptFrameStop: CorruptFrameStop = { breaks: 0, truncatedVersions: new Set(), midLogBreak: false };
 		const failedLogs = new Set<string>();
+		const exactStartFailures = new Map<string, ExactStartFailure>();
 		const failedIterators = new WeakSet<IterableIterator<TransactionEntry>>();
 		const safeNext = (iterator: IterableIterator<TransactionEntry>, log: TransactionLog) => {
 			if (failedIterators.has(iterator)) return { value: undefined, done: true } as IteratorResult<TransactionEntry>;
@@ -282,6 +288,30 @@ export class RocksTransactionLogStore extends EventEmitter {
 				});
 				return { value: undefined, done: true } as IteratorResult<TransactionEntry>;
 			}
+		};
+		const resumePastExactStart = (
+			result: IteratorResult<TransactionEntry>,
+			iterator: TrackedIterator,
+			log: TransactionLog,
+			expected: number
+		): IteratorResult<TransactionEntry> => {
+			if (result.done || result.value.timestamp !== expected) {
+				exactStartFailures.set(log.name, 'missing');
+				return { value: undefined, done: true };
+			}
+			while (!result.value.endTxn) {
+				result = safeNext(iterator, log);
+				if (result.done || result.value.timestamp !== expected) {
+					exactStartFailures.set(log.name, 'incomplete');
+					return { value: undefined, done: true };
+				}
+			}
+			result = safeNext(iterator, log);
+			if (!result.done && result.value.timestamp === expected) {
+				exactStartFailures.set(log.name, 'duplicate');
+				return { value: undefined, done: true };
+			}
+			return result;
 		};
 		// Each log's iterator carries the version and endTxn of the last entry it yielded, so a break
 		// can be attributed to the source transaction whose remaining entries it swallowed — unless
@@ -320,22 +350,34 @@ export class RocksTransactionLogStore extends EventEmitter {
 					log = this.rootStore.useLog(options.log);
 				}
 			}
-			const queryIterator = trackCorruptFrames(log, options);
+			const resumeAfterExactStart =
+				options.resumeAfterExactStart === true && options.exactStart === true && options.start !== undefined;
+			const queryOptions = resumeAfterExactStart ? { ...options, exclusiveStart: false } : options;
+			const queryIterator = trackCorruptFrames(log, queryOptions);
 			singleLogIterator = queryIterator;
-			iterable.iterate = options.includeLogName
-				? () => ({
-						next: () => {
-							const result = queryIterator.next();
-							if (!result.done) (result.value as NamedTransactionEntry).logName = log.name;
-							return result;
-						},
-						return: (value?: any) => queryIterator.return?.(value) ?? { value, done: true },
-						throw: (error?: any) => {
-							if (queryIterator.throw) return queryIterator.throw(error);
-							throw error;
-						},
-					})
-				: () => queryIterator;
+			let exactStartObserved = !resumeAfterExactStart;
+			iterable.iterate =
+				options.includeLogName || resumeAfterExactStart
+					? () => ({
+							next: () => {
+								let result = safeNext(queryIterator, log);
+								if (!exactStartObserved) {
+									exactStartObserved = true;
+									if (resumeAfterExactStart) result = resumePastExactStart(result, queryIterator, log, options.start);
+								}
+								if (!result.done && options.includeLogName) (result.value as NamedTransactionEntry).logName = log.name;
+								return result;
+							},
+							[Symbol.iterator]() {
+								return this;
+							},
+							return: (value?: any) => queryIterator.return?.(value) ?? { value, done: true },
+							throw: (error?: any) => {
+								if (queryIterator.throw) return queryIterator.throw(error);
+								throw error;
+							},
+						})
+					: () => queryIterator;
 		} else {
 			const onlyKeys = options.onlyKeys;
 			let logs: TransactionLog[] = [];
@@ -343,6 +385,8 @@ export class RocksTransactionLogStore extends EventEmitter {
 			let nextEntries: any[];
 			let latestUpdates: number;
 			const iterators: TrackedIterator[] = [];
+			const expectedExactStarts: Array<number | undefined> = [];
+			const observedExactStarts = new Set<string>();
 			const updateIterators = () => {
 				if (latestUpdates !== this.updates) {
 					const latestLogs = (this.nodeLogs || this.loadLogs()).filter(
@@ -352,9 +396,18 @@ export class RocksTransactionLogStore extends EventEmitter {
 						if (!logs.includes(log)) {
 							logs.push(log);
 							let queryOptions = options;
+							let expectedExactStart: number | undefined;
 							if (options.startByLog) {
-								// if the startByLog is provided, we use that
-								queryOptions = { ...options, start: options.startByLog.get(log.name) ?? 0 };
+								if (options.startByLog.has(log.name)) {
+									expectedExactStart = options.startByLog.get(log.name)!;
+									queryOptions = {
+										...options,
+										start: expectedExactStart,
+										exclusiveStart: options.resumeAfterExactStart ? false : options.exclusiveStart,
+									};
+								} else {
+									queryOptions = { ...options, start: 0, exactStart: false, exclusiveStart: false };
+								}
 							} else if (latestUpdates >= 0) {
 								// if this is not the first update, that means that this is a brand new log and if start wasn't specified
 								// that means we are taking all future requests, so we need to start at zero so we don't introduce a race
@@ -362,6 +415,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 								queryOptions = { ...options, start: options.start ?? 0 };
 							}
 							iterators.push(trackCorruptFrames(log, queryOptions));
+							expectedExactStarts.push(expectedExactStart);
 						}
 					}
 					latestUpdates = this.updates;
@@ -370,12 +424,22 @@ export class RocksTransactionLogStore extends EventEmitter {
 							let log = logs[i];
 							if (!latestLogs.includes(log)) {
 								logs.splice(i, 1);
-								iterators.splice(i--, 1);
+								iterators.splice(i, 1);
+								expectedExactStarts.splice(i--, 1);
 							}
 						}
 					}
 				}
-				nextEntries = iterators.map((iterator, i) => safeNext(iterator, logs[i]));
+				nextEntries = iterators.map((iterator, i) => {
+					const result = safeNext(iterator, logs[i]);
+					const expected = expectedExactStarts[i];
+					if (expected !== undefined && !observedExactStarts.has(logs[i].name)) {
+						observedExactStarts.add(logs[i].name);
+						if (options.resumeAfterExactStart) return resumePastExactStart(result, iterator, logs[i], expected);
+						if (result.done || result.value.timestamp !== expected) exactStartFailures.set(logs[i].name, 'missing');
+					}
+					return result;
+				});
 			};
 			updateIterators();
 
@@ -449,6 +513,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 					if (index >= 0) {
 						logs.splice(index, 1);
 						iterators.splice(index, 1);
+						expectedExactStarts.splice(index, 1);
 						nextEntries.splice(index, 1);
 						options.excludeLogs.push(logName);
 					}
@@ -523,6 +588,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 		}
 		mappedAggregateIterable.corruptFrameStop = corruptFrameStop;
 		mappedAggregateIterable.failedLogs = failedLogs;
+		mappedAggregateIterable.exactStartFailures = exactStartFailures;
 		return mappedAggregateIterable as TransactionLogIterable;
 	}
 	getKeys(_options?: any) {

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -29,10 +29,13 @@ type TransactionLogIterator = Iterator<TransactionEntry | number> & {
 };
 
 type TrackedIterator = IterableIterator<TransactionEntry> & { lastVersion?: number; lastEndTxn?: boolean };
+type NamedTransactionEntry = TransactionEntry & { logName?: string };
 
 export type TransactionLogIterable = Iterable<AuditRecord> & {
 	/** Corrupt frames that ended a log's iteration during this range. */
 	corruptFrameStop: CorruptFrameStop;
+	/** Physical logs whose iterators ended with an unexpected, non-corruption error. */
+	failedLogs: Set<string>;
 };
 
 const reportCorruptFrame = createCorruptFrameReporter(harperLogger);
@@ -242,6 +245,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 	getRange(options: {
 		start?: number;
 		exactStart?: boolean;
+		exclusiveStart?: boolean;
 		end?: number;
 		log?: string | number;
 		excludeLogs?: string[];
@@ -249,6 +253,8 @@ export class RocksTransactionLogStore extends EventEmitter {
 		startByLog?: Map<string, number>;
 		startFromLastFlushed?: boolean;
 		readUncommitted?: boolean;
+		/** Include the source transaction-log name on each returned audit record. */
+		includeLogName?: boolean;
 		/**
 		 * Track which version a break truncated, in `corruptFrameStop.truncatedVersions`. Costs two
 		 * property stores per yielded entry (see below), so it defaults off: only boot replay reads
@@ -262,6 +268,21 @@ export class RocksTransactionLogStore extends EventEmitter {
 		let singleLogIterator: TrackedIterator;
 		const attributeCorruption = options.trackCorruptTransactions === true;
 		const corruptFrameStop: CorruptFrameStop = { breaks: 0, truncatedVersions: new Set(), midLogBreak: false };
+		const failedLogs = new Set<string>();
+		const failedIterators = new WeakSet<IterableIterator<TransactionEntry>>();
+		const safeNext = (iterator: IterableIterator<TransactionEntry>, log: TransactionLog) => {
+			if (failedIterators.has(iterator)) return { value: undefined, done: true } as IteratorResult<TransactionEntry>;
+			try {
+				return iterator.next();
+			} catch (error) {
+				failedIterators.add(iterator);
+				failedLogs.add(log.name);
+				harperLogger.error('Transaction log iterator failed; terminating this log', error, {
+					log: log.name,
+				});
+				return { value: undefined, done: true } as IteratorResult<TransactionEntry>;
+			}
+		};
 		// Each log's iterator carries the version and endTxn of the last entry it yielded, so a break
 		// can be attributed to the source transaction whose remaining entries it swallowed — unless
 		// that entry's own endTxn already closed the transaction, in which case the break fell after
@@ -301,7 +322,20 @@ export class RocksTransactionLogStore extends EventEmitter {
 			}
 			const queryIterator = trackCorruptFrames(log, options);
 			singleLogIterator = queryIterator;
-			iterable.iterate = () => queryIterator;
+			iterable.iterate = options.includeLogName
+				? () => ({
+						next: () => {
+							const result = queryIterator.next();
+							if (!result.done) (result.value as NamedTransactionEntry).logName = log.name;
+							return result;
+						},
+						return: (value?: any) => queryIterator.return?.(value) ?? { value, done: true },
+						throw: (error?: any) => {
+							if (queryIterator.throw) return queryIterator.throw(error);
+							throw error;
+						},
+					})
+				: () => queryIterator;
 		} else {
 			const onlyKeys = options.onlyKeys;
 			let logs: TransactionLog[] = [];
@@ -309,30 +343,6 @@ export class RocksTransactionLogStore extends EventEmitter {
 			let nextEntries: any[];
 			let latestUpdates: number;
 			const iterators: TrackedIterator[] = [];
-			// Iterators that have permanently failed (corrupt entry stuck at the same
-			// position). Tracked by identity so the retry-poll path in next() and
-			// updateIterators() never calls .next() on them again — otherwise every
-			// subsequent drain cycle would re-throw the same RangeError, spamming logs
-			// and burning CPU.
-			const failedIterators = new WeakSet<IterableIterator<TransactionEntry>>();
-			// Per-log advance that converts a thrown corrupt-entry error from rocksdb-js
-			// into a clean `done: true` for that iterator. The reader's RangeError leaves
-			// `position` at the bad entry; re-calling next() would re-throw indefinitely.
-			// Terminating just this log lets the aggregate keep draining the other peers'
-			// logs and prevents the throw from escaping into setImmediate-scheduled
-			// consumers (notifyFromTransactionData) where it becomes an uncaughtException.
-			const safeNext = (iterator: IterableIterator<TransactionEntry>, log?: TransactionLog) => {
-				if (failedIterators.has(iterator)) return { value: undefined, done: true };
-				try {
-					return iterator.next();
-				} catch (error) {
-					failedIterators.add(iterator);
-					harperLogger.error('Transaction log iterator failed; terminating this log', error, {
-						log: log?.name,
-					});
-					return { value: undefined, done: true };
-				}
-			};
 			const updateIterators = () => {
 				if (latestUpdates !== this.updates) {
 					const latestLogs = (this.nodeLogs || this.loadLogs()).filter(
@@ -408,6 +418,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 							}
 						}
 						if (earliestIndex >= 0) {
+							if (options.includeLogName) (earliest as NamedTransactionEntry).logName = logs[earliestIndex].name;
 							if (attributeCorruption) {
 								// before the refill, which is where a break surfaces and needs this entry's version
 								iterators[earliestIndex].lastVersion = earliest.timestamp;
@@ -445,7 +456,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 			};
 			iterable.iterate = () => aggregateIterator;
 		}
-		const mappedAggregateIterable = iterable.map(({ timestamp, data, endTxn }: TransactionEntry) => {
+		const mappedAggregateIterable = iterable.map(({ timestamp, data, endTxn, logName }: NamedTransactionEntry) => {
 			// A break surfaces on the pull after this entry, so recording it here is in time to attribute
 			// that break to this entry's transaction. The aggregate branch records its own, per source
 			// log, because there this callback cannot tell which log an entry came from.
@@ -478,6 +489,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 					position += 8;
 				}
 				const auditRecord = readAuditEntry(data, position, undefined);
+				if (options.includeLogName) auditRecord.logName = logName;
 				auditRecord.txnLogKey = timestamp;
 				auditRecord.endTxn = endTxn;
 				auditRecord.previousResidencyId = previousResidencyId;
@@ -493,6 +505,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 					// the log key is all this entry still yields; its record version is undecodable
 					version: timestamp,
 					txnLogKey: timestamp,
+					logName: options.includeLogName ? logName : undefined,
 					endTxn,
 					type: undefined,
 					tableId: undefined,
@@ -509,6 +522,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 			mappedAggregateIterable.removeLog = aggregateIterator.removeLog;
 		}
 		mappedAggregateIterable.corruptFrameStop = corruptFrameStop;
+		mappedAggregateIterable.failedLogs = failedLogs;
 		return mappedAggregateIterable as TransactionLogIterable;
 	}
 	getKeys(_options?: any) {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -80,7 +80,8 @@ import { Addition, assignTrackedAccessors, updateAndFreeze, hasChanges, GenericT
 import { transaction, contextStorage } from './transaction.ts';
 import { MAXIMUM_KEY, writeKey, compareKeys } from 'ordered-binary';
 import { getWorkerIndex, getWorkerCount } from '../server/threads/manageThreads.js';
-import { HAS_BLOBS, auditRetention, removeAuditEntry } from './auditStore.ts';
+import { HAS_BLOBS, LOCAL_ONLY, auditRetention, removeAuditEntry } from './auditStore.ts';
+import { hasDerivedIndexRegistration } from './derivedIndexRegistry.ts';
 import { buildEmbedBefore, createDefaultEmbedder, type EmbedAttribute, type Embedder } from './models/embedHook.ts';
 import { autoCast, autoCastBooleanStrict } from '../utility/common_utils.ts';
 import {
@@ -745,6 +746,22 @@ export function makeTable(options) {
 				return { txnLogKey: version, nodeId };
 		}
 		return { txnLogKey: version, nodeId };
+	}
+	function stageDerivedIndexEviction(transaction: RocksTransaction, id: Id, version: number) {
+		if (!hasDerivedIndexRegistration(auditStore, tableId)) return;
+		const nodeId = getThisNodeId(auditStore) ?? 0;
+		auditStore.put(
+			null,
+			{
+				type: 'evict',
+				tableId,
+				recordId: id,
+				version,
+				nodeId,
+				extendedType: LOCAL_ONLY,
+			},
+			{ transaction, nodeId }
+		);
 	}
 	class TableResource<Record extends object = any> extends Resource<Record> {
 		#record: any; // the stored/frozen record from the database and stored in the cache (should not be modified directly)
@@ -2428,9 +2445,8 @@ export function makeTable(options) {
 					// if there is a resolution in-progress, abandon the eviction
 					if (primaryStore.hasLock(id, entry.version)) return;
 				}
-				// evictions never go in the audit log, so we can not record a deletion entry for the eviction
-				// as there is no corresponding audit entry and it would never get cleaned up. So we must simply
-				// removed the entry entirely, but first cleanup indices
+				// Eviction is not a canonical delete. Indexed caching tables add a local-only control entry so
+				// their derived indexes can remove the resident projection without exposing a delete event.
 				let lmdbCompletion: MaybePromise<unknown>;
 				if (primaryStore.ifVersion) {
 					// lmdb: the index cleanup and the record removal are both version-guarded optimistic writes.
@@ -2443,6 +2459,7 @@ export function makeTable(options) {
 					lmdbCompletion = Promise.all([indexCleanup, removal]);
 				} else {
 					updateIndices(id, existingRecord, null, options);
+					stageDerivedIndexEviction(transaction as RocksTransaction, id, existingVersion);
 					removeEntry(primaryStore, entry ?? primaryStore.getEntry(id), options);
 				}
 				committed = true;
@@ -4949,7 +4966,7 @@ export function makeTable(options) {
 									await rest();
 									if (!isActive()) return;
 								}
-								if (auditRecord.tableId !== tableId) continue;
+								if (auditRecord.tableId !== tableId || auditRecord.type === 'evict') continue;
 								const id = auditRecord.recordId;
 								if (thisId == null || isDescendantId(thisId, id)) {
 									const value = auditRecord.getValue(primaryStore, getFullRecord, auditRecord.txnLogKey);
@@ -4986,7 +5003,7 @@ export function makeTable(options) {
 								if (!isActive()) return;
 							}
 							try {
-								if (auditRecord.tableId !== tableId) continue;
+								if (auditRecord.tableId !== tableId || auditRecord.type === 'evict') continue;
 								const id = auditRecord.recordId;
 								if (thisId == null || isDescendantId(thisId, id)) {
 									// Bound entries INSPECTED for THIS scope, independent of `count` (entries
@@ -6113,7 +6130,7 @@ export function makeTable(options) {
 				end: endTime,
 			})) {
 				await rest(); // yield to other async operations
-				if (auditRecord.tableId !== tableId) continue;
+				if (auditRecord.tableId !== tableId || auditRecord.type === 'evict') continue;
 				yield {
 					id: auditRecord.recordId,
 					// Compatibility-facing LMDB history has always reported/grouped by record version.
@@ -6143,7 +6160,11 @@ export function makeTable(options) {
 				let highestPreviousVersion = 0;
 				const start = nextVersion - auditWindow;
 				for (const auditRecord of auditStore.getRange({ start, end: nextVersion + 0.001 })) {
-					if (auditRecord.tableId === tableId && compareKeys(auditRecord.recordId, id) === 0) {
+					if (
+						auditRecord.tableId === tableId &&
+						auditRecord.type !== 'evict' &&
+						compareKeys(auditRecord.recordId, id) === 0
+					) {
 						history.splice(insertionPoint, 0, {
 							id: auditRecord.recordId,
 							localTime: isRocksDB ? auditRecord.txnLogKey : auditRecord.version,
@@ -7238,6 +7259,7 @@ export function makeTable(options) {
 					if (entry.value == null) continue; // already removed
 					if (hasSourceGet && primaryStore.hasLock(item.key, entry.version)) continue; // resolution in progress
 					updateIndices(item.key, entry.value, null, options);
+					stageDerivedIndexEviction(transaction, item.key, entry.version);
 				}
 				removeEntry(primaryStore, entry, options);
 				staged++;

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -35,6 +35,8 @@ initSync();
 export type AuditRecord = {
 	version: number; // the record's own version: LWW ordering, @updatedTime, ETag
 	txnLogKey: number; // position in the origin's transaction log
+	/** Physical transaction log that yielded this entry, populated only when requested by the reader. */
+	logName?: string;
 	type: string;
 	encodedRecord?: Buffer;
 	extendedType?: number;
@@ -840,6 +842,7 @@ export function readAuditEntry(buffer: Uint8Array, start = 0, end = undefined): 
 			// reserved); the flag bits (HAS_RECORD, HAS_PARTIAL_RECORD, …) sit above it. `& 0xf` is
 			// identical to the historical `& 7` for every pre-reload entry (bit 3 was always clear).
 			type: EVENT_TYPES[action & 0xf],
+			logName: undefined,
 			tableId,
 			nodeId,
 			get recordId() {
@@ -956,6 +959,7 @@ function corruptEntry(buffer: Uint8Array, start: number, end: number | undefined
 function createCorruptAuditSentinel(buffer: Uint8Array, start: number, end: number | undefined): AuditRecord {
 	return {
 		type: undefined,
+		logName: undefined,
 		tableId: undefined,
 		nodeId: undefined,
 		recordId: undefined,

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -469,9 +469,10 @@ const STRUCTURES = 7;
 // Whole-table "reload" marker: a control entry (no record) signalling that a table was bulk-reloaded
 // and subscribers should re-read it. Used after a copyApply base copy, whose per-row snapshot writes
 // carry no audit entry (harper-pro#489). The entry type lives in the low nibble of the action byte
-// (decoded via `action & 0xf`); 1–7 are the record actions above, 8 is reload, leaving 9–15 free for
+// (decoded via `action & 0xf`); 1–7 are the record actions above, 8 is reload, 9 is eviction, leaving 10–15 free for
 // future actions. Markers are always written LOCAL_ONLY so an unknown type never reaches a peer.
 const RELOAD = 8;
+const EVICT = 9;
 export const ACTION_32_BIT = 14;
 export const ACTION_64_BIT = 15;
 /** Used to indicate we have received a remote local time update */
@@ -509,6 +510,8 @@ const EVENT_TYPES = {
 	[STRUCTURES]: 'structures',
 	reload: RELOAD,
 	[RELOAD]: 'reload',
+	evict: EVICT,
+	[EVICT]: 'evict',
 	remoteSequenceUpdate: REMOTE_SEQUENCE_UPDATE,
 	[REMOTE_SEQUENCE_UPDATE]: 'remoteSequenceUpdate',
 };
@@ -838,7 +841,7 @@ export function readAuditEntry(buffer: Uint8Array, start = 0, end = undefined): 
 		const usernameEnd = (decoder.position += length);
 		let value: any;
 		return {
-			// The entry type is the low nibble of the action byte (1–7 record actions, 8 reload, 9–15
+			// The entry type is the low nibble of the action byte (1–7 record actions, 8 reload, 9 eviction, 10–15
 			// reserved); the flag bits (HAS_RECORD, HAS_PARTIAL_RECORD, …) sit above it. `& 0xf` is
 			// identical to the historical `& 7` for every pre-reload entry (bit 3 was always clear).
 			type: EVENT_TYPES[action & 0xf],

--- a/resources/derivedIndexRegistry.ts
+++ b/resources/derivedIndexRegistry.ts
@@ -1,0 +1,23 @@
+const registrations = new WeakMap<object, Map<number, number>>();
+
+export function registerDerivedIndexTables(auditStore: object, tableIds: Iterable<number>): () => void {
+	const registeredTableIds = new Set(tableIds);
+	let counts = registrations.get(auditStore);
+	if (!counts) registrations.set(auditStore, (counts = new Map()));
+	for (const tableId of registeredTableIds) counts.set(tableId, (counts.get(tableId) ?? 0) + 1);
+	let registered = true;
+	return () => {
+		if (!registered) return;
+		registered = false;
+		for (const tableId of registeredTableIds) {
+			const count = counts!.get(tableId);
+			if (count === 1) counts!.delete(tableId);
+			else if (count) counts!.set(tableId, count - 1);
+		}
+		if (counts!.size === 0) registrations.delete(auditStore);
+	};
+}
+
+export function hasDerivedIndexRegistration(auditStore: object, tableId: number): boolean {
+	return registrations.get(auditStore)?.has(tableId) ?? false;
+}

--- a/resources/derivedIndexRuntime.ts
+++ b/resources/derivedIndexRuntime.ts
@@ -1,0 +1,615 @@
+import type { Id } from './ResourceInterface.ts';
+import type { AuditRecord } from './auditStore.ts';
+import type { RocksTransactionLogStore, TransactionLogIterable } from './RocksTransactionLogStore.ts';
+import { writeKeyId } from './DatabaseTransaction.ts';
+import { loggerWithTag } from '../utility/logging/logger.ts';
+
+const logger = loggerWithTag('derived-index');
+
+export const DERIVED_INDEX_ACCEPTED = 1;
+export const DERIVED_INDEX_DEFERRED = 0;
+export const DERIVED_INDEX_FAILED = -1;
+
+export type DerivedIndexDeliveryResult =
+	typeof DERIVED_INDEX_ACCEPTED | typeof DERIVED_INDEX_DEFERRED | typeof DERIVED_INDEX_FAILED;
+
+export type DerivedIndexCursor = {
+	format: 1;
+	logs: Record<string, number>;
+};
+
+export type DerivedIndexState = { kind: 'record'; version: number; projection: unknown } | { kind: 'absent' };
+
+export type DerivedIndexMutation = {
+	tableId: number;
+	recordId: Id;
+	logVersion: number;
+	state: DerivedIndexState;
+};
+
+export type DerivedIndexTransaction = {
+	logName: string;
+	timestamp: number;
+	mutations: DerivedIndexMutation[];
+};
+
+export type DerivedIndexBatch = {
+	ownerEpoch: bigint;
+	transactions: DerivedIndexTransaction[];
+	through: DerivedIndexCursor;
+};
+
+export interface DerivedIndexBackend {
+	readonly id: string;
+	getDurableCursor(): DerivedIndexCursor | undefined;
+	deliver(batch: DerivedIndexBatch): DerivedIndexDeliveryResult;
+	onStateChange(wake: (change?: DerivedIndexBackendStateChange) => void): () => void;
+}
+
+export type DerivedIndexBackendStateChange = 'changed' | 'accepted-work-lost' | 'failed';
+
+export type DerivedIndexRegistration = {
+	backend: DerivedIndexBackend;
+	projections: ReadonlyMap<number, (record: unknown) => unknown>;
+};
+
+export type DerivedIndexRecord = { version: number; value: unknown } | undefined;
+
+export type DerivedIndexRuntimeOptions = {
+	maxTransactionsPerTurn?: number;
+	maxBytesPerTurn?: number;
+	maxMillisecondsPerTurn?: number;
+	maxAcceptedBatchesAhead?: number;
+	idleGraceMilliseconds?: number;
+	now?: () => number;
+};
+
+export type DerivedIndexRunnerStatus =
+	| { state: 'idle' | 'running' | 'deferred' | 'waiting-durable' | 'stopped'; ownerEpoch?: bigint }
+	| { state: 'needs-rebuild'; reason: string; ownerEpoch?: bigint };
+
+const ELIGIBLE_ACTIONS = new Set(['put', 'patch', 'delete', 'invalidate', 'relocate']);
+
+export class DerivedIndexRuntime {
+	#logStore: RocksTransactionLogStore;
+	#resolveRecord: (tableId: number, recordId: Id) => DerivedIndexRecord;
+	#options: Required<DerivedIndexRuntimeOptions>;
+	#runners = new Map<string, DerivedIndexRunner>();
+	#onCommit = () => this.wake();
+	#listening = false;
+	#stopped = false;
+
+	constructor(
+		logStore: RocksTransactionLogStore,
+		resolveRecord: (tableId: number, recordId: Id) => DerivedIndexRecord,
+		options: DerivedIndexRuntimeOptions = {}
+	) {
+		this.#logStore = logStore;
+		this.#resolveRecord = resolveRecord;
+		this.#options = {
+			maxTransactionsPerTurn: options.maxTransactionsPerTurn ?? 256,
+			maxBytesPerTurn: options.maxBytesPerTurn ?? 4 * 1024 * 1024,
+			maxMillisecondsPerTurn: options.maxMillisecondsPerTurn ?? 5,
+			maxAcceptedBatchesAhead: Math.max(1, options.maxAcceptedBatchesAhead ?? 64),
+			idleGraceMilliseconds: options.idleGraceMilliseconds ?? 30_000,
+			now: options.now ?? Date.now,
+		};
+	}
+
+	register(registration: DerivedIndexRegistration): () => void {
+		if (this.#stopped) throw new Error('Derived index runtime is stopped');
+		if (!registration.backend.id) throw new Error('Derived index backend id is required');
+		if (this.#runners.has(registration.backend.id))
+			throw new Error(`Derived index backend '${registration.backend.id}' is already registered`);
+		const runner = new DerivedIndexRunner(this.#logStore, this.#resolveRecord, registration, this.#options);
+		this.#runners.set(registration.backend.id, runner);
+		if (!this.#listening) {
+			this.#logStore.rootStore.on('committed', this.#onCommit);
+			this.#listening = true;
+		}
+		runner.wake(true);
+		return () => {
+			if (this.#runners.get(registration.backend.id) !== runner) return;
+			this.#runners.delete(registration.backend.id);
+			runner.stop();
+			this.#stopListeningIfIdle();
+		};
+	}
+
+	wake() {
+		if (this.#stopped) return;
+		for (const runner of this.#runners.values()) runner.wake();
+	}
+
+	getStatus(backendId: string): DerivedIndexRunnerStatus | undefined {
+		return this.#runners.get(backendId)?.status;
+	}
+
+	stop() {
+		if (this.#stopped) return;
+		this.#stopped = true;
+		for (const runner of this.#runners.values()) runner.stop();
+		this.#runners.clear();
+		this.#stopListening();
+	}
+
+	#stopListeningIfIdle() {
+		if (this.#runners.size === 0) this.#stopListening();
+	}
+
+	#stopListening() {
+		if (!this.#listening) return;
+		this.#logStore.rootStore.off?.('committed', this.#onCommit);
+		this.#listening = false;
+	}
+}
+
+class DerivedIndexRunner {
+	#logStore: RocksTransactionLogStore;
+	#resolveRecord: (tableId: number, recordId: Id) => DerivedIndexRecord;
+	#registration: DerivedIndexRegistration;
+	#options: Required<DerivedIndexRuntimeOptions>;
+	#lockKey: string;
+	#iterator?: Iterator<AuditRecord>;
+	#iterable?: TransactionLogIterable;
+	#knownLogs = new Set<string>();
+	#pendingTimestamps = new Map<string, number[]>();
+	#seenTimestamps = new Map<string, Set<number>>();
+	#offeredCursors: DerivedIndexCursor[] = [];
+	#offered?: DerivedIndexCursor;
+	#pendingBatch?: DerivedIndexBatch;
+	#scheduled = false;
+	#waitingForLock = false;
+	#owned = false;
+	#stopped = false;
+	#idleTimer?: NodeJS.Timeout;
+	#unsubscribeBackend: () => void;
+	#ownerEpoch?: bigint;
+	status: DerivedIndexRunnerStatus = { state: 'idle' };
+
+	constructor(
+		logStore: RocksTransactionLogStore,
+		resolveRecord: (tableId: number, recordId: Id) => DerivedIndexRecord,
+		registration: DerivedIndexRegistration,
+		options: Required<DerivedIndexRuntimeOptions>
+	) {
+		this.#logStore = logStore;
+		this.#resolveRecord = resolveRecord;
+		this.#registration = registration;
+		this.#options = options;
+		this.#lockKey = `derived-index:${registration.backend.id}:runner`;
+		this.#unsubscribeBackend = registration.backend.onStateChange((change = 'changed') =>
+			this.#backendStateChanged(change)
+		);
+	}
+
+	wake(fromBackend = false) {
+		if (this.#stopped || this.status.state === 'needs-rebuild') return;
+		if (!fromBackend && (this.status.state === 'deferred' || this.status.state === 'waiting-durable')) return;
+		if (this.#idleTimer) {
+			clearTimeout(this.#idleTimer);
+			this.#idleTimer = undefined;
+		}
+		if (this.#scheduled) return;
+		this.#scheduled = true;
+		setImmediate(() => {
+			this.#scheduled = false;
+			if (this.#stopped) return;
+			if (this.#owned) this.#drain();
+			else this.#acquire();
+		});
+	}
+
+	stop() {
+		if (this.#stopped) return;
+		this.#stopped = true;
+		this.status = { state: 'stopped', ownerEpoch: this.#ownerEpoch };
+		if (this.#idleTimer) clearTimeout(this.#idleTimer);
+		this.#unsubscribeBackend?.();
+		this.#release();
+	}
+
+	#acquire() {
+		if (this.#waitingForLock) return;
+		this.#waitingForLock = true;
+		const retry = () => {
+			this.#waitingForLock = false;
+			try {
+				this.wake(true);
+			} catch (error) {
+				this.#fail('unlock notification failed', error);
+			}
+		};
+		try {
+			if (!this.#logStore.tryLock(this.#lockKey, retry)) return;
+			this.#waitingForLock = false;
+			this.#owned = true;
+			this.#ownerEpoch = this.#nextOwnerEpoch();
+			this.status = { state: 'running', ownerEpoch: this.#ownerEpoch };
+			this.#resetFromDurableCursor();
+			if (this.#owned) this.#drain();
+		} catch (error) {
+			this.#waitingForLock = false;
+			this.#fail('failed to acquire or initialize the runner', error);
+		}
+	}
+
+	#nextOwnerEpoch(): bigint {
+		const buffer = this.#logStore.getUserSharedBuffer(
+			`derived-index:${this.#registration.backend.id}:owner-epoch`,
+			new ArrayBuffer(8)
+		);
+		return Atomics.add(new BigInt64Array(buffer), 0, 1n) + 1n;
+	}
+
+	#resetFromDurableCursor() {
+		const durable = this.#registration.backend.getDurableCursor();
+		if (!isValidCursor(durable)) {
+			this.#needsRebuild(durable ? 'backend returned an invalid durable cursor' : 'backend has no durable cursor');
+			return;
+		}
+		this.#validateLogSet(durable);
+		if (this.status.state === 'needs-rebuild') return;
+		this.#offered = cloneCursor(durable);
+		this.#offeredCursors = [cloneCursor(durable)];
+		this.#pendingTimestamps.clear();
+		this.#seenTimestamps.clear();
+		for (const [logName, timestamp] of Object.entries(durable.logs)) {
+			this.#pendingTimestamps.set(logName, [timestamp]);
+			this.#seenTimestamps.set(logName, new Set([timestamp]));
+		}
+		this.#iterable = this.#logStore.getRange({
+			startByLog: new Map(Object.entries(durable.logs)),
+			exactStart: true,
+			exclusiveStart: true,
+			resumeAfterExactStart: true,
+			includeLogName: true,
+		});
+		this.#iterator = this.#iterable[Symbol.iterator]();
+		this.#checkRangeHealth();
+	}
+
+	#validateLogSet(cursor: DerivedIndexCursor) {
+		const currentLogs = this.#logStore.rootStore.listLogs();
+		const current = new Set(currentLogs);
+		for (const logName of Object.keys(cursor.logs)) {
+			if (!current.has(logName)) {
+				this.#needsRebuild(`saved transaction log '${logName}' is missing`);
+				return;
+			}
+		}
+		this.#knownLogs = current;
+		for (const logName of currentLogs) {
+			if (cursor.logs[logName] !== undefined) continue;
+			const oldestSequenceNumber = this.#logStore.rootStore.useLog(logName).getStats().oldestSequenceNumber;
+			if (oldestSequenceNumber !== 1) {
+				this.#needsRebuild(`new transaction log '${logName}' no longer retains its beginning`);
+				return;
+			}
+		}
+	}
+
+	#drain() {
+		if (!this.#owned || this.#stopped || this.status.state === 'needs-rebuild') return;
+		try {
+			if (!this.#checkNewLogs() || !this.#checkRangeHealth()) return;
+			if (this.status.state === 'waiting-durable') {
+				if (!this.#reconcileDurableCursor()) return;
+				if (this.#offeredCursors.length - 1 >= this.#options.maxAcceptedBatchesAhead) return;
+				this.status = { state: 'running', ownerEpoch: this.#ownerEpoch };
+			}
+			const batch = this.#pendingBatch ?? this.#collectBatch();
+			if (!this.#owned) return;
+			if (!batch) {
+				this.#finishIdlePass();
+				return;
+			}
+			let result: DerivedIndexDeliveryResult;
+			const deliveryIterator = this.#iterator;
+			try {
+				result = this.#registration.backend.deliver(batch);
+			} catch (error) {
+				this.#fail('backend delivery threw', error);
+				return;
+			}
+			if (!this.#owned || this.#iterator !== deliveryIterator) return;
+			if (result === DERIVED_INDEX_DEFERRED) {
+				this.#pendingBatch = batch;
+				this.status = { state: 'deferred', ownerEpoch: this.#ownerEpoch };
+				return;
+			}
+			if (result !== DERIVED_INDEX_ACCEPTED) {
+				this.#needsRebuild(
+					result === DERIVED_INDEX_FAILED ? 'backend rejected a delivery batch' : 'backend returned an invalid result'
+				);
+				return;
+			}
+			this.#pendingBatch = undefined;
+			this.#offered = cloneCursor(batch.through);
+			this.#offeredCursors.push(cloneCursor(batch.through));
+			if (!this.#reconcileDurableCursor()) return;
+			if (this.#offeredCursors.length - 1 >= this.#options.maxAcceptedBatchesAhead) {
+				this.status = { state: 'waiting-durable', ownerEpoch: this.#ownerEpoch };
+				return;
+			}
+			this.status = { state: 'running', ownerEpoch: this.#ownerEpoch };
+			this.wake();
+		} catch (error) {
+			this.#fail('runner drain failed', error);
+		}
+	}
+
+	#collectBatch(): DerivedIndexBatch | undefined {
+		const started = this.#options.now();
+		let transactions = 0;
+		let bytes = 0;
+		let progressed = false;
+		const through = cloneCursor(this.#offered!);
+		const pending: Array<{
+			logName: string;
+			timestamp: number;
+			records: Map<number, Map<unknown, { recordId: Id; logVersion: number }>>;
+		}> = [];
+		while (true) {
+			const first = this.#iterator!.next();
+			if (first.done) break;
+			const firstRecord = first.value;
+			let records: Map<number, Map<unknown, { recordId: Id; logVersion: number }>> | undefined;
+			let current = firstRecord;
+			this.#assertRecord(current);
+			const logName = current.logName!;
+			const timestamp = current.txnLogKey;
+			let seen = this.#seenTimestamps.get(logName);
+			if (!seen) this.#seenTimestamps.set(logName, (seen = new Set()));
+			if (seen.has(timestamp))
+				throw new Error(`transaction log '${logName}' repeated completed timestamp ${timestamp}`);
+			while (true) {
+				if (current.logName !== logName || current.txnLogKey !== timestamp)
+					throw new Error(`transaction ${timestamp} from '${logName}' ended without an endTxn boundary`);
+				bytes += current.size ?? 0;
+				const projection = this.#registration.projections.get(current.tableId);
+				if (projection) {
+					if (current.type === 'reload') throw new Error(`table ${current.tableId} requires a derived-index rebuild`);
+					if (ELIGIBLE_ACTIONS.has(current.type)) {
+						records ??= new Map();
+						let byRecord = records.get(current.tableId);
+						if (!byRecord) records.set(current.tableId, (byRecord = new Map()));
+						byRecord.set(writeKeyId(current.recordId), {
+							recordId: current.recordId,
+							logVersion: current.version,
+						});
+					}
+				}
+				if (current.endTxn) break;
+				const next = this.#iterator!.next();
+				if (next.done) throw new Error(`transaction ${timestamp} from '${logName}' is incomplete`);
+				current = next.value;
+				this.#assertRecord(current);
+			}
+			seen.add(timestamp);
+			let pendingTimestamps = this.#pendingTimestamps.get(logName);
+			if (!pendingTimestamps) this.#pendingTimestamps.set(logName, (pendingTimestamps = []));
+			pendingTimestamps.push(timestamp);
+			through.logs[logName] = timestamp;
+			progressed = true;
+			transactions++;
+			if (records) pending.push({ logName, timestamp, records });
+			if (
+				transactions >= this.#options.maxTransactionsPerTurn ||
+				bytes >= this.#options.maxBytesPerTurn ||
+				this.#options.now() - started >= this.#options.maxMillisecondsPerTurn
+			)
+				break;
+		}
+		if (!this.#checkRangeHealth()) return;
+		if (!progressed) return;
+		return { ownerEpoch: this.#ownerEpoch!, transactions: this.#resolveTransactions(pending), through };
+	}
+
+	#resolveTransactions(
+		pending: Array<{
+			logName: string;
+			timestamp: number;
+			records: Map<number, Map<unknown, { recordId: Id; logVersion: number }>>;
+		}>
+	): DerivedIndexTransaction[] {
+		const resolved = new Map<number, Map<unknown, DerivedIndexState>>();
+		for (const transaction of pending) {
+			for (const [tableId, records] of transaction.records) {
+				let byRecord = resolved.get(tableId);
+				if (!byRecord) resolved.set(tableId, (byRecord = new Map()));
+				for (const [key, record] of records) {
+					if (byRecord.has(key)) continue;
+					const current = this.#resolveRecord(tableId, record.recordId);
+					const state: DerivedIndexState = current
+						? {
+								kind: 'record',
+								version: current.version,
+								projection: this.#registration.projections.get(tableId)!(current.value),
+							}
+						: { kind: 'absent' };
+					byRecord.set(key, state);
+				}
+			}
+		}
+		return pending.map(({ logName, timestamp, records }) => {
+			const mutations: DerivedIndexMutation[] = [];
+			for (const [tableId, byRecord] of records) {
+				for (const key of byRecord.keys()) {
+					const record = byRecord.get(key)!;
+					mutations.push({ tableId, ...record, state: resolved.get(tableId)!.get(key)! });
+				}
+			}
+			return { logName, timestamp, mutations };
+		});
+	}
+
+	#assertRecord(record: AuditRecord) {
+		if (!record || record.logName === undefined || record.tableId === undefined || record.type === undefined)
+			throw new Error('transaction log yielded an undecodable audit entry');
+	}
+
+	#checkNewLogs(): boolean {
+		const current = this.#logStore.rootStore.listLogs();
+		const currentSet = new Set(current);
+		for (const logName of this.#knownLogs) {
+			if (!currentSet.has(logName)) {
+				this.#needsRebuild(`transaction log '${logName}' was removed`);
+				return false;
+			}
+		}
+		for (const logName of current) {
+			if (this.#knownLogs.has(logName)) continue;
+			const oldest = this.#logStore.rootStore.useLog(logName).getStats().oldestSequenceNumber;
+			if (oldest !== 1) {
+				this.#needsRebuild(`new transaction log '${logName}' no longer retains its beginning`);
+				return false;
+			}
+			this.#knownLogs.add(logName);
+		}
+		return true;
+	}
+
+	#checkRangeHealth(): boolean {
+		if (!this.#iterable) return true;
+		if (this.#iterable.corruptFrameStop.breaks > 0) {
+			this.#needsRebuild('transaction log contains a corrupt frame');
+			return false;
+		}
+		if (this.#iterable.failedLogs.size > 0) {
+			this.#needsRebuild(`transaction log iterator failed for '${this.#iterable.failedLogs.values().next().value}'`);
+			return false;
+		}
+		if (this.#iterable.exactStartFailures.size > 0) {
+			const [logName, failure] = this.#iterable.exactStartFailures.entries().next().value;
+			this.#needsRebuild(`transaction log '${logName}' has a ${failure} durable cursor boundary`);
+			return false;
+		}
+		return true;
+	}
+
+	#finishIdlePass() {
+		const durable = this.#registration.backend.getDurableCursor();
+		if (!isValidCursor(durable)) {
+			this.#needsRebuild('backend lost its durable cursor');
+			return;
+		}
+		if (!this.#reconcileDurableCursor(durable)) return;
+		if (!sameCursor(durable, this.#offered!)) return;
+		if (this.#idleTimer) return;
+		this.status = { state: 'idle', ownerEpoch: this.#ownerEpoch };
+		this.#idleTimer = setTimeout(() => {
+			this.#idleTimer = undefined;
+			if (!this.#stopped && sameCursor(this.#registration.backend.getDurableCursor(), this.#offered!)) this.#release();
+		}, this.#options.idleGraceMilliseconds);
+	}
+
+	#reconcileDurableCursor(cursor = this.#registration.backend.getDurableCursor()): boolean {
+		if (!isValidCursor(cursor)) {
+			this.#needsRebuild('backend returned an invalid durable cursor');
+			return false;
+		}
+		const offeredIndex = this.#offeredCursors.findIndex((offered) => sameCursor(cursor, offered));
+		if (offeredIndex < 0) {
+			this.#needsRebuild('backend advanced to an unoffered cursor vector');
+			return false;
+		}
+		for (const [logName, timestamp] of Object.entries(cursor.logs)) {
+			const pending = this.#pendingTimestamps.get(logName);
+			if (!pending) {
+				this.#needsRebuild(`backend advanced unknown transaction log '${logName}'`);
+				return false;
+			}
+			const index = pending.indexOf(timestamp);
+			if (index < 0) {
+				this.#needsRebuild(`backend advanced '${logName}' to an unoffered cursor`);
+				return false;
+			}
+			if (index > 0) {
+				const retained = pending.slice(index);
+				this.#pendingTimestamps.set(logName, retained);
+				this.#seenTimestamps.set(logName, new Set(retained));
+			}
+		}
+		if (offeredIndex > 0) this.#offeredCursors.splice(0, offeredIndex);
+		return true;
+	}
+
+	#backendStateChanged(change: DerivedIndexBackendStateChange) {
+		if (this.#stopped || this.status.state === 'needs-rebuild') return;
+		if (change === 'failed') {
+			this.#needsRebuild('backend reported a permanent failure');
+			return;
+		}
+		if (change === 'accepted-work-lost' && this.#owned) {
+			this.#pendingBatch = undefined;
+			try {
+				this.#resetFromDurableCursor();
+			} catch (error) {
+				this.#fail('failed to reset lost accepted work', error);
+				return;
+			}
+		}
+		this.wake(true);
+	}
+
+	#fail(reason: string, error: unknown) {
+		const detail = error instanceof Error && error.message ? `${reason}: ${error.message}` : reason;
+		this.#needsRebuild(detail, error);
+	}
+
+	#needsRebuild(reason: string, error?: unknown) {
+		if (this.status.state !== 'needs-rebuild')
+			logger.error(`Derived index '${this.#registration.backend.id}' needs rebuild: ${reason}`, error);
+		this.status = { state: 'needs-rebuild', reason, ownerEpoch: this.#ownerEpoch };
+		this.#pendingBatch = undefined;
+		this.#iterator = undefined;
+		this.#iterable = undefined;
+		this.#release();
+	}
+
+	#release() {
+		if (!this.#owned) return;
+		if (this.#idleTimer) {
+			clearTimeout(this.#idleTimer);
+			this.#idleTimer = undefined;
+		}
+		this.#owned = false;
+		try {
+			this.#logStore.unlock(this.#lockKey);
+		} catch (error) {
+			logger.error(`Failed to release derived index runner '${this.#registration.backend.id}'`, error);
+		}
+		this.#iterator = undefined;
+		this.#iterable = undefined;
+	}
+}
+
+function isValidCursor(cursor: DerivedIndexCursor | undefined): cursor is DerivedIndexCursor {
+	if (
+		!cursor ||
+		typeof cursor !== 'object' ||
+		cursor.format !== 1 ||
+		!cursor.logs ||
+		typeof cursor.logs !== 'object' ||
+		Array.isArray(cursor.logs)
+	)
+		return false;
+	for (const timestamp of Object.values(cursor.logs)) {
+		if (!Number.isFinite(timestamp) || timestamp <= 0) return false;
+	}
+	return true;
+}
+
+function cloneCursor(cursor: DerivedIndexCursor): DerivedIndexCursor {
+	return { format: 1, logs: { ...cursor.logs } };
+}
+
+function sameCursor(left: DerivedIndexCursor | undefined, right: DerivedIndexCursor): boolean {
+	if (!isValidCursor(left)) return false;
+	const leftNames = Object.keys(left.logs);
+	const rightNames = Object.keys(right.logs);
+	if (leftNames.length !== rightNames.length) return false;
+	for (const name of leftNames) if (left.logs[name] !== right.logs[name]) return false;
+	return true;
+}

--- a/resources/derivedIndexRuntime.ts
+++ b/resources/derivedIndexRuntime.ts
@@ -2,6 +2,7 @@ import type { Id } from './ResourceInterface.ts';
 import type { AuditRecord } from './auditStore.ts';
 import type { RocksTransactionLogStore, TransactionLogIterable } from './RocksTransactionLogStore.ts';
 import { writeKeyId } from './DatabaseTransaction.ts';
+import { registerDerivedIndexTables } from './derivedIndexRegistry.ts';
 import { loggerWithTag } from '../utility/logging/logger.ts';
 
 const logger = loggerWithTag('derived-index');
@@ -68,7 +69,7 @@ export type DerivedIndexRunnerStatus =
 	| { state: 'idle' | 'running' | 'deferred' | 'waiting-durable' | 'stopped'; ownerEpoch?: bigint }
 	| { state: 'needs-rebuild'; reason: string; ownerEpoch?: bigint };
 
-const ELIGIBLE_ACTIONS = new Set(['put', 'patch', 'delete', 'invalidate', 'relocate']);
+const ELIGIBLE_ACTIONS = new Set(['put', 'patch', 'delete', 'invalidate', 'relocate', 'evict']);
 
 export class DerivedIndexRuntime {
 	#logStore: RocksTransactionLogStore;
@@ -164,6 +165,7 @@ class DerivedIndexRunner {
 	#stopped = false;
 	#idleTimer?: NodeJS.Timeout;
 	#unsubscribeBackend: () => void;
+	#unregisterTables: () => void;
 	#ownerEpoch?: bigint;
 	status: DerivedIndexRunnerStatus = { state: 'idle' };
 
@@ -181,6 +183,7 @@ class DerivedIndexRunner {
 		this.#unsubscribeBackend = registration.backend.onStateChange((change = 'changed') =>
 			this.#backendStateChanged(change)
 		);
+		this.#unregisterTables = registerDerivedIndexTables(logStore, registration.projections.keys());
 	}
 
 	wake(fromBackend = false) {
@@ -206,6 +209,7 @@ class DerivedIndexRunner {
 		this.status = { state: 'stopped', ownerEpoch: this.#ownerEpoch };
 		if (this.#idleTimer) clearTimeout(this.#idleTimer);
 		this.#unsubscribeBackend?.();
+		this.#unregisterTables();
 		this.#release();
 	}
 

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -165,6 +165,11 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 					noProgressRun++;
 					continue;
 				}
+				if (type === 'evict') {
+					noProgressRun = 0;
+					lastProgressTime = performance.now();
+					continue;
+				}
 				const Table = tableById.get(tableId);
 				if (!Table) {
 					// Entry for a table this node no longer has (dropped/foreign). Not an

--- a/unitTests/resources/derivedIndexRegistry.test.js
+++ b/unitTests/resources/derivedIndexRegistry.test.js
@@ -1,0 +1,28 @@
+const assert = require('node:assert');
+const { hasDerivedIndexRegistration, registerDerivedIndexTables } = require('#src/resources/derivedIndexRegistry');
+
+describe('derived index registration tracking', () => {
+	it('counts registrations independently by audit store and table', () => {
+		const firstStore = {};
+		const secondStore = {};
+		const releaseFirst = registerDerivedIndexTables(firstStore, [1, 2, 2]);
+		const releaseSecond = registerDerivedIndexTables(firstStore, [1]);
+		const releaseOtherStore = registerDerivedIndexTables(secondStore, [1]);
+
+		assert.strictEqual(hasDerivedIndexRegistration(firstStore, 1), true);
+		assert.strictEqual(hasDerivedIndexRegistration(firstStore, 2), true);
+		assert.strictEqual(hasDerivedIndexRegistration(secondStore, 1), true);
+
+		releaseFirst();
+		assert.strictEqual(hasDerivedIndexRegistration(firstStore, 1), true);
+		assert.strictEqual(hasDerivedIndexRegistration(firstStore, 2), false);
+
+		releaseSecond();
+		releaseSecond();
+		assert.strictEqual(hasDerivedIndexRegistration(firstStore, 1), false);
+		assert.strictEqual(hasDerivedIndexRegistration(secondStore, 1), true);
+
+		releaseOtherStore();
+		assert.strictEqual(hasDerivedIndexRegistration(secondStore, 1), false);
+	});
+});

--- a/unitTests/resources/derivedIndexRuntime.test.js
+++ b/unitTests/resources/derivedIndexRuntime.test.js
@@ -1,0 +1,506 @@
+const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
+const { waitFor } = require('../waitFor');
+const {
+	DERIVED_INDEX_ACCEPTED,
+	DERIVED_INDEX_DEFERRED,
+	DerivedIndexRuntime,
+} = require('#src/resources/derivedIndexRuntime');
+
+class FakeLogStore {
+	constructor(entriesByCursor, logNames = ['local']) {
+		this.entriesByCursor = entriesByCursor;
+		this.locks = new Set();
+		this.waiters = new Map();
+		this.sharedBuffers = new Map();
+		this.rangeCalls = [];
+		this.rootStore = new EventEmitter();
+		this.rootStore.listLogs = () => logNames.slice();
+		this.rootStore.useLog = (name) => ({ name, getStats: () => ({ oldestSequenceNumber: 1 }) });
+	}
+
+	getRange(options) {
+		this.rangeCalls.push(options);
+		const start = options.startByLog.get('local');
+		const iterable = (this.entriesByCursor.get(start) ?? []).map((entry) => ({ ...entry }));
+		iterable.corruptFrameStop = { breaks: 0, truncatedVersions: new Set(), midLogBreak: false };
+		iterable.failedLogs = new Set();
+		iterable.exactStartFailures = new Map();
+		return iterable;
+	}
+
+	tryLock(key, onUnlocked) {
+		if (!this.locks.has(key)) {
+			this.locks.add(key);
+			return true;
+		}
+		if (onUnlocked) {
+			let waiters = this.waiters.get(key);
+			if (!waiters) this.waiters.set(key, (waiters = []));
+			waiters.push(onUnlocked);
+		}
+		return false;
+	}
+
+	unlock(key) {
+		this.locks.delete(key);
+		for (const waiter of this.waiters.get(key) ?? []) setImmediate(waiter);
+		this.waiters.delete(key);
+	}
+
+	getUserSharedBuffer(key, defaultBuffer) {
+		let buffer = this.sharedBuffers.get(key);
+		if (!buffer) {
+			buffer = new SharedArrayBuffer(defaultBuffer.byteLength);
+			this.sharedBuffers.set(key, buffer);
+		}
+		return buffer;
+	}
+}
+
+class FakeBackend {
+	constructor(id, cursor, deliver) {
+		this.id = id;
+		this.cursor = cursor;
+		this.deliveries = [];
+		this.deliverImpl = deliver;
+	}
+
+	getDurableCursor() {
+		return this.cursor;
+	}
+
+	deliver(batch) {
+		this.deliveries.push(batch);
+		if (this.deliverImpl) return this.deliverImpl(batch, this);
+		this.cursor = batch.through;
+		return DERIVED_INDEX_ACCEPTED;
+	}
+
+	onStateChange(wake) {
+		this.stateChange = wake;
+		return () => {
+			if (this.stateChange === wake) this.stateChange = undefined;
+		};
+	}
+}
+
+const cursor = (timestamp) => ({ format: 1, logs: { local: timestamp } });
+const audit = ({ timestamp, recordId, tableId = 1, version = timestamp, type = 'put', endTxn = true }) => ({
+	logName: 'local',
+	txnLogKey: timestamp,
+	version,
+	recordId,
+	tableId,
+	type,
+	endTxn,
+	size: 32,
+});
+
+function runtimeFor(store, records, options) {
+	let reads = 0;
+	const runtime = new DerivedIndexRuntime(
+		store,
+		(tableId, recordId) => {
+			reads++;
+			return records.get(`${tableId}:${recordId}`);
+		},
+		{ idleGraceMilliseconds: 5, ...options }
+	);
+	return { runtime, getReads: () => reads };
+}
+
+const registration = (backend) => ({
+	backend,
+	projections: new Map([[1, (record) => ({ title: record.title })]]),
+});
+
+describe('DerivedIndexRuntime', () => {
+	it('delivers authoritative projected state once per record and advances through unrelated transactions', async () => {
+		const store = new FakeLogStore(
+			new Map([
+				[
+					10,
+					[
+						audit({ timestamp: 20, recordId: 'a', version: 100 }),
+						audit({ timestamp: 30, recordId: 'a', version: 200 }),
+						audit({ timestamp: 40, recordId: 'ignored', tableId: 2 }),
+					],
+				],
+			])
+		);
+		const backend = new FakeBackend('search', cursor(10));
+		const { runtime, getReads } = runtimeFor(store, new Map([['1:a', { version: 300, value: { title: 'current' } }]]));
+		runtime.register(registration(backend));
+
+		await waitFor(() => backend.deliveries.length === 1);
+		const [batch] = backend.deliveries;
+		assert.deepStrictEqual(batch.through, cursor(40));
+		assert.strictEqual(batch.transactions.length, 2);
+		assert.deepStrictEqual(
+			batch.transactions.map(({ timestamp, mutations }) => [timestamp, mutations[0].logVersion, mutations[0].state]),
+			[
+				[20, 100, { kind: 'record', version: 300, projection: { title: 'current' } }],
+				[30, 200, { kind: 'record', version: 300, projection: { title: 'current' } }],
+			]
+		);
+		assert.strictEqual(getReads(), 1);
+		assert.strictEqual(store.rootStore.listenerCount('committed'), 1);
+		assert.strictEqual(store.rangeCalls[0].readUncommitted, undefined);
+		runtime.stop();
+		assert.strictEqual(store.rootStore.listenerCount('committed'), 0);
+	});
+
+	it('retains a deferred batch and retries it only after the backend wakes', async () => {
+		const store = new FakeLogStore(new Map([[10, [audit({ timestamp: 20, recordId: 'a' })]]]));
+		let accept = false;
+		const backend = new FakeBackend('deferred', cursor(10), (batch, target) => {
+			if (!accept) return DERIVED_INDEX_DEFERRED;
+			target.cursor = batch.through;
+			return DERIVED_INDEX_ACCEPTED;
+		});
+		const { runtime } = runtimeFor(store, new Map([['1:a', { version: 20, value: { title: 'a' } }]]));
+		runtime.register(registration(backend));
+
+		await waitFor(() => backend.deliveries.length === 1);
+		assert.strictEqual(runtime.getStatus('deferred').state, 'deferred');
+		assert.deepStrictEqual(backend.cursor, cursor(10));
+		store.rootStore.emit('committed');
+		store.rootStore.emit('committed');
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.strictEqual(backend.deliveries.length, 1, 'commits must not retry backend-deferred work');
+		accept = true;
+		backend.stateChange();
+		await waitFor(() => backend.deliveries.length === 2);
+		assert.strictEqual(backend.deliveries[1], backend.deliveries[0]);
+		assert.deepStrictEqual(backend.cursor, cursor(20));
+		runtime.stop();
+	});
+
+	it('does not resume after a synchronous permanent-failure callback from deliver', async () => {
+		const store = new FakeLogStore(new Map([[10, [audit({ timestamp: 20, recordId: 'a' })]]]));
+		const backend = new FakeBackend('synchronous-failure', cursor(10), (_batch, target) => {
+			target.stateChange('failed');
+			return DERIVED_INDEX_ACCEPTED;
+		});
+		const { runtime } = runtimeFor(store, new Map([['1:a', { version: 20, value: { title: 'a' } }]]));
+		runtime.register(registration(backend));
+
+		await waitFor(() => runtime.getStatus('synchronous-failure')?.state === 'needs-rebuild');
+		assert.strictEqual(backend.deliveries.length, 1);
+		store.rootStore.emit('committed');
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.strictEqual(backend.deliveries.length, 1);
+		runtime.stop();
+	});
+
+	it('reconstructs before handling a result returned after synchronous accepted-work loss', async () => {
+		const store = new FakeLogStore(new Map([[10, [audit({ timestamp: 20, recordId: 'a' })]]]));
+		let first = true;
+		const backend = new FakeBackend('synchronous-loss', cursor(10), (batch, target) => {
+			if (first) {
+				first = false;
+				target.stateChange('accepted-work-lost');
+				return DERIVED_INDEX_ACCEPTED;
+			}
+			target.cursor = batch.through;
+			return DERIVED_INDEX_ACCEPTED;
+		});
+		const { runtime } = runtimeFor(store, new Map([['1:a', { version: 20, value: { title: 'a' } }]]));
+		runtime.register(registration(backend));
+
+		await waitFor(() => backend.deliveries.length === 2 && backend.cursor.logs.local === 20);
+		assert(store.rangeCalls.length >= 2);
+		assert.deepStrictEqual(backend.deliveries[1].transactions, backend.deliveries[0].transactions);
+		runtime.stop();
+	});
+
+	it('replays from the durable cursor when a backend reports lost accepted work', async () => {
+		const entries = new Map([[10, [audit({ timestamp: 20, recordId: 'a' })]]]);
+		const store = new FakeLogStore(entries);
+		let persist = false;
+		const backend = new FakeBackend('loss', cursor(10), (batch, target) => {
+			if (persist) target.cursor = batch.through;
+			return DERIVED_INDEX_ACCEPTED;
+		});
+		const { runtime } = runtimeFor(store, new Map([['1:a', { version: 20, value: { title: 'a' } }]]));
+		runtime.register(registration(backend));
+
+		await waitFor(() => backend.deliveries.length === 1);
+		persist = true;
+		backend.stateChange('accepted-work-lost');
+		await waitFor(() => backend.deliveries.length === 2);
+		assert.deepStrictEqual(backend.deliveries[1], backend.deliveries[0]);
+		assert.deepStrictEqual(backend.cursor, cursor(20));
+		assert(store.rangeCalls.length >= 2, 'lost work must reconstruct the exact-resume iterator');
+		runtime.stop();
+	});
+
+	it('fails closed when the exact durable cursor boundary is unavailable', async () => {
+		const store = new FakeLogStore(new Map());
+		store.getRange = function (options) {
+			const iterable = FakeLogStore.prototype.getRange.call(this, options);
+			iterable.exactStartFailures.set('local', 'missing');
+			return iterable;
+		};
+		const backend = new FakeBackend('broken', cursor(10));
+		const { runtime } = runtimeFor(store, new Map());
+		runtime.register(registration(backend));
+
+		await waitFor(() => runtime.getStatus('broken')?.state === 'needs-rebuild');
+		assert.match(runtime.getStatus('broken').reason, /missing durable cursor boundary/);
+		assert.strictEqual(backend.deliveries.length, 0);
+		assert.strictEqual(store.locks.size, 0);
+		runtime.stop();
+	});
+
+	for (const [name, mutateRange, reason] of [
+		[
+			'a corrupt transaction-log frame',
+			(iterable) => {
+				iterable.corruptFrameStop.breaks = 1;
+			},
+			/corrupt frame/,
+		],
+		['an unexpected transaction-log failure', (iterable) => iterable.failedLogs.add('local'), /iterator failed/],
+	]) {
+		it(`fails closed on ${name}`, async () => {
+			const store = new FakeLogStore(new Map([[10, []]]));
+			store.getRange = function (options) {
+				const iterable = FakeLogStore.prototype.getRange.call(this, options);
+				mutateRange(iterable);
+				return iterable;
+			};
+			const backend = new FakeBackend(`range-failure-${reason}`, cursor(10));
+			const { runtime } = runtimeFor(store, new Map());
+			runtime.register(registration(backend));
+
+			await waitFor(() => runtime.getStatus(backend.id)?.state === 'needs-rebuild');
+			assert.match(runtime.getStatus(backend.id).reason, reason);
+			assert.strictEqual(backend.deliveries.length, 0);
+			runtime.stop();
+		});
+	}
+
+	it('delivers a cursor-only batch for unrelated committed work', async () => {
+		const store = new FakeLogStore(new Map([[10, [audit({ timestamp: 20, recordId: 'ignored', tableId: 2 })]]]));
+		const backend = new FakeBackend('cursor-only', cursor(10));
+		const { runtime, getReads } = runtimeFor(store, new Map());
+		runtime.register(registration(backend));
+
+		await waitFor(() => backend.deliveries.length === 1);
+		assert.deepStrictEqual(backend.deliveries[0], { ownerEpoch: 1n, transactions: [], through: cursor(20) });
+		assert.strictEqual(getReads(), 0);
+		runtime.stop();
+	});
+
+	it('bounds accepted work while the backend durability barrier lags', async () => {
+		const store = new FakeLogStore(
+			new Map([
+				[
+					10,
+					[
+						audit({ timestamp: 20, recordId: 'a' }),
+						audit({ timestamp: 30, recordId: 'b' }),
+						audit({ timestamp: 40, recordId: 'c' }),
+					],
+				],
+			])
+		);
+		const backend = new FakeBackend('durability-cap', cursor(10), () => DERIVED_INDEX_ACCEPTED);
+		const records = new Map(['a', 'b', 'c'].map((id) => [`1:${id}`, { version: 40, value: { title: id } }]));
+		const { runtime } = runtimeFor(store, records, {
+			maxTransactionsPerTurn: 1,
+			maxAcceptedBatchesAhead: 2,
+		});
+		runtime.register(registration(backend));
+
+		await waitFor(() => runtime.getStatus('durability-cap')?.state === 'waiting-durable');
+		assert.strictEqual(backend.deliveries.length, 2);
+		store.rootStore.emit('committed');
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.strictEqual(backend.deliveries.length, 2, 'commits must not bypass the durability cap');
+
+		backend.cursor = backend.deliveries[0].through;
+		backend.stateChange();
+		await waitFor(() => backend.deliveries.length === 3);
+		assert.strictEqual(backend.deliveries[2].through.logs.local, 40);
+		runtime.stop();
+	});
+
+	it('applies drain budgets only between complete transactions', async () => {
+		const store = new FakeLogStore(
+			new Map([
+				[
+					10,
+					[
+						{ ...audit({ timestamp: 20, recordId: 'a' }), endTxn: false },
+						audit({ timestamp: 20, recordId: 'b' }),
+						audit({ timestamp: 30, recordId: 'c' }),
+					],
+				],
+			])
+		);
+		const records = new Map(['a', 'b', 'c'].map((id) => [`1:${id}`, { version: 30, value: { title: id } }]));
+		const backend = new FakeBackend('bounded', cursor(10));
+		const { runtime } = runtimeFor(store, records, { maxTransactionsPerTurn: 1, maxBytesPerTurn: 1 });
+		runtime.register(registration(backend));
+
+		await waitFor(() => backend.deliveries.length === 2);
+		assert.strictEqual(backend.deliveries[0].transactions.length, 1);
+		assert.strictEqual(backend.deliveries[0].transactions[0].mutations.length, 2);
+		assert.strictEqual(backend.deliveries[0].through.logs.local, 20);
+		assert.strictEqual(backend.deliveries[1].through.logs.local, 30);
+		runtime.stop();
+	});
+
+	it('isolates one backend failure from another backend runner', async () => {
+		const store = new FakeLogStore(new Map([[10, [audit({ timestamp: 20, recordId: 'a' })]]]));
+		const failed = new FakeBackend('failed', cursor(10), () => {
+			throw new Error('backend failure');
+		});
+		const healthy = new FakeBackend('healthy', cursor(10));
+		const { runtime } = runtimeFor(store, new Map([['1:a', { version: 20, value: { title: 'a' } }]]));
+		runtime.register(registration(failed));
+		runtime.register(registration(healthy));
+
+		await waitFor(() => runtime.getStatus('failed')?.state === 'needs-rebuild' && healthy.deliveries.length === 1);
+		assert.match(runtime.getStatus('failed').reason, /backend delivery threw/);
+		assert.deepStrictEqual(healthy.cursor, cursor(20));
+		runtime.stop();
+	});
+
+	it('requires a fresh lock acquisition after another worker releases ownership', async () => {
+		const store = new FakeLogStore(
+			new Map([
+				[10, [audit({ timestamp: 20, recordId: 'a' })]],
+				[20, []],
+			])
+		);
+		const backend = new FakeBackend('shared', cursor(10));
+		const records = new Map([['1:a', { version: 20, value: { title: 'a' } }]]);
+		const first = runtimeFor(store, records).runtime;
+		const second = runtimeFor(store, records).runtime;
+		first.register(registration(backend));
+		second.register(registration(backend));
+
+		await waitFor(() => backend.deliveries.length === 1 && store.rangeCalls.length >= 2);
+		assert.deepStrictEqual(backend.cursor, cursor(20));
+		assert.strictEqual(backend.deliveries.length, 1, 'the waiting runner must exact-resume after acquiring the lock');
+		first.stop();
+		second.stop();
+	});
+
+	it('does not lose a synchronous lock-release notification', async () => {
+		const store = new FakeLogStore(new Map([[10, [audit({ timestamp: 20, recordId: 'a' })]]]));
+		let attempts = 0;
+		store.tryLock = (key, onUnlocked) => {
+			attempts++;
+			if (attempts === 1) {
+				onUnlocked();
+				return false;
+			}
+			store.locks.add(key);
+			return true;
+		};
+		const backend = new FakeBackend('synchronous-unlock', cursor(10));
+		const { runtime } = runtimeFor(store, new Map([['1:a', { version: 20, value: { title: 'a' } }]]));
+		runtime.register(registration(backend));
+
+		await waitFor(() => backend.deliveries.length === 1);
+		assert.strictEqual(attempts, 2);
+		runtime.stop();
+	});
+
+	it('rejects a durable cursor assembled from different offered batch boundaries', async () => {
+		const initial = { format: 1, logs: { local: 10, remote: 11 } };
+		const store = new FakeLogStore(
+			new Map([
+				[
+					10,
+					[audit({ timestamp: 20, recordId: 'a' }), { ...audit({ timestamp: 21, recordId: 'b' }), logName: 'remote' }],
+				],
+			]),
+			['local', 'remote']
+		);
+		const backend = new FakeBackend('mixed-cursor', initial, () => DERIVED_INDEX_ACCEPTED);
+		const records = new Map(['a', 'b'].map((id) => [`1:${id}`, { version: 21, value: { title: id } }]));
+		const { runtime } = runtimeFor(store, records, { maxTransactionsPerTurn: 1 });
+		runtime.register(registration(backend));
+
+		await waitFor(() => backend.deliveries.length === 2);
+		assert.deepStrictEqual(
+			backend.deliveries.map((batch) => batch.through),
+			[
+				{ format: 1, logs: { local: 20, remote: 11 } },
+				{ format: 1, logs: { local: 20, remote: 21 } },
+			]
+		);
+		backend.cursor = { format: 1, logs: { local: 10, remote: 21 } };
+		backend.stateChange();
+
+		await waitFor(() => runtime.getStatus('mixed-cursor')?.state === 'needs-rebuild');
+		assert.match(runtime.getStatus('mixed-cursor').reason, /unoffered cursor vector/);
+		runtime.stop();
+	});
+
+	it('fails closed when one physical log repeats a completed timestamp', async () => {
+		const store = new FakeLogStore(
+			new Map([[10, [audit({ timestamp: 20, recordId: 'a' }), audit({ timestamp: 20, recordId: 'b' })]]])
+		);
+		const backend = new FakeBackend('duplicate', cursor(10));
+		const { runtime } = runtimeFor(store, new Map());
+		runtime.register(registration(backend));
+
+		await waitFor(() => runtime.getStatus('duplicate')?.state === 'needs-rebuild');
+		assert.match(runtime.getStatus('duplicate').reason, /repeated completed timestamp/);
+		assert.strictEqual(backend.deliveries.length, 0);
+		runtime.stop();
+	});
+
+	it('reacquires after the idle grace period when a later commit wakes it', async () => {
+		const entries = new Map([[10, []]]);
+		const store = new FakeLogStore(entries);
+		const backend = new FakeBackend('idle-wake', cursor(10));
+		const { runtime } = runtimeFor(store, new Map([['1:a', { version: 20, value: { title: 'a' } }]]));
+		runtime.register(registration(backend));
+
+		await waitFor(() => store.locks.size === 0);
+		entries.set(10, [audit({ timestamp: 20, recordId: 'a' })]);
+		store.rootStore.emit('committed');
+
+		await waitFor(() => backend.deliveries.length === 1);
+		assert.deepStrictEqual(backend.cursor, cursor(20));
+		runtime.stop();
+	});
+
+	it('unregisters the backend wake and root commit listeners', async () => {
+		const store = new FakeLogStore(new Map([[10, []]]));
+		const backend = new FakeBackend('unregister', cursor(10));
+		const { runtime } = runtimeFor(store, new Map());
+		const unregister = runtime.register(registration(backend));
+
+		await waitFor(() => backend.stateChange !== undefined);
+		unregister();
+		assert.strictEqual(backend.stateChange, undefined);
+		assert.strictEqual(store.rootStore.listenerCount('committed'), 0);
+		assert.strictEqual(runtime.getStatus('unregister'), undefined);
+		runtime.stop();
+	});
+
+	it('fails closed if a saved physical log disappears', async () => {
+		const logNames = ['local'];
+		const store = new FakeLogStore(new Map([[10, []]]), logNames);
+		const backend = new FakeBackend('removed-log', cursor(10));
+		const { runtime } = runtimeFor(store, new Map());
+		runtime.register(registration(backend));
+
+		await waitFor(() => store.locks.size === 0);
+		logNames.length = 0;
+		store.rootStore.emit('committed');
+
+		await waitFor(() => runtime.getStatus('removed-log')?.state === 'needs-rebuild');
+		assert.match(runtime.getStatus('removed-log').reason, /saved transaction log 'local' is missing/);
+		runtime.stop();
+	});
+});

--- a/unitTests/resources/derivedIndexRuntimeRocks.test.js
+++ b/unitTests/resources/derivedIndexRuntimeRocks.test.js
@@ -4,6 +4,7 @@ const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { waitFor } = require('../waitFor');
+const { LOCAL_ONLY } = require('#src/resources/auditStore');
 const { DERIVED_INDEX_ACCEPTED, DerivedIndexRuntime } = require('#src/resources/derivedIndexRuntime');
 
 describe('DerivedIndexRuntime with an audited RocksDB table', () => {
@@ -26,6 +27,16 @@ describe('DerivedIndexRuntime with an audited RocksDB table', () => {
 			audit: true,
 			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'title' }, { name: 'privateInventory' }],
 		});
+		await Product.put('unregistered-eviction', { title: 'not indexed' });
+		let entry = Product.primaryStore.getEntry('unregistered-eviction');
+		await Product.evict('unregistered-eviction', entry.value, entry.version);
+		assert.strictEqual(
+			[...Product.auditStore.getRange({ start: 1 })].some(
+				(record) => record.type === 'evict' && record.recordId === 'unregistered-eviction'
+			),
+			false
+		);
+
 		await Product.put('anchor', { title: 'anchor' });
 		const anchor = [...Product.auditStore.getRange({ start: 1 })]
 			.filter((entry) => entry.tableId === Product.tableId && entry.recordId === 'anchor')
@@ -53,7 +64,7 @@ describe('DerivedIndexRuntime with an audited RocksDB table', () => {
 			const entry = Product.primaryStore.getEntry(recordId);
 			return entry?.value ? { version: entry.version, value: entry.value } : undefined;
 		});
-		runtime.register({
+		const unregister = runtime.register({
 			backend,
 			projections: new Map([[Product.tableId, (record) => ({ title: record.title })]]),
 		});
@@ -74,6 +85,34 @@ describe('DerivedIndexRuntime with an audited RocksDB table', () => {
 		await Product.delete('p1');
 		await waitFor(() => mutationsFor(backend, 'p1').some((mutation) => mutation.state.kind === 'absent'));
 		assert.strictEqual(mutationsFor(backend, 'p1').at(-1).state.kind, 'absent');
+
+		await Product.put('evicted', { title: 'resident' });
+		await waitFor(() => mutationsFor(backend, 'evicted').length > 0);
+		entry = Product.primaryStore.getEntry('evicted');
+		await Product.evict('evicted', entry.value, entry.version);
+		await waitFor(() => mutationsFor(backend, 'evicted').at(-1)?.state.kind === 'absent');
+		const markers = [...Product.auditStore.getRange({ start: 1 })].filter(
+			(record) => record.type === 'evict' && record.recordId === 'evicted'
+		);
+		assert.strictEqual(markers.length, 1);
+		assert.strictEqual(markers[0].extendedType & LOCAL_ONLY, LOCAL_ONLY);
+		const history = [];
+		for await (const record of Product.getHistory()) history.push(record);
+		assert.strictEqual(
+			history.some((record) => record.type === 'evict'),
+			false
+		);
+
+		unregister();
+		await Product.put('after-unregister', { title: 'not indexed' });
+		entry = Product.primaryStore.getEntry('after-unregister');
+		await Product.evict('after-unregister', entry.value, entry.version);
+		assert.strictEqual(
+			[...Product.auditStore.getRange({ start: 1 })].some(
+				(record) => record.type === 'evict' && record.recordId === 'after-unregister'
+			),
+			false
+		);
 	});
 });
 

--- a/unitTests/resources/derivedIndexRuntimeRocks.test.js
+++ b/unitTests/resources/derivedIndexRuntimeRocks.test.js
@@ -1,0 +1,86 @@
+require('../testUtils');
+const assert = require('node:assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { waitFor } = require('../waitFor');
+const { DERIVED_INDEX_ACCEPTED, DerivedIndexRuntime } = require('#src/resources/derivedIndexRuntime');
+
+describe('DerivedIndexRuntime with an audited RocksDB table', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+
+	let runtime;
+	before(function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+	});
+
+	after(function () {
+		runtime?.stop();
+	});
+
+	it('tails committed writes and projects the current primary state', async () => {
+		const Product = table({
+			database: 'derived-index-runtime-rocks',
+			table: 'Product',
+			audit: true,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'title' }, { name: 'privateInventory' }],
+		});
+		await Product.put('anchor', { title: 'anchor' });
+		const anchor = [...Product.auditStore.getRange({ start: 1 })]
+			.filter((entry) => entry.tableId === Product.tableId && entry.recordId === 'anchor')
+			.at(-1).txnLogKey;
+
+		const backend = {
+			id: 'products',
+			cursor: { format: 1, logs: { local: anchor } },
+			deliveries: [],
+			getDurableCursor() {
+				return this.cursor;
+			},
+			deliver(batch) {
+				this.deliveries.push(batch);
+				this.cursor = batch.through;
+				return DERIVED_INDEX_ACCEPTED;
+			},
+			onStateChange(wake) {
+				this.wake = wake;
+				return () => (this.wake = undefined);
+			},
+		};
+		runtime = new DerivedIndexRuntime(Product.auditStore, (tableId, recordId) => {
+			if (tableId !== Product.tableId) throw new Error(`unknown table ${tableId}`);
+			const entry = Product.primaryStore.getEntry(recordId);
+			return entry?.value ? { version: entry.version, value: entry.value } : undefined;
+		});
+		runtime.register({
+			backend,
+			projections: new Map([[Product.tableId, (record) => ({ title: record.title })]]),
+		});
+
+		await Product.put('p1', { title: 'first', privateInventory: 12 });
+		await waitFor(() => mutationsFor(backend, 'p1').length >= 1);
+		assert.deepStrictEqual(mutationsFor(backend, 'p1').at(-1).state.projection, { title: 'first' });
+		assert.strictEqual('privateInventory' in mutationsFor(backend, 'p1').at(-1).state.projection, false);
+
+		await Product.patch('p1', { title: 'second' });
+		await waitFor(() => mutationsFor(backend, 'p1').length >= 2);
+		assert.deepStrictEqual(mutationsFor(backend, 'p1').at(-1).state, {
+			kind: 'record',
+			version: Product.primaryStore.getEntry('p1').version,
+			projection: { title: 'second' },
+		});
+
+		await Product.delete('p1');
+		await waitFor(() => mutationsFor(backend, 'p1').some((mutation) => mutation.state.kind === 'absent'));
+		assert.strictEqual(mutationsFor(backend, 'p1').at(-1).state.kind, 'absent');
+	});
+});
+
+function mutationsFor(backend, recordId) {
+	return backend.deliveries.flatMap((batch) =>
+		batch.transactions.flatMap((transaction) =>
+			transaction.mutations.filter((mutation) => mutation.recordId === recordId)
+		)
+	);
+}

--- a/unitTests/resources/evictionBatch.test.js
+++ b/unitTests/resources/evictionBatch.test.js
@@ -4,6 +4,7 @@ const { setTimeout: delay } = require('timers/promises');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { Resource } = require('#src/resources/Resource');
+const { registerDerivedIndexTables } = require('#src/resources/derivedIndexRegistry');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 
 // Exercises the RocksDB batched-eviction path in Table.ts's cleanup scan: when more than
@@ -83,25 +84,35 @@ describe('Batched eviction (RocksDB)', () => {
 	it('physically evicts >EVICTION_BATCH_SIZE records across multiple batches and cleans indices', async function () {
 		const N = 250; // > EVICTION_BATCH_SIZE (100) so the scan must commit multiple batches
 		const ids = Array.from({ length: N }, (_, i) => i);
-		EvictTable.setTTLExpiration(HOLD); // keep records resident through warming
-		for (const id of ids) await EvictTable.get(id);
+		const unregister = registerDerivedIndexTables(EvictTable.auditStore, [EvictTable.tableId]);
+		try {
+			EvictTable.setTTLExpiration(HOLD); // keep records resident through warming
+			for (const id of ids) await EvictTable.get(id);
 
-		// Sanity: records and their index entries are resident before eviction.
-		assert.equal(await waitForResident(EvictTable, ids), N, 'records should be resident after warming');
-		assert.equal(
-			EvictTable.indices['name'].getValuesCount('group 7'),
-			N / 10,
-			'index should be populated before eviction'
-		);
+			// Sanity: records and their index entries are resident before eviction.
+			assert.equal(await waitForResident(EvictTable, ids), N, 'records should be resident after warming');
+			assert.equal(
+				EvictTable.indices['name'].getValuesCount('group 7'),
+				N / 10,
+				'index should be populated before eviction'
+			);
 
-		// No resource get() here — the only thing that can remove these records is the batched scan.
-		const resident = await evictAndWait(EvictTable, ids);
-		assert.equal(resident, 0, 'cleanup scan should physically evict every expired record');
-		assert.equal(
-			EvictTable.indices['name'].getValuesCount('group 7'),
-			0,
-			'index entries must be removed with the records'
-		);
+			// No resource get() here — the only thing that can remove these records is the batched scan.
+			const resident = await evictAndWait(EvictTable, ids);
+			assert.equal(resident, 0, 'cleanup scan should physically evict every expired record');
+			assert.equal(
+				EvictTable.indices['name'].getValuesCount('group 7'),
+				0,
+				'index entries must be removed with the records'
+			);
+			const idSet = new Set(ids);
+			const markers = [...EvictTable.auditStore.getRange({ start: 1 })].filter(
+				(record) => record.type === 'evict' && idSet.has(record.recordId)
+			);
+			assert.equal(markers.length, N, 'every committed batched removal must have one marker');
+		} finally {
+			unregister();
+		}
 	});
 
 	it('recovers from an optimistic commit conflict (ERR_BUSY) and still evicts', async function () {

--- a/unitTests/resources/evictionBusy.test.js
+++ b/unitTests/resources/evictionBusy.test.js
@@ -2,6 +2,7 @@ require('../testUtils');
 const assert = require('assert');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
+const { registerDerivedIndexTables } = require('#src/resources/derivedIndexRegistry');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 
 // Regression for #1287 (RocksDB leg). The cleanup scan's batcher retries ERR_BUSY, but the two
@@ -29,6 +30,7 @@ describe('evict() swallows a commit conflict instead of rejecting (#1287)', () =
 		const originalCommit = Transaction.prototype.commit;
 		await BusyTable.put('b1', { id: 'b1' });
 		const entry = BusyTable.primaryStore.getEntry('b1');
+		const unregister = registerDerivedIndexTables(BusyTable.auditStore, [BusyTable.tableId]);
 
 		let injected = false;
 		// Arm a single ERR_BUSY into the next commit — the eviction commit issued synchronously by evict().
@@ -48,8 +50,17 @@ describe('evict() swallows a commit conflict instead of rejecting (#1287)', () =
 			// Must resolve, not reject: a rejection here is the unhandledRejection that crashed [main/0].
 			await resolution;
 			assert.ok(injected, 'the injected ERR_BUSY conflict should have fired on the eviction commit');
+			assert.ok(BusyTable.primaryStore.getEntry('b1'), 'the failed transaction must leave the resident record intact');
+			assert.strictEqual(
+				[...BusyTable.auditStore.getRange({ start: 1 })].some(
+					(record) => record.type === 'evict' && record.recordId === 'b1'
+				),
+				false,
+				'the failed transaction must not commit an eviction marker'
+			);
 		} finally {
 			Transaction.prototype.commit = originalCommit;
+			unregister();
 		}
 	});
 });

--- a/unitTests/resources/transactionLogRangeMetadata.test.js
+++ b/unitTests/resources/transactionLogRangeMetadata.test.js
@@ -18,10 +18,11 @@ function encodedDelete(recordId) {
 	);
 }
 
-function makeLog(name, entries) {
+function makeLog(name, entries, onQuery) {
 	return {
 		name,
-		query() {
+		query(options) {
+			onQuery?.(options);
 			let index = 0;
 			return {
 				next() {
@@ -113,5 +114,102 @@ describe('RocksTransactionLogStore range metadata', () => {
 			[['record', 'local']]
 		);
 		assert.deepStrictEqual([...iterable.failedLogs], ['failed-peer']);
+	});
+
+	it('preserves the legacy single-log exactStart error behavior without the new opt-in flags', () => {
+		const failedLog = makeLog('local', []);
+		failedLog.query = () => ({
+			next() {
+				throw new Error('legacy exact-start failure');
+			},
+			[Symbol.iterator]() {
+				return this;
+			},
+		});
+		const iterable = makeStore([failedLog]).getRange({ log: 'local', start: 50, exactStart: true });
+
+		assert.throws(() => [...iterable], /legacy exact-start failure/);
+		assert.strictEqual(iterable.failedLogs.size, 0);
+	});
+
+	it('reports an exact-start miss by physical log', () => {
+		const store = makeStore([makeLog('local', [])]);
+		const iterable = store.getRange({
+			startByLog: new Map([['local', 50]]),
+			exactStart: true,
+			includeLogName: true,
+		});
+
+		assert.deepStrictEqual([...iterable], []);
+		assert.deepStrictEqual([...iterable.exactStartFailures], [['local', 'missing']]);
+	});
+
+	it('validates and consumes one complete anchor before returning later physical transactions', () => {
+		let queryOptions;
+		const log = makeLog(
+			'local',
+			[{ ...entry(50, 'anchor-a'), endTxn: false }, entry(50, 'anchor-b'), entry(10, 'later-lower-timestamp')],
+			(options) => (queryOptions = options)
+		);
+		const iterable = makeStore([log]).getRange({
+			startByLog: new Map([['local', 50]]),
+			exactStart: true,
+			exclusiveStart: true,
+			resumeAfterExactStart: true,
+			includeLogName: true,
+		});
+
+		assert.deepStrictEqual(
+			[...iterable].map(({ recordId, txnLogKey }) => [recordId, txnLogKey]),
+			[['later-lower-timestamp', 10]]
+		);
+		assert.strictEqual(
+			queryOptions.exclusiveStart,
+			false,
+			'Harper consumes the boundary instead of filtering by value'
+		);
+		assert.strictEqual(iterable.exactStartFailures.size, 0);
+	});
+
+	for (const [name, entries, reason] of [
+		['an incomplete anchor', [{ ...entry(50, 'anchor'), endTxn: false }], 'incomplete'],
+		['a duplicate transaction timestamp', [entry(50, 'anchor'), entry(50, 'duplicate')], 'duplicate'],
+	]) {
+		it(`reports ${name} as an invalid exact resume boundary`, () => {
+			const iterable = makeStore([makeLog('local', entries)]).getRange({
+				startByLog: new Map([['local', 50]]),
+				exactStart: true,
+				resumeAfterExactStart: true,
+			});
+
+			assert.deepStrictEqual([...iterable], []);
+			assert.deepStrictEqual([...iterable.exactStartFailures], [['local', reason]]);
+		});
+	}
+
+	it('starts a newly discovered log from its beginning without an exact anchor', () => {
+		let cursorOptions;
+		let newLogOptions;
+		const cursorLog = makeLog('local', [entry(50, 'anchor')], (options) => (cursorOptions = options));
+		const newLog = makeLog('new-peer', [entry(10, 'new')], (options) => (newLogOptions = options));
+		const iterable = makeStore([cursorLog, newLog]).getRange({
+			startByLog: new Map([['local', 50]]),
+			exactStart: true,
+			includeLogName: true,
+		});
+
+		assert.deepStrictEqual(
+			[...iterable].map(({ recordId, logName }) => [recordId, logName]),
+			[
+				['new', 'new-peer'],
+				['anchor', 'local'],
+			]
+		);
+		assert.strictEqual(cursorOptions.start, 50);
+		assert.strictEqual(cursorOptions.exactStart, true);
+		assert.strictEqual(newLogOptions.start, 0);
+		assert.strictEqual(newLogOptions.exactStart, false);
+		assert.strictEqual(newLogOptions.exclusiveStart, false);
+		assert.strictEqual(iterable.exactStartFailures.size, 0);
 	});
 });

--- a/unitTests/resources/transactionLogRangeMetadata.test.js
+++ b/unitTests/resources/transactionLogRangeMetadata.test.js
@@ -1,0 +1,117 @@
+const assert = require('node:assert');
+const { RocksTransactionLogStore } = require('#src/resources/RocksTransactionLogStore');
+const { createAuditEntry, ENTRY_DATAVIEW } = require('#src/resources/auditStore');
+
+function encodedDelete(recordId) {
+	ENTRY_DATAVIEW.setUint32(0, 0);
+	return Buffer.from(
+		createAuditEntry(
+			{
+				type: 'delete',
+				tableId: 1,
+				recordId,
+				nodeId: 0,
+				version: 100,
+			},
+			4
+		)
+	);
+}
+
+function makeLog(name, entries) {
+	return {
+		name,
+		query() {
+			let index = 0;
+			return {
+				next() {
+					return index < entries.length ? { value: entries[index++], done: false } : { value: undefined, done: true };
+				},
+				[Symbol.iterator]() {
+					return this;
+				},
+			};
+		},
+	};
+}
+
+function makeStore(logs) {
+	const byName = new Map(logs.map((log) => [log.name, log]));
+	const rootStore = {
+		path: '/transaction-log-range-metadata-test',
+		useLog: (name) => byName.get(name) ?? logs[0],
+		listLogs: () => logs.map((log) => log.name),
+		on() {},
+	};
+	const store = new RocksTransactionLogStore(rootStore);
+	store.nodeLogs = logs;
+	store.logByName = byName;
+	return store;
+}
+
+function entry(timestamp, recordId) {
+	return { timestamp, data: encodedDelete(recordId), endTxn: true };
+}
+
+describe('RocksTransactionLogStore range metadata', () => {
+	it('preserves the physical log name on aggregate and single-log results when requested', () => {
+		const local = makeLog('local', [entry(20, 'local-record')]);
+		const peer = makeLog('peer-a', [entry(10, 'peer-record')]);
+		const store = makeStore([local, peer]);
+
+		const aggregate = [...store.getRange({ includeLogName: true })];
+		assert.deepStrictEqual(
+			aggregate.map(({ recordId, logName }) => [recordId, logName]),
+			[
+				['peer-record', 'peer-a'],
+				['local-record', 'local'],
+			]
+		);
+
+		const single = [...store.getRange({ log: 'peer-a', includeLogName: true })];
+		assert.strictEqual(single.length, 1);
+		assert.strictEqual(single[0].logName, 'peer-a');
+	});
+
+	it('keeps logName in the audit-record shape without populating it by default', () => {
+		const store = makeStore([makeLog('local', [entry(10, 'record')])]);
+		const iterable = store.getRange({});
+		const [record] = iterable;
+
+		assert(Object.prototype.hasOwnProperty.call(record, 'logName'));
+		assert.strictEqual(record.logName, undefined);
+		assert.strictEqual(iterable.failedLogs.size, 0);
+	});
+
+	it('keeps logName in malformed-entry sentinels with and without source metadata', () => {
+		const malformed = { timestamp: 10, data: new Uint8Array(2), endTxn: true };
+		const store = makeStore([makeLog('local', [malformed])]);
+		const [defaultRecord] = store.getRange({});
+		const [namedRecord] = store.getRange({ includeLogName: true });
+
+		assert(Object.prototype.hasOwnProperty.call(defaultRecord, 'logName'));
+		assert.strictEqual(defaultRecord.logName, undefined);
+		assert(Object.prototype.hasOwnProperty.call(namedRecord, 'logName'));
+		assert.strictEqual(namedRecord.logName, 'local');
+	});
+
+	it('reports the physical log when an unexpected iterator failure is contained', () => {
+		const failedLog = makeLog('failed-peer', []);
+		failedLog.query = () => ({
+			next() {
+				throw new Error('unexpected read failure');
+			},
+			[Symbol.iterator]() {
+				return this;
+			},
+		});
+		const healthyLog = makeLog('local', [entry(10, 'record')]);
+		const iterable = makeStore([failedLog, healthyLog]).getRange({ includeLogName: true });
+
+		assert.deepStrictEqual(
+			[...iterable].map(({ recordId, logName }) => [recordId, logName]),
+			[['record', 'local']]
+		);
+		assert.deepStrictEqual([...iterable.failedLogs], ['failed-peer']);
+	});
+});


### PR DESCRIPTION
## Outcome

Adds Harper’s shared post-commit delivery and exact-replay foundation for non-transactional derived indexes. Each backend has an independent lock-elected runner, cursor vector, bounded backlog, and failure state; record commits never await derived-index work.

## What changed

- exposes physical log identity and exact-resume failure metadata from transaction-log ranges
- adds the `DerivedIndexRuntime` delivery, cursor, ownership, and backpressure contract
- resolves projections from authoritative committed records rather than staged audit bodies
- emits atomic, local-only cache-eviction markers only for registered derived-index tables
- keeps internal eviction markers out of customer history, subscriptions, replication, and boot replay
- documents the per-worker registration invariant and the remaining generation/schema work

Closes #2489

## Validation

- `npm run build`
- `npm run lint:required`
- 75 focused derived-index/eviction tests passed
- 38 adjacent subscription/reload/audit tests passed; 9 pending
- full resource gate reaches the existing native abort in `Audit cleanup retirement`, reproduced on unmodified `main`
- local Claude and Gemini review completed; no accepted findings remain

Comment generated by kAIle (GPT-5)