### PR TITLE
Add Harper RocksDB storage for derived indexes

### DIFF
--- a/resources/DESIGN.md
+++ b/resources/DESIGN.md
@@ -12,26 +12,27 @@ See also: `../DESIGN.md` for cross-cutting non-obvious internals (RecordObject p
 
 ## File overview
 
-| File                      | Purpose                                                                                                                                      |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Resource.ts`             | Base class; `transactional()` wrapper; method routing                                                                                        |
-| `Table.ts`                | Table-as-Resource implementation. Factory `makeTable()` returns a `TableResource` subclass per table. **See section markers below.**         |
-| `Resources.ts`            | Registry mapping URL paths → Resource classes                                                                                                |
-| `RequestTarget.ts`        | Parses path/query into a structured target                                                                                                   |
-| `ResourceInterface.ts`    | Type definitions (`Context`, `Record`, etc.)                                                                                                 |
-| `RecordEncoder.ts`        | msgpack encoding + `entryMap` (record → storage entry)                                                                                       |
-| `IterableEventQueue.ts`   | Async iterable used for subscriptions and streaming responses                                                                                |
-| `transaction.ts`          | Per-request transaction object stored in `contextStorage`                                                                                    |
-| `auditStore.ts`           | Append-only audit log records                                                                                                                |
-| `derivedIndexRuntime.ts`  | Lock-elected, cursor-based delivery of committed RocksDB log mutations to derived-index backends                                             |
-| `derivedIndexRegistry.ts` | Worker-local registration counts used to emit cache-eviction markers only for tables with derived indexes                                    |
-| `recordLock.ts`           | Exclusive record locks (harper#483): option contract, native key lock primitives (`lockAttemptKey`, `makeKeyLockHandle`, `acquireRecordKey`) |
-| `nodeIdMapping.ts`        | Maps node IDs ↔ timestamps for replication ordering                                                                                          |
-| `openApi.ts`              | Generates OpenAPI/JSON Schema from `@export` schemas                                                                                         |
-| `defineTable.ts`          | Code-first table authoring (`defineTable` + `types`) — a TS front-end to the canonical `table()` model                                       |
-| `defineResource.ts`       | Per-method request contract (`defineResource` / `Resource.withSchema`, `t`, `schemaOf`) — typed handlers + edge validation                   |
-| `jsonSchemaTypes.ts`      | Shared `JsonSchemaFragment` IR + `attributeToFragment` projector (one vocabulary for validation/OpenAPI/MCP)                                 |
-| `analytics/`              | Telemetry recording (separate from monitoring)                                                                                               |
+| File                          | Purpose                                                                                                                                      |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Resource.ts`                 | Base class; `transactional()` wrapper; method routing                                                                                        |
+| `Table.ts`                    | Table-as-Resource implementation. Factory `makeTable()` returns a `TableResource` subclass per table. **See section markers below.**         |
+| `Resources.ts`                | Registry mapping URL paths → Resource classes                                                                                                |
+| `RequestTarget.ts`            | Parses path/query into a structured target                                                                                                   |
+| `ResourceInterface.ts`        | Type definitions (`Context`, `Record`, etc.)                                                                                                 |
+| `RecordEncoder.ts`            | msgpack encoding + `entryMap` (record → storage entry)                                                                                       |
+| `IterableEventQueue.ts`       | Async iterable used for subscriptions and streaming responses                                                                                |
+| `transaction.ts`              | Per-request transaction object stored in `contextStorage`                                                                                    |
+| `auditStore.ts`               | Append-only audit log records                                                                                                                |
+| `derivedIndexRuntime.ts`      | Lock-elected, cursor-based delivery of committed RocksDB log mutations to derived-index backends                                             |
+| `derivedIndexRegistry.ts`     | Worker-local registration counts used to emit cache-eviction markers only for tables with derived indexes                                    |
+| `RocksDerivedIndexStorage.ts` | Binary, WAL-backed host storage used by native derived indexes; batches through one RocksDB transaction and syncs through the shared root    |
+| `recordLock.ts`               | Exclusive record locks (harper#483): option contract, native key lock primitives (`lockAttemptKey`, `makeKeyLockHandle`, `acquireRecordKey`) |
+| `nodeIdMapping.ts`            | Maps node IDs ↔ timestamps for replication ordering                                                                                          |
+| `openApi.ts`                  | Generates OpenAPI/JSON Schema from `@export` schemas                                                                                         |
+| `defineTable.ts`              | Code-first table authoring (`defineTable` + `types`) — a TS front-end to the canonical `table()` model                                       |
+| `defineResource.ts`           | Per-method request contract (`defineResource` / `Resource.withSchema`, `t`, `schemaOf`) — typed handlers + edge validation                   |
+| `jsonSchemaTypes.ts`          | Shared `JsonSchemaFragment` IR + `attributeToFragment` projector (one vocabulary for validation/OpenAPI/MCP)                                 |
+| `analytics/`                  | Telemetry recording (separate from monitoring)                                                                                               |
 
 ---
 

--- a/resources/RocksDerivedIndexStorage.ts
+++ b/resources/RocksDerivedIndexStorage.ts
@@ -1,0 +1,104 @@
+import { RocksDatabase, type Transaction } from '@harperfast/rocksdb-js';
+import {
+	closeDerivedIndexStore,
+	dropDerivedIndexStore,
+	openDerivedIndexStore,
+	type RootDatabaseKind,
+} from './databases.ts';
+
+export type DerivedIndexWritePolicy = 'wal' | 'no-wal';
+
+export type DerivedIndexStorageMutation = { type: 'put'; key: Buffer; value: Buffer } | { type: 'delete'; key: Buffer };
+
+/**
+ * Synchronous host-storage surface used by native derived indexes. It deliberately exposes only
+ * operations Harper can satisfy with its existing RocksDB ownership and durability primitives.
+ */
+export class RocksDerivedIndexStorage {
+	#closed = false;
+	#rootStore: RootDatabaseKind & RocksDatabase;
+	#store: RocksDatabase;
+
+	constructor(rootStore: RootDatabaseKind, storeName: string) {
+		if (!(rootStore instanceof RocksDatabase)) throw new Error('Derived indexes require RocksDB storage');
+		this.#rootStore = rootStore;
+		this.#store = openDerivedIndexStore(rootStore, storeName);
+	}
+
+	read(key: Buffer): Buffer | undefined {
+		this.#assertOpen();
+		if (!Buffer.isBuffer(key)) throw new TypeError('Derived index storage keys must be Buffers');
+		const value = this.#store.getSync(key);
+		if (value === undefined) return undefined;
+		if (!Buffer.isBuffer(value)) throw new Error('Derived index storage contains a non-binary value');
+		return value;
+	}
+
+	write(mutations: Array<DerivedIndexStorageMutation>, policy: DerivedIndexWritePolicy): void {
+		this.#assertOpen();
+		if (policy !== 'wal') throw new Error('Harper derived index writes require the RocksDB WAL');
+		validateMutations(mutations);
+		if (mutations.length === 0) return;
+
+		const committed = this.#rootStore.transactionSync(
+			(transaction: Transaction) => {
+				for (const mutation of mutations) {
+					if (mutation.type === 'put') {
+						this.#store.putSync(mutation.key, mutation.value, { transaction });
+					} else {
+						this.#store.removeSync(mutation.key, { transaction });
+					}
+				}
+				return true;
+			},
+			{ retryOnBusy: true }
+		);
+		if (committed !== true) throw new Error('Derived index storage transaction did not commit');
+	}
+
+	/**
+	 * Establish durability for preceding WAL writes. rocksdb-js DBDescriptor::flush flushes every
+	 * registered column family regardless of the calling handle. This can stall unrelated writes,
+	 * so the fulltext publication scheduler must coalesce and rate-limit calls.
+	 */
+	sync(): void {
+		this.#assertOpen();
+		this.#rootStore.flushSync({ allowWriteStall: true });
+	}
+
+	/** Close only this derived column-family handle; the caller retains ownership of the root store. */
+	close(): void {
+		if (this.#closed) return;
+		closeDerivedIndexStore(this.#rootStore, this.#store);
+		this.#closed = true;
+	}
+
+	/** Drop this derived column family after its native readers and writer have drained. */
+	drop(): void {
+		this.#assertOpen();
+		dropDerivedIndexStore(this.#rootStore, this.#store);
+		this.#closed = true;
+	}
+
+	#assertOpen(): void {
+		if (this.#closed || !this.#rootStore.isOpen() || !this.#store.isOpen()) {
+			throw new Error('Derived index storage is closed');
+		}
+	}
+}
+
+function validateMutations(mutations: Array<DerivedIndexStorageMutation>): void {
+	if (!Array.isArray(mutations)) throw new TypeError('Derived index mutations must be an array');
+	for (const mutation of mutations) {
+		if (!mutation || !Buffer.isBuffer(mutation.key)) {
+			throw new TypeError('Derived index storage keys must be Buffers');
+		}
+		if (mutation.type === 'put') {
+			if (!Buffer.isBuffer(mutation.value)) {
+				throw new TypeError('Derived index storage values must be Buffers');
+			}
+		} else if (mutation.type !== 'delete') {
+			throw new TypeError('Unknown derived index storage mutation');
+		}
+	}
+}

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -305,6 +305,9 @@ interface RocksRootDatabase extends RocksDatabaseEx {
 	rootStore?: RocksRootDatabase;
 }
 
+const DERIVED_INDEX_STORES = Symbol('derived-index-stores');
+const DERIVED_INDEX_STORE_PREFIX = '`derived-index`/';
+
 export type RootDatabaseKind = LMDBRootDatabase | RocksRootDatabase;
 
 export type DatabaseWatcherEventMap = {
@@ -351,7 +354,7 @@ export function toRocksCompression(compression: unknown): unknown {
 	return compression;
 }
 
-function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSort?: boolean }) {
+function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSort?: boolean }, raw: boolean = false) {
 	options.disableWAL ??= true;
 	const legacyOptions = options as { compression?: unknown };
 	// A configured codec applies to every column family, overriding whatever per-table metadata
@@ -396,6 +399,8 @@ function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSo
 	let db: RocksRootDatabase;
 	if (options.dupSort) {
 		db = new RocksIndexStore(path, options).open() as any;
+	} else if (raw) {
+		db = new RocksDatabase(path, options).open() as RocksRootDatabase;
 	} else {
 		db = new PrimaryRocksDatabase(path, options).open() as unknown as RocksRootDatabase;
 		// the RocksDB put and remove return promises, which masks thrown errors in non-awaiting calls to put/remove,
@@ -410,6 +415,84 @@ function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSo
 	}
 	db.env = {};
 	return db;
+}
+
+/**
+ * Open an unencoded RocksDB column family for a derived index. The returned handle participates in
+ * Harper's existing RocksDB descriptor, memory configuration, compression policy, and backup
+ * boundary, but its lifecycle remains with the derived-index owner until that owner is registered
+ * in the database close graph.
+ */
+export function openDerivedIndexStore(rootStore: RootDatabaseKind, dbiKey: string): RocksDatabase {
+	if (!(rootStore instanceof RocksDatabase)) throw new Error('Derived indexes require RocksDB storage');
+	if (!rootStore.isOpen()) throw new Error('Cannot open a derived index on a closed RocksDB root store');
+	if (rocksdbDatabaseEnvs.get(rootStore.path) !== rootStore) {
+		throw new Error('Derived index storage requires the RocksDB root store, not a column-family handle');
+	}
+	if (rootStore.store.disableWAL) {
+		throw new Error('Derived indexes require a WAL-enabled RocksDB root store');
+	}
+	if (typeof dbiKey !== 'string' || dbiKey.length === 0) {
+		throw new TypeError('Derived index store name must be a non-empty string');
+	}
+	const store = openRocksDatabase(
+		rootStore.path,
+		{
+			// Backticks are forbidden in customer schema names, so this can never alias a table,
+			// secondary index, or existing Harper internal column family.
+			name: `${DERIVED_INDEX_STORE_PREFIX}${dbiKey}`,
+			disableWAL: false,
+			encoding: 'binary',
+			keyEncoding: 'binary',
+		},
+		true
+	);
+	((rootStore as any)[DERIVED_INDEX_STORES] ??= new Set()).add(store);
+	return store;
+}
+
+/** Release a derived handle opened by openDerivedIndexStore without closing its shared root. */
+export function closeDerivedIndexStore(rootStore: RootDatabaseKind, store: RocksDatabase): void {
+	if (store.isOpen()) store.close();
+	// A failed close may still own a native descriptor claim. Keep it discoverable so a later
+	// database teardown can retry instead of converting the resource leak into unreachable state.
+	(rootStore as any)[DERIVED_INDEX_STORES]?.delete(store);
+}
+
+/** Drop a retired derived column family, tolerating another worker having already dropped it. */
+export function dropDerivedIndexStore(rootStore: RootDatabaseKind, store: RocksDatabase): void {
+	let dropError: unknown;
+	try {
+		store.dropSync();
+	} catch (error) {
+		try {
+			ignoreAlreadyDropped(error);
+		} catch (error) {
+			dropError = error;
+		}
+	}
+	try {
+		closeDerivedIndexStore(rootStore, store);
+	} catch (closeError) {
+		if (!dropError) throw closeError;
+		logger.warn('Error closing derived index store after its drop failed:', closeError);
+	}
+	if (dropError) throw dropError;
+}
+
+function closeDerivedIndexStores(rootStore: RootDatabaseKind, description: string): void {
+	const stores: Set<RocksDatabase> | undefined = (rootStore as any)[DERIVED_INDEX_STORES];
+	if (!stores) return;
+	for (const store of stores) {
+		try {
+			if (store.isOpen()) store.close();
+			stores.delete(store);
+		} catch (error) {
+			// Retain a handle whose close failed; removing it would make the live native claim
+			// unreachable and prevent a later teardown attempt from releasing it.
+			logger.warn(`Error closing derived index store ${description}:`, error);
+		}
+	}
 }
 
 const lmdbDatabaseEnvs = new Map<string, LMDBRootDatabase>();
@@ -1674,6 +1757,7 @@ function closeBranchHandles(path: string, rootStore?: RootDatabaseKind, openedSt
 		}
 	};
 	for (const store of openedStores) closeStore(store, 'column family');
+	if (rootStore) closeDerivedIndexStores(rootStore, `for branch database at ${path}`);
 	closeStore((rootStore as any)?.dbisDb, 'attributes store');
 	closeStore((rootStore as any)?.auditStore, 'audit store');
 	closeStore(rootStore, 'root store');
@@ -1953,6 +2037,7 @@ export async function dropDatabase(databaseName) {
 			// already running has released the stores this is about to close and unlink
 			await rootStore.auditStore?.stopAuditCleanup?.();
 			removeStorageReclamation(rootStore.path);
+			closeDerivedIndexStores(rootStore, `while dropping database ${databaseName}`);
 			if (rootStore.status === 'open') {
 				if (rootStore instanceof RocksDatabase) {
 					rootStore.close();
@@ -1969,6 +2054,7 @@ export async function dropDatabase(databaseName) {
 			if (rootStore instanceof RocksDatabase) lockDatabaseForDrop(rootStore.path, databaseName, restoreLocks);
 			await rootStore.auditStore?.stopAuditCleanup?.();
 			removeStorageReclamation(rootStore.path);
+			closeDerivedIndexStores(rootStore, `while dropping database ${databaseName}`);
 			if (rootStore instanceof RocksDatabase) {
 				rootStore.close();
 				rootStore.destroy();
@@ -2027,6 +2113,7 @@ export function closeDatabase(databaseName: string): boolean {
 	}
 	for (const rootStore of rootStores) {
 		removeStorageReclamation(rootStore.path);
+		closeDerivedIndexStores(rootStore, `while closing database ${databaseName}`);
 		closeStore(rootStore.dbisDb, 'attributes store');
 		closeStore(rootStore, 'root store');
 		lmdbDatabaseEnvs.delete(rootStore.path);

--- a/unitTests/resources/rocksDerivedIndexStorage.test.js
+++ b/unitTests/resources/rocksDerivedIndexStorage.test.js
@@ -1,0 +1,257 @@
+require('../testUtils');
+const assert = require('node:assert');
+const { RocksDatabase } = require('@harperfast/rocksdb-js');
+const { setupTestDBPath } = require('../testUtils');
+const {
+	closeDatabase,
+	closeDerivedIndexStore,
+	dropDerivedIndexStore,
+	openDerivedIndexStore,
+	table,
+} = require('#src/resources/databases');
+const { RocksDerivedIndexStorage } = require('#src/resources/RocksDerivedIndexStorage');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+describe('RocksDerivedIndexStorage', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+
+	let Anchor;
+	const opened = [];
+
+	before(() => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		Anchor = table({
+			database: 'derived-index-storage',
+			table: 'Anchor',
+			attributes: [{ name: 'id', isPrimaryKey: true }],
+		});
+	});
+
+	after(() => {
+		for (const storage of opened) storage.close();
+	});
+
+	function open(name) {
+		const storage = new RocksDerivedIndexStorage(Anchor.primaryStore.rootStore, name);
+		opened.push(storage);
+		return storage;
+	}
+
+	it('round-trips binary keys and values without crossing namespaces', () => {
+		const first = open('__test_derived_first');
+		const second = open('__test_derived_second');
+		const key = Buffer.from([0, 255, 1]);
+		const value = Buffer.from([3, 0, 254]);
+
+		first.write([{ type: 'put', key, value }], 'wal');
+
+		const held = first.read(key);
+		first.read(Buffer.from('another read'));
+		assert.deepStrictEqual(held, value, 'read buffers remain stable across later reads');
+		assert.strictEqual(first.read(Buffer.from([0, 255, 1, 0])), undefined);
+		assert.strictEqual(second.read(key), undefined);
+	});
+
+	it('cannot alias a Harper internal column family', () => {
+		const storage = open('__dbis__');
+		const key = Buffer.from('opaque-key');
+		storage.write([{ type: 'put', key, value: Buffer.from('opaque-value') }], 'wal');
+
+		assert.strictEqual(Anchor.dbisDB.getSync(key), undefined);
+		assert.deepStrictEqual(storage.read(key), Buffer.from('opaque-value'));
+	});
+
+	it('prevalidates an entire mutation batch before applying it', () => {
+		const storage = open('__test_derived_atomic');
+		const key = Buffer.from('key');
+		storage.write([{ type: 'put', key, value: Buffer.from('before') }], 'wal');
+
+		assert.throws(
+			() =>
+				storage.write(
+					[
+						{ type: 'put', key, value: Buffer.from('after') },
+						{ type: 'put', key: Buffer.from('bad'), value: 'not-a-buffer' },
+					],
+					'wal'
+				),
+			/values must be Buffers/
+		);
+		assert.deepStrictEqual(storage.read(key), Buffer.from('before'));
+	});
+
+	it('atomically applies puts and deletes through one RocksDB transaction', () => {
+		const storage = open('__test_derived_batch');
+		const removed = Buffer.from('removed');
+		storage.write([{ type: 'put', key: removed, value: Buffer.from('old') }], 'wal');
+
+		storage.write(
+			[
+				{ type: 'put', key: Buffer.from('first'), value: Buffer.from('one') },
+				{ type: 'put', key: Buffer.from('second'), value: Buffer.from('two') },
+				{ type: 'delete', key: removed },
+			],
+			'wal'
+		);
+
+		assert.deepStrictEqual(storage.read(Buffer.from('first')), Buffer.from('one'));
+		assert.deepStrictEqual(storage.read(Buffer.from('second')), Buffer.from('two'));
+		assert.strictEqual(storage.read(removed), undefined);
+	});
+
+	it('does not treat a swallowed transaction abort as a committed batch', () => {
+		const rootStore = Anchor.primaryStore.rootStore;
+		const originalTransactionSync = rootStore.transactionSync;
+		rootStore.transactionSync = () => undefined;
+		try {
+			const storage = open('__test_derived_aborted');
+			assert.throws(
+				() => storage.write([{ type: 'put', key: Buffer.from('key'), value: Buffer.from('value') }], 'wal'),
+				/transaction did not commit/
+			);
+		} finally {
+			rootStore.transactionSync = originalTransactionSync;
+		}
+	});
+
+	it('rejects WAL-disabled writes before touching RocksDB', () => {
+		const storage = open('__test_derived_wal');
+		const key = Buffer.from('key');
+
+		assert.throws(
+			() => storage.write([{ type: 'put', key, value: Buffer.from('value') }], 'no-wal'),
+			/require the RocksDB WAL/
+		);
+		assert.strictEqual(storage.read(key), undefined);
+	});
+
+	it('rejects a root store whose transactions have the WAL disabled', () => {
+		const rootStore = Anchor.primaryStore.rootStore;
+		const previous = rootStore.store.disableWAL;
+		rootStore.store.disableWAL = true;
+		try {
+			assert.throws(
+				() => new RocksDerivedIndexStorage(rootStore, '__test_derived_disabled_root'),
+				/WAL-enabled RocksDB root store/
+			);
+		} finally {
+			rootStore.store.disableWAL = previous;
+		}
+	});
+
+	it('rejects a table or index handle in place of the RocksDB root store', () => {
+		assert.throws(
+			() => new RocksDerivedIndexStorage(Anchor.primaryStore, '__test_derived_child_handle'),
+			/requires the RocksDB root store/
+		);
+		assert.throws(
+			() => new RocksDerivedIndexStorage(Anchor.dbisDB, '__test_derived_metadata_handle'),
+			/requires the RocksDB root store/
+		);
+	});
+
+	it('uses the root database flush as its barrier and preserves bytes across handle reopen', () => {
+		const rootStore = Anchor.primaryStore.rootStore;
+		const originalFlushSync = rootStore.flushSync;
+		let flushOptions;
+		rootStore.flushSync = function (options) {
+			flushOptions = options;
+			return originalFlushSync.call(this, options);
+		};
+
+		const key = Buffer.from('durable');
+		const value = Buffer.from('value');
+		let storage = open('__test_derived_reopen');
+		try {
+			storage.write([{ type: 'put', key, value }], 'wal');
+			storage.sync();
+		} finally {
+			rootStore.flushSync = originalFlushSync;
+			storage.close();
+		}
+
+		assert.deepStrictEqual(flushOptions, { allowWriteStall: true });
+		storage = open('__test_derived_reopen');
+		assert.deepStrictEqual(storage.read(key), value);
+	});
+
+	it('drops and recreates a retired derived column family', () => {
+		const key = Buffer.from('retired');
+		let storage = open('__test_derived_drop');
+		const otherWorker = open('__test_derived_drop');
+		storage.write([{ type: 'put', key, value: Buffer.from('value') }], 'wal');
+		storage.drop();
+		assert.doesNotThrow(() => otherWorker.drop(), 'a redundant worker drop is successful');
+
+		assert.throws(() => storage.read(key), /storage is closed/);
+		storage = open('__test_derived_drop');
+		assert.strictEqual(storage.read(key), undefined);
+	});
+
+	it('preserves a drop failure when closing the failed handle also fails', () => {
+		const rootStore = Anchor.primaryStore.rootStore;
+		const store = openDerivedIndexStore(rootStore, '__test_derived_drop_error');
+		const originalDropSync = store.dropSync;
+		const originalClose = store.close;
+		store.dropSync = () => {
+			throw new Error('injected drop failure');
+		};
+		store.close = () => {
+			throw new Error('injected close failure');
+		};
+		try {
+			assert.throws(() => dropDerivedIndexStore(rootStore, store), /injected drop failure/);
+		} finally {
+			store.dropSync = originalDropSync;
+			store.close = originalClose;
+			closeDerivedIndexStore(rootStore, store);
+		}
+	});
+
+	it("closes its own handle without closing Harper's root database", async () => {
+		const storage = open('__test_derived_close');
+		storage.close();
+
+		assert.throws(() => storage.read(Buffer.from('key')), /storage is closed/);
+		await Anchor.put('root-still-open', {});
+		assert.ok(await Anchor.get('root-still-open'));
+	});
+
+	it('retains a failed close for a later retry', () => {
+		const storage = open('__test_derived_close_retry');
+		const originalClose = RocksDatabase.prototype.close;
+		let fail = true;
+		RocksDatabase.prototype.close = function () {
+			if (fail && this.name.includes('__test_derived_close_retry')) {
+				fail = false;
+				throw new Error('injected close failure');
+			}
+			return originalClose.call(this);
+		};
+		try {
+			assert.throws(() => storage.close(), /injected close failure/);
+			assert.doesNotThrow(() => storage.close());
+		} finally {
+			RocksDatabase.prototype.close = originalClose;
+		}
+	});
+
+	it('is invalidated when Harper closes its root database', () => {
+		const Closing = table({
+			database: 'derived-index-storage-close',
+			table: 'Anchor',
+			attributes: [{ name: 'id', isPrimaryKey: true }],
+		});
+		const rootStore = Closing.primaryStore.rootStore;
+		const storage = new RocksDerivedIndexStorage(rootStore, '__test_derived_root_close');
+		opened.push(storage);
+
+		assert.strictEqual(closeDatabase('derived-index-storage-close'), true);
+		assert.throws(() => storage.read(Buffer.from('key')), /storage is closed/);
+		assert.throws(
+			() => new RocksDerivedIndexStorage(rootStore, '__test_derived_after_root_close'),
+			/closed RocksDB root store/
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- add an internal binary RocksDB store for native derived indexes without adding or changing rocksdb-js primitives
- apply each host-storage mutation batch in one WAL-enabled RocksDB transaction and fail closed unless the transaction reports a definite commit
- use Harper's existing database-wide RocksDB flush as the durability barrier, with the cost called out for coalescing and measurement
- reserve derived column-family names so opaque Tantivy bytes cannot alias Harper tables, secondary indexes, or metadata
- register derived handles with Harper's existing close/drop paths while leaving native drain ordering for the later lifecycle integration
- support explicit derived-index retirement, concurrent worker drops, stale-root rejection, and retryable close failures

This is stacked on [Implement the shared derived-index transaction-log runtime #2533](https://github.com/HarperFast/harper/pull/2533). It does not activate `@fullText`, add a fulltext package dependency, or expose a customer storage-provider API. Those remain gated on the full Harper/fulltext lifecycle integration.

## Validation

- `npm run build`
- focused oxlint on the changed TypeScript and test files
- 19 focused Harper tests covering the storage adapter, derived runtime, and RocksDB handle release
- local cross-repo proof: the fulltext Tantivy Directory conformance and lifecycle harness passed through the native host transport into this adapter on a Harper-owned RocksDB database
- Gemini CLI and Claude CLI review; findings were adjudicated and the applicable transaction, namespace, liveness, close/drop, and error-preservation fixes are included
- final Gemini remediation-delta check: no findings

## Known performance boundary

rocksdb-js currently provides the required durability barrier as a database-wide flush over every registered column family. The fulltext publication scheduler must coalesce and rate-limit that barrier, and Phase 0 must measure foreground-write stalls, flush latency, compaction pressure, and multi-index behavior before schema activation.

Comment generated by kAIle (GPT-5)

<sub>Review-Coverage: authored=unknown; ran=none; rounds=1 @ 541339df0187</sub>

<sub>Human-Review-Need: 4 @ 541339df0187</sub>
