### PR TITLE
Index backfills resume from their checkpoint and yield the event loop, so large tables converge (harper#2536)

### DIFF
--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -3124,6 +3124,19 @@ export function canonicalizeIndexOptions(value: any): any {
 }
 const MAX_OUTSTANDING_INDEXING = 1000;
 const MIN_OUTSTANDING_INDEXING = 10;
+// Records scanned between event-loop yields, and between resume checkpoints.
+const INDEXING_YIELD_INTERVAL = 100;
+const yieldEventTurn = () => new Promise((resolve) => setImmediate(resolve));
+// The primary-store key a resumed backfill scans from: the minimum persisted checkpoint across the
+// attributes being built, or undefined (scan everything) when any attribute has none. Exported for tests.
+export function resumeStartKey(attributes: { lastIndexedKey?: any }[]): any {
+	let start: any;
+	for (const attribute of attributes) {
+		if (attribute.lastIndexedKey == undefined) return undefined;
+		if (start === undefined || compareKeys(attribute.lastIndexedKey, start) < 0) start = attribute.lastIndexedKey;
+	}
+	return start;
+}
 async function runIndexing(Table, attributes, indicesToRemove, branchPath?: string) {
 	try {
 		logger.info(`Indexing ${Table.tableName} attributes`, attributes);
@@ -3141,10 +3154,8 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 		const attributesLength = attributes.length;
 		await new Promise((resolve) => setImmediate(resolve)); // yield event turn, indexing should consistently take at least one event turn
 		if (attributesLength > 0) {
-			let start: any;
+			const start = resumeStartKey(attributes);
 			for (const attribute of attributes) {
-				// if we are resuming, we need to start from the last key we indexed by all attributes
-				if (compareKeys(attribute.lastIndexedKey, start) < 0) start = attribute.lastIndexedKey;
 				if (attribute.lastIndexedKey == undefined) {
 					// if we are starting from the beginning, clear out any previous index entries since we are rewriting
 					if (attribute.dbi.clearAsync) {
@@ -3163,7 +3174,12 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 				versions: true,
 				snapshot: false, // don't hold a read transaction this whole time
 			})) {
-				if (!record) continue; // deletion entry
+				const atInterval = ++indexed % INDEXING_YIELD_INTERVAL === 0;
+				if (!record) {
+					// deletion entry
+					if (atInterval) await yieldEventTurn();
+					continue;
+				}
 				// TODO: Do we ever need to interrupt due to a schema change that was not a restart?
 				//if (Table.schemaVersion !== schemaVersion) return; // break out if there are any schema changes and let someone else pick it up
 				outstanding++;
@@ -3219,18 +3235,31 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 				if (workerData && workerData.restartNumber !== manageThreads.restartNumber) {
 					interrupted = true;
 				}
-				if (++indexed % 100 === 0 || interrupted) {
-					// occasionally update our progress so if we crash, we can resume
-					for (const attribute of attributes) {
-						attribute.lastIndexedKey = key;
-						Table.dbisDB.put(attribute.key, attribute);
-					}
+				if (atInterval || interrupted) {
+					// Checkpoint our progress so a crash can resume. A resumed scan starts at the checkpoint, so
+					// it must only ever name a key whose every predecessor was indexed: wait for the writes it
+					// covers to settle, and stop advancing it once any record has failed so the retry re-covers
+					// that record.
+					when(
+						lastResolution,
+						() => {
+							if (hadIndexingErrors) return;
+							try {
+								for (const attribute of attributes) {
+									attribute.lastIndexedKey = key;
+									Table.dbisDB.put(attribute.key, attribute);
+								}
+							} catch (error) {
+								// a lost checkpoint only costs the retry a rescan of this stretch
+								logger.debug(`Could not persist the indexing checkpoint for ${Table.tableName}`, error);
+							}
+						},
+						() => {} // already counted and logged by the rejection handler above
+					);
 					if (interrupted) return;
 				}
 				if (outstanding > MAX_OUTSTANDING_INDEXING) await lastResolution;
-				else if (outstanding > MIN_OUTSTANDING_INDEXING)
-					await new Promise((resolve) => setImmediate(resolve)); // yield event turn, don't want to use all computation
-				else if (didSynchronousIndexing) await new Promise((resolve) => setImmediate(resolve)); // custom indexes (e.g. HNSW) index synchronously and never raise `outstanding`; without this yield a large backfill runs in a single event-loop turn, starving keepalive/replication and queries and never letting the isIndexing flag be observed
+				else if (outstanding > MIN_OUTSTANDING_INDEXING || didSynchronousIndexing || atInterval) await yieldEventTurn(); // custom indexes (e.g. HNSW) index synchronously and a RocksDB put resolves synchronously, so neither raises `outstanding`; without this yield a large backfill runs in a single event-loop turn, starving keepalive/replication and queries and never letting the isIndexing flag be observed
 			}
 		}
 		// Await the last pending put. If it rejects, that is also an indexing error.

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -3180,13 +3180,14 @@ export function resumeStartKey(attributes: { lastIndexedKey?: any }[]): any {
 async function runIndexing(Table, attributes, indicesToRemove, branchPath?: string) {
 	let checkpointing;
 	let hadIndexingErrors = false;
-	let asyncRejectionReported = false;
-	const onIndexPutRejected = (error) => {
+	const attributeErrorReported = {};
+	const onIndexPutRejected = (property, error) => {
 		hadIndexingErrors = true;
-		if (asyncRejectionReported) return;
-		asyncRejectionReported = true;
-		logger.error(`Error indexing ${Table.tableName}`, error);
+		if (attributeErrorReported[property]) return;
+		attributeErrorReported[property] = true;
+		logger.error(`Error indexing attribute ${property}`, error);
 	};
+	const putRejectionHandlers = attributes.map((attribute) => (error) => onIndexPutRejected(attribute.name, error));
 	try {
 		logger.info(`Indexing ${Table.tableName} attributes`, attributes);
 		await signalling.signalSchemaChange(
@@ -3195,17 +3196,15 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 		let lastResolution;
 		for (const index of indicesToRemove) {
 			lastResolution = index.drop();
-			if (lastResolution?.then) lastResolution.then(undefined, onIndexPutRejected);
+			if (lastResolution?.then) lastResolution.then(undefined, (error) => onIndexPutRejected(index.name, error));
 		}
 		let interrupted;
-		const attributeErrorReported = {};
 		let indexed = 0;
 		const attributesLength = attributes.length;
 		await new Promise((resolve) => setImmediate(resolve)); // yield event turn, indexing should consistently take at least one event turn
 		if (attributesLength > 0) {
 			const start = resumeStartKey(attributes);
 			if (start === undefined) {
-				// a full scan rewrites every index it builds, so clear them all first
 				for (const attribute of attributes) {
 					if (attribute.dbi.clearAsync) {
 						// LMDB, note that we don't need to wait for this to complete, just gets enqueued in front of the other writes
@@ -3260,6 +3259,7 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 						const attribute = attributes[i];
 						const property = attribute.name;
 						const index = attribute.dbi;
+						const onPutRejected = putRejectionHandlers[i];
 						try {
 							const resolver = attribute.resolve;
 							const value = record && (resolver ? resolver(record) : record[property]);
@@ -3272,7 +3272,7 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 							if (values) {
 								for (let i = 0, l = values.length; i < l; i++) {
 									lastResolution = index.put(values[i], key);
-									if (lastResolution?.then) lastResolution.then(undefined, onIndexPutRejected);
+									if (lastResolution?.then) lastResolution.then(undefined, onPutRejected);
 								}
 							}
 						} catch (error) {
@@ -3293,7 +3293,7 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 				when(
 					lastResolution,
 					() => outstanding--,
-					() => outstanding-- // counted and logged by onIndexPutRejected
+					() => outstanding--
 				);
 				if (workerData && workerData.restartNumber !== manageThreads.restartNumber) {
 					interrupted = true;

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -3139,8 +3139,18 @@ export function setIndexingCheckpointPeriod(ms: number): number {
 	return previous;
 }
 const yieldEventTurn = () => new Promise((resolve) => setImmediate(resolve));
-// The primary-store key a resumed backfill scans from: the minimum persisted checkpoint across the
-// attributes being built, or undefined (scan everything) when any attribute has none.
+// Index stores have no WAL, so a flush is what makes a checkpoint's entries durable; one flush per root
+// store at a time, shared by every backfill running on that database.
+const indexingFlushes = new WeakMap<object, Promise<void>>();
+function flushIndexStores(rootStore: any): Promise<void> | undefined {
+	if (!(rootStore instanceof RocksDatabase)) return;
+	let flush = indexingFlushes.get(rootStore);
+	if (!flush) {
+		flush = rootStore.flush().finally(() => indexingFlushes.delete(rootStore));
+		indexingFlushes.set(rootStore, flush);
+	}
+	return flush;
+}
 export function resumeStartKey(attributes: { lastIndexedKey?: any }[]): any {
 	let start: any;
 	for (const attribute of attributes) {
@@ -3187,18 +3197,23 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			const persistCheckpoint = async (key) => {
 				if (hadIndexingErrors) return;
 				try {
-					const rootStore = Table.primaryStore.rootStore;
-					if (rootStore instanceof RocksDatabase) await rootStore.flush({ allowWriteStall: true });
+					await flushIndexStores(Table.primaryStore.rootStore);
+					const puts = [];
 					for (const attribute of attributes) {
 						attribute.lastIndexedKey = key;
 						attribute.checkpointCertified = true;
-						Table.dbisDB.put(attribute.key, attribute);
+						puts.push(Table.dbisDB.put(attribute.key, attribute));
 					}
+					await Promise.all(puts);
 				} catch (error) {
 					logger.debug(`Could not persist the indexing checkpoint for ${Table.tableName}`, error);
 				}
 			};
-			let nextCheckpointAt = Date.now() + indexingCheckpointPeriodMs;
+			const onIndexPutRejected = (error) => {
+				hadIndexingErrors = true;
+				logger.error(error);
+			};
+			let nextCheckpointAt = performance.now() + indexingCheckpointPeriodMs;
 			// this means that a new attribute has been introduced that needs to be indexed
 			for (const { key, value: record } of Table.primaryStore.getRange({
 				start,
@@ -3218,7 +3233,6 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 				// we index, that's fine because indexing is idempotent, we can just put the same values again. If it changes
 				// during the indexing, the indexing here will fail. This is also fine because it means the other thread will have
 				// performed indexing and we don't need to do anything further
-				// a deletion entry has nothing to index but still paces the checkpoints and yields
 				if (record) {
 					for (let i = 0; i < attributesLength; i++) {
 						const attribute = attributes[i];
@@ -3236,6 +3250,9 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 							if (values) {
 								for (let i = 0, l = values.length; i < l; i++) {
 									lastResolution = index.put(values[i], key);
+									// only the last put's settlement is awaited below; a rejection of any other must
+									// still stop the checkpoint
+									if (lastResolution?.then) lastResolution.then(undefined, onIndexPutRejected);
 								}
 							}
 						} catch (error) {
@@ -3256,11 +3273,7 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 				when(
 					lastResolution,
 					() => outstanding--,
-					(error) => {
-						outstanding--;
-						hadIndexingErrors = true;
-						logger.error(error);
-					}
+					() => outstanding-- // counted and logged by onIndexPutRejected
 				);
 				if (workerData && workerData.restartNumber !== manageThreads.restartNumber) {
 					interrupted = true;
@@ -3275,8 +3288,8 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 					await persistCheckpoint(key);
 					return;
 				}
-				if (atInterval && Date.now() >= nextCheckpointAt) {
-					nextCheckpointAt = Date.now() + indexingCheckpointPeriodMs;
+				if (atInterval && performance.now() >= nextCheckpointAt) {
+					nextCheckpointAt = performance.now() + indexingCheckpointPeriodMs;
 					await checkpointing;
 					checkpointing = when(
 						lastResolution,
@@ -3285,20 +3298,13 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 					);
 				}
 				if (outstanding > MAX_OUTSTANDING_INDEXING) await lastResolution;
-				// A RocksDB put resolves synchronously and custom indexes (e.g. HNSW) index synchronously, so
-				// neither raises `outstanding`; without a yield of its own a large backfill would run as one
-				// event-loop turn, starving keepalive, replication and queries.
+				// RocksDB puts and custom indexes complete synchronously and never raise `outstanding`
 				if (atInterval || didSynchronousIndexing || outstanding > MIN_OUTSTANDING_INDEXING) await yieldEventTurn();
 			}
 		}
 		await checkpointing;
-		// Await the last pending put. If it rejects, that is also an indexing error.
-		// Note: the when() calls above already attach rejection handlers to each record's
-		// last-put promise; this try-catch specifically handles the case where lastResolution
-		// itself rejects (i.e. the very last put in the loop failed) which would otherwise
-		// throw past the hadIndexingErrors check to the outer catch. The broader issue of
-		// unhandled rejections from non-last puts in multi-value attributes is pre-existing
-		// and out of scope for this fix.
+		// Await the last pending put. If it rejects, that is also an indexing error (already counted by
+		// onIndexPutRejected); catching it here keeps it from escaping to the outer catch.
 		try {
 			await lastResolution;
 		} catch (error) {

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -2875,13 +2875,16 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 							// resumes rather than restarts. Canonicalized to match structurallyChanged above.
 							const indexOptionsChanged =
 								canonicalIndexKey(attributeDescriptor?.indexed) !== canonicalIndexKey(attribute.indexed);
-							// Only a checkpoint runIndexing stamped as certified resumes: earlier releases advanced
-							// lastIndexedKey past failed and unflushed index writes, so an unstamped one is a full rebuild.
+							// Only a checkpoint runIndexing stamped with its own key resumes: earlier releases advanced
+							// lastIndexedKey past failed and unflushed index writes, so any other is a full rebuild.
+							const uncertifiedCheckpoint =
+								attributeDescriptor?.lastIndexedKey !== undefined &&
+								compareKeys(attributeDescriptor.checkpointCertified, attributeDescriptor.lastIndexedKey) !== 0;
 							attribute.lastIndexedKey =
-								indexOptionsChanged || !attributeDescriptor?.checkpointCertified
+								indexOptionsChanged || uncertifiedCheckpoint
 									? undefined
-									: (attributeDescriptor.lastIndexedKey ?? undefined);
-							if (attribute.lastIndexedKey !== undefined) attribute.checkpointCertified = true;
+									: (attributeDescriptor?.lastIndexedKey ?? undefined);
+							if (attribute.lastIndexedKey !== undefined) attribute.checkpointCertified = attribute.lastIndexedKey;
 							// Explicit reindex is the upgrade path from a legacy (un-versioned) custom-index
 							// object store to the versioned, VT-cacheable format. A full rebuild from scratch
 							// (lastIndexedKey === undefined) clears the store and rewrites every node, so the
@@ -2918,6 +2921,7 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 							if (attributeDescriptor?.indexingPID && attributeDescriptor.indexingPID !== process.pid)
 								reindexReasons.push(`crash-recovery(pid=${attributeDescriptor.indexingPID})`);
 							if (attributeDescriptor?.restartNumber < currentRestartGeneration) reindexReasons.push('restart-number');
+							if (uncertifiedCheckpoint) reindexReasons.push('uncertified-checkpoint');
 							logger.info(
 								`reindex ${databaseName}.${tableName}.${attribute.name}: reason=${reindexReasons.join(',') || 'unknown'}`
 							);
@@ -2931,7 +2935,8 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 						// workers / a reload would treat the still-partial index as ready and return incomplete results.
 						attribute.indexingPID = attributeDescriptor.indexingPID;
 						attribute.lastIndexedKey = attributeDescriptor.lastIndexedKey;
-						if (attributeDescriptor.checkpointCertified) attribute.checkpointCertified = true;
+						if (attributeDescriptor.checkpointCertified !== undefined)
+							attribute.checkpointCertified = attributeDescriptor.checkpointCertified;
 						// Carry the in-progress restart generation too, so persisting this metadata-only
 						// change doesn't drop it and break the crash-recovery trigger for the running backfill.
 						attribute.restartNumber = attributeDescriptor.restartNumber;
@@ -3139,17 +3144,25 @@ export function setIndexingCheckpointPeriod(ms: number): number {
 	return previous;
 }
 const yieldEventTurn = () => new Promise((resolve) => setImmediate(resolve));
-// Index stores have no WAL, so a flush is what makes a checkpoint's entries durable; one flush per root
-// store at a time, shared by every backfill running on that database.
-const indexingFlushes = new WeakMap<object, Promise<void>>();
+// Index stores have no WAL, so a flush is what makes a checkpoint's entries durable. A flush only covers
+// writes issued before it started, so a caller never joins one in flight: it joins the next one, which
+// every backfill on that database asking meanwhile shares — at most one in flight and one queued.
+const indexingFlushes = new WeakMap<object, { inFlight?: Promise<void>; queued?: Promise<void> }>();
 function flushIndexStores(rootStore: any): Promise<void> | undefined {
 	if (!(rootStore instanceof RocksDatabase)) return;
-	let flush = indexingFlushes.get(rootStore);
-	if (!flush) {
-		flush = rootStore.flush().finally(() => indexingFlushes.delete(rootStore));
-		indexingFlushes.set(rootStore, flush);
-	}
-	return flush;
+	let flushes = indexingFlushes.get(rootStore);
+	if (!flushes) indexingFlushes.set(rootStore, (flushes = {}));
+	if (flushes.queued) return flushes.queued;
+	const start = () => {
+		flushes.queued = undefined;
+		const flush = rootStore.flush().finally(() => {
+			if (flushes.inFlight === flush) flushes.inFlight = undefined;
+		});
+		flushes.inFlight = flush;
+		return flush;
+	};
+	if (!flushes.inFlight) return start();
+	return (flushes.queued = flushes.inFlight.then(start, start));
 }
 export function resumeStartKey(attributes: { lastIndexedKey?: any }[]): any {
 	let start: any;
@@ -3193,7 +3206,8 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			// A resumed scan starts at the checkpoint, so it must only name a key whose every predecessor is
 			// durably indexed: it is persisted once the writes it covers have settled and the index stores are
 			// flushed, it stops advancing after any record has failed so the retry re-covers that record, and
-			// checkpointCertified marks it as written under these rules (an unstamped checkpoint is ignored).
+			// checkpointCertified repeats the key to mark it as written under these rules (a checkpoint
+			// without a matching stamp is ignored).
 			const persistCheckpoint = async (key) => {
 				if (hadIndexingErrors) return;
 				try {
@@ -3201,7 +3215,7 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 					const puts = [];
 					for (const attribute of attributes) {
 						attribute.lastIndexedKey = key;
-						attribute.checkpointCertified = true;
+						attribute.checkpointCertified = key;
 						puts.push(Table.dbisDB.put(attribute.key, attribute));
 					}
 					await Promise.all(puts);
@@ -3315,6 +3329,16 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 		// microtasks when their tracked promise settles) have a chance to set hadIndexingErrors
 		// before we decide whether to mark indexing as complete.
 		await new Promise((resolve) => setImmediate(resolve));
+		// the ready descriptor is WAL-backed while the index entries are not: flush the tail written since
+		// the last checkpoint before announcing the index complete, and park it if that flush fails
+		if (!hadIndexingErrors) {
+			try {
+				await flushIndexStores(Table.primaryStore.rootStore);
+			} catch (error) {
+				hadIndexingErrors = true;
+				logger.error(`Could not flush the indexes of ${Table.tableName} before marking them complete`, error);
+			}
+		}
 		if (hadIndexingErrors) {
 			// Some records failed to index. Persist the failure marker in the descriptor so
 			// the next call to table() (including after a restart with a fresh PID) re-triggers

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -3124,11 +3124,10 @@ export function canonicalizeIndexOptions(value: any): any {
 }
 const MAX_OUTSTANDING_INDEXING = 1000;
 const MIN_OUTSTANDING_INDEXING = 10;
-// Records scanned between event-loop yields, and between resume checkpoints.
 const INDEXING_YIELD_INTERVAL = 100;
 const yieldEventTurn = () => new Promise((resolve) => setImmediate(resolve));
 // The primary-store key a resumed backfill scans from: the minimum persisted checkpoint across the
-// attributes being built, or undefined (scan everything) when any attribute has none. Exported for tests.
+// attributes being built, or undefined (scan everything) when any attribute has none.
 export function resumeStartKey(attributes: { lastIndexedKey?: any }[]): any {
 	let start: any;
 	for (const attribute of attributes) {
@@ -3236,10 +3235,9 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 					interrupted = true;
 				}
 				if (atInterval || interrupted) {
-					// Checkpoint our progress so a crash can resume. A resumed scan starts at the checkpoint, so
-					// it must only ever name a key whose every predecessor was indexed: wait for the writes it
-					// covers to settle, and stop advancing it once any record has failed so the retry re-covers
-					// that record.
+					// A resumed scan starts at the checkpoint, so it must only name a key whose every predecessor
+					// was indexed: persist it once the writes it covers have settled, and stop advancing it after
+					// any record has failed so the retry re-covers that record.
 					when(
 						lastResolution,
 						() => {
@@ -3250,7 +3248,6 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 									Table.dbisDB.put(attribute.key, attribute);
 								}
 							} catch (error) {
-								// a lost checkpoint only costs the retry a rescan of this stretch
 								logger.debug(`Could not persist the indexing checkpoint for ${Table.tableName}`, error);
 							}
 						},
@@ -3259,7 +3256,10 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 					if (interrupted) return;
 				}
 				if (outstanding > MAX_OUTSTANDING_INDEXING) await lastResolution;
-				else if (outstanding > MIN_OUTSTANDING_INDEXING || didSynchronousIndexing || atInterval) await yieldEventTurn(); // custom indexes (e.g. HNSW) index synchronously and a RocksDB put resolves synchronously, so neither raises `outstanding`; without this yield a large backfill runs in a single event-loop turn, starving keepalive/replication and queries and never letting the isIndexing flag be observed
+				// A RocksDB put resolves synchronously and custom indexes (e.g. HNSW) index synchronously, so
+				// neither raises `outstanding`; without a yield of its own a large backfill would run as one
+				// event-loop turn, starving keepalive, replication and queries.
+				if (atInterval || didSynchronousIndexing || outstanding > MIN_OUTSTANDING_INDEXING) await yieldEventTurn();
 			}
 		}
 		// Await the last pending put. If it rejects, that is also an indexing error.

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -2875,9 +2875,13 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 							// resumes rather than restarts. Canonicalized to match structurallyChanged above.
 							const indexOptionsChanged =
 								canonicalIndexKey(attributeDescriptor?.indexed) !== canonicalIndexKey(attribute.indexed);
-							attribute.lastIndexedKey = indexOptionsChanged
-								? undefined
-								: (attributeDescriptor?.lastIndexedKey ?? undefined);
+							// Only a checkpoint runIndexing stamped as certified resumes: earlier releases advanced
+							// lastIndexedKey past failed and unflushed index writes, so an unstamped one is a full rebuild.
+							attribute.lastIndexedKey =
+								indexOptionsChanged || !attributeDescriptor?.checkpointCertified
+									? undefined
+									: (attributeDescriptor.lastIndexedKey ?? undefined);
+							if (attribute.lastIndexedKey !== undefined) attribute.checkpointCertified = true;
 							// Explicit reindex is the upgrade path from a legacy (un-versioned) custom-index
 							// object store to the versioned, VT-cacheable format. A full rebuild from scratch
 							// (lastIndexedKey === undefined) clears the store and rewrites every node, so the
@@ -2927,6 +2931,7 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 						// workers / a reload would treat the still-partial index as ready and return incomplete results.
 						attribute.indexingPID = attributeDescriptor.indexingPID;
 						attribute.lastIndexedKey = attributeDescriptor.lastIndexedKey;
+						if (attributeDescriptor.checkpointCertified) attribute.checkpointCertified = true;
 						// Carry the in-progress restart generation too, so persisting this metadata-only
 						// change doesn't drop it and break the crash-recovery trigger for the running backfill.
 						attribute.restartNumber = attributeDescriptor.restartNumber;
@@ -3125,6 +3130,14 @@ export function canonicalizeIndexOptions(value: any): any {
 const MAX_OUTSTANDING_INDEXING = 1000;
 const MIN_OUTSTANDING_INDEXING = 10;
 const INDEXING_YIELD_INTERVAL = 100;
+// RocksDB index stores have no WAL (openRocksDatabase defaults disableWAL), so a resumable checkpoint is
+// only written after a flush; the period bounds both the flush rate and the work a crash can lose.
+let indexingCheckpointPeriodMs = 5000;
+export function setIndexingCheckpointPeriod(ms: number): number {
+	const previous = indexingCheckpointPeriodMs;
+	indexingCheckpointPeriodMs = ms;
+	return previous;
+}
 const yieldEventTurn = () => new Promise((resolve) => setImmediate(resolve));
 // The primary-store key a resumed backfill scans from: the minimum persisted checkpoint across the
 // attributes being built, or undefined (scan everything) when any attribute has none.
@@ -3137,6 +3150,7 @@ export function resumeStartKey(attributes: { lastIndexedKey?: any }[]): any {
 	return start;
 }
 async function runIndexing(Table, attributes, indicesToRemove, branchPath?: string) {
+	let checkpointing; // at most one flush-gated checkpoint in flight
 	try {
 		logger.info(`Indexing ${Table.tableName} attributes`, attributes);
 		await signalling.signalSchemaChange(
@@ -3166,20 +3180,25 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 				}
 			}
 			let outstanding = 0;
-			// A resumed scan starts at the checkpoint, so it must only name a key whose every predecessor was
-			// indexed: callers persist it once the writes it covers have settled, and it stops advancing after
-			// any record has failed so the retry re-covers that record.
-			const persistCheckpoint = (key) => {
+			// A resumed scan starts at the checkpoint, so it must only name a key whose every predecessor is
+			// durably indexed: it is persisted once the writes it covers have settled and the index stores are
+			// flushed, it stops advancing after any record has failed so the retry re-covers that record, and
+			// checkpointCertified marks it as written under these rules (an unstamped checkpoint is ignored).
+			const persistCheckpoint = async (key) => {
 				if (hadIndexingErrors) return;
 				try {
+					const rootStore = Table.primaryStore.rootStore;
+					if (rootStore instanceof RocksDatabase) await rootStore.flush({ allowWriteStall: true });
 					for (const attribute of attributes) {
 						attribute.lastIndexedKey = key;
+						attribute.checkpointCertified = true;
 						Table.dbisDB.put(attribute.key, attribute);
 					}
 				} catch (error) {
 					logger.debug(`Could not persist the indexing checkpoint for ${Table.tableName}`, error);
 				}
 			};
+			let nextCheckpointAt = Date.now() + indexingCheckpointPeriodMs;
 			// this means that a new attribute has been introduced that needs to be indexed
 			for (const { key, value: record } of Table.primaryStore.getRange({
 				start,
@@ -3252,15 +3271,19 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 					} catch {
 						// already counted and logged by the rejection handler above
 					}
-					persistCheckpoint(key);
+					await checkpointing;
+					await persistCheckpoint(key);
 					return;
 				}
-				if (atInterval)
-					when(
+				if (atInterval && Date.now() >= nextCheckpointAt) {
+					nextCheckpointAt = Date.now() + indexingCheckpointPeriodMs;
+					await checkpointing;
+					checkpointing = when(
 						lastResolution,
 						() => persistCheckpoint(key),
 						() => {}
 					);
+				}
 				if (outstanding > MAX_OUTSTANDING_INDEXING) await lastResolution;
 				// A RocksDB put resolves synchronously and custom indexes (e.g. HNSW) index synchronously, so
 				// neither raises `outstanding`; without a yield of its own a large backfill would run as one
@@ -3268,6 +3291,7 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 				if (atInterval || didSynchronousIndexing || outstanding > MIN_OUTSTANDING_INDEXING) await yieldEventTurn();
 			}
 		}
+		await checkpointing;
 		// Await the last pending put. If it rejects, that is also an indexing error.
 		// Note: the when() calls above already attach rejection handlers to each record's
 		// last-put promise; this try-catch specifically handles the case where lastResolution
@@ -3313,6 +3337,7 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			// update the attributes to indicate that we are finished
 			for (const attribute of attributes) {
 				delete attribute.lastIndexedKey;
+				delete attribute.checkpointCertified;
 				delete attribute.indexingPID;
 				delete attribute.indexingFailed;
 				delete attribute.restartNumber;
@@ -3332,6 +3357,7 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			logger.info(`Finished indexing ${Table.tableName} attributes`, attributes);
 		}
 	} catch (error) {
+		await checkpointing;
 		// A worker shutting down closes its stores mid-backfill, so the range iterator or a
 		// put throws (e.g. "Database not open" / "Iterator not initialized"). This is an
 		// interruption, not a data error: the next worker generation re-runs the backfill via

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -3166,6 +3166,20 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 				}
 			}
 			let outstanding = 0;
+			// A resumed scan starts at the checkpoint, so it must only name a key whose every predecessor was
+			// indexed: callers persist it once the writes it covers have settled, and it stops advancing after
+			// any record has failed so the retry re-covers that record.
+			const persistCheckpoint = (key) => {
+				if (hadIndexingErrors) return;
+				try {
+					for (const attribute of attributes) {
+						attribute.lastIndexedKey = key;
+						Table.dbisDB.put(attribute.key, attribute);
+					}
+				} catch (error) {
+					logger.debug(`Could not persist the indexing checkpoint for ${Table.tableName}`, error);
+				}
+			};
 			// this means that a new attribute has been introduced that needs to be indexed
 			for (const { key, value: record } of Table.primaryStore.getRange({
 				start,
@@ -3174,11 +3188,6 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 				snapshot: false, // don't hold a read transaction this whole time
 			})) {
 				const atInterval = ++indexed % INDEXING_YIELD_INTERVAL === 0;
-				if (!record) {
-					// deletion entry
-					if (atInterval) await yieldEventTurn();
-					continue;
-				}
 				// TODO: Do we ever need to interrupt due to a schema change that was not a restart?
 				//if (Table.schemaVersion !== schemaVersion) return; // break out if there are any schema changes and let someone else pick it up
 				outstanding++;
@@ -3190,35 +3199,38 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 				// we index, that's fine because indexing is idempotent, we can just put the same values again. If it changes
 				// during the indexing, the indexing here will fail. This is also fine because it means the other thread will have
 				// performed indexing and we don't need to do anything further
-				for (let i = 0; i < attributesLength; i++) {
-					const attribute = attributes[i];
-					const property = attribute.name;
-					const index = attribute.dbi;
-					try {
-						const resolver = attribute.resolve;
-						const value = record && (resolver ? resolver(record) : record[property]);
-						if (index.customIndex) {
-							index.customIndex.index(key, value);
-							didSynchronousIndexing = true;
-							continue;
-						}
-						const values = getIndexedValues(value, index.indexNulls);
-						if (values) {
-							for (let i = 0, l = values.length; i < l; i++) {
-								lastResolution = index.put(values[i], key);
+				// a deletion entry has nothing to index but still paces the checkpoints and yields
+				if (record) {
+					for (let i = 0; i < attributesLength; i++) {
+						const attribute = attributes[i];
+						const property = attribute.name;
+						const index = attribute.dbi;
+						try {
+							const resolver = attribute.resolve;
+							const value = record && (resolver ? resolver(record) : record[property]);
+							if (index.customIndex) {
+								index.customIndex.index(key, value);
+								didSynchronousIndexing = true;
+								continue;
 							}
-						}
-					} catch (error) {
-						hadIndexingErrors = true;
-						if (!attributeErrorReported[property]) {
-							// just report an indexing error once per attribute so we don't spam the logs.
-							// A store closed by worker shutdown surfaces here as "Database not open"; that is
-							// a benign interruption (the next generation re-runs the backfill), so don't log
-							// it as an error — the outer catch returns quietly once the iterator also throws.
-							attributeErrorReported[property] = true;
-							if (Table.primaryStore?.rootStore?.status === 'closed')
-								logger.debug(`Indexing attribute ${property} interrupted by store shutdown`, error);
-							else logger.error(`Error indexing attribute ${property}`, error);
+							const values = getIndexedValues(value, index.indexNulls);
+							if (values) {
+								for (let i = 0, l = values.length; i < l; i++) {
+									lastResolution = index.put(values[i], key);
+								}
+							}
+						} catch (error) {
+							hadIndexingErrors = true;
+							if (!attributeErrorReported[property]) {
+								// just report an indexing error once per attribute so we don't spam the logs.
+								// A store closed by worker shutdown surfaces here as "Database not open"; that is
+								// a benign interruption (the next generation re-runs the backfill), so don't log
+								// it as an error — the outer catch returns quietly once the iterator also throws.
+								attributeErrorReported[property] = true;
+								if (Table.primaryStore?.rootStore?.status === 'closed')
+									logger.debug(`Indexing attribute ${property} interrupted by store shutdown`, error);
+								else logger.error(`Error indexing attribute ${property}`, error);
+							}
 						}
 					}
 				}
@@ -3234,27 +3246,21 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 				if (workerData && workerData.restartNumber !== manageThreads.restartNumber) {
 					interrupted = true;
 				}
-				if (atInterval || interrupted) {
-					// A resumed scan starts at the checkpoint, so it must only name a key whose every predecessor
-					// was indexed: persist it once the writes it covers have settled, and stop advancing it after
-					// any record has failed so the retry re-covers that record.
+				if (interrupted) {
+					try {
+						await lastResolution;
+					} catch {
+						// already counted and logged by the rejection handler above
+					}
+					persistCheckpoint(key);
+					return;
+				}
+				if (atInterval)
 					when(
 						lastResolution,
-						() => {
-							if (hadIndexingErrors) return;
-							try {
-								for (const attribute of attributes) {
-									attribute.lastIndexedKey = key;
-									Table.dbisDB.put(attribute.key, attribute);
-								}
-							} catch (error) {
-								logger.debug(`Could not persist the indexing checkpoint for ${Table.tableName}`, error);
-							}
-						},
-						() => {} // already counted and logged by the rejection handler above
+						() => persistCheckpoint(key),
+						() => {}
 					);
-					if (interrupted) return;
-				}
 				if (outstanding > MAX_OUTSTANDING_INDEXING) await lastResolution;
 				// A RocksDB put resolves synchronously and custom indexes (e.g. HNSW) index synchronously, so
 				// neither raises `outstanding`; without a yield of its own a large backfill would run as one

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -2879,7 +2879,8 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 							// lastIndexedKey past failed and unflushed index writes, so any other is a full rebuild.
 							const uncertifiedCheckpoint =
 								attributeDescriptor?.lastIndexedKey !== undefined &&
-								compareKeys(attributeDescriptor.checkpointCertified, attributeDescriptor.lastIndexedKey) !== 0;
+								(attributeDescriptor.checkpointCertified === undefined ||
+									compareKeys(attributeDescriptor.checkpointCertified, attributeDescriptor.lastIndexedKey) !== 0);
 							attribute.lastIndexedKey =
 								indexOptionsChanged || uncertifiedCheckpoint
 									? undefined
@@ -3135,18 +3136,22 @@ export function canonicalizeIndexOptions(value: any): any {
 const MAX_OUTSTANDING_INDEXING = 1000;
 const MIN_OUTSTANDING_INDEXING = 10;
 const INDEXING_YIELD_INTERVAL = 100;
-// RocksDB index stores have no WAL (openRocksDatabase defaults disableWAL), so a resumable checkpoint is
-// only written after a flush; the period bounds both the flush rate and the work a crash can lose.
+// A resumable checkpoint is written only after a flush (see flushIndexStores), at most once per period
+// and never before this many more records: the flush seals every column family in the database, so a
+// slow backfill must not impose the period's flush rate on unrelated tables.
 let indexingCheckpointPeriodMs = 5000;
-export function setIndexingCheckpointPeriod(ms: number): number {
-	const previous = indexingCheckpointPeriodMs;
+let indexingCheckpointMinRecords = 10000;
+export function setIndexingCheckpointPeriod(ms: number, minRecords = indexingCheckpointMinRecords) {
+	const previous = { ms: indexingCheckpointPeriodMs, minRecords: indexingCheckpointMinRecords };
 	indexingCheckpointPeriodMs = ms;
+	indexingCheckpointMinRecords = minRecords;
 	return previous;
 }
 const yieldEventTurn = () => new Promise((resolve) => setImmediate(resolve));
-// Index stores have no WAL, so a flush is what makes a checkpoint's entries durable. A flush only covers
-// writes issued before it started, so a caller never joins one in flight: it joins the next one, which
-// every backfill on that database asking meanwhile shares — at most one in flight and one queued.
+// RocksDB index stores have no WAL (openRocksDatabase defaults disableWAL), so a flush is what makes the
+// entries a checkpoint certifies durable. A flush only covers writes issued before it started, so a caller
+// never joins one in flight: it joins the next one, which every backfill on that database asking meanwhile
+// shares — at most one in flight and one queued.
 const indexingFlushes = new WeakMap<object, { inFlight?: Promise<void>; queued?: Promise<void> }>();
 function flushIndexStores(rootStore: any): Promise<void> | undefined {
 	if (!(rootStore instanceof RocksDatabase)) return;
@@ -3173,7 +3178,15 @@ export function resumeStartKey(attributes: { lastIndexedKey?: any }[]): any {
 	return start;
 }
 async function runIndexing(Table, attributes, indicesToRemove, branchPath?: string) {
-	let checkpointing; // at most one flush-gated checkpoint in flight
+	let checkpointing;
+	let hadIndexingErrors = false;
+	let asyncRejectionReported = false;
+	const onIndexPutRejected = (error) => {
+		hadIndexingErrors = true;
+		if (asyncRejectionReported) return;
+		asyncRejectionReported = true;
+		logger.error(`Error indexing ${Table.tableName}`, error);
+	};
 	try {
 		logger.info(`Indexing ${Table.tableName} attributes`, attributes);
 		await signalling.signalSchemaChange(
@@ -3182,18 +3195,18 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 		let lastResolution;
 		for (const index of indicesToRemove) {
 			lastResolution = index.drop();
+			if (lastResolution?.then) lastResolution.then(undefined, onIndexPutRejected);
 		}
 		let interrupted;
-		let hadIndexingErrors = false;
 		const attributeErrorReported = {};
 		let indexed = 0;
 		const attributesLength = attributes.length;
 		await new Promise((resolve) => setImmediate(resolve)); // yield event turn, indexing should consistently take at least one event turn
 		if (attributesLength > 0) {
 			const start = resumeStartKey(attributes);
-			for (const attribute of attributes) {
-				if (attribute.lastIndexedKey == undefined) {
-					// if we are starting from the beginning, clear out any previous index entries since we are rewriting
+			if (start === undefined) {
+				// a full scan rewrites every index it builds, so clear them all first
+				for (const attribute of attributes) {
 					if (attribute.dbi.clearAsync) {
 						// LMDB, note that we don't need to wait for this to complete, just gets enqueued in front of the other writes
 						attribute.dbi.clearAsync();
@@ -3204,10 +3217,8 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			}
 			let outstanding = 0;
 			// A resumed scan starts at the checkpoint, so it must only name a key whose every predecessor is
-			// durably indexed: it is persisted once the writes it covers have settled and the index stores are
-			// flushed, it stops advancing after any record has failed so the retry re-covers that record, and
-			// checkpointCertified repeats the key to mark it as written under these rules (a checkpoint
-			// without a matching stamp is ignored).
+			// durably indexed: persisted once the writes it covers have settled and flushed, frozen after any
+			// record fails so the retry re-covers it, and stamped with its own key (see the trigger in table()).
 			const persistCheckpoint = async (key) => {
 				if (hadIndexingErrors) return;
 				try {
@@ -3220,14 +3231,11 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 					}
 					await Promise.all(puts);
 				} catch (error) {
-					logger.debug(`Could not persist the indexing checkpoint for ${Table.tableName}`, error);
+					logger.warn(`Could not persist the indexing checkpoint for ${Table.tableName}`, error);
 				}
 			};
-			const onIndexPutRejected = (error) => {
-				hadIndexingErrors = true;
-				logger.error(error);
-			};
 			let nextCheckpointAt = performance.now() + indexingCheckpointPeriodMs;
+			let nextCheckpointRecord = indexingCheckpointMinRecords;
 			// this means that a new attribute has been introduced that needs to be indexed
 			for (const { key, value: record } of Table.primaryStore.getRange({
 				start,
@@ -3264,8 +3272,6 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 							if (values) {
 								for (let i = 0, l = values.length; i < l; i++) {
 									lastResolution = index.put(values[i], key);
-									// only the last put's settlement is awaited below; a rejection of any other must
-									// still stop the checkpoint
 									if (lastResolution?.then) lastResolution.then(undefined, onIndexPutRejected);
 								}
 							}
@@ -3302,8 +3308,9 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 					await persistCheckpoint(key);
 					return;
 				}
-				if (atInterval && performance.now() >= nextCheckpointAt) {
+				if (atInterval && indexed >= nextCheckpointRecord && performance.now() >= nextCheckpointAt) {
 					nextCheckpointAt = performance.now() + indexingCheckpointPeriodMs;
+					nextCheckpointRecord = indexed + indexingCheckpointMinRecords;
 					await checkpointing;
 					checkpointing = when(
 						lastResolution,
@@ -3312,7 +3319,6 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 					);
 				}
 				if (outstanding > MAX_OUTSTANDING_INDEXING) await lastResolution;
-				// RocksDB puts and custom indexes complete synchronously and never raise `outstanding`
 				if (atInterval || didSynchronousIndexing || outstanding > MIN_OUTSTANDING_INDEXING) await yieldEventTurn();
 			}
 		}
@@ -3329,8 +3335,8 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 		// microtasks when their tracked promise settles) have a chance to set hadIndexingErrors
 		// before we decide whether to mark indexing as complete.
 		await new Promise((resolve) => setImmediate(resolve));
-		// the ready descriptor is WAL-backed while the index entries are not: flush the tail written since
-		// the last checkpoint before announcing the index complete, and park it if that flush fails
+		// the tail since the last checkpoint is not durable until flushed; announcing the index complete
+		// before that would outlive a crash that loses it
 		if (!hadIndexingErrors) {
 			try {
 				await flushIndexStores(Table.primaryStore.rootStore);

--- a/unitTests/resources/indexBackfillConvergence-crash.js
+++ b/unitTests/resources/indexBackfillConvergence-crash.js
@@ -1,0 +1,71 @@
+// Child-process half of the crash-resume case in indexBackfillConvergence.test.js: seed a table,
+// start an index backfill, and die with SIGKILL as soon as its first checkpoint is persisted,
+// leaving the checkpoint key in the marker file. Harper opens RocksDB data and index stores
+// without a WAL, so the index entries the checkpoint covers are flushed first, as a clean
+// shutdown would; the descriptor store is WAL-backed and needs no flush. Loaded by the mocha
+// glob too, hence the entry guard.
+const path = require('node:path');
+const { mkdirSync, writeFileSync } = require('node:fs');
+
+if (require.main === module) {
+	const [rootPath, databasePath, database, tableName, markerPath, rowCount] = process.argv.slice(2);
+	const env = require('#src/utility/environment/environmentManager');
+	const terms = require('#src/utility/hdbTerms');
+	// A private root keeps this process off the parent's system database (RocksDB's lock is
+	// per process); only the database under test is shared, at the path the parent chose.
+	env.setProperty(terms.HDB_SETTINGS_NAMES.HDB_ROOT_KEY, rootPath);
+	env.setProperty(terms.CONFIG_PARAMS.STORAGE_PATH, path.join(rootPath, 'database'));
+	env.setProperty(terms.CONFIG_PARAMS.DATABASES, { [database]: { path: databasePath } });
+	const { table, resetDatabases } = require('#src/resources/databases');
+	const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+	setMainIsWorker(true);
+
+	mkdirSync(path.join(rootPath, 'database'), { recursive: true });
+	const seed = async () => {
+		const Tbl = table({
+			table: tableName,
+			database,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < Number(rowCount); i++) {
+			last = Tbl.put({ id: 'c-' + String(i).padStart(6, '0'), tag: 't-' + (i % 7) });
+		}
+		await last;
+	};
+
+	const dieAtFirstCheckpoint = () => {
+		resetDatabases();
+		const Tbl = table({
+			table: tableName,
+			database,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		const prefix = tableName + '/';
+		const poll = () => {
+			for (const { key, value } of Tbl.dbisDB.getRange({ start: false })) {
+				if (value?.name !== 'tag' || !key.toString().startsWith(prefix)) continue;
+				if (value.lastIndexedKey !== undefined) {
+					// synchronous, so the backfill cannot advance past this checkpoint before the kill
+					Tbl.primaryStore.flushSync?.();
+					writeFileSync(markerPath, value.lastIndexedKey);
+					process.kill(process.pid, 'SIGKILL');
+				}
+				if (!value.indexingPID) {
+					writeFileSync(markerPath, 'COMPLETED');
+					process.exit(0);
+				}
+			}
+			setImmediate(poll);
+		};
+		setImmediate(poll);
+	};
+
+	seed().then(dieAtFirstCheckpoint, (error) => {
+		console.error(error);
+		process.exit(1);
+	});
+}

--- a/unitTests/resources/indexBackfillConvergence-crash.js
+++ b/unitTests/resources/indexBackfillConvergence-crash.js
@@ -1,11 +1,11 @@
-// Child-process half of the crash-resume case in indexBackfillConvergence.test.js: seed a table,
-// start an index backfill, and die with SIGKILL as soon as its first checkpoint is persisted,
-// leaving the checkpoint key in the marker file. Loaded by the mocha glob too, hence the entry guard.
+// Child-process half of the crash cases in indexBackfillConvergence.test.js: seed a table, start an
+// index backfill, and die with SIGKILL at its first persisted checkpoint or right after the ready
+// descriptor, leaving what it saw in the marker file. Loaded by the mocha glob too, hence the guard.
 const path = require('node:path');
 const { mkdirSync, writeFileSync } = require('node:fs');
 
 if (require.main === module) {
-	const [rootPath, databasePath, database, tableName, markerPath, rowCount] = process.argv.slice(2);
+	const [rootPath, databasePath, database, tableName, markerPath, rowCount, mode] = process.argv.slice(2);
 	const env = require('#src/utility/environment/environmentManager');
 	const terms = require('#src/utility/hdbTerms');
 	// A private root keeps this process off the parent's system database (RocksDB's lock is
@@ -16,7 +16,9 @@ if (require.main === module) {
 	const { table, resetDatabases, setIndexingCheckpointPeriod } = require('#src/resources/databases');
 	const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 	setMainIsWorker(true);
-	setIndexingCheckpointPeriod(0);
+	// kill-at-checkpoint: die at the first persisted checkpoint (checkpoint on every interval);
+	// kill-after-complete: never checkpoint, die once the ready descriptor is persisted
+	setIndexingCheckpointPeriod(mode === 'kill-after-complete' ? 3600000 : 0);
 
 	mkdirSync(path.join(rootPath, 'database'), { recursive: true });
 	const seed = async () => {
@@ -52,6 +54,7 @@ if (require.main === module) {
 				}
 				if (!value.indexingPID) {
 					writeFileSync(markerPath, 'COMPLETED');
+					if (mode === 'kill-after-complete') process.kill(process.pid, 'SIGKILL');
 					process.exit(0);
 				}
 			}

--- a/unitTests/resources/indexBackfillConvergence-crash.js
+++ b/unitTests/resources/indexBackfillConvergence-crash.js
@@ -1,6 +1,5 @@
-// Child-process half of the crash cases in indexBackfillConvergence.test.js: seed a table, start an
-// index backfill, and die with SIGKILL at its first persisted checkpoint or right after the ready
-// descriptor, leaving what it saw in the marker file. Loaded by the mocha glob too, hence the guard.
+// Child-process half of the crash cases in indexBackfillConvergence.test.js; the mocha glob loads it
+// too, hence the entry guard.
 const path = require('node:path');
 const { mkdirSync, writeFileSync } = require('node:fs');
 
@@ -18,7 +17,7 @@ if (require.main === module) {
 	setMainIsWorker(true);
 	// kill-at-checkpoint: die at the first persisted checkpoint (checkpoint on every interval);
 	// kill-after-complete: never checkpoint, die once the ready descriptor is persisted
-	setIndexingCheckpointPeriod(mode === 'kill-after-complete' ? 3600000 : 0);
+	setIndexingCheckpointPeriod(mode === 'kill-after-complete' ? 3600000 : 0, 0);
 
 	mkdirSync(path.join(rootPath, 'database'), { recursive: true });
 	const seed = async () => {

--- a/unitTests/resources/indexBackfillConvergence-crash.js
+++ b/unitTests/resources/indexBackfillConvergence-crash.js
@@ -1,9 +1,6 @@
 // Child-process half of the crash-resume case in indexBackfillConvergence.test.js: seed a table,
 // start an index backfill, and die with SIGKILL as soon as its first checkpoint is persisted,
-// leaving the checkpoint key in the marker file. Harper opens RocksDB data and index stores
-// without a WAL, so the index entries the checkpoint covers are flushed first, as a clean
-// shutdown would; the descriptor store is WAL-backed and needs no flush. Loaded by the mocha
-// glob too, hence the entry guard.
+// leaving the checkpoint key in the marker file. Loaded by the mocha glob too, hence the entry guard.
 const path = require('node:path');
 const { mkdirSync, writeFileSync } = require('node:fs');
 
@@ -16,9 +13,10 @@ if (require.main === module) {
 	env.setProperty(terms.HDB_SETTINGS_NAMES.HDB_ROOT_KEY, rootPath);
 	env.setProperty(terms.CONFIG_PARAMS.STORAGE_PATH, path.join(rootPath, 'database'));
 	env.setProperty(terms.CONFIG_PARAMS.DATABASES, { [database]: { path: databasePath } });
-	const { table, resetDatabases } = require('#src/resources/databases');
+	const { table, resetDatabases, setIndexingCheckpointPeriod } = require('#src/resources/databases');
 	const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 	setMainIsWorker(true);
+	setIndexingCheckpointPeriod(0);
 
 	mkdirSync(path.join(rootPath, 'database'), { recursive: true });
 	const seed = async () => {
@@ -49,8 +47,6 @@ if (require.main === module) {
 			for (const { key, value } of Tbl.dbisDB.getRange({ start: false })) {
 				if (value?.name !== 'tag' || !key.toString().startsWith(prefix)) continue;
 				if (value.lastIndexedKey !== undefined) {
-					// synchronous, so the backfill cannot advance past this checkpoint before the kill
-					Tbl.primaryStore.flushSync?.();
 					writeFileSync(markerPath, value.lastIndexedKey);
 					process.kill(process.pid, 'SIGKILL');
 				}

--- a/unitTests/resources/indexBackfillConvergence.test.js
+++ b/unitTests/resources/indexBackfillConvergence.test.js
@@ -1,0 +1,405 @@
+/**
+ * Regression coverage for harper#2536: a secondary-index backfill that could not converge on a
+ * large table because runIndexing (resources/databases.ts) (1) never used its resume checkpoint —
+ * `start` stayed undefined and every retrigger rescanned from the first record — and (2) never
+ * yielded the event loop on a plain index whose put resolves synchronously, so the whole backfill
+ * ran as one uninterrupted turn.
+ */
+require('../testUtils');
+const assert = require('node:assert/strict');
+const { setupTestDBPath } = require('../testUtils');
+const { table, resetDatabases, resumeStartKey } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+const DB = 'test';
+const LMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
+const INDEXING_YIELD_INTERVAL = 100;
+
+async function collect(iter) {
+	const out = [];
+	for await (const x of iter) out.push(x);
+	return out;
+}
+
+function pad(i) {
+	return String(i).padStart(4, '0');
+}
+
+// The per-attribute descriptor lives in Table.dbisDB under the table's key prefix; the dbisDB is
+// shared by every table in the database, so scope the scan to this table.
+function findDescriptor(Tbl, attrName) {
+	const prefix = Tbl.tableName + '/';
+	for (const { key, value } of Tbl.dbisDB.getRange({ start: false })) {
+		if (value && value.name === attrName && key.toString().startsWith(prefix)) return { key, value };
+	}
+	return null;
+}
+
+// Wrap Table.primaryStore.getRange so the test can observe the range runIndexing actually opens
+// (its `start` option and every key it visits) and optionally abort the scan partway. runIndexing
+// only reads the store after awaiting a schema-change signal and an event turn, so wrapping right
+// after table() returns is early enough.
+function observeRange(Tbl, { onKey, abortAfter } = {}) {
+	const store = Tbl.primaryStore;
+	const original = store.getRange;
+	const observed = { start: undefined, keys: [] };
+	store.getRange = function (options) {
+		observed.start = options?.start;
+		const inner = original.call(this, options);
+		return {
+			[Symbol.iterator]() {
+				const iterator = inner[Symbol.iterator]();
+				return {
+					next: () => {
+						if (abortAfter !== undefined && observed.keys.length >= abortAfter) {
+							iterator.return?.();
+							throw new Error('simulated primary-store iterator failure');
+						}
+						const result = iterator.next();
+						if (!result.done) {
+							observed.keys.push(result.value.key);
+							onKey?.(result.value.key);
+						}
+						return result;
+					},
+					return: () => iterator.return?.(),
+				};
+			},
+		};
+	};
+	observed.restore = () => {
+		store.getRange = original;
+	};
+	return observed;
+}
+
+describe('resumeStartKey: minimum resume checkpoint across the attributes being built (#2536)', () => {
+	it('returns the shared checkpoint when every attribute checkpointed at the same key', () => {
+		assert.equal(resumeStartKey([{ lastIndexedKey: 'k-0500' }, { lastIndexedKey: 'k-0500' }]), 'k-0500');
+	});
+
+	it('returns the minimum when the attributes checkpointed at different keys', () => {
+		assert.equal(
+			resumeStartKey([{ lastIndexedKey: 'k-0700' }, { lastIndexedKey: 'k-0300' }, { lastIndexedKey: 'k-0500' }]),
+			'k-0300'
+		);
+		assert.equal(resumeStartKey([{ lastIndexedKey: 42 }, { lastIndexedKey: 7 }]), 7);
+	});
+
+	it('returns undefined (full scan) when any attribute has never checkpointed', () => {
+		assert.equal(resumeStartKey([{ lastIndexedKey: 'k-0700' }, {}]), undefined);
+		assert.equal(resumeStartKey([{ lastIndexedKey: 'k-0700' }, { lastIndexedKey: undefined }]), undefined);
+	});
+
+	it('returns the checkpoint of a single attribute', () => {
+		assert.equal(resumeStartKey([{ lastIndexedKey: 'k-0900' }]), 'k-0900');
+	});
+});
+
+describe('index backfill convergence (#2536)', () => {
+	it('resumes an interrupted backfill from its persisted checkpoint, not from the first record', async () => {
+		const TABLE = 'BackfillResume';
+		const N = 600;
+		const ABORT_AFTER = 250;
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }, { name: 'group' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + pad(i), tag: 't-' + (i % 3), group: 'g-' + (i % 2) });
+		await last;
+
+		// Add two indexed attributes and abort the backfill's primary-store scan partway, the way a
+		// store/iterator failure does; the outer catch persists indexingFailed with the checkpoint.
+		resetDatabases();
+		Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+				{ name: 'group', indexed: true },
+			],
+		});
+		assert.ok(Tbl.indexingOperation, 'adding indexed attributes should trigger a backfill');
+		const firstPass = observeRange(Tbl, { abortAfter: ABORT_AFTER });
+		try {
+			await Tbl.indexingOperation;
+		} finally {
+			firstPass.restore();
+		}
+		assert.equal(firstPass.keys.length, ABORT_AFTER, 'the first pass should have been aborted partway');
+		// runIndexing checkpoints every 100 entries it visits (LMDB yields a leading structures entry
+		// too), but only once the index writes the checkpoint covers have settled; LMDB commits them
+		// asynchronously, so the persisted checkpoint may lag one interval behind the abort point.
+		const checkpoint = findDescriptor(Tbl, 'tag').value.lastIndexedKey;
+		const expectedCheckpoints = LMDB ? [firstPass.keys[99], firstPass.keys[199]] : [firstPass.keys[199]];
+		assert.ok(
+			expectedCheckpoints.includes(checkpoint),
+			`persisted checkpoint ${checkpoint} should be one of ${expectedCheckpoints}`
+		);
+		for (const name of ['tag', 'group']) {
+			const parked = findDescriptor(Tbl, name);
+			assert.equal(parked?.value.indexingFailed, true, `${name}: interrupted backfill should be parked`);
+			assert.equal(parked.value.lastIndexedKey, checkpoint, `${name}: checkpoint should be persisted`);
+		}
+
+		// The parked descriptor retriggers the backfill; it must open its scan at the checkpoint.
+		resetDatabases();
+		const Tbl2 = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+				{ name: 'group', indexed: true },
+			],
+		});
+		assert.ok(Tbl2.indexingOperation, 'a parked backfill should retrigger');
+		const resumed = observeRange(Tbl2);
+		try {
+			await Tbl2.indexingOperation;
+		} finally {
+			resumed.restore();
+		}
+
+		assert.equal(resumed.start, checkpoint, 'the resumed scan should start at the persisted checkpoint');
+		assert.equal(resumed.keys[0], checkpoint, 'the first key visited after resume should be the checkpoint');
+		assert.equal(
+			resumed.keys.length,
+			N - Number(checkpoint.slice(2)),
+			'the resumed scan should only cover the checkpoint and the records after it'
+		);
+
+		for (const name of ['tag', 'group']) {
+			const done = findDescriptor(Tbl2, name);
+			assert.equal(done.value.indexingFailed, undefined, `${name}: indexingFailed cleared after completion`);
+			assert.equal(done.value.lastIndexedKey, undefined, `${name}: checkpoint cleared after completion`);
+		}
+		let total = 0;
+		for (const v of ['t-0', 't-1', 't-2']) {
+			total += (await collect(Tbl2.search({ conditions: [{ attribute: 'tag', value: v }] }))).length;
+		}
+		assert.equal(total, N, 'every row should be indexed once the resumed backfill completes');
+	});
+
+	it('does not advance the checkpoint past a record whose index write failed, so the retry re-covers it', async () => {
+		const TABLE = 'BackfillFailedRecord';
+		const N = 600;
+		const FAILING_ID = 'k-' + pad(250);
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + pad(i), tag: 't-' + (i % 3) });
+		await last;
+
+		resetDatabases();
+		Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.ok(Tbl.indexingOperation, 'adding an indexed attribute should trigger a backfill');
+		const tagIndex = Tbl.indices.tag;
+		const originalPut = tagIndex.put;
+		tagIndex.put = function (indexedValue, primaryKey, options) {
+			if (primaryKey === FAILING_ID) throw new Error('simulated transient index put failure');
+			return originalPut.call(this, indexedValue, primaryKey, options);
+		};
+		const firstPass = observeRange(Tbl);
+		try {
+			await Tbl.indexingOperation;
+		} finally {
+			tagIndex.put = originalPut;
+			firstPass.restore();
+		}
+		const failedAt = firstPass.keys.indexOf(FAILING_ID);
+		const lastSafeCheckpoint = firstPass.keys[Math.floor(failedAt / 100) * 100 - 1];
+		const parked = findDescriptor(Tbl, 'tag');
+		assert.equal(parked?.value.indexingFailed, true, 'a backfill with a failed record should be parked');
+		const persisted = parked.value.lastIndexedKey;
+		if (LMDB) {
+			// checkpoints wait for their writes to commit, so a failure that lands first withholds them
+			const safe = [undefined, ...firstPass.keys.slice(0, failedAt).filter((_, i) => i % 100 === 99)];
+			assert.ok(safe.includes(persisted), `checkpoint ${persisted} must not pass the failed record`);
+		} else {
+			assert.equal(
+				persisted,
+				lastSafeCheckpoint,
+				'the checkpoint must stop at the last one written before the failed record'
+			);
+		}
+
+		resetDatabases();
+		const Tbl2 = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.ok(Tbl2.indexingOperation, 'a parked backfill should retrigger');
+		const resumed = observeRange(Tbl2);
+		try {
+			await Tbl2.indexingOperation;
+		} finally {
+			resumed.restore();
+		}
+		assert.equal(resumed.start, persisted, 'the retry should resume from the persisted safe checkpoint');
+		assert.ok(resumed.keys.includes(FAILING_ID), 'the retry must revisit the record that failed');
+		assert.equal(findDescriptor(Tbl2, 'tag').value.indexingFailed, undefined, 'the retry should complete cleanly');
+		const viaIndex = await collect(Tbl2.search({ conditions: [{ attribute: 'tag', value: 't-' + (250 % 3) }] }));
+		assert.ok(
+			viaIndex.some((row) => row.id === FAILING_ID),
+			'the record whose index write failed must be indexed after the retry'
+		);
+	});
+
+	it('resumes from the minimum of unequal persisted checkpoints, and scans everything when one is absent', async () => {
+		const TABLE = 'BackfillUnequalCheckpoints';
+		const N = 500;
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }, { name: 'group' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + pad(i), tag: 't-' + (i % 3), group: 'g-' + (i % 2) });
+		await last;
+		const indexedAttributes = [
+			{ name: 'id', isPrimaryKey: true },
+			{ name: 'tag', indexed: true },
+			{ name: 'group', indexed: true },
+		];
+		resetDatabases();
+		Tbl = table({ table: TABLE, database: DB, attributes: indexedAttributes });
+		await Tbl.indexingOperation;
+
+		// Park both indexes at different checkpoints, the way two attributes whose checkpoint writes
+		// straddled an interruption would be left.
+		const park = (Tbl, checkpoints) => {
+			for (const [name, lastIndexedKey] of Object.entries(checkpoints)) {
+				const { key, value } = findDescriptor(Tbl, name);
+				value.indexingFailed = true;
+				if (lastIndexedKey === undefined) delete value.lastIndexedKey;
+				else value.lastIndexedKey = lastIndexedKey;
+				Tbl.dbisDB.putSync(key, value);
+			}
+		};
+		park(Tbl, { tag: 'k-' + pad(300), group: 'k-' + pad(200) });
+		resetDatabases();
+		let Tbl2 = table({ table: TABLE, database: DB, attributes: indexedAttributes });
+		assert.ok(Tbl2.indexingOperation, 'parked indexes should retrigger');
+		let resumed = observeRange(Tbl2);
+		try {
+			await Tbl2.indexingOperation;
+		} finally {
+			resumed.restore();
+		}
+		assert.equal(resumed.start, 'k-' + pad(200), 'the scan should start at the lower checkpoint');
+		assert.equal(resumed.keys[0], 'k-' + pad(200));
+
+		park(Tbl2, { tag: 'k-' + pad(300), group: undefined });
+		resetDatabases();
+		Tbl2 = table({ table: TABLE, database: DB, attributes: indexedAttributes });
+		assert.ok(Tbl2.indexingOperation, 'parked indexes should retrigger');
+		resumed = observeRange(Tbl2);
+		try {
+			await Tbl2.indexingOperation;
+		} finally {
+			resumed.restore();
+		}
+		assert.equal(resumed.start, undefined, 'an attribute with no checkpoint forces a full scan');
+		assert.equal(
+			resumed.keys.find((key) => typeof key === 'string'),
+			'k-' + pad(0)
+		);
+		for (const name of ['tag', 'group']) {
+			assert.equal(findDescriptor(Tbl2, name).value.lastIndexedKey, undefined, `${name}: completed`);
+		}
+		const evens = await collect(Tbl2.search({ conditions: [{ attribute: 'group', value: 'g-0' }] }));
+		assert.equal(evens.length, N / 2, 'the cleared index should be fully repopulated');
+	});
+
+	it('yields the event loop at a bounded record interval on a plain index whose put resolves synchronously', async () => {
+		const TABLE = 'BackfillYield';
+		const N = 2000;
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'y-' + pad(i), tag: 't-' + (i % 5) });
+		await last;
+
+		resetDatabases();
+		Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.ok(Tbl.indexingOperation, 'adding an indexed attribute should trigger a backfill');
+
+		// A setImmediate ticker advances once per event-loop turn the backfill gives up; stamp each
+		// visited key with the current tick so the longest run of keys on one tick is the longest
+		// stretch the loop ran without yielding.
+		let tick = 0;
+		let running = true;
+		const ticksPerKey = [];
+		const ticker = () => {
+			if (!running) return;
+			tick++;
+			setImmediate(ticker);
+		};
+		setImmediate(ticker);
+		const observed = observeRange(Tbl, {
+			onKey: (key) => {
+				if (typeof key === 'string') ticksPerKey.push(tick);
+			},
+		});
+		try {
+			await Tbl.indexingOperation;
+		} finally {
+			running = false;
+			observed.restore();
+		}
+
+		assert.equal(ticksPerKey.length, N, 'the backfill should visit every record');
+		let longestRun = 0;
+		let run = 0;
+		for (let i = 0; i < ticksPerKey.length; i++) {
+			run = i > 0 && ticksPerKey[i] === ticksPerKey[i - 1] ? run + 1 : 1;
+			if (run > longestRun) longestRun = run;
+		}
+		assert.ok(
+			longestRun <= INDEXING_YIELD_INTERVAL,
+			`backfill ran ${longestRun} records without yielding the event loop (bound ${INDEXING_YIELD_INTERVAL})`
+		);
+		const complete = await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: 't-0' }] }));
+		assert.equal(complete.length, N / 5, 'the backfill should still index every row');
+	});
+});

--- a/unitTests/resources/indexBackfillConvergence.test.js
+++ b/unitTests/resources/indexBackfillConvergence.test.js
@@ -11,7 +11,6 @@ const path = require('node:path');
 const { readFileSync, rmSync } = require('node:fs');
 const { spawn } = require('node:child_process');
 const { setupTestDBPath } = require('../testUtils');
-const { waitFor } = require('../waitFor');
 const env = require('#src/utility/environment/environmentManager');
 const terms = require('#src/utility/hdbTerms');
 const { table, resetDatabases, closeDatabase, resumeStartKey } = require('#src/resources/databases');
@@ -41,18 +40,11 @@ function findDescriptor(Tbl, attrName) {
 	return null;
 }
 
-// LMDB commits checkpoint writes asynchronously, so read the descriptor only once it has stopped
-// changing (three consecutive identical polls, 10ms apart).
+// LMDB commits checkpoint writes asynchronously; every checkpoint put is queued by the time
+// runIndexing resolves, so waiting for the queue to flush makes the read authoritative.
 async function settledCheckpoint(Tbl, attrName) {
-	let last = findDescriptor(Tbl, attrName).value.lastIndexedKey;
-	let stable = 0;
-	await waitFor(() => {
-		const current = findDescriptor(Tbl, attrName).value.lastIndexedKey;
-		stable = current === last ? stable + 1 : 0;
-		last = current;
-		return stable >= 3;
-	});
-	return last;
+	await Tbl.dbisDB.flushed;
+	return findDescriptor(Tbl, attrName).value.lastIndexedKey;
 }
 
 // Wrap Table.primaryStore.getRange so the test can observe the range runIndexing actually opens
@@ -157,9 +149,7 @@ describe('index backfill convergence (#2536)', () => {
 		// too), once the index writes the checkpoint covers have settled; LMDB commits those
 		// asynchronously, so the last checkpoint can land after the interruption itself was recorded.
 		const checkpoint = firstPass.keys[199];
-		await waitFor(() => findDescriptor(Tbl, 'tag').value.lastIndexedKey === checkpoint, {
-			message: `the checkpoint ${checkpoint} should be persisted after the interrupted pass`,
-		});
+		assert.strictEqual(await settledCheckpoint(Tbl, 'tag'), checkpoint, 'the last checkpoint should be persisted');
 		for (const name of ['tag', 'group']) {
 			const parked = findDescriptor(Tbl, name);
 			assert.strictEqual(parked?.value.indexingFailed, true, `${name}: interrupted backfill should be parked`);

--- a/unitTests/resources/indexBackfillConvergence.test.js
+++ b/unitTests/resources/indexBackfillConvergence.test.js
@@ -6,9 +6,15 @@
  * ran as one uninterrupted turn.
  */
 require('../testUtils');
-const assert = require('node:assert/strict');
+const assert = require('node:assert');
+const path = require('node:path');
+const { readFileSync, rmSync } = require('node:fs');
+const { spawn } = require('node:child_process');
 const { setupTestDBPath } = require('../testUtils');
-const { table, resetDatabases, resumeStartKey } = require('#src/resources/databases');
+const { waitFor } = require('../waitFor');
+const env = require('#src/utility/environment/environmentManager');
+const terms = require('#src/utility/hdbTerms');
+const { table, resetDatabases, closeDatabase, resumeStartKey } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 
 const DB = 'test';
@@ -75,24 +81,24 @@ function observeRange(Tbl, { onKey, abortAfter } = {}) {
 
 describe('resumeStartKey: minimum resume checkpoint across the attributes being built (#2536)', () => {
 	it('returns the shared checkpoint when every attribute checkpointed at the same key', () => {
-		assert.equal(resumeStartKey([{ lastIndexedKey: 'k-0500' }, { lastIndexedKey: 'k-0500' }]), 'k-0500');
+		assert.strictEqual(resumeStartKey([{ lastIndexedKey: 'k-0500' }, { lastIndexedKey: 'k-0500' }]), 'k-0500');
 	});
 
 	it('returns the minimum when the attributes checkpointed at different keys', () => {
-		assert.equal(
+		assert.strictEqual(
 			resumeStartKey([{ lastIndexedKey: 'k-0700' }, { lastIndexedKey: 'k-0300' }, { lastIndexedKey: 'k-0500' }]),
 			'k-0300'
 		);
-		assert.equal(resumeStartKey([{ lastIndexedKey: 42 }, { lastIndexedKey: 7 }]), 7);
+		assert.strictEqual(resumeStartKey([{ lastIndexedKey: 42 }, { lastIndexedKey: 7 }]), 7);
 	});
 
 	it('returns undefined (full scan) when any attribute has never checkpointed', () => {
-		assert.equal(resumeStartKey([{ lastIndexedKey: 'k-0700' }, {}]), undefined);
-		assert.equal(resumeStartKey([{ lastIndexedKey: 'k-0700' }, { lastIndexedKey: undefined }]), undefined);
+		assert.strictEqual(resumeStartKey([{ lastIndexedKey: 'k-0700' }, {}]), undefined);
+		assert.strictEqual(resumeStartKey([{ lastIndexedKey: 'k-0700' }, { lastIndexedKey: undefined }]), undefined);
 	});
 
 	it('returns the checkpoint of a single attribute', () => {
-		assert.equal(resumeStartKey([{ lastIndexedKey: 'k-0900' }]), 'k-0900');
+		assert.strictEqual(resumeStartKey([{ lastIndexedKey: 'k-0900' }]), 'k-0900');
 	});
 });
 
@@ -132,11 +138,14 @@ describe('index backfill convergence (#2536)', () => {
 		} finally {
 			firstPass.restore();
 		}
-		assert.equal(firstPass.keys.length, ABORT_AFTER, 'the first pass should have been aborted partway');
+		assert.strictEqual(firstPass.keys.length, ABORT_AFTER, 'the first pass should have been aborted partway');
 		// runIndexing checkpoints every 100 entries it visits (LMDB yields a leading structures entry
 		// too), but only once the index writes the checkpoint covers have settled; LMDB commits them
-		// asynchronously, so the persisted checkpoint may lag one interval behind the abort point.
-		const checkpoint = findDescriptor(Tbl, 'tag').value.lastIndexedKey;
+		// asynchronously, so the persisted checkpoint may lag one interval behind the abort point and
+		// land after the interruption itself was recorded.
+		const checkpoint = await waitFor(() => findDescriptor(Tbl, 'tag').value.lastIndexedKey, {
+			message: 'a checkpoint should be persisted after the interrupted pass',
+		});
 		const expectedCheckpoints = LMDB ? [firstPass.keys[99], firstPass.keys[199]] : [firstPass.keys[199]];
 		assert.ok(
 			expectedCheckpoints.includes(checkpoint),
@@ -144,8 +153,8 @@ describe('index backfill convergence (#2536)', () => {
 		);
 		for (const name of ['tag', 'group']) {
 			const parked = findDescriptor(Tbl, name);
-			assert.equal(parked?.value.indexingFailed, true, `${name}: interrupted backfill should be parked`);
-			assert.equal(parked.value.lastIndexedKey, checkpoint, `${name}: checkpoint should be persisted`);
+			assert.strictEqual(parked?.value.indexingFailed, true, `${name}: interrupted backfill should be parked`);
+			assert.strictEqual(parked.value.lastIndexedKey, checkpoint, `${name}: checkpoint should be persisted`);
 		}
 
 		// The parked descriptor retriggers the backfill; it must open its scan at the checkpoint.
@@ -167,9 +176,9 @@ describe('index backfill convergence (#2536)', () => {
 			resumed.restore();
 		}
 
-		assert.equal(resumed.start, checkpoint, 'the resumed scan should start at the persisted checkpoint');
-		assert.equal(resumed.keys[0], checkpoint, 'the first key visited after resume should be the checkpoint');
-		assert.equal(
+		assert.strictEqual(resumed.start, checkpoint, 'the resumed scan should start at the persisted checkpoint');
+		assert.strictEqual(resumed.keys[0], checkpoint, 'the first key visited after resume should be the checkpoint');
+		assert.strictEqual(
 			resumed.keys.length,
 			N - Number(checkpoint.slice(2)),
 			'the resumed scan should only cover the checkpoint and the records after it'
@@ -177,14 +186,14 @@ describe('index backfill convergence (#2536)', () => {
 
 		for (const name of ['tag', 'group']) {
 			const done = findDescriptor(Tbl2, name);
-			assert.equal(done.value.indexingFailed, undefined, `${name}: indexingFailed cleared after completion`);
-			assert.equal(done.value.lastIndexedKey, undefined, `${name}: checkpoint cleared after completion`);
+			assert.strictEqual(done.value.indexingFailed, undefined, `${name}: indexingFailed cleared after completion`);
+			assert.strictEqual(done.value.lastIndexedKey, undefined, `${name}: checkpoint cleared after completion`);
 		}
 		let total = 0;
 		for (const v of ['t-0', 't-1', 't-2']) {
 			total += (await collect(Tbl2.search({ conditions: [{ attribute: 'tag', value: v }] }))).length;
 		}
-		assert.equal(total, N, 'every row should be indexed once the resumed backfill completes');
+		assert.strictEqual(total, N, 'every row should be indexed once the resumed backfill completes');
 	});
 
 	it('does not advance the checkpoint past a record whose index write failed, so the retry re-covers it', async () => {
@@ -229,14 +238,14 @@ describe('index backfill convergence (#2536)', () => {
 		const failedAt = firstPass.keys.indexOf(FAILING_ID);
 		const lastSafeCheckpoint = firstPass.keys[Math.floor(failedAt / 100) * 100 - 1];
 		const parked = findDescriptor(Tbl, 'tag');
-		assert.equal(parked?.value.indexingFailed, true, 'a backfill with a failed record should be parked');
+		assert.strictEqual(parked?.value.indexingFailed, true, 'a backfill with a failed record should be parked');
 		const persisted = parked.value.lastIndexedKey;
 		if (LMDB) {
 			// checkpoints wait for their writes to commit, so a failure that lands first withholds them
 			const safe = [undefined, ...firstPass.keys.slice(0, failedAt).filter((_, i) => i % 100 === 99)];
 			assert.ok(safe.includes(persisted), `checkpoint ${persisted} must not pass the failed record`);
 		} else {
-			assert.equal(
+			assert.strictEqual(
 				persisted,
 				lastSafeCheckpoint,
 				'the checkpoint must stop at the last one written before the failed record'
@@ -259,9 +268,13 @@ describe('index backfill convergence (#2536)', () => {
 		} finally {
 			resumed.restore();
 		}
-		assert.equal(resumed.start, persisted, 'the retry should resume from the persisted safe checkpoint');
+		assert.strictEqual(resumed.start, persisted, 'the retry should resume from the persisted safe checkpoint');
 		assert.ok(resumed.keys.includes(FAILING_ID), 'the retry must revisit the record that failed');
-		assert.equal(findDescriptor(Tbl2, 'tag').value.indexingFailed, undefined, 'the retry should complete cleanly');
+		assert.strictEqual(
+			findDescriptor(Tbl2, 'tag').value.indexingFailed,
+			undefined,
+			'the retry should complete cleanly'
+		);
 		const viaIndex = await collect(Tbl2.search({ conditions: [{ attribute: 'tag', value: 't-' + (250 % 3) }] }));
 		assert.ok(
 			viaIndex.some((row) => row.id === FAILING_ID),
@@ -313,8 +326,8 @@ describe('index backfill convergence (#2536)', () => {
 		} finally {
 			resumed.restore();
 		}
-		assert.equal(resumed.start, 'k-' + pad(200), 'the scan should start at the lower checkpoint');
-		assert.equal(resumed.keys[0], 'k-' + pad(200));
+		assert.strictEqual(resumed.start, 'k-' + pad(200), 'the scan should start at the lower checkpoint');
+		assert.strictEqual(resumed.keys[0], 'k-' + pad(200));
 
 		park(Tbl2, { tag: 'k-' + pad(300), group: undefined });
 		resetDatabases();
@@ -326,16 +339,99 @@ describe('index backfill convergence (#2536)', () => {
 		} finally {
 			resumed.restore();
 		}
-		assert.equal(resumed.start, undefined, 'an attribute with no checkpoint forces a full scan');
-		assert.equal(
+		assert.strictEqual(resumed.start, undefined, 'an attribute with no checkpoint forces a full scan');
+		assert.strictEqual(
 			resumed.keys.find((key) => typeof key === 'string'),
 			'k-' + pad(0)
 		);
 		for (const name of ['tag', 'group']) {
-			assert.equal(findDescriptor(Tbl2, name).value.lastIndexedKey, undefined, `${name}: completed`);
+			assert.strictEqual(findDescriptor(Tbl2, name).value.lastIndexedKey, undefined, `${name}: completed`);
 		}
 		const evens = await collect(Tbl2.search({ conditions: [{ attribute: 'group', value: 'g-0' }] }));
-		assert.equal(evens.length, N / 2, 'the cleared index should be fully repopulated');
+		assert.strictEqual(evens.length, N / 2, 'the cleared index should be fully repopulated');
+	});
+
+	it('resumes from the checkpoint a process killed mid-backfill left behind, after it flushed', async () => {
+		const DATABASE = 'backfillcrash';
+		const TABLE = 'BackfillCrash';
+		const N = 50000;
+		const dbPath = setupTestDBPath();
+		setMainIsWorker(true);
+		// The database under test lives outside storage.path and is opened only by the child until
+		// it is dead, so no store is ever shared between the two processes.
+		const crashDir = path.join(dbPath, 'backfill-crash');
+		rmSync(crashDir, { recursive: true, force: true });
+		const markerPath = path.join(crashDir, 'checkpoint.marker');
+		const databasesConfig = env.get(terms.CONFIG_PARAMS.DATABASES);
+		env.setProperty(terms.CONFIG_PARAMS.DATABASES, {
+			...databasesConfig,
+			[DATABASE]: { path: path.join(crashDir, 'shared') },
+		});
+
+		const child = spawn(
+			process.execPath,
+			[
+				path.join(__dirname, 'indexBackfillConvergence-crash.js'),
+				path.join(crashDir, 'child-root'),
+				path.join(crashDir, 'shared'),
+				DATABASE,
+				TABLE,
+				markerPath,
+				String(N),
+			],
+			{ stdio: ['ignore', 'ignore', 'pipe'] }
+		);
+		let stderr = '';
+		child.stderr.on('data', (chunk) => (stderr += chunk));
+		const [code, signal] = await new Promise((resolve, reject) => {
+			child.once('error', reject);
+			child.once('exit', (code, signal) => resolve([code, signal]));
+		});
+		assert.strictEqual(
+			signal,
+			'SIGKILL',
+			`the child should have killed itself at its first checkpoint (exit ${code}): ${stderr}`
+		);
+		const checkpoint = readFileSync(markerPath, 'utf8');
+		assert.match(checkpoint, /^c-\d{6}$/, 'the child should have recorded a durable checkpoint');
+
+		// The dead process's PID on the descriptor is the crash-recovery trigger.
+		const Tbl = table({
+			table: TABLE,
+			database: DATABASE,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		try {
+			assert.ok(Tbl.indexingOperation, 'reopening after the crash should retrigger the backfill');
+			const resumed = observeRange(Tbl);
+			try {
+				await Tbl.indexingOperation;
+			} finally {
+				resumed.restore();
+			}
+			assert.strictEqual(
+				resumed.start,
+				checkpoint,
+				"the resumed scan should start at the crashed process's checkpoint"
+			);
+			assert.strictEqual(resumed.keys[0], checkpoint);
+			assert.strictEqual(
+				findDescriptor(Tbl, 'tag').value.indexingPID,
+				undefined,
+				'the resumed backfill should complete'
+			);
+			let total = 0;
+			for (let i = 0; i < 7; i++) {
+				total += (await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: 't-' + i }] }))).length;
+			}
+			assert.strictEqual(total, N, 'every row should be indexed after the resumed backfill');
+		} finally {
+			closeDatabase(DATABASE);
+			env.setProperty(terms.CONFIG_PARAMS.DATABASES, databasesConfig);
+		}
 	});
 
 	it('yields the event loop at a bounded record interval on a plain index whose put resolves synchronously', async () => {
@@ -388,18 +484,27 @@ describe('index backfill convergence (#2536)', () => {
 			observed.restore();
 		}
 
-		assert.equal(ticksPerKey.length, N, 'the backfill should visit every record');
+		assert.strictEqual(ticksPerKey.length, N, 'the backfill should visit every record');
 		let longestRun = 0;
 		let run = 0;
 		for (let i = 0; i < ticksPerKey.length; i++) {
 			run = i > 0 && ticksPerKey[i] === ticksPerKey[i - 1] ? run + 1 : 1;
 			if (run > longestRun) longestRun = run;
 		}
-		assert.ok(
-			longestRun <= INDEXING_YIELD_INTERVAL,
-			`backfill ran ${longestRun} records without yielding the event loop (bound ${INDEXING_YIELD_INTERVAL})`
-		);
+		// LMDB index puts are asynchronous, so the pre-existing backpressure branch yields more often there
+		if (LMDB) {
+			assert.ok(
+				longestRun <= INDEXING_YIELD_INTERVAL,
+				`backfill ran ${longestRun} records without yielding the event loop (bound ${INDEXING_YIELD_INTERVAL})`
+			);
+		} else {
+			assert.strictEqual(
+				longestRun,
+				INDEXING_YIELD_INTERVAL,
+				`backfill should yield the event loop every ${INDEXING_YIELD_INTERVAL} records, ran ${longestRun}`
+			);
+		}
 		const complete = await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: 't-0' }] }));
-		assert.equal(complete.length, N / 5, 'the backfill should still index every row');
+		assert.strictEqual(complete.length, N / 5, 'the backfill should still index every row');
 	});
 });

--- a/unitTests/resources/indexBackfillConvergence.test.js
+++ b/unitTests/resources/indexBackfillConvergence.test.js
@@ -140,8 +140,6 @@ describe('index backfill convergence (#2536)', () => {
 		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + pad(i), tag: 't-' + (i % 3), group: 'g-' + (i % 2) });
 		await last;
 
-		// Add two indexed attributes and abort the backfill's primary-store scan partway, the way a
-		// store/iterator failure does; the outer catch persists indexingFailed with the checkpoint.
 		resetDatabases();
 		Tbl = table({
 			table: TABLE,
@@ -212,91 +210,110 @@ describe('index backfill convergence (#2536)', () => {
 		assert.strictEqual(total, N, 'every row should be indexed once the resumed backfill completes');
 	});
 
-	it('does not advance the checkpoint past a record whose index write failed, so the retry re-covers it', async () => {
-		const TABLE = 'BackfillFailedRecord';
-		const N = 600;
-		const FAILING_ID = 'k-' + pad(250);
-		setupTestDBPath();
-		setMainIsWorker(true);
+	// A failed index write must freeze the checkpoint before that record whether it throws
+	// synchronously (RocksDB) or a non-last value's put rejects asynchronously (LMDB), since only a
+	// record's last put is awaited.
+	for (const [failure, tagOf, failPut] of [
+		[
+			'throws synchronously',
+			(i) => 't-' + (i % 3),
+			() => {
+				throw new Error('simulated transient index put failure');
+			},
+		],
+		[
+			'rejects asynchronously on a non-last value',
+			(i) => ['t-' + (i % 3), 'u-' + (i % 5)],
+			() => new Promise((_, reject) => setImmediate(() => reject(new Error('simulated async index put failure')))),
+		],
+	]) {
+		it(`does not advance the checkpoint past a record whose index write ${failure}, so the retry re-covers it`, async () => {
+			const TABLE = 'BackfillFailedRecord' + (Array.isArray(tagOf(0)) ? 'Multi' : '');
+			const N = 600;
+			const FAILING_ID = 'k-' + pad(250);
+			const failingValue = [].concat(tagOf(250))[0];
+			setupTestDBPath();
+			setMainIsWorker(true);
 
-		let Tbl = table({
-			table: TABLE,
-			database: DB,
-			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
-		});
-		let last;
-		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + pad(i), tag: 't-' + (i % 3) });
-		await last;
+			let Tbl = table({
+				table: TABLE,
+				database: DB,
+				attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+			});
+			let last;
+			for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + pad(i), tag: tagOf(i) });
+			await last;
 
-		resetDatabases();
-		Tbl = table({
-			table: TABLE,
-			database: DB,
-			attributes: [
-				{ name: 'id', isPrimaryKey: true },
-				{ name: 'tag', indexed: true },
-			],
-		});
-		assert.ok(Tbl.indexingOperation, 'adding an indexed attribute should trigger a backfill');
-		const tagIndex = Tbl.indices.tag;
-		const originalPut = tagIndex.put;
-		tagIndex.put = function (indexedValue, primaryKey, options) {
-			if (primaryKey === FAILING_ID) throw new Error('simulated transient index put failure');
-			return originalPut.call(this, indexedValue, primaryKey, options);
-		};
-		const firstPass = observeRange(Tbl);
-		try {
-			await Tbl.indexingOperation;
-		} finally {
-			tagIndex.put = originalPut;
-			firstPass.restore();
-		}
-		const failedAt = firstPass.keys.indexOf(FAILING_ID);
-		const lastSafeCheckpoint = firstPass.keys[Math.floor(failedAt / 100) * 100 - 1];
-		const parked = findDescriptor(Tbl, 'tag');
-		assert.strictEqual(parked?.value.indexingFailed, true, 'a backfill with a failed record should be parked');
-		const persisted = await settledCheckpoint(Tbl, 'tag');
-		if (LMDB) {
-			// checkpoints wait for their writes to commit, so a failure that lands first withholds them
-			const safe = [undefined, ...firstPass.keys.slice(0, failedAt).filter((_, i) => i % 100 === 99)];
-			assert.ok(safe.includes(persisted), `checkpoint ${persisted} must not pass the failed record`);
-		} else {
+			resetDatabases();
+			Tbl = table({
+				table: TABLE,
+				database: DB,
+				attributes: [
+					{ name: 'id', isPrimaryKey: true },
+					{ name: 'tag', indexed: true },
+				],
+			});
+			assert.ok(Tbl.indexingOperation, 'adding an indexed attribute should trigger a backfill');
+			const tagIndex = Tbl.indices.tag;
+			const originalPut = tagIndex.put;
+			tagIndex.put = function (indexedValue, primaryKey, options) {
+				if (primaryKey === FAILING_ID && indexedValue === failingValue) return failPut();
+				return originalPut.call(this, indexedValue, primaryKey, options);
+			};
+			const firstPass = observeRange(Tbl);
+			try {
+				await Tbl.indexingOperation;
+			} finally {
+				tagIndex.put = originalPut;
+				firstPass.restore();
+			}
+			const failedAt = firstPass.keys.indexOf(FAILING_ID);
+			const lastSafeCheckpoint = firstPass.keys[Math.floor(failedAt / 100) * 100 - 1];
+			const parked = findDescriptor(Tbl, 'tag');
+			assert.strictEqual(parked?.value.indexingFailed, true, 'a backfill with a failed record should be parked');
+			const persisted = await settledCheckpoint(Tbl, 'tag');
+			if (LMDB) {
+				// checkpoints wait for their writes to commit, so a failure that lands first withholds them
+				const safe = [undefined, ...firstPass.keys.slice(0, failedAt).filter((_, i) => i % 100 === 99)];
+				assert.ok(safe.includes(persisted), `checkpoint ${persisted} must not pass the failed record`);
+			} else {
+				assert.strictEqual(
+					persisted,
+					lastSafeCheckpoint,
+					'the checkpoint must stop at the last one written before the failed record'
+				);
+			}
+
+			resetDatabases();
+			const Tbl2 = table({
+				table: TABLE,
+				database: DB,
+				attributes: [
+					{ name: 'id', isPrimaryKey: true },
+					{ name: 'tag', indexed: true },
+				],
+			});
+			assert.ok(Tbl2.indexingOperation, 'a parked backfill should retrigger');
+			const resumed = observeRange(Tbl2);
+			try {
+				await Tbl2.indexingOperation;
+			} finally {
+				resumed.restore();
+			}
+			assert.strictEqual(resumed.start, persisted, 'the retry should resume from the persisted safe checkpoint');
+			assert.ok(resumed.keys.includes(FAILING_ID), 'the retry must revisit the record that failed');
 			assert.strictEqual(
-				persisted,
-				lastSafeCheckpoint,
-				'the checkpoint must stop at the last one written before the failed record'
+				findDescriptor(Tbl2, 'tag').value.indexingFailed,
+				undefined,
+				'the retry should complete cleanly'
 			);
-		}
-
-		resetDatabases();
-		const Tbl2 = table({
-			table: TABLE,
-			database: DB,
-			attributes: [
-				{ name: 'id', isPrimaryKey: true },
-				{ name: 'tag', indexed: true },
-			],
+			const viaIndex = await collect(Tbl2.search({ conditions: [{ attribute: 'tag', value: failingValue }] }));
+			assert.ok(
+				viaIndex.some((row) => row.id === FAILING_ID),
+				'the record whose index write failed must be indexed after the retry'
+			);
 		});
-		assert.ok(Tbl2.indexingOperation, 'a parked backfill should retrigger');
-		const resumed = observeRange(Tbl2);
-		try {
-			await Tbl2.indexingOperation;
-		} finally {
-			resumed.restore();
-		}
-		assert.strictEqual(resumed.start, persisted, 'the retry should resume from the persisted safe checkpoint');
-		assert.ok(resumed.keys.includes(FAILING_ID), 'the retry must revisit the record that failed');
-		assert.strictEqual(
-			findDescriptor(Tbl2, 'tag').value.indexingFailed,
-			undefined,
-			'the retry should complete cleanly'
-		);
-		const viaIndex = await collect(Tbl2.search({ conditions: [{ attribute: 'tag', value: 't-' + (250 % 3) }] }));
-		assert.ok(
-			viaIndex.some((row) => row.id === FAILING_ID),
-			'the record whose index write failed must be indexed after the retry'
-		);
-	});
+	}
 
 	it('resumes from the minimum of unequal persisted checkpoints, and scans everything when one is absent', async () => {
 		const TABLE = 'BackfillUnequalCheckpoints';

--- a/unitTests/resources/indexBackfillConvergence.test.js
+++ b/unitTests/resources/indexBackfillConvergence.test.js
@@ -610,6 +610,64 @@ describe('index backfill convergence (#2536)', () => {
 		assert.strictEqual(findDescriptor(Tbl2, 'tag').value.indexingFailed, undefined, 'the retry should complete');
 	});
 
+	it('does not persist a checkpoint before the record floor, whatever the period', async () => {
+		const TABLE = 'BackfillCheckpointFloor';
+		const N = 25000;
+		const FLOOR = 10000;
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'f-' + String(i).padStart(5, '0'), tag: 't-' + (i % 3) });
+		await last;
+
+		const policy = setIndexingCheckpointPeriod(0, FLOOR);
+		try {
+			resetDatabases();
+			Tbl = table({
+				table: TABLE,
+				database: DB,
+				attributes: [
+					{ name: 'id', isPrimaryKey: true },
+					{ name: 'tag', indexed: true },
+				],
+			});
+			assert.ok(Tbl.indexingOperation, 'adding an indexed attribute should trigger a backfill');
+			const checkpoints = [];
+			const originalPut = Tbl.dbisDB.put;
+			Tbl.dbisDB.put = function (key, value, options) {
+				if (value?.name === 'tag' && value.lastIndexedKey !== undefined) checkpoints.push(value.lastIndexedKey);
+				return originalPut.call(this, key, value, options);
+			};
+			try {
+				await Tbl.indexingOperation;
+			} finally {
+				Tbl.dbisDB.put = originalPut;
+			}
+			assert.ok(checkpoints.length > 0, 'a 25k-row backfill should checkpoint');
+			const stringKeys = (key) => typeof key === 'string';
+			const visitedBefore = (key) => Number(key.slice(2)) + (LMDB ? 1 : 0) + 1;
+			assert.ok(
+				visitedBefore(checkpoints[0]) >= FLOOR,
+				`the first checkpoint ${checkpoints[0]} should come after ${FLOOR} records`
+			);
+			for (let i = 1; i < checkpoints.length; i++) {
+				assert.ok(
+					visitedBefore(checkpoints[i]) - visitedBefore(checkpoints[i - 1]) >= FLOOR,
+					`checkpoints ${checkpoints[i - 1]} and ${checkpoints[i]} are closer than ${FLOOR} records`
+				);
+			}
+			assert.ok(checkpoints.every(stringKeys));
+		} finally {
+			setIndexingCheckpointPeriod(policy.ms, policy.minRecords);
+		}
+	});
+
 	it('yields the event loop at a bounded record interval on a plain index whose put resolves synchronously', async () => {
 		const TABLE = 'BackfillYield';
 		const N = 2000;

--- a/unitTests/resources/indexBackfillConvergence.test.js
+++ b/unitTests/resources/indexBackfillConvergence.test.js
@@ -53,6 +53,25 @@ async function settledCheckpoint(Tbl, attrName) {
 	return findDescriptor(Tbl, attrName).value.lastIndexedKey;
 }
 
+// Run the crash fixture as a child process; it is expected to SIGKILL itself, so a child that never
+// reaches its marker is killed by the parent instead of wedging the run (.mocharc.json has timeout 0).
+async function runCrashChild(args) {
+	const child = spawn(process.execPath, [path.join(__dirname, 'indexBackfillConvergence-crash.js'), ...args], {
+		stdio: ['ignore', 'ignore', 'pipe'],
+	});
+	let stderr = '';
+	child.stderr.on('data', (chunk) => (stderr += chunk));
+	const timer = setTimeout(() => child.kill('SIGTERM'), 60000);
+	try {
+		return await new Promise((resolve, reject) => {
+			child.once('error', reject);
+			child.once('exit', (code, signal) => resolve({ code, signal, stderr }));
+		});
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
 // Wrap Table.primaryStore.getRange so the test can observe the range runIndexing actually opens
 // (its `start` option and every key it visits) and optionally abort the scan partway. runIndexing
 // only reads the store after awaiting a schema-change signal and an event turn, so wrapping right
@@ -116,12 +135,12 @@ describe('resumeStartKey: minimum resume checkpoint across the attributes being 
 
 describe('index backfill convergence (#2536)', () => {
 	// checkpoint at every yield interval instead of every few seconds, so small tables checkpoint
-	let checkpointPeriod;
+	let checkpointPolicy;
 	before(() => {
-		checkpointPeriod = setIndexingCheckpointPeriod(0);
+		checkpointPolicy = setIndexingCheckpointPeriod(0, 0);
 	});
 	after(() => {
-		setIndexingCheckpointPeriod(checkpointPeriod);
+		setIndexingCheckpointPeriod(checkpointPolicy.ms, checkpointPolicy.minRecords);
 	});
 
 	it('resumes an interrupted backfill from its persisted checkpoint, not from the first record', async () => {
@@ -213,46 +232,52 @@ describe('index backfill convergence (#2536)', () => {
 	// A failed index write must freeze the checkpoint before that record whether it throws
 	// synchronously (RocksDB) or a non-last value's put rejects asynchronously (LMDB), since only a
 	// record's last put is awaited.
-	for (const [failure, tagOf, failPut] of [
-		[
-			'throws synchronously',
-			(i) => 't-' + (i % 3),
-			() => {
+	for (const { failure, tagOf, failPut, secondAttribute } of [
+		{
+			failure: 'throws synchronously',
+			tagOf: (i) => 't-' + (i % 3),
+			failPut: () => {
 				throw new Error('simulated transient index put failure');
 			},
-		],
-		[
-			'rejects asynchronously on a non-last value',
-			(i) => ['t-' + (i % 3), 'u-' + (i % 5)],
-			() => new Promise((_, reject) => setImmediate(() => reject(new Error('simulated async index put failure')))),
-		],
+		},
+		{
+			failure: 'rejects asynchronously on a non-last value',
+			tagOf: (i) => ['t-' + (i % 3), 'u-' + (i % 5)],
+			failPut: () =>
+				new Promise((_, reject) => setImmediate(() => reject(new Error('simulated async index put failure')))),
+		},
+		{
+			failure: "rejects asynchronously while a later attribute's put resolves",
+			tagOf: (i) => 't-' + (i % 3),
+			failPut: () =>
+				new Promise((_, reject) => setImmediate(() => reject(new Error('simulated async index put failure')))),
+			secondAttribute: true,
+		},
 	]) {
 		it(`does not advance the checkpoint past a record whose index write ${failure}, so the retry re-covers it`, async () => {
-			const TABLE = 'BackfillFailedRecord' + (Array.isArray(tagOf(0)) ? 'Multi' : '');
+			const TABLE = 'BackfillFailedRecord' + (Array.isArray(tagOf(0)) ? 'Multi' : secondAttribute ? 'Two' : '');
 			const N = 600;
 			const FAILING_ID = 'k-' + pad(250);
 			const failingValue = [].concat(tagOf(250))[0];
+			const indexedAttributes = [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+				{ name: 'group', indexed: !!secondAttribute },
+			];
 			setupTestDBPath();
 			setMainIsWorker(true);
 
 			let Tbl = table({
 				table: TABLE,
 				database: DB,
-				attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+				attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }, { name: 'group' }],
 			});
 			let last;
-			for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + pad(i), tag: tagOf(i) });
+			for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + pad(i), tag: tagOf(i), group: 'g-' + (i % 2) });
 			await last;
 
 			resetDatabases();
-			Tbl = table({
-				table: TABLE,
-				database: DB,
-				attributes: [
-					{ name: 'id', isPrimaryKey: true },
-					{ name: 'tag', indexed: true },
-				],
-			});
+			Tbl = table({ table: TABLE, database: DB, attributes: indexedAttributes });
 			assert.ok(Tbl.indexingOperation, 'adding an indexed attribute should trigger a backfill');
 			const tagIndex = Tbl.indices.tag;
 			const originalPut = tagIndex.put;
@@ -285,14 +310,7 @@ describe('index backfill convergence (#2536)', () => {
 			}
 
 			resetDatabases();
-			const Tbl2 = table({
-				table: TABLE,
-				database: DB,
-				attributes: [
-					{ name: 'id', isPrimaryKey: true },
-					{ name: 'tag', indexed: true },
-				],
-			});
+			const Tbl2 = table({ table: TABLE, database: DB, attributes: indexedAttributes });
 			assert.ok(Tbl2.indexingOperation, 'a parked backfill should retrigger');
 			const resumed = observeRange(Tbl2);
 			try {
@@ -425,26 +443,15 @@ describe('index backfill convergence (#2536)', () => {
 			[DATABASE]: { path: path.join(crashDir, 'shared') },
 		});
 
-		const child = spawn(
-			process.execPath,
-			[
-				path.join(__dirname, 'indexBackfillConvergence-crash.js'),
-				path.join(crashDir, 'child-root'),
-				path.join(crashDir, 'shared'),
-				DATABASE,
-				TABLE,
-				markerPath,
-				String(N),
-				'kill-at-checkpoint',
-			],
-			{ stdio: ['ignore', 'ignore', 'pipe'] }
-		);
-		let stderr = '';
-		child.stderr.on('data', (chunk) => (stderr += chunk));
-		const [code, signal] = await new Promise((resolve, reject) => {
-			child.once('error', reject);
-			child.once('exit', (code, signal) => resolve([code, signal]));
-		});
+		const { code, signal, stderr } = await runCrashChild([
+			path.join(crashDir, 'child-root'),
+			path.join(crashDir, 'shared'),
+			DATABASE,
+			TABLE,
+			markerPath,
+			String(N),
+			'kill-at-checkpoint',
+		]);
 		assert.strictEqual(
 			signal,
 			'SIGKILL',
@@ -514,26 +521,15 @@ describe('index backfill convergence (#2536)', () => {
 		});
 
 		// a long period means the whole index is the unflushed tail when the ready descriptor lands
-		const child = spawn(
-			process.execPath,
-			[
-				path.join(__dirname, 'indexBackfillConvergence-crash.js'),
-				path.join(crashDir, 'child-root'),
-				path.join(crashDir, 'shared'),
-				DATABASE,
-				TABLE,
-				markerPath,
-				String(N),
-				'kill-after-complete',
-			],
-			{ stdio: ['ignore', 'ignore', 'pipe'] }
-		);
-		let stderr = '';
-		child.stderr.on('data', (chunk) => (stderr += chunk));
-		const [code, signal] = await new Promise((resolve, reject) => {
-			child.once('error', reject);
-			child.once('exit', (code, signal) => resolve([code, signal]));
-		});
+		const { code, signal, stderr } = await runCrashChild([
+			path.join(crashDir, 'child-root'),
+			path.join(crashDir, 'shared'),
+			DATABASE,
+			TABLE,
+			markerPath,
+			String(N),
+			'kill-after-complete',
+		]);
 		assert.strictEqual(
 			signal,
 			'SIGKILL',

--- a/unitTests/resources/indexBackfillConvergence.test.js
+++ b/unitTests/resources/indexBackfillConvergence.test.js
@@ -167,7 +167,7 @@ describe('index backfill convergence (#2536)', () => {
 			const parked = findDescriptor(Tbl, name);
 			assert.strictEqual(parked?.value.indexingFailed, true, `${name}: interrupted backfill should be parked`);
 			assert.strictEqual(parked.value.lastIndexedKey, checkpoint, `${name}: checkpoint should be persisted`);
-			assert.strictEqual(parked.value.checkpointCertified, true, `${name}: checkpoint should be stamped`);
+			assert.strictEqual(parked.value.checkpointCertified, checkpoint, `${name}: checkpoint should be stamped`);
 		}
 
 		// The parked descriptor retriggers the backfill; it must open its scan at the checkpoint.
@@ -348,7 +348,7 @@ describe('index backfill convergence (#2536)', () => {
 				if (lastIndexedKey === undefined) delete value.lastIndexedKey;
 				else {
 					value.lastIndexedKey = lastIndexedKey;
-					if (certified) value.checkpointCertified = true;
+					if (certified) value.checkpointCertified = lastIndexedKey;
 				}
 				Tbl.dbisDB.putSync(key, value);
 			}
@@ -435,6 +435,7 @@ describe('index backfill convergence (#2536)', () => {
 				TABLE,
 				markerPath,
 				String(N),
+				'kill-at-checkpoint',
 			],
 			{ stdio: ['ignore', 'ignore', 'pipe'] }
 		);
@@ -495,6 +496,122 @@ describe('index backfill convergence (#2536)', () => {
 			closeDatabase(DATABASE);
 			env.setProperty(terms.CONFIG_PARAMS.DATABASES, databasesConfig);
 		}
+	});
+
+	it('flushes the tail written since the last checkpoint before announcing the index complete', async () => {
+		const DATABASE = 'backfillcomplete';
+		const TABLE = 'BackfillComplete';
+		const N = 10000;
+		const dbPath = setupTestDBPath();
+		setMainIsWorker(true);
+		const crashDir = path.join(dbPath, 'backfill-complete');
+		rmSync(crashDir, { recursive: true, force: true });
+		const markerPath = path.join(crashDir, 'complete.marker');
+		const databasesConfig = env.get(terms.CONFIG_PARAMS.DATABASES);
+		env.setProperty(terms.CONFIG_PARAMS.DATABASES, {
+			...databasesConfig,
+			[DATABASE]: { path: path.join(crashDir, 'shared') },
+		});
+
+		// a long period means the whole index is the unflushed tail when the ready descriptor lands
+		const child = spawn(
+			process.execPath,
+			[
+				path.join(__dirname, 'indexBackfillConvergence-crash.js'),
+				path.join(crashDir, 'child-root'),
+				path.join(crashDir, 'shared'),
+				DATABASE,
+				TABLE,
+				markerPath,
+				String(N),
+				'kill-after-complete',
+			],
+			{ stdio: ['ignore', 'ignore', 'pipe'] }
+		);
+		let stderr = '';
+		child.stderr.on('data', (chunk) => (stderr += chunk));
+		const [code, signal] = await new Promise((resolve, reject) => {
+			child.once('error', reject);
+			child.once('exit', (code, signal) => resolve([code, signal]));
+		});
+		assert.strictEqual(
+			signal,
+			'SIGKILL',
+			`the child should have killed itself once complete (exit ${code}): ${stderr}`
+		);
+		assert.strictEqual(readFileSync(markerPath, 'utf8'), 'COMPLETED');
+
+		const Tbl = table({
+			table: TABLE,
+			database: DATABASE,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		try {
+			assert.strictEqual(Tbl.indexingOperation, undefined, 'a completed index must not retrigger');
+			let total = 0;
+			for (let i = 0; i < 7; i++) {
+				total += (await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: 't-' + i }] }))).length;
+			}
+			assert.strictEqual(total, N, 'every index entry must survive a kill right after completion');
+		} finally {
+			closeDatabase(DATABASE);
+			env.setProperty(terms.CONFIG_PARAMS.DATABASES, databasesConfig);
+		}
+	});
+
+	it('parks the index instead of certifying a checkpoint or completing when the flush fails', async function () {
+		if (LMDB) return this.skip(); // LMDB commits in order and never flushes
+		const TABLE = 'BackfillFlushFails';
+		const N = 300;
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + pad(i), tag: 't-' + (i % 3) });
+		await last;
+
+		resetDatabases();
+		Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.ok(Tbl.indexingOperation, 'adding an indexed attribute should trigger a backfill');
+		const rootStore = Tbl.primaryStore.rootStore;
+		const originalFlush = rootStore.flush;
+		rootStore.flush = () => Promise.reject(new Error('simulated flush failure'));
+		try {
+			await Tbl.indexingOperation;
+		} finally {
+			rootStore.flush = originalFlush;
+		}
+		const parked = findDescriptor(Tbl, 'tag');
+		assert.strictEqual(parked.value.indexingFailed, true, 'the index must stay parked when it cannot be flushed');
+		assert.strictEqual(parked.value.lastIndexedKey, undefined, 'no checkpoint may be certified without a flush');
+
+		resetDatabases();
+		const Tbl2 = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.ok(Tbl2.indexingOperation, 'the parked index should retrigger');
+		await Tbl2.indexingOperation;
+		assert.strictEqual(findDescriptor(Tbl2, 'tag').value.indexingFailed, undefined, 'the retry should complete');
 	});
 
 	it('yields the event loop at a bounded record interval on a plain index whose put resolves synchronously', async () => {

--- a/unitTests/resources/indexBackfillConvergence.test.js
+++ b/unitTests/resources/indexBackfillConvergence.test.js
@@ -498,9 +498,8 @@ describe('index backfill convergence (#2536)', () => {
 				`backfill ran ${longestRun} records without yielding the event loop (bound ${INDEXING_YIELD_INTERVAL})`
 			);
 		} else {
-			assert.strictEqual(
-				longestRun,
-				INDEXING_YIELD_INTERVAL,
+			assert.ok(
+				longestRun >= INDEXING_YIELD_INTERVAL / 2 && longestRun <= INDEXING_YIELD_INTERVAL,
 				`backfill should yield the event loop every ${INDEXING_YIELD_INTERVAL} records, ran ${longestRun}`
 			);
 		}

--- a/unitTests/resources/indexBackfillConvergence.test.js
+++ b/unitTests/resources/indexBackfillConvergence.test.js
@@ -41,6 +41,20 @@ function findDescriptor(Tbl, attrName) {
 	return null;
 }
 
+// LMDB commits checkpoint writes asynchronously, so read the descriptor only once it has stopped
+// changing (three consecutive identical polls, 10ms apart).
+async function settledCheckpoint(Tbl, attrName) {
+	let last = findDescriptor(Tbl, attrName).value.lastIndexedKey;
+	let stable = 0;
+	await waitFor(() => {
+		const current = findDescriptor(Tbl, attrName).value.lastIndexedKey;
+		stable = current === last ? stable + 1 : 0;
+		last = current;
+		return stable >= 3;
+	});
+	return last;
+}
+
 // Wrap Table.primaryStore.getRange so the test can observe the range runIndexing actually opens
 // (its `start` option and every key it visits) and optionally abort the scan partway. runIndexing
 // only reads the store after awaiting a schema-change signal and an event turn, so wrapping right
@@ -140,17 +154,12 @@ describe('index backfill convergence (#2536)', () => {
 		}
 		assert.strictEqual(firstPass.keys.length, ABORT_AFTER, 'the first pass should have been aborted partway');
 		// runIndexing checkpoints every 100 entries it visits (LMDB yields a leading structures entry
-		// too), but only once the index writes the checkpoint covers have settled; LMDB commits them
-		// asynchronously, so the persisted checkpoint may lag one interval behind the abort point and
-		// land after the interruption itself was recorded.
-		const checkpoint = await waitFor(() => findDescriptor(Tbl, 'tag').value.lastIndexedKey, {
-			message: 'a checkpoint should be persisted after the interrupted pass',
+		// too), once the index writes the checkpoint covers have settled; LMDB commits those
+		// asynchronously, so the last checkpoint can land after the interruption itself was recorded.
+		const checkpoint = firstPass.keys[199];
+		await waitFor(() => findDescriptor(Tbl, 'tag').value.lastIndexedKey === checkpoint, {
+			message: `the checkpoint ${checkpoint} should be persisted after the interrupted pass`,
 		});
-		const expectedCheckpoints = LMDB ? [firstPass.keys[99], firstPass.keys[199]] : [firstPass.keys[199]];
-		assert.ok(
-			expectedCheckpoints.includes(checkpoint),
-			`persisted checkpoint ${checkpoint} should be one of ${expectedCheckpoints}`
-		);
 		for (const name of ['tag', 'group']) {
 			const parked = findDescriptor(Tbl, name);
 			assert.strictEqual(parked?.value.indexingFailed, true, `${name}: interrupted backfill should be parked`);
@@ -239,7 +248,7 @@ describe('index backfill convergence (#2536)', () => {
 		const lastSafeCheckpoint = firstPass.keys[Math.floor(failedAt / 100) * 100 - 1];
 		const parked = findDescriptor(Tbl, 'tag');
 		assert.strictEqual(parked?.value.indexingFailed, true, 'a backfill with a failed record should be parked');
-		const persisted = parked.value.lastIndexedKey;
+		const persisted = await settledCheckpoint(Tbl, 'tag');
 		if (LMDB) {
 			// checkpoints wait for their writes to commit, so a failure that lands first withholds them
 			const safe = [undefined, ...firstPass.keys.slice(0, failedAt).filter((_, i) => i % 100 === 99)];
@@ -412,12 +421,18 @@ describe('index backfill convergence (#2536)', () => {
 			} finally {
 				resumed.restore();
 			}
-			assert.strictEqual(
-				resumed.start,
-				checkpoint,
-				"the resumed scan should start at the crashed process's checkpoint"
-			);
-			assert.strictEqual(resumed.keys[0], checkpoint);
+			if (LMDB) {
+				// the child read a committed checkpoint, but LMDB's write thread can commit the next one
+				// (already queued) before the kill lands
+				assert.ok(resumed.start >= checkpoint, `the resumed scan should start at or after ${checkpoint}`);
+			} else {
+				assert.strictEqual(
+					resumed.start,
+					checkpoint,
+					"the resumed scan should start at the crashed process's checkpoint"
+				);
+			}
+			assert.strictEqual(resumed.keys[0], resumed.start);
 			assert.strictEqual(
 				findDescriptor(Tbl, 'tag').value.indexingPID,
 				undefined,

--- a/unitTests/resources/indexBackfillConvergence.test.js
+++ b/unitTests/resources/indexBackfillConvergence.test.js
@@ -13,7 +13,13 @@ const { spawn } = require('node:child_process');
 const { setupTestDBPath } = require('../testUtils');
 const env = require('#src/utility/environment/environmentManager');
 const terms = require('#src/utility/hdbTerms');
-const { table, resetDatabases, closeDatabase, resumeStartKey } = require('#src/resources/databases');
+const {
+	table,
+	resetDatabases,
+	closeDatabase,
+	resumeStartKey,
+	setIndexingCheckpointPeriod,
+} = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 
 const DB = 'test';
@@ -109,6 +115,15 @@ describe('resumeStartKey: minimum resume checkpoint across the attributes being 
 });
 
 describe('index backfill convergence (#2536)', () => {
+	// checkpoint at every yield interval instead of every few seconds, so small tables checkpoint
+	let checkpointPeriod;
+	before(() => {
+		checkpointPeriod = setIndexingCheckpointPeriod(0);
+	});
+	after(() => {
+		setIndexingCheckpointPeriod(checkpointPeriod);
+	});
+
 	it('resumes an interrupted backfill from its persisted checkpoint, not from the first record', async () => {
 		const TABLE = 'BackfillResume';
 		const N = 600;
@@ -154,6 +169,7 @@ describe('index backfill convergence (#2536)', () => {
 			const parked = findDescriptor(Tbl, name);
 			assert.strictEqual(parked?.value.indexingFailed, true, `${name}: interrupted backfill should be parked`);
 			assert.strictEqual(parked.value.lastIndexedKey, checkpoint, `${name}: checkpoint should be persisted`);
+			assert.strictEqual(parked.value.checkpointCertified, true, `${name}: checkpoint should be stamped`);
 		}
 
 		// The parked descriptor retriggers the backfill; it must open its scan at the checkpoint.
@@ -187,6 +203,7 @@ describe('index backfill convergence (#2536)', () => {
 			const done = findDescriptor(Tbl2, name);
 			assert.strictEqual(done.value.indexingFailed, undefined, `${name}: indexingFailed cleared after completion`);
 			assert.strictEqual(done.value.lastIndexedKey, undefined, `${name}: checkpoint cleared after completion`);
+			assert.strictEqual(done.value.checkpointCertified, undefined, `${name}: stamp cleared after completion`);
 		}
 		let total = 0;
 		for (const v of ['t-0', 't-1', 't-2']) {
@@ -306,12 +323,16 @@ describe('index backfill convergence (#2536)', () => {
 
 		// Park both indexes at different checkpoints, the way two attributes whose checkpoint writes
 		// straddled an interruption would be left.
-		const park = (Tbl, checkpoints) => {
+		const park = (Tbl, checkpoints, { certified = true } = {}) => {
 			for (const [name, lastIndexedKey] of Object.entries(checkpoints)) {
 				const { key, value } = findDescriptor(Tbl, name);
 				value.indexingFailed = true;
+				delete value.checkpointCertified;
 				if (lastIndexedKey === undefined) delete value.lastIndexedKey;
-				else value.lastIndexedKey = lastIndexedKey;
+				else {
+					value.lastIndexedKey = lastIndexedKey;
+					if (certified) value.checkpointCertified = true;
+				}
 				Tbl.dbisDB.putSync(key, value);
 			}
 		};
@@ -348,12 +369,32 @@ describe('index backfill convergence (#2536)', () => {
 		}
 		const evens = await collect(Tbl2.search({ conditions: [{ attribute: 'group', value: 'g-0' }] }));
 		assert.strictEqual(evens.length, N / 2, 'the cleared index should be fully repopulated');
+
+		// A checkpoint written by a release without the stamp advanced past failed and unflushed index
+		// writes, so it must not be resumed: full rebuild, including the clear of the existing entries.
+		park(Tbl2, { tag: 'k-' + pad(300), group: 'k-' + pad(300) }, { certified: false });
+		resetDatabases();
+		Tbl2 = table({ table: TABLE, database: DB, attributes: indexedAttributes });
+		assert.ok(Tbl2.indexingOperation, 'a parked legacy checkpoint should retrigger');
+		resumed = observeRange(Tbl2);
+		try {
+			await Tbl2.indexingOperation;
+		} finally {
+			resumed.restore();
+		}
+		assert.strictEqual(resumed.start, undefined, 'an unstamped legacy checkpoint must not be resumed');
+		assert.strictEqual(
+			resumed.keys.find((key) => typeof key === 'string'),
+			'k-' + pad(0)
+		);
+		const odds = await collect(Tbl2.search({ conditions: [{ attribute: 'group', value: 'g-1' }] }));
+		assert.strictEqual(odds.length, N / 2, 'the rebuilt index should be complete');
 	});
 
-	it('resumes from the checkpoint a process killed mid-backfill left behind, after it flushed', async () => {
+	it('resumes from the checkpoint a process killed mid-backfill left behind', async () => {
 		const DATABASE = 'backfillcrash';
 		const TABLE = 'BackfillCrash';
-		const N = 50000;
+		const N = 10000;
 		const dbPath = setupTestDBPath();
 		setMainIsWorker(true);
 		// The database under test lives outside storage.path and is opened only by the child until


### PR DESCRIPTION
A secondary-index backfill on a large table could never converge: `runIndexing` discarded its own resume checkpoint (ordered-binary sorts `undefined` lowest, so the running-minimum guard never fired and every retrigger rescanned from the first record), and on a plain RocksDB index it never yielded the event loop (`RocksIndexStore.put` is synchronous, so the `outstanding` counter the yields were keyed to never left 0 and a 19M-row build ran as one ~18-minute turn until the worker was terminated). Backfills now resume from [the minimum persisted checkpoint across the attributes being built](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3172) ([used as the scan's `start`](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3206), [clearing every index when a full scan is needed](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3207)), [yield every 100 scanned entries](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3322) regardless of write-completion timing ([deletion entries count too](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3245) and [still pace the checkpoints](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3257)). Because the checkpoint is now actually consumed, it has to be trustworthy: [`persistCheckpoint`](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3221) writes it only after the index writes it covers have settled and the RocksDB store has been flushed ([`flushIndexStores`](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3156): index stores have no WAL), [at most once per 5s and never before 10k more records](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3311), never advances after any index write fails ([every put's rejection is tracked](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3275), not only a record's last), and stamps each checkpoint with its own key so [the trigger ignores a checkpoint left by an earlier release](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R2880) (which advanced past failed and unflushed writes) and rebuilds instead of resuming past a gap. [The completion path flushes the tail before persisting the ready descriptor and parks the index if that flush fails](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3345); [the interrupt path awaits the in-flight checkpoint and persists synchronously](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3301). Where to look hardest: `persistCheckpoint`, `flushIndexStores` and the trigger's `uncertifiedCheckpoint` — everything else is plumbing around them. Fixes #2536 (the per-thread `isIndexing` divergence and the dead-backfill marker are #2537, whose PR #2543 edits lines adjacent to the trigger change here; expect a trivial rebase on whichever lands second).

## For the human reviewer

Step-6 planning review returned `Framing-Verdict: better-alternative-exists` twice and both were **adopted**: round 1 made the checkpoint certify a successfully indexed prefix; after the task owner's ruling on the two open questions (1b, 2a) and a teammate's rig repro, the recheck accepted the layer and all four rejected alternatives (WAL-on index column families, colocating the checkpoint in the index CF, a trigger-side discard on process change, and accept-and-document) and asked for three corrections, all in: never join a flush already in flight, bind the stamp to its key, flush before readiness. Nine pre-push rounds; the last two produced no new actionable finding.

1. **Flush-gated, rate-limited checkpoints (ruling 1b).** RocksDB data and index stores open with `disableWAL: true` but the descriptor store with the WAL on, so a checkpoint written every 100 records could outlive the entries it certifies after a SIGKILL/OOM (proven on a child-process kill: 99 of the first 100 entries lost, checkpoint intact). A checkpoint is now persisted only after a flush, [at most once per 5s and never before 10k more records](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3142) (`setIndexingCheckpointPeriod()` is the test seam) — the flush seals every column family in the database (`atomic_flush`), so the record floor keeps a slow backfill from imposing the 5s rate on unrelated tables. [At most one flush in flight and one queued per root store](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3156); a caller never joins one already running because a flush only covers writes issued before it started. Consequences to weigh: a table under 10k rows never checkpoints mid-scan (a crash costs a sub-second rescan; the final barrier still flushes), each interruption reworks ≤10k records or ≤5s, and a crash loop shorter than that cannot converge. LMDB commits one environment in order and needs no flush.
2. **Only a key-stamped checkpoint resumes (ruling 2a, in the form the teammate's comment asked for).** `checkpointCertified` repeats the checkpoint key; [the trigger resumes only when it equals `lastIndexedKey`](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R2880) and otherwise rebuilds ([logged as reindex reason `uncertified-checkpoint`](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R2925)). That covers both legacy exits — `indexingFailed` and the marker-less `interrupted` return — so no field cleanup is needed before deploying; the one-time cost is that an in-progress legacy backfill restarts from record 0 on upgrade. This is the one descriptor schema addition in the PR (a field the old trigger drops, since it rebuilds the descriptor from the schema definition).
3. **The completion barrier.** [A flush before the ready descriptor](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3345) closes a hole that exists on `main` too: a kill right after completion lost 0 of 10,000 index entries with it and all 10,000 without it (child-process test). A flush failure parks the index (`indexingFailed`) rather than announcing it complete.
4. **Checkpoint safety rests on index writes settling in dispatch order**: RocksDB puts throw synchronously, LMDB puts settle FIFO in one environment, so an earlier rejection is always visible before a later checkpoint fires. An explicit per-interval barrier over every put is a contained change if an engine ever settles out of order. The per-put rejection handler allocates one derived promise per LMDB put (bounded by the promise lmdb-js already creates per put; the RocksDB path never allocates).
5. **Checkpoint freezes at the first per-record error for the rest of the pass** (follow-up): a table with recurring transient errors advances one error-gap per retrigger — monotone, strictly better than main's full rescan, not single-pass convergence. An in-process retry of the failed keys would close it.
6. **One `start` at the minimum checkpoint across attributes**, re-putting already-indexed rows for attributes that were further ahead: index puts are idempotent and the redundant range is at most one interval. Reversible.
7. **Custom (HNSW) indexes still yield once per record** — unchanged from `main`'s `didSynchronousIndexing` branch; reviewers flagged it as a throughput ceiling, but it is not this change's to alter.
8. **`resumeStartKey` and `setIndexingCheckpointPeriod` are exported** solely for the unit tests; internal, trivially reversible.

## Verification

Route (b): new in-process end-to-end tests through `table()` → `runIndexing` → the real primary store on both engines, plus two real process kills. `unitTests/resources/indexBackfillConvergence.test.js` (with `indexBackfillConvergence-crash.js` as the child fixture): [the four `resumeStartKey` cases](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-7c2107e8bc4d28f75d46aab61a3e874430788e811bc434a1dd7a7b10d6b930c6R114); [an interrupted two-attribute backfill resumes with its scan opened at the persisted, key-stamped checkpoint](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-7c2107e8bc4d28f75d46aab61a3e874430788e811bc434a1dd7a7b10d6b930c6R146) (asserted on the `start` option and the first key visited, and that the stamp is cleared on completion); [a record whose index write throws, rejects asynchronously on a non-last value, or rejects while a later attribute's put resolves freezes the checkpoint before it and the retry revisits and indexes that record](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-7c2107e8bc4d28f75d46aab61a3e874430788e811bc434a1dd7a7b10d6b930c6R257); [unequal persisted checkpoints resume at the lower one, an absent one forces a full scan, and an unstamped legacy checkpoint is rebuilt from the first record](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-7c2107e8bc4d28f75d46aab61a3e874430788e811bc434a1dd7a7b10d6b930c6R336); [a child process SIGKILLs itself at its first persisted checkpoint](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-59f8e0017fc73f7982e4cc21e99259e7c429cf68970ee6b0da9d0302232af1e3R52) and [the parent resumes from that key through the PID-mismatch trigger](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-7c2107e8bc4d28f75d46aab61a3e874430788e811bc434a1dd7a7b10d6b930c6R429); [a child killed right after the ready descriptor](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-59f8e0017fc73f7982e4cc21e99259e7c429cf68970ee6b0da9d0302232af1e3R56) leaves [an index every entry of which survives](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-7c2107e8bc4d28f75d46aab61a3e874430788e811bc434a1dd7a7b10d6b930c6R508); [a rejecting flush parks the index and the retry completes](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-7c2107e8bc4d28f75d46aab61a3e874430788e811bc434a1dd7a7b10d6b930c6R561); [checkpoints are never closer than the record floor](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-7c2107e8bc4d28f75d46aab61a3e874430788e811bc434a1dd7a7b10d6b930c6R613); and [a 2000-row plain-index backfill yields every 100 records on RocksDB](https://github.com/HarperFast/harper/pull/2539/changes?w=1#diff-7c2107e8bc4d28f75d46aab61a3e874430788e811bc434a1dd7a7b10d6b930c6R671) (a `setImmediate` ticker stamps every visited key).

Fails-on-base (base `dist` built from `origin/main`'s `databases.ts`): the resumed scan's `start` was `undefined` (expected the checkpoint) and all 2000 records were visited in one event-loop turn; on the parent commit of the completion barrier, the kill-after-complete test kept 0 of 10,000 index entries. With the fix: 14/14 on RocksDB and 13/13 (+1 skipped) under `HARPER_STORAGE_ENGINE=lmdb`.

Gates on the final head: `npm run test:unit:resources` RocksDB 2266 passing / 0 failing; LMDB 1763 passing / 0 failing; `npm run test:unit:main` 5461 passing / 2 failing (the `configValidator` domain-socket path-length case, a local worktree-path artifact, and the `rsa_keys` token-authentication flake, both known on this box and unrelated). Earlier runs on this branch hit the pre-existing `longLivedTransactions` chain-link flake once per run; it passes alone. `oxlint` and `prettier --check` clean on the changed files. Measured: 0.8µs per `setImmediate` yield; a 100k-row RocksDB backfill ran at 216k rec/s on base and 219–244k rec/s with the fix; an `await` at the checkpoint instead of the deferred write made the LMDB backfill 8x slower, which is why the checkpoint write is attached to the last put's settlement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVCC8xu4zk7eirYMg1ZHPb

Complexity: complicated

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=9 @ 763ba6f4d068</sub>

<sub>Human-Review-Need: 3 @ 763ba6f4d068</sub>
