### PR TITLE
Stamp isIndexing on the schema load path so no thread serves a partially built index (harper#2537)

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -4137,9 +4137,9 @@ export function makeTable(options) {
 					}
 				} else {
 					// if we had to add an aligned condition that isn't first, we remove it and do ordering later.
-					// Only the pseudo-condition we added: a caller's own condition on the sort attribute is a
-					// filter the result must still satisfy, and dropping it returned rows that do not match.
-					if (syntheticOrderCondition) conditions.splice(conditions.indexOf(syntheticOrderCondition), 1);
+					// Only the one we added: a caller's own condition on the sort attribute is still a filter.
+					const syntheticIndex = syntheticOrderCondition ? conditions.indexOf(syntheticOrderCondition) : -1;
+					if (syntheticIndex >= 0) conditions.splice(syntheticIndex, 1);
 					postOrdering = sort;
 				}
 			}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -3967,6 +3967,7 @@ export function makeTable(options) {
 			// objects. Entries are small and shallow; the clone is cheap next to the query.
 			conditions = cloneConditions(conditions);
 			let orderAlignedCondition;
+			let syntheticOrderCondition;
 			const filtered = {};
 
 			function prepareConditions(conditions: any[], operator: string) {
@@ -4105,7 +4106,7 @@ export function makeTable(options) {
 							// if it is indexed, we add a pseudo-condition to align with the natural sort order of the index.
 							// the primary key has no secondary index, but the primary store is itself keyed in
 							// primary-key order, so scanning it is already aligned with the sort
-							orderAlignedCondition = { ...sort, comparator: 'sort' };
+							orderAlignedCondition = syntheticOrderCondition = { ...sort, comparator: 'sort' };
 							conditions.push(orderAlignedCondition);
 						} else if (conditions.length === 0 && !target.allowFullScan)
 							throw handleHDBError(
@@ -4135,8 +4136,10 @@ export function makeTable(options) {
 						};
 					}
 				} else {
-					// if we had to add an aligned condition that isn't first, we remove it and do ordering later
-					if (orderAlignedCondition) conditions.splice(conditions.indexOf(orderAlignedCondition), 1);
+					// if we had to add an aligned condition that isn't first, we remove it and do ordering later.
+					// Only the pseudo-condition we added: a caller's own condition on the sort attribute is a
+					// filter the result must still satisfy, and dropping it returned rows that do not match.
+					if (syntheticOrderCondition) conditions.splice(conditions.indexOf(syntheticOrderCondition), 1);
 					postOrdering = sort;
 				}
 			}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -4136,8 +4136,8 @@ export function makeTable(options) {
 						};
 					}
 				} else {
-					// if we had to add an aligned condition that isn't first, we remove it and do ordering later.
-					// Only the one we added: a caller's own condition on the sort attribute is still a filter.
+					// if we had to add an aligned condition that isn't first, we remove it and do ordering later —
+					// only the one we added; a caller's own condition on the sort attribute is still a filter
 					const syntheticIndex = syntheticOrderCondition ? conditions.indexOf(syntheticOrderCondition) : -1;
 					if (syntheticIndex >= 0) conditions.splice(syntheticIndex, 1);
 					postOrdering = sort;

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -446,6 +446,23 @@ function applyDurableDeclaration(attribute: any, descriptor: any) {
 		else delete attribute[field];
 	}
 }
+
+/**
+ * True when a descriptor claims an index build that no live operation in this process can own, so the
+ * trigger must rebuild it rather than trust it. Beyond the PID and worker-generation checks this has
+ * always made, it compares the process incarnation: a container restart reuses PID 1 and resets the
+ * in-memory restart generation to 1 while the persisted one is higher, so those two alone can never
+ * detect a process restart there. A descriptor carrying no incarnation predates the field, so it too
+ * belongs to an earlier process. A thread that was started without an incarnation of its own cannot
+ * judge, and falls back to the PID and generation checks rather than declaring a live build dead.
+ */
+function isAbandonedIndexBuild(descriptor: any, currentRestartGeneration: number): boolean {
+	if (!descriptor) return false;
+	if (descriptor.indexingPID && descriptor.indexingPID !== process.pid) return true;
+	if (descriptor.restartNumber < currentRestartGeneration) return true;
+	const incarnation = manageThreads.processIncarnation;
+	return !!descriptor.indexingPID && incarnation != null && descriptor.indexingIncarnation !== incarnation;
+}
 // How many times the schema load will try to finish a tombstoned drop before
 // giving up for the rest of this process's lifetime. A drop that fails once
 // almost always fails identically forever - the usual cause is a RocksDB
@@ -1204,6 +1221,11 @@ function initStores(
 						indices[attribute.name] = dbi;
 						indices[attribute.name].indexNulls = attribute.indexNulls;
 					}
+					// The descriptor owns whether the index is complete; this is the only path a thread that
+					// never declares the schema (the main and operations threads) takes to reach Table.indices,
+					// so without it such a thread holds isIndexing = false and serves a partially-built index.
+					// Assigned, not just set: the same reload is what must clear the flag once a build finishes.
+					indices[attribute.name].isIndexing = !!attribute.indexingPID;
 					const existingAttribute = existingAttributes.find(
 						(existingAttribute) => existingAttribute.name === attribute.name
 					);
@@ -2754,8 +2776,7 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 				const abandonedIndexBuild =
 					attribute.indexed &&
 					(attributeDescriptor.indexingFailed ||
-						(attributeDescriptor.indexingPID && attributeDescriptor.indexingPID !== process.pid) ||
-						attributeDescriptor.restartNumber < (workerData?.restartNumber ?? manageThreads.restartNumber));
+						isAbandonedIndexBuild(attributeDescriptor, workerData?.restartNumber ?? manageThreads.restartNumber));
 				if (abandonedIndexBuild) {
 					// Recovery is the exception to skipping the handling below, because without it `isIndexing`
 					// stays pinned on with nothing left to clear it and every query on the attribute fails with
@@ -2845,8 +2866,7 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 					changed ||
 					indexFormatNeedsPersist ||
 					attributeDescriptor?.indexingFailed ||
-					(attributeDescriptor?.indexingPID && attributeDescriptor?.indexingPID !== process.pid) ||
-					attributeDescriptor?.restartNumber < currentRestartGeneration
+					isAbandonedIndexBuild(attributeDescriptor, currentRestartGeneration)
 				) {
 					hasChanges = true;
 					exclusiveLock();
@@ -2854,8 +2874,7 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 					if (
 						structurallyChanged ||
 						attributeDescriptor?.indexingFailed ||
-						(attributeDescriptor?.indexingPID && attributeDescriptor?.indexingPID !== process.pid) ||
-						attributeDescriptor?.restartNumber < currentRestartGeneration
+						isAbandonedIndexBuild(attributeDescriptor, currentRestartGeneration)
 					) {
 						hasChanges = true;
 						if (attribute.indexNulls === undefined) attribute.indexNulls = true;
@@ -2909,6 +2928,10 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 							// the new process reuses the old PID. Cleared on clean completion; left in place
 							// on failure/crash so the next, higher-numbered restart re-triggers the backfill.
 							attribute.restartNumber = currentRestartGeneration;
+							// Alongside them, the incarnation of the process that owns this build; see
+							// isAbandonedIndexBuild for why the PID and the generation cannot identify it alone.
+							if (manageThreads.processIncarnation != null)
+								attribute.indexingIncarnation = manageThreads.processIncarnation;
 							delete attribute.indexingFailed; // clear failure flag for the new run
 							dbi.isIndexing = true;
 							Object.defineProperty(attribute, 'dbi', { value: dbi, configurable: true, enumerable: false });
@@ -2923,6 +2946,12 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 								reindexReasons.push(`crash-recovery(pid=${attributeDescriptor.indexingPID})`);
 							if (attributeDescriptor?.restartNumber < currentRestartGeneration) reindexReasons.push('restart-number');
 							if (uncertifiedCheckpoint) reindexReasons.push('uncertified-checkpoint');
+							if (
+								attributeDescriptor?.indexingPID === process.pid &&
+								manageThreads.processIncarnation != null &&
+								attributeDescriptor.indexingIncarnation !== manageThreads.processIncarnation
+							)
+								reindexReasons.push('abandoned-build(previous process incarnation)');
 							logger.info(
 								`reindex ${databaseName}.${tableName}.${attribute.name}: reason=${reindexReasons.join(',') || 'unknown'}`
 							);
@@ -2941,6 +2970,7 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 						// Carry the in-progress restart generation too, so persisting this metadata-only
 						// change doesn't drop it and break the crash-recovery trigger for the running backfill.
 						attribute.restartNumber = attributeDescriptor.restartNumber;
+						attribute.indexingIncarnation = attributeDescriptor.indexingIncarnation;
 						if (attributeDescriptor.indexingFailed) attribute.indexingFailed = attributeDescriptor.indexingFailed;
 					}
 					attributesDbi.put(dbiKey, attribute);
@@ -3005,7 +3035,16 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 	logger.trace(`${tableName} table loading, running index`);
 	const branchPath = target.branch?.path;
 	if (attributesToIndex.length > 0 || indicesToRemove.length > 0) {
-		Table.indexingOperation = runIndexing(Table, attributesToIndex, indicesToRemove, branchPath);
+		const buildGeneration = workerData?.restartNumber ?? manageThreads.restartNumber;
+		// runIndexing swallows its own errors, so both arms run the same marker pass; awaiting it inside
+		// the tracked operation is what keeps its writes from becoming an unobserved rejection.
+		const markSettled = () =>
+			markAbandonedIndexBuild(Table, attributesToIndex, buildGeneration, () => Table.indexingOperation === operation);
+		const operation: Promise<void> = runIndexing(Table, attributesToIndex, indicesToRemove, branchPath).then(
+			markSettled,
+			markSettled
+		);
+		Table.indexingOperation = operation;
 	} else if (hasChanges)
 		signalling.signalSchemaChange(
 			new SchemaEventMsg(process.pid, 'schema-change', Table.databaseName, Table.tableName, undefined, branchPath)
@@ -3176,6 +3215,48 @@ export function resumeStartKey(attributes: { lastIndexedKey?: any }[]): any {
 		if (start === undefined || compareKeys(attribute.lastIndexedKey, start) < 0) start = attribute.lastIndexedKey;
 	}
 	return start;
+}
+
+/**
+ * A backfill can end without running either of runIndexing's own exit paths — the restart-interrupt
+ * return inside the loop and the closed-store return in its catch — leaving the descriptor claiming an
+ * armed, in-progress build with no failure marker, nothing logged above debug, and nothing to
+ * re-trigger it. Persist that marker once the operation settles.
+ *
+ * Only for the exact build this call scheduled: a replacement worker generation can claim the build
+ * under the catalog lock before the exiting generation's promise settles, and marking that would fail a
+ * live build. The PID, incarnation and generation fence the cross-generation case; `isCurrentOperation`
+ * fences successive builds on this thread, where the generation is unchanged.
+ */
+async function markAbandonedIndexBuild(
+	Table,
+	attributes: any[],
+	buildGeneration: number,
+	isCurrentOperation: () => boolean
+) {
+	for (const attribute of attributes) {
+		try {
+			const descriptor = Table.dbisDB.getSync(attribute.key);
+			if (
+				!descriptor?.indexingPID ||
+				descriptor.indexingFailed ||
+				descriptor.indexingPID !== process.pid ||
+				descriptor.restartNumber !== buildGeneration ||
+				descriptor.indexingIncarnation !== manageThreads.processIncarnation ||
+				!isCurrentOperation()
+			)
+				continue;
+			await Table.dbisDB.put(attribute.key, { ...descriptor, indexingFailed: true });
+			logger.warn(
+				`Indexing of ${Table.databaseName}.${Table.tableName}.${attribute.name} ended without completing. ` +
+					`The index stays incomplete and every query on the attribute reports it as not indexed yet; ` +
+					`the next load of the table retries the backfill from the last checkpoint (indexingFailed=true).`
+			);
+		} catch (error) {
+			// A store closed by shutdown is the common case here, and it cannot be written to at all.
+			logger.debug(`Could not mark the abandoned index build of ${Table.tableName}.${attribute.name}`, error);
+		}
+	}
 }
 async function runIndexing(Table, attributes, indicesToRemove, branchPath?: string) {
 	let checkpointing;
@@ -3377,6 +3458,7 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 				delete attribute.indexingPID;
 				delete attribute.indexingFailed;
 				delete attribute.restartNumber;
+				delete attribute.indexingIncarnation;
 				attribute.dbi.isIndexing = false;
 				// Also clear isIndexing on the currently-active dbi in Table.indices, which may
 				// differ from attribute.dbi if a resetDatabases() call during this migration

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1220,8 +1220,7 @@ function initStores(
 						indices[attribute.name] = dbi;
 						indices[attribute.name].indexNulls = attribute.indexNulls;
 					}
-					// The catalog owns index completeness, and this reload is the only way a thread that never
-					// declares the schema reaches Table.indices. Assigned, not set: the same reload clears it.
+					// the only way a thread that never declares the schema reaches Table.indices
 					indices[attribute.name].isIndexing = !!attribute.indexingPID;
 					const existingAttribute = existingAttributes.find(
 						(existingAttribute) => existingAttribute.name === attribute.name
@@ -3213,56 +3212,52 @@ export function resumeStartKey(attributes: { lastIndexedKey?: any }[]): any {
 }
 
 /**
- * runIndexing has two returns that write nothing — the restart-interrupt return in its loop and the
- * closed-store return in its catch — leaving a descriptor that claims an armed build with no failure
- * marker and nothing to re-trigger it. Persist that marker when the operation settles.
- *
- * `indexingBuildId` is what makes this safe: a replacement worker generation, or another thread
- * declaring different index options, can claim the attribute before an outgoing build's promise
- * settles, and marking that would fail a live build. The re-read and the write share the exclusive
- * catalog lock the declaration takes, so the claim cannot land between them. The locked section stays
- * synchronous (see acquireUpdateAttributesLock); the write is awaited after the release.
+ * Persists the failure marker for a build that ended without running one of runIndexing's own exit
+ * paths, so something re-triggers it. Fenced on `indexingBuildId` under the exclusive catalog lock,
+ * because a replacement generation (or another thread declaring different index options) can claim the
+ * attribute before an outgoing build's promise settles, and marking that would fail a live build. The
+ * locked section stays synchronous (see acquireUpdateAttributesLock) and the write is awaited after
+ * the release. Nothing here may throw: `Table.indexingOperation` reaches operations-API callers.
  */
 async function markAbandonedIndexBuild(Table, rootStore, buildIds: Map<any, string>) {
 	for (const [attribute, buildId] of buildIds) {
-		let pending;
-		let marked;
-		let releaseExclusiveLock;
 		try {
-			if (buildId == null || Table.dbisDB.getSync(attribute.key)?.indexingBuildId !== buildId) continue;
-			if (rootStore instanceof RocksDatabase) {
-				acquireUpdateAttributesLock(rootStore, `abandoned index build '${Table.tableName}.${attribute.name}'`);
-				releaseExclusiveLock = () => releaseUpdateAttributesLock(rootStore);
-			} else {
-				rootStore.transactionSync(() => ({
-					then(callback) {
-						releaseExclusiveLock = callback;
-					},
-				}));
+			let pending;
+			let marked;
+			let releaseExclusiveLock;
+			try {
+				if (buildId == null || Table.dbisDB.getSync(attribute.key)?.indexingBuildId !== buildId) continue;
+				if (rootStore instanceof RocksDatabase) {
+					acquireUpdateAttributesLock(rootStore, `abandoned index build '${Table.tableName}.${attribute.name}'`);
+					releaseExclusiveLock = () => releaseUpdateAttributesLock(rootStore);
+				} else {
+					rootStore.transactionSync(() => ({
+						then(callback) {
+							releaseExclusiveLock = callback;
+						},
+					}));
+				}
+				const descriptor = Table.dbisDB.getSync(attribute.key);
+				if (descriptor?.indexingBuildId === buildId && !descriptor.indexingFailed) {
+					pending = Table.dbisDB.put(attribute.key, { ...descriptor, indexingFailed: true });
+					marked = true;
+				}
+			} finally {
+				if (releaseExclusiveLock) releaseExclusiveLock();
 			}
-			const descriptor = Table.dbisDB.getSync(attribute.key);
-			if (descriptor?.indexingBuildId === buildId && !descriptor.indexingFailed) {
-				pending = Table.dbisDB.put(attribute.key, { ...descriptor, indexingFailed: true });
-				marked = true;
-			}
+			if (pending?.then) await pending;
+			if (marked)
+				logger.warn(
+					`Indexing of ${Table.databaseName}.${Table.tableName}.${attribute.name} ended without completing. ` +
+						`The index stays incomplete and every query on the attribute reports it as not indexed yet; ` +
+						`the next load of the table retries the backfill from the last checkpoint (indexingFailed=true).`
+				);
 		} catch (error) {
 			// A store closed by shutdown is the common case, and it cannot be written to at all.
-			logger.debug(`Could not mark the abandoned index build of ${Table.tableName}.${attribute.name}`, error);
-		} finally {
-			if (releaseExclusiveLock) releaseExclusiveLock();
+			try {
+				logger.debug(`Could not mark the abandoned index build of ${Table.tableName}.${attribute.name}`, error);
+			} catch {}
 		}
-		try {
-			if (pending?.then) await pending;
-		} catch (error) {
-			marked = false;
-			logger.debug(`Could not persist the abandoned index build of ${Table.tableName}.${attribute.name}`, error);
-		}
-		if (marked)
-			logger.warn(
-				`Indexing of ${Table.databaseName}.${Table.tableName}.${attribute.name} ended without completing. ` +
-					`The index stays incomplete and every query on the attribute reports it as not indexed yet; ` +
-					`the next load of the table retries the backfill from the last checkpoint (indexingFailed=true).`
-			);
 	}
 }
 async function runIndexing(Table, attributes, indicesToRemove, branchPath?: string) {

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -3223,26 +3223,23 @@ async function markAbandonedIndexBuild(Table, rootStore, buildIds: Map<any, stri
 	for (const [attribute, buildId] of buildIds) {
 		try {
 			let marked;
-			let releaseExclusiveLock;
-			try {
-				if (buildId == null || Table.dbisDB.getSync(attribute.key)?.indexingBuildId !== buildId) continue;
-				if (rootStore instanceof RocksDatabase) {
-					acquireUpdateAttributesLock(rootStore, `abandoned index build '${Table.tableName}.${attribute.name}'`);
-					releaseExclusiveLock = () => releaseUpdateAttributesLock(rootStore);
-				} else {
-					rootStore.transactionSync(() => ({
-						then(callback) {
-							releaseExclusiveLock = callback;
-						},
-					}));
-				}
+			if (buildId == null || Table.dbisDB.getSync(attribute.key)?.indexingBuildId !== buildId) continue;
+			const markIfOwned = () => {
 				const descriptor = Table.dbisDB.getSync(attribute.key);
 				if (descriptor?.indexingBuildId === buildId && !descriptor.indexingFailed) {
 					Table.dbisDB.putSync(attribute.key, { ...descriptor, indexingFailed: true });
 					marked = true;
 				}
-			} finally {
-				if (releaseExclusiveLock) releaseExclusiveLock();
+			};
+			if (rootStore instanceof RocksDatabase) {
+				acquireUpdateAttributesLock(rootStore, `abandoned index build '${Table.tableName}.${attribute.name}'`);
+				try {
+					markIfOwned();
+				} finally {
+					releaseUpdateAttributesLock(rootStore);
+				}
+			} else {
+				rootStore.transactionSync(markIfOwned);
 			}
 			if (marked)
 				logger.warn(

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -3033,7 +3033,6 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 	if (attributesToIndex.length > 0 || indicesToRemove.length > 0) {
 		// captured before the backfill can rewrite the attributes
 		const buildIds = new Map(attributesToIndex.map((attribute) => [attribute, attribute.indexingBuildId]));
-		// both arms, and inside the tracked operation, so a marker write cannot reject unobserved
 		const markSettled = () => markAbandonedIndexBuild(Table, rootStore, buildIds);
 		Table.indexingOperation = runIndexing(Table, attributesToIndex, indicesToRemove, branchPath).then(
 			markSettled,

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events';
+import { randomBytes } from 'node:crypto';
 import { initSync, getHdbBasePath, get as envGet } from '../utility/environment/environmentManager.ts';
 import { INTERNAL_DBIS_NAME } from '../utility/lmdb/terms.ts';
 import { open, compareKeys, type Database, type RootDatabase } from 'lmdb';
@@ -448,13 +449,11 @@ function applyDurableDeclaration(attribute: any, descriptor: any) {
 }
 
 /**
- * True when a descriptor claims an index build that no live operation in this process can own, so the
- * trigger must rebuild it rather than trust it. Beyond the PID and worker-generation checks this has
- * always made, it compares the process incarnation: a container restart reuses PID 1 and resets the
- * in-memory restart generation to 1 while the persisted one is higher, so those two alone can never
- * detect a process restart there. A descriptor carrying no incarnation predates the field, so it too
- * belongs to an earlier process. A thread that was started without an incarnation of its own cannot
- * judge, and falls back to the PID and generation checks rather than declaring a live build dead.
+ * True when a descriptor claims an index build no live operation in this process can own. The PID and
+ * worker generation cannot answer that alone: a container reuses PID 1 and starts the in-memory
+ * generation back at 1 while the persisted one is higher. A descriptor with no incarnation was written
+ * before the field existed, so it belongs to an earlier process; a thread started without one of its
+ * own cannot judge, and falls back rather than declaring a live build dead.
  */
 function isAbandonedIndexBuild(descriptor: any, currentRestartGeneration: number): boolean {
 	if (!descriptor) return false;
@@ -1221,10 +1220,8 @@ function initStores(
 						indices[attribute.name] = dbi;
 						indices[attribute.name].indexNulls = attribute.indexNulls;
 					}
-					// The descriptor owns whether the index is complete; this is the only path a thread that
-					// never declares the schema (the main and operations threads) takes to reach Table.indices,
-					// so without it such a thread holds isIndexing = false and serves a partially-built index.
-					// Assigned, not just set: the same reload is what must clear the flag once a build finishes.
+					// The catalog owns index completeness, and this reload is the only way a thread that never
+					// declares the schema reaches Table.indices. Assigned, not set: the same reload clears it.
 					indices[attribute.name].isIndexing = !!attribute.indexingPID;
 					const existingAttribute = existingAttributes.find(
 						(existingAttribute) => existingAttribute.name === attribute.name
@@ -2928,10 +2925,10 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 							// the new process reuses the old PID. Cleared on clean completion; left in place
 							// on failure/crash so the next, higher-numbered restart re-triggers the backfill.
 							attribute.restartNumber = currentRestartGeneration;
-							// Alongside them, the incarnation of the process that owns this build; see
-							// isAbandonedIndexBuild for why the PID and the generation cannot identify it alone.
 							if (manageThreads.processIncarnation != null)
 								attribute.indexingIncarnation = manageThreads.processIncarnation;
+							// Identifies this build itself, so its settle handler cannot mark a later one failed.
+							attribute.indexingBuildId = randomBytes(8).toString('hex');
 							delete attribute.indexingFailed; // clear failure flag for the new run
 							dbi.isIndexing = true;
 							Object.defineProperty(attribute, 'dbi', { value: dbi, configurable: true, enumerable: false });
@@ -2971,6 +2968,7 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 						// change doesn't drop it and break the crash-recovery trigger for the running backfill.
 						attribute.restartNumber = attributeDescriptor.restartNumber;
 						attribute.indexingIncarnation = attributeDescriptor.indexingIncarnation;
+						attribute.indexingBuildId = attributeDescriptor.indexingBuildId;
 						if (attributeDescriptor.indexingFailed) attribute.indexingFailed = attributeDescriptor.indexingFailed;
 					}
 					attributesDbi.put(dbiKey, attribute);
@@ -3035,16 +3033,15 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 	logger.trace(`${tableName} table loading, running index`);
 	const branchPath = target.branch?.path;
 	if (attributesToIndex.length > 0 || indicesToRemove.length > 0) {
-		const buildGeneration = workerData?.restartNumber ?? manageThreads.restartNumber;
-		// runIndexing swallows its own errors, so both arms run the same marker pass; awaiting it inside
-		// the tracked operation is what keeps its writes from becoming an unobserved rejection.
-		const markSettled = () =>
-			markAbandonedIndexBuild(Table, attributesToIndex, buildGeneration, () => Table.indexingOperation === operation);
-		const operation: Promise<void> = runIndexing(Table, attributesToIndex, indicesToRemove, branchPath).then(
+		// The ids the arming block just wrote, captured before the backfill can rewrite the attributes.
+		const buildIds = new Map(attributesToIndex.map((attribute) => [attribute, attribute.indexingBuildId]));
+		// runIndexing resolves on every path it takes, including its silent returns, so both arms run the
+		// same pass; it is awaited inside the tracked operation so its writes cannot reject unobserved.
+		const markSettled = () => markAbandonedIndexBuild(Table, rootStore, buildIds);
+		Table.indexingOperation = runIndexing(Table, attributesToIndex, indicesToRemove, branchPath).then(
 			markSettled,
 			markSettled
 		);
-		Table.indexingOperation = operation;
 	} else if (hasChanges)
 		signalling.signalSchemaChange(
 			new SchemaEventMsg(process.pid, 'schema-change', Table.databaseName, Table.tableName, undefined, branchPath)
@@ -3218,44 +3215,56 @@ export function resumeStartKey(attributes: { lastIndexedKey?: any }[]): any {
 }
 
 /**
- * A backfill can end without running either of runIndexing's own exit paths — the restart-interrupt
- * return inside the loop and the closed-store return in its catch — leaving the descriptor claiming an
- * armed, in-progress build with no failure marker, nothing logged above debug, and nothing to
- * re-trigger it. Persist that marker once the operation settles.
+ * runIndexing has two returns that write nothing — the restart-interrupt return in its loop and the
+ * closed-store return in its catch — leaving a descriptor that claims an armed build with no failure
+ * marker and nothing to re-trigger it. Persist that marker when the operation settles.
  *
- * Only for the exact build this call scheduled: a replacement worker generation can claim the build
- * under the catalog lock before the exiting generation's promise settles, and marking that would fail a
- * live build. The PID, incarnation and generation fence the cross-generation case; `isCurrentOperation`
- * fences successive builds on this thread, where the generation is unchanged.
+ * `indexingBuildId` is what makes this safe: a replacement worker generation, or another thread
+ * declaring different index options, can claim the attribute before an outgoing build's promise
+ * settles, and marking that would fail a live build. The re-read and the write share the exclusive
+ * catalog lock the declaration takes, so the claim cannot land between them. The locked section stays
+ * synchronous (see acquireUpdateAttributesLock); the write is awaited after the release.
  */
-async function markAbandonedIndexBuild(
-	Table,
-	attributes: any[],
-	buildGeneration: number,
-	isCurrentOperation: () => boolean
-) {
-	for (const attribute of attributes) {
+async function markAbandonedIndexBuild(Table, rootStore, buildIds: Map<any, string>) {
+	for (const [attribute, buildId] of buildIds) {
+		let pending;
+		let marked;
+		let releaseExclusiveLock;
 		try {
+			if (buildId == null || Table.dbisDB.getSync(attribute.key)?.indexingBuildId !== buildId) continue;
+			if (rootStore instanceof RocksDatabase) {
+				acquireUpdateAttributesLock(rootStore, `abandoned index build '${Table.tableName}.${attribute.name}'`);
+				releaseExclusiveLock = () => releaseUpdateAttributesLock(rootStore);
+			} else {
+				rootStore.transactionSync(() => ({
+					then(callback) {
+						releaseExclusiveLock = callback;
+					},
+				}));
+			}
 			const descriptor = Table.dbisDB.getSync(attribute.key);
-			if (
-				!descriptor?.indexingPID ||
-				descriptor.indexingFailed ||
-				descriptor.indexingPID !== process.pid ||
-				descriptor.restartNumber !== buildGeneration ||
-				descriptor.indexingIncarnation !== manageThreads.processIncarnation ||
-				!isCurrentOperation()
-			)
-				continue;
-			await Table.dbisDB.put(attribute.key, { ...descriptor, indexingFailed: true });
+			if (descriptor?.indexingBuildId === buildId && !descriptor.indexingFailed) {
+				pending = Table.dbisDB.put(attribute.key, { ...descriptor, indexingFailed: true });
+				marked = true;
+			}
+		} catch (error) {
+			// A store closed by shutdown is the common case, and it cannot be written to at all.
+			logger.debug(`Could not mark the abandoned index build of ${Table.tableName}.${attribute.name}`, error);
+		} finally {
+			if (releaseExclusiveLock) releaseExclusiveLock();
+		}
+		try {
+			if (pending?.then) await pending;
+		} catch (error) {
+			marked = false;
+			logger.debug(`Could not persist the abandoned index build of ${Table.tableName}.${attribute.name}`, error);
+		}
+		if (marked)
 			logger.warn(
 				`Indexing of ${Table.databaseName}.${Table.tableName}.${attribute.name} ended without completing. ` +
 					`The index stays incomplete and every query on the attribute reports it as not indexed yet; ` +
 					`the next load of the table retries the backfill from the last checkpoint (indexingFailed=true).`
 			);
-		} catch (error) {
-			// A store closed by shutdown is the common case here, and it cannot be written to at all.
-			logger.debug(`Could not mark the abandoned index build of ${Table.tableName}.${attribute.name}`, error);
-		}
 	}
 }
 async function runIndexing(Table, attributes, indicesToRemove, branchPath?: string) {
@@ -3459,6 +3468,7 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 				delete attribute.indexingFailed;
 				delete attribute.restartNumber;
 				delete attribute.indexingIncarnation;
+				delete attribute.indexingBuildId;
 				attribute.dbi.isIndexing = false;
 				// Also clear isIndexing on the currently-active dbi in Table.indices, which may
 				// differ from attribute.dbi if a resetDatabases() call during this migration

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -926,7 +926,7 @@ export function readMetaDb(
 			lmdbDatabaseEnvs.set(path, rootStore);
 		}
 
-		rootStore.dbisDb?.resetReadTxn?.();
+		rootStore.dbisDb?.resetReadTxn();
 		return initStores(path, rootStore, databaseName, { defaultTable, auditPath, isLegacy });
 	} catch (error) {
 		error.message += ` opening database ${path}`;
@@ -3216,13 +3216,12 @@ export function resumeStartKey(attributes: { lastIndexedKey?: any }[]): any {
  * paths, so something re-triggers it. Fenced on `indexingBuildId` under the exclusive catalog lock,
  * because a replacement generation (or another thread declaring different index options) can claim the
  * attribute before an outgoing build's promise settles, and marking that would fail a live build. The
- * locked section stays synchronous (see acquireUpdateAttributesLock) and the write is awaited after
- * the release. Nothing here may throw: `Table.indexingOperation` reaches operations-API callers.
+ * locked read and write stay synchronous (see acquireUpdateAttributesLock). Nothing here may throw:
+ * `Table.indexingOperation` reaches operations-API callers.
  */
 async function markAbandonedIndexBuild(Table, rootStore, buildIds: Map<any, string>) {
 	for (const [attribute, buildId] of buildIds) {
 		try {
-			let pending;
 			let marked;
 			let releaseExclusiveLock;
 			try {
@@ -3239,13 +3238,12 @@ async function markAbandonedIndexBuild(Table, rootStore, buildIds: Map<any, stri
 				}
 				const descriptor = Table.dbisDB.getSync(attribute.key);
 				if (descriptor?.indexingBuildId === buildId && !descriptor.indexingFailed) {
-					pending = Table.dbisDB.put(attribute.key, { ...descriptor, indexingFailed: true });
+					Table.dbisDB.putSync(attribute.key, { ...descriptor, indexingFailed: true });
 					marked = true;
 				}
 			} finally {
 				if (releaseExclusiveLock) releaseExclusiveLock();
 			}
-			if (pending?.then) await pending;
 			if (marked)
 				logger.warn(
 					`Indexing of ${Table.databaseName}.${Table.tableName}.${attribute.name} ended without completing. ` +

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -2927,7 +2927,6 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 							attribute.restartNumber = currentRestartGeneration;
 							if (manageThreads.processIncarnation != null)
 								attribute.indexingIncarnation = manageThreads.processIncarnation;
-							// Identifies this build itself, so its settle handler cannot mark a later one failed.
 							attribute.indexingBuildId = randomBytes(8).toString('hex');
 							delete attribute.indexingFailed; // clear failure flag for the new run
 							dbi.isIndexing = true;
@@ -3033,10 +3032,9 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 	logger.trace(`${tableName} table loading, running index`);
 	const branchPath = target.branch?.path;
 	if (attributesToIndex.length > 0 || indicesToRemove.length > 0) {
-		// The ids the arming block just wrote, captured before the backfill can rewrite the attributes.
+		// captured before the backfill can rewrite the attributes
 		const buildIds = new Map(attributesToIndex.map((attribute) => [attribute, attribute.indexingBuildId]));
-		// runIndexing resolves on every path it takes, including its silent returns, so both arms run the
-		// same pass; it is awaited inside the tracked operation so its writes cannot reject unobserved.
+		// both arms, and inside the tracked operation, so a marker write cannot reject unobserved
 		const markSettled = () => markAbandonedIndexBuild(Table, rootStore, buildIds);
 		Table.indexingOperation = runIndexing(Table, attributesToIndex, indicesToRemove, branchPath).then(
 			markSettled,

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -926,6 +926,7 @@ export function readMetaDb(
 			lmdbDatabaseEnvs.set(path, rootStore);
 		}
 
+		rootStore.dbisDb?.resetReadTxn?.();
 		return initStores(path, rootStore, databaseName, { defaultTable, auditPath, isLegacy });
 	} catch (error) {
 		error.message += ` opening database ${path}`;

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -3213,10 +3213,10 @@ export function resumeStartKey(attributes: { lastIndexedKey?: any }[]): any {
 
 /**
  * Persists the failure marker for a build that ended without running one of runIndexing's own exit
- * paths, so something re-triggers it. Fenced on `indexingBuildId` under the exclusive catalog lock,
- * because a replacement generation (or another thread declaring different index options) can claim the
- * attribute before an outgoing build's promise settles, and marking that would fail a live build. The
- * locked read and write stay synchronous (see acquireUpdateAttributesLock). Nothing here may throw:
+ * paths, so something re-triggers it. Fenced on `indexingBuildId` inside the storage engine's catalog
+ * serialization boundary, because a replacement generation (or another thread declaring different index
+ * options) can claim the attribute before an outgoing build's promise settles, and marking that would fail
+ * a live build. The fence read and write stay synchronous, and nothing here may throw because
  * `Table.indexingOperation` reaches operations-API callers.
  */
 async function markAbandonedIndexBuild(Table, rootStore, buildIds: Map<any, string>) {

--- a/resources/search.ts
+++ b/resources/search.ts
@@ -1252,21 +1252,22 @@ function usableIndex(table, attributeName): any {
 }
 
 /**
- * True when an index this condition would have to be driven by is still being built, following a
- * relationship path to the local join index and on to the related table's leaf index. Deliberately
- * comparator-independent: only the equality branch below resolves a relationship, so a range predicate
- * across a join would otherwise reach a finite table-fraction estimate and win the lead.
+ * True when an index this attribute would have to be driven by is still being built, following a
+ * relationship path to the local join index and on to the related table's leaf index. Comparator-
+ * independent: only the equality branch below resolves a relationship, so a range predicate across a
+ * join would otherwise reach a finite table-fraction estimate and win the lead.
  */
-function drivesRebuildingIndex(table, condition): boolean {
-	const attributeName = condition[0] ?? condition.attribute;
-	const path = Array.isArray(attributeName) ? attributeName : [attributeName];
-	if (path.length < 2) return path[0] !== table.primaryKey && !!table.indices[path[0]]?.isIndexing;
-	const attribute = findAttribute(table.attributes, path[0]);
+function drivesRebuildingIndex(table, attributeName): boolean {
+	if (!Array.isArray(attributeName))
+		return attributeName !== table.primaryKey && !!table.indices[attributeName]?.isIndexing;
+	if (attributeName.length < 2) return drivesRebuildingIndex(table, attributeName[0]);
+	const attribute = findAttribute(table.attributes, attributeName[0]);
 	if (!attribute) return false;
 	if (table.indices[attribute.relationship?.from]?.isIndexing) return true;
 	const relatedTable = attribute.definition?.tableClass || attribute.elements?.definition?.tableClass;
 	return (
-		!!relatedTable && drivesRebuildingIndex(relatedTable, { attribute: path.length > 2 ? path.slice(1) : path[1] })
+		!!relatedTable &&
+		drivesRebuildingIndex(relatedTable, attributeName.length > 2 ? attributeName.slice(1) : attributeName[1])
 	);
 }
 
@@ -1299,9 +1300,8 @@ export function estimateCondition(table) {
 			// skip if it is cached
 			let searchType = condition.comparator || condition.search_type;
 			searchType = ALTERNATE_COMPARATOR_NAMES[searchType] || searchType;
-			if (drivesRebuildingIndex(table, condition)) {
-				// Assigned before comparator dispatch: several branches fall back to a finite table-fraction
-				// heuristic that can still beat an available index and take the lead.
+			if (drivesRebuildingIndex(table, condition[0] ?? condition.attribute)) {
+				// before comparator dispatch: several branches fall back to a finite table-fraction heuristic
 				condition.estimated_count = Infinity;
 			} else if (condition.negated) {
 				// a negated condition always executes as a full scan (searchByIndex forces

--- a/resources/search.ts
+++ b/resources/search.ts
@@ -1103,7 +1103,7 @@ export function filterByType(searchCondition, Table, context, filtered, isPrimar
 		canUseIndex =
 			canUseIndex && // is it a comparator that makes sense to use index
 			!isPrimaryKey && // no need to use index for primary keys, since we will be iterating over the primary keys
-			Table?.indices[attribute] && // is there an index for this attribute
+			!!(Table && usableIndex(Table, attribute)) && // is there an index for this attribute, and is it complete
 			estimatedIncomingCount > 3; // do we have a valid estimate of multiple incoming records (that is worth using an index for)
 		if (canUseIndex) {
 			if (searchCondition.estimated_count == undefined) estimateCondition(Table)(searchCondition);
@@ -1245,6 +1245,17 @@ function estimateRangeCondition(table, condition, searchType, fraction) {
 	return Math.max(1, Math.round(confidence * count + (1 - confidence) * heuristic));
 }
 
+/**
+ * The index a condition would be driven by, or undefined when there is none usable. searchByIndex
+ * refuses a rebuilding index (IndexRebuildingError), so the planner has to see it as absent too: a
+ * condition ranked by a partially-built index's cardinality can win the lead and then be refused, when
+ * leading with a sibling and applying this one as a record filter answers the query completely.
+ */
+function usableIndex(table, attributeName): any {
+	const index = table.indices[attributeName];
+	return index?.isIndexing ? undefined : index;
+}
+
 export function estimateCondition(table) {
 	function estimateConditionForTable(condition) {
 		if (condition.estimated_count === undefined) {
@@ -1274,7 +1285,16 @@ export function estimateCondition(table) {
 			// skip if it is cached
 			let searchType = condition.comparator || condition.search_type;
 			searchType = ALTERNATE_COMPARATOR_NAMES[searchType] || searchType;
-			if (condition.negated) {
+			const conditionAttribute = condition[0] ?? condition.attribute;
+			if (
+				typeof conditionAttribute === 'string' &&
+				conditionAttribute !== table.primaryKey &&
+				table.indices[conditionAttribute]?.isIndexing
+			) {
+				// Assigned here rather than left to the per-comparator branches: several of them fall back to
+				// a finite table-fraction heuristic, which can still beat an available index and take the lead.
+				condition.estimated_count = Infinity;
+			} else if (condition.negated) {
 				// a negated condition always executes as a full scan (searchByIndex forces
 				// needFullScan), so follow the filter-only convention used by contains/ends_with:
 				// estimate Infinity so its positive-range estimate can never win the driving-condition
@@ -1296,7 +1316,7 @@ export function estimateCondition(table) {
 							attribute: attribute_name.length > 2 ? attribute_name.slice(1) : attribute_name[1],
 							comparator: 'equals',
 						});
-						const fromIndex = table.indices[attribute.relationship?.from];
+						const fromIndex = usableIndex(table, attribute.relationship?.from);
 						// the estimated count is sum of the estimate of the related table and the estimate of the index
 						condition.estimated_count =
 							estimate +

--- a/resources/search.ts
+++ b/resources/search.ts
@@ -1255,18 +1255,16 @@ function usableIndex(table, attributeName): any {
  * True when an index this attribute would have to be driven by is still being built, following a
  * relationship path to the local join index and on to the related table's leaf index.
  */
-function drivesRebuildingIndex(table, attributeName): boolean {
+function drivesRebuildingIndex(table, attributeName, relationshipOffset = 0): boolean {
 	if (!Array.isArray(attributeName))
-		return attributeName !== table.primaryKey && !!table.indices[attributeName]?.isIndexing;
-	if (attributeName.length < 2) return drivesRebuildingIndex(table, attributeName[0]);
-	const attribute = findAttribute(table.attributes, attributeName[0]);
+		return attributeName != null && attributeName !== table.primaryKey && !!table.indices[attributeName]?.isIndexing;
+	if (relationshipOffset >= attributeName.length - 1)
+		return drivesRebuildingIndex(table, attributeName[relationshipOffset]);
+	const attribute = findAttribute(table.attributes, attributeName[relationshipOffset]);
 	if (!attribute) return false;
 	if (table.indices[attribute.relationship?.from]?.isIndexing) return true;
 	const relatedTable = attribute.definition?.tableClass || attribute.elements?.definition?.tableClass;
-	return (
-		!!relatedTable &&
-		drivesRebuildingIndex(relatedTable, attributeName.length > 2 ? attributeName.slice(1) : attributeName[1])
-	);
+	return !!relatedTable && drivesRebuildingIndex(relatedTable, attributeName, relationshipOffset + 1);
 }
 
 export function estimateCondition(table) {

--- a/resources/search.ts
+++ b/resources/search.ts
@@ -1245,19 +1245,29 @@ function estimateRangeCondition(table, condition, searchType, fraction) {
 	return Math.max(1, Math.round(confidence * count + (1 - confidence) * heuristic));
 }
 
-/**
- * The index a condition can actually be driven by. searchByIndex refuses a rebuilding one, so the
- * planner has to rank it as absent or it can win the lead and then be refused.
- */
+/** The index a condition can be driven by; searchByIndex refuses a rebuilding one, so it reads as absent. */
 function usableIndex(table, attributeName): any {
 	const index = attributeName == null ? undefined : table.indices[attributeName];
 	return index?.isIndexing ? undefined : index;
 }
 
-/** The attribute a condition would drive an index on. A single-element path names one attribute. */
-function drivingAttribute(condition): any {
+/**
+ * True when an index this condition would have to be driven by is still being built, following a
+ * relationship path to the local join index and on to the related table's leaf index. Deliberately
+ * comparator-independent: only the equality branch below resolves a relationship, so a range predicate
+ * across a join would otherwise reach a finite table-fraction estimate and win the lead.
+ */
+function drivesRebuildingIndex(table, condition): boolean {
 	const attributeName = condition[0] ?? condition.attribute;
-	return Array.isArray(attributeName) ? (attributeName.length === 1 ? attributeName[0] : undefined) : attributeName;
+	const path = Array.isArray(attributeName) ? attributeName : [attributeName];
+	if (path.length < 2) return path[0] !== table.primaryKey && !!table.indices[path[0]]?.isIndexing;
+	const attribute = findAttribute(table.attributes, path[0]);
+	if (!attribute) return false;
+	if (table.indices[attribute.relationship?.from]?.isIndexing) return true;
+	const relatedTable = attribute.definition?.tableClass || attribute.elements?.definition?.tableClass;
+	return (
+		!!relatedTable && drivesRebuildingIndex(relatedTable, { attribute: path.length > 2 ? path.slice(1) : path[1] })
+	);
 }
 
 export function estimateCondition(table) {
@@ -1289,10 +1299,9 @@ export function estimateCondition(table) {
 			// skip if it is cached
 			let searchType = condition.comparator || condition.search_type;
 			searchType = ALTERNATE_COMPARATOR_NAMES[searchType] || searchType;
-			const conditionAttribute = drivingAttribute(condition);
-			if (conditionAttribute !== table.primaryKey && table.indices[conditionAttribute]?.isIndexing) {
-				// Assigned here rather than left to the per-comparator branches: several of them fall back to
-				// a finite table-fraction heuristic, which can still beat an available index and take the lead.
+			if (drivesRebuildingIndex(table, condition)) {
+				// Assigned before comparator dispatch: several branches fall back to a finite table-fraction
+				// heuristic that can still beat an available index and take the lead.
 				condition.estimated_count = Infinity;
 			} else if (condition.negated) {
 				// a negated condition always executes as a full scan (searchByIndex forces

--- a/resources/search.ts
+++ b/resources/search.ts
@@ -1253,9 +1253,7 @@ function usableIndex(table, attributeName): any {
 
 /**
  * True when an index this attribute would have to be driven by is still being built, following a
- * relationship path to the local join index and on to the related table's leaf index. Comparator-
- * independent: only the equality branch below resolves a relationship, so a range predicate across a
- * join would otherwise reach a finite table-fraction estimate and win the lead.
+ * relationship path to the local join index and on to the related table's leaf index.
  */
 function drivesRebuildingIndex(table, attributeName): boolean {
 	if (!Array.isArray(attributeName))
@@ -1300,8 +1298,8 @@ export function estimateCondition(table) {
 			// skip if it is cached
 			let searchType = condition.comparator || condition.search_type;
 			searchType = ALTERNATE_COMPARATOR_NAMES[searchType] || searchType;
+			// before comparator dispatch: several branches fall back to a finite table-fraction heuristic
 			if (drivesRebuildingIndex(table, condition[0] ?? condition.attribute)) {
-				// before comparator dispatch: several branches fall back to a finite table-fraction heuristic
 				condition.estimated_count = Infinity;
 			} else if (condition.negated) {
 				// a negated condition always executes as a full scan (searchByIndex forces
@@ -1327,13 +1325,12 @@ export function estimateCondition(table) {
 						});
 						const fromIndex = table.indices[attribute.relationship?.from];
 						// the estimated count is sum of the estimate of the related table and the estimate of the index
-						condition.estimated_count = table.indices[attribute.relationship?.from]?.isIndexing
-							? Infinity // the join would be driven by an index searchByIndex will refuse
-							: estimate +
-								(fromIndex
-									? (estimate * estimatedEntryCount(table.indices[attribute.relationship.from])) /
-										(estimatedEntryCount(relatedTable.primaryStore) || 1)
-									: estimate);
+						condition.estimated_count =
+							estimate +
+							(fromIndex
+								? (estimate * estimatedEntryCount(table.indices[attribute.relationship.from])) /
+									(estimatedEntryCount(relatedTable.primaryStore) || 1)
+								: estimate);
 					}
 				} else {
 					// we only attempt to estimate count on equals operator because that's really all that LMDB supports (some other key-value stores like libmdbx could be considered if we need to do estimated counts of ranges at some point)

--- a/resources/search.ts
+++ b/resources/search.ts
@@ -1103,7 +1103,7 @@ export function filterByType(searchCondition, Table, context, filtered, isPrimar
 		canUseIndex =
 			canUseIndex && // is it a comparator that makes sense to use index
 			!isPrimaryKey && // no need to use index for primary keys, since we will be iterating over the primary keys
-			!!(Table && usableIndex(Table, attribute)) && // is there an index for this attribute, and is it complete
+			!!(Table && usableIndex(Table, attribute)) && // is there a usable (complete) index for this attribute
 			estimatedIncomingCount > 3; // do we have a valid estimate of multiple incoming records (that is worth using an index for)
 		if (canUseIndex) {
 			if (searchCondition.estimated_count == undefined) estimateCondition(Table)(searchCondition);
@@ -1169,7 +1169,7 @@ export function filterByType(searchCondition, Table, context, filtered, isPrimar
 function estimateRangeCondition(table, condition, searchType, fraction) {
 	const attributeName = condition[0] ?? condition.attribute;
 	const isPrimaryKey = attributeName === table.primaryKey;
-	const store = isPrimaryKey ? table.primaryStore : table.indices[attributeName];
+	const store = isPrimaryKey ? table.primaryStore : usableIndex(table, attributeName);
 	// LMDB-backed and custom index stores do not implement estimateCount
 	if (typeof store?.estimateCount !== 'function') return undefined;
 	let value = condition[1] ?? condition.value;
@@ -1246,14 +1246,18 @@ function estimateRangeCondition(table, condition, searchType, fraction) {
 }
 
 /**
- * The index a condition would be driven by, or undefined when there is none usable. searchByIndex
- * refuses a rebuilding index (IndexRebuildingError), so the planner has to see it as absent too: a
- * condition ranked by a partially-built index's cardinality can win the lead and then be refused, when
- * leading with a sibling and applying this one as a record filter answers the query completely.
+ * The index a condition can actually be driven by. searchByIndex refuses a rebuilding one, so the
+ * planner has to rank it as absent or it can win the lead and then be refused.
  */
 function usableIndex(table, attributeName): any {
-	const index = table.indices[attributeName];
+	const index = attributeName == null ? undefined : table.indices[attributeName];
 	return index?.isIndexing ? undefined : index;
+}
+
+/** The attribute a condition would drive an index on. A single-element path names one attribute. */
+function drivingAttribute(condition): any {
+	const attributeName = condition[0] ?? condition.attribute;
+	return Array.isArray(attributeName) ? (attributeName.length === 1 ? attributeName[0] : undefined) : attributeName;
 }
 
 export function estimateCondition(table) {
@@ -1285,12 +1289,8 @@ export function estimateCondition(table) {
 			// skip if it is cached
 			let searchType = condition.comparator || condition.search_type;
 			searchType = ALTERNATE_COMPARATOR_NAMES[searchType] || searchType;
-			const conditionAttribute = condition[0] ?? condition.attribute;
-			if (
-				typeof conditionAttribute === 'string' &&
-				conditionAttribute !== table.primaryKey &&
-				table.indices[conditionAttribute]?.isIndexing
-			) {
+			const conditionAttribute = drivingAttribute(condition);
+			if (conditionAttribute !== table.primaryKey && table.indices[conditionAttribute]?.isIndexing) {
 				// Assigned here rather than left to the per-comparator branches: several of them fall back to
 				// a finite table-fraction heuristic, which can still beat an available index and take the lead.
 				condition.estimated_count = Infinity;
@@ -1316,23 +1316,24 @@ export function estimateCondition(table) {
 							attribute: attribute_name.length > 2 ? attribute_name.slice(1) : attribute_name[1],
 							comparator: 'equals',
 						});
-						const fromIndex = usableIndex(table, attribute.relationship?.from);
+						const fromIndex = table.indices[attribute.relationship?.from];
 						// the estimated count is sum of the estimate of the related table and the estimate of the index
-						condition.estimated_count =
-							estimate +
-							(fromIndex
-								? (estimate * estimatedEntryCount(table.indices[attribute.relationship.from])) /
-									(estimatedEntryCount(relatedTable.primaryStore) || 1)
-								: estimate);
+						condition.estimated_count = table.indices[attribute.relationship?.from]?.isIndexing
+							? Infinity // the join would be driven by an index searchByIndex will refuse
+							: estimate +
+								(fromIndex
+									? (estimate * estimatedEntryCount(table.indices[attribute.relationship.from])) /
+										(estimatedEntryCount(relatedTable.primaryStore) || 1)
+									: estimate);
 					}
 				} else {
 					// we only attempt to estimate count on equals operator because that's really all that LMDB supports (some other key-value stores like libmdbx could be considered if we need to do estimated counts of ranges at some point)
-					const index = table.indices[attribute_name];
+					const index = usableIndex(table, attribute_name);
 					condition.estimated_count = index ? index.getValuesCount(condition[1] ?? condition.value) : Infinity;
 				}
 			} else if (searchType === 'contains' || searchType === 'ends_with' || searchType === 'ne') {
 				const attribute_name = condition[0] ?? condition.attribute;
-				const index = table.indices[attribute_name];
+				const index = usableIndex(table, attribute_name);
 				if (condition.value === null && searchType === 'ne') {
 					condition.estimated_count = Math.max(
 						estimatedEntryCount(table.primaryStore) - (index ? index.getValuesCount(null) : 0),
@@ -1341,7 +1342,7 @@ export function estimateCondition(table) {
 				} else condition.estimated_count = Infinity;
 			} else if (searchType === 'in') {
 				const attribute_name = condition[0] ?? condition.attribute;
-				const index = table.indices[attribute_name];
+				const index = usableIndex(table, attribute_name);
 				if (Array.isArray(condition.value) && index) {
 					// Sum of per-value matches (over-counts duplicates but is a fine ceiling)
 					let estimate = 0;
@@ -1362,7 +1363,7 @@ export function estimateCondition(table) {
 					BETWEEN_ESTIMATE * estimatedEntryCount(table.primaryStore) + 1;
 			else if (searchType === 'sort') {
 				const attribute_name = condition[0] ?? condition.attribute;
-				const index = table.indices[attribute_name];
+				const index = usableIndex(table, attribute_name);
 				if (index?.customIndex?.estimateCountAsSort)
 					// allow custom index to define its own estimation of counts
 					condition.estimated_count = index.customIndex.estimateCountAsSort(condition);
@@ -1370,7 +1371,7 @@ export function estimateCondition(table) {
 			} else {
 				// for the search types that use the broadest range, try do them last
 				const attribute_name = condition[0] ?? condition.attribute;
-				const index = table.indices[attribute_name];
+				const index = usableIndex(table, attribute_name);
 				if (index?.customIndex?.estimateCount)
 					// allow custom index to define its own estimation of counts
 					condition.estimated_count = index.customIndex.estimateCount(condition.value);

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -173,6 +173,12 @@ module.exports = {
 	isThreadRunning,
 	waitUntilConfirmedGone,
 	restartNumber: workerData?.restartNumber || 1,
+	// Identifies this process incarnation to every thread in it. Minted once on the main thread and
+	// carried to workers through workerData, so all threads agree on it — a value each thread derived
+	// for itself (from clocks, or its own randomness) would disagree between live siblings. `undefined`
+	// on a worker started without it: consumers must fall back rather than treat that as a mismatch.
+	// PID cannot serve this role: a container restart reuses PID 1.
+	processIncarnation: workerData ? workerData.processIncarnation : randomBytes(8).toString('hex'),
 };
 
 connectedPorts.onMessageByType = onMessageByType;
@@ -239,6 +245,7 @@ const RESERVED_WORKER_DATA_KEYS = [
 	'workerCount',
 	'name',
 	'restartNumber',
+	'processIncarnation',
 	'ticketKeys',
 	'noServerStart',
 	'__proto__', // never a legitimate payload name; spread would define it as an own property
@@ -433,6 +440,7 @@ function startWorker(path, options = {}) {
 			workerCount: (workerCount = options.threadCount),
 			name: options.name,
 			restartNumber: module.exports.restartNumber,
+			processIncarnation: module.exports.processIncarnation,
 			ticketKeys: getTicketKeys(),
 		},
 		transferList: portsToSend,

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -173,11 +173,10 @@ module.exports = {
 	isThreadRunning,
 	waitUntilConfirmedGone,
 	restartNumber: workerData?.restartNumber || 1,
-	// Identifies this process incarnation to every thread in it. Minted once on the main thread and
-	// carried to workers through workerData, so all threads agree on it — a value each thread derived
-	// for itself (from clocks, or its own randomness) would disagree between live siblings. `undefined`
-	// on a worker started without it: consumers must fall back rather than treat that as a mismatch.
-	// PID cannot serve this role: a container restart reuses PID 1.
+	// Identifies this process incarnation, where the PID cannot: a container reuses PID 1. Minted once
+	// on the main thread and carried to workers, so live siblings agree on it — one derived per thread
+	// would not. `undefined` on a worker started without it; consumers must fall back, not treat that
+	// as a mismatch.
 	processIncarnation: workerData ? workerData.processIncarnation : randomBytes(8).toString('hex'),
 };
 

--- a/unitTests/resources/indexBuildAbandonment.test.js
+++ b/unitTests/resources/indexBuildAbandonment.test.js
@@ -14,6 +14,7 @@
 
 require('../testUtils');
 const assert = require('node:assert');
+const { RocksDatabase } = require('@harperfast/rocksdb-js');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const manageThreads = require('#js/server/threads/manageThreads');
@@ -129,14 +130,22 @@ describe('an index build that ends without completing is marked and recovered', 
 		// that read, which is the window a replacement worker generation actually claims the build in.
 		const dbisDB = Rebuilding.dbisDB;
 		const rootStore = Rebuilding.primaryStore.rootStore;
+		const isRocksDatabase = rootStore instanceof RocksDatabase;
 		const originalGetSync = dbisDB.getSync.bind(dbisDB);
+		const originalTransactionSync = rootStore.transactionSync;
 		let reads = 0;
 		let heldOnReread = null;
+		if (!isRocksDatabase) {
+			rootStore.transactionSync = function (...args) {
+				heldOnReread = true;
+				return originalTransactionSync.apply(this, args);
+			};
+		}
 		dbisDB.getSync = (readKey, ...rest) => {
 			const value = originalGetSync(readKey, ...rest);
 			if (readKey === key && ++reads === 2) {
 				// tryLock fails even for the thread already holding it, so this observes the locked section
-				if (typeof rootStore.tryLock === 'function') {
+				if (isRocksDatabase) {
 					heldOnReread = !rootStore.tryLock(UPDATE_ATTRIBUTES_LOCK_KEY);
 					if (!heldOnReread) rootStore.unlock(UPDATE_ATTRIBUTES_LOCK_KEY);
 				}
@@ -157,15 +166,15 @@ describe('an index build that ends without completing is marked and recovered', 
 			if (originalStatus) Object.defineProperty(rootStore, 'status', originalStatus);
 			else delete rootStore.status;
 			dbisDB.getSync = originalGetSync;
+			if (!isRocksDatabase) rootStore.transactionSync = originalTransactionSync;
 		}
 
 		assert.ok(reads >= 2, 'the settle handler must re-read the descriptor after its first check');
-		if (typeof rootStore.tryLock === 'function')
-			assert.strictEqual(
-				heldOnReread,
-				true,
-				'the re-read and the write must happen under the exclusive catalog lock the declaration takes'
-			);
+		assert.strictEqual(
+			heldOnReread,
+			true,
+			'the re-read and the write must happen under the exclusive catalog lock the declaration takes'
+		);
 		await catalogFlushed(Rebuilding);
 		assert.strictEqual(
 			originalGetSync(key).indexingFailed,

--- a/unitTests/resources/indexBuildAbandonment.test.js
+++ b/unitTests/resources/indexBuildAbandonment.test.js
@@ -188,6 +188,52 @@ describe('an index build that ends without completing is marked and recovered', 
 		);
 	});
 
+	it('aborts the LMDB catalog transaction when persisting the failure marker throws', async function () {
+		if (process.env.HARPER_STORAGE_ENGINE !== 'lmdb') this.skip();
+		const tableName = 'IndexAbandonMarkerAbort';
+		const key = `${tableName}/tag`;
+		const Seeded = seed(tableName, false);
+		let lastPut;
+		for (let i = 0; i < 10; i++) lastPut = Seeded.put({ id: `k-${i}`, tag: i % 2 ? 'odd' : 'even' });
+		await lastPut;
+
+		const Rebuilding = seed(tableName, true);
+		const dbisDB = Rebuilding.dbisDB;
+		const originalPut = dbisDB.put;
+		const originalPutSync = dbisDB.putSync;
+		function throwAfterMarkerWrite(write) {
+			return function (writeKey, value, ...rest) {
+				const result = write.call(this, writeKey, value, ...rest);
+				if (writeKey === key && value?.indexingFailed) throw new Error('marker write failed after staging');
+				return result;
+			};
+		}
+		dbisDB.put = throwAfterMarkerWrite(originalPut);
+		dbisDB.putSync = throwAfterMarkerWrite(originalPutSync);
+		const rootStore = Rebuilding.primaryStore.rootStore;
+		const originalStatus = Object.getOwnPropertyDescriptor(rootStore, 'status');
+		const originalGetRange = Rebuilding.primaryStore.getRange;
+		Rebuilding.primaryStore.getRange = () => {
+			throw new Error('Database not open');
+		};
+		Object.defineProperty(rootStore, 'status', { value: 'closed', configurable: true, writable: true });
+		try {
+			await Rebuilding.indexingOperation;
+		} finally {
+			Rebuilding.primaryStore.getRange = originalGetRange;
+			if (originalStatus) Object.defineProperty(rootStore, 'status', originalStatus);
+			else delete rootStore.status;
+			dbisDB.put = originalPut;
+			dbisDB.putSync = originalPutSync;
+		}
+
+		assert.strictEqual(
+			dbisDB.getSync(key).indexingFailed,
+			undefined,
+			'a failed marker write must abort instead of committing its staged catalog change'
+		);
+	});
+
 	it('re-triggers a build whose process incarnation is not this process, including one that has none', async () => {
 		const tableName = 'IndexAbandonIncarnation';
 		const Seeded = seed(tableName, true);

--- a/unitTests/resources/indexBuildAbandonment.test.js
+++ b/unitTests/resources/indexBuildAbandonment.test.js
@@ -1,0 +1,214 @@
+/**
+ * harper#2537 / harper#2536. A backfill can end without running either of runIndexing's own exit paths
+ * — the restart-interrupt return inside the loop, and the closed-store return in its catch — leaving a
+ * descriptor that claims an armed, in-progress build with no `indexingFailed`, nothing logged above
+ * debug, and nothing to re-trigger it. Two guards cover that:
+ *
+ *   1. the operation's settle handler persists the failure marker for the exact build it scheduled;
+ *   2. the trigger treats a build whose process incarnation is not this process's — including a
+ *      descriptor written before that field existed — as abandoned, which is the only way to detect a
+ *      process restart when Harper is PID 1 and the restart generation resets to 1 in memory.
+ */
+
+require('../testUtils');
+const assert = require('node:assert/strict');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const manageThreads = require('#js/server/threads/manageThreads');
+const { forComponent } = require('#src/utility/logging/harper_logger');
+
+describe('an index build that ends without completing is marked and recovered', function () {
+	this.timeout(60000);
+
+	before(() => {
+		setupTestDBPath();
+		manageThreads.setMainIsWorker(true);
+	});
+
+	async function catalogFlushed(Table) {
+		if (Table.dbisDB.committed) await Table.dbisDB.committed;
+	}
+
+	function seed(tableName, indexed) {
+		const Table = table({
+			table: tableName,
+			database: 'test',
+			schemaDefined: true,
+			attributes: [
+				{ name: 'id', type: 'ID', isPrimaryKey: true },
+				{ name: 'tag', type: 'String', indexed },
+			],
+		});
+		return Table;
+	}
+
+	it('persists a failure marker when the backfill returns through its silent store-shutdown path', async () => {
+		const tableName = 'IndexAbandonShutdown';
+		const Seeded = seed(tableName, false);
+		let lastPut;
+		for (let i = 0; i < 10; i++) lastPut = Seeded.put({ id: `k-${i}`, tag: i % 2 ? 'odd' : 'even' });
+		await lastPut;
+
+		const storageLogger = forComponent('storage');
+		const originalWarn = storageLogger.warn;
+		const warnings = [];
+		storageLogger.warn = (...args) => warnings.push(args);
+
+		// table() reads the primary store to decide there is data to backfill, so the interruption is
+		// installed only once it has returned — runIndexing suspends at its first await before iterating.
+		const Rebuilding = seed(tableName, true);
+		const primaryStore = Rebuilding.primaryStore;
+		const rootStore = primaryStore.rootStore;
+		const originalGetRange = primaryStore.getRange;
+		const originalStatus = Object.getOwnPropertyDescriptor(rootStore, 'status');
+		primaryStore.getRange = () => {
+			throw new Error('Database not open');
+		};
+		Object.defineProperty(rootStore, 'status', { value: 'closed', configurable: true, writable: true });
+		try {
+			await Rebuilding.indexingOperation;
+		} finally {
+			primaryStore.getRange = originalGetRange;
+			if (originalStatus) Object.defineProperty(rootStore, 'status', originalStatus);
+			else delete rootStore.status;
+			storageLogger.warn = originalWarn;
+		}
+
+		await catalogFlushed(Rebuilding);
+		const descriptor = Rebuilding.dbisDB.getSync(`${tableName}/tag`);
+		assert.equal(
+			descriptor.indexingFailed,
+			true,
+			'a backfill that returned without completing must leave a durable failure marker, or nothing re-triggers it'
+		);
+		assert.ok(descriptor.indexingPID, 'the build must still read as incomplete so queries keep refusing');
+		assert.equal(
+			Rebuilding.indices.tag.isIndexing,
+			true,
+			'the index must stay marked as rebuilding after an abandoned build'
+		);
+		const reported = warnings
+			.map(([message]) => message)
+			.filter((message) => typeof message === 'string' && message.includes(`${tableName}.tag`));
+		assert.equal(reported.length, 1, `the abandoned build must be reported above debug: ${JSON.stringify(warnings)}`);
+
+		// The marker is what the next load acts on.
+		const Recovered = seed(tableName, true);
+		assert.ok(Recovered.indexingOperation, 'the persisted marker must re-trigger the backfill on the next load');
+		await Recovered.indexingOperation;
+		await catalogFlushed(Recovered);
+		assert.equal(
+			Recovered.dbisDB.getSync(`${tableName}/tag`).indexingPID,
+			undefined,
+			'the recovered build must complete and clear the descriptor'
+		);
+		assert.equal(Recovered.indices.tag.isIndexing, false, 'the recovered index must be usable again');
+	});
+
+	it('does not mark a build the settle handler no longer owns', async () => {
+		const tableName = 'IndexAbandonNotOwned';
+		const Seeded = seed(tableName, true);
+		let lastPut;
+		for (let i = 0; i < 10; i++) lastPut = Seeded.put({ id: `k-${i}`, tag: i % 2 ? 'odd' : 'even' });
+		await lastPut;
+		if (Seeded.indexingOperation) await Seeded.indexingOperation;
+		await catalogFlushed(Seeded);
+
+		// A descriptor re-armed by a later owner, exactly as a replacement worker generation would leave
+		// it: the settled handler must not write a failure marker over a build that is not its own.
+		const key = `${tableName}/tag`;
+		const descriptor = Seeded.dbisDB.getSync(key);
+		const written = Seeded.dbisDB.put(key, {
+			...descriptor,
+			indexingPID: process.pid,
+			restartNumber: (manageThreads.restartNumber ?? 1) + 1,
+			indexingIncarnation: manageThreads.processIncarnation,
+		});
+		if (written?.then) await written;
+
+		await Seeded.indexingOperation;
+		await catalogFlushed(Seeded);
+		assert.equal(
+			Seeded.dbisDB.getSync(key).indexingFailed,
+			undefined,
+			'the settle handler marked a build owned by a newer generation as failed'
+		);
+	});
+
+	it('re-triggers a build whose process incarnation is not this process, including one that has none', async () => {
+		const tableName = 'IndexAbandonIncarnation';
+		const Seeded = seed(tableName, true);
+		let lastPut;
+		for (let i = 0; i < 10; i++) lastPut = Seeded.put({ id: `k-${i}`, tag: i % 2 ? 'odd' : 'even' });
+		await lastPut;
+		if (Seeded.indexingOperation) await Seeded.indexingOperation;
+		await catalogFlushed(Seeded);
+		const completedBuild = Seeded.indexingOperation;
+		const key = `${tableName}/tag`;
+		const complete = Seeded.dbisDB.getSync(key);
+
+		// Both shapes a container restart leaves behind: the PID is reused (Harper is PID 1) and the
+		// in-memory restart generation is back to its starting value, so neither existing check fires.
+		for (const [label, incarnation] of [
+			['written by an older version, with no incarnation at all', undefined],
+			['written by a previous incarnation of this same PID', 'not-this-process'],
+		]) {
+			const armed = {
+				...complete,
+				indexingPID: process.pid,
+				restartNumber: manageThreads.restartNumber ?? 1,
+				lastIndexedKey: 'k-4',
+			};
+			if (incarnation === undefined) delete armed.indexingIncarnation;
+			else armed.indexingIncarnation = incarnation;
+			const written = Seeded.dbisDB.put(key, armed);
+			if (written?.then) await written;
+
+			const Recovered = seed(tableName, true);
+			assert.notEqual(
+				Recovered.indexingOperation,
+				completedBuild,
+				`an armed build ${label} must be re-triggered, not trusted`
+			);
+			await Recovered.indexingOperation;
+			await catalogFlushed(Recovered);
+			assert.equal(
+				Recovered.dbisDB.getSync(key).indexingPID,
+				undefined,
+				`the recovered build (${label}) must complete and clear the descriptor`
+			);
+			assert.equal(Recovered.indices.tag.isIndexing, false, `the recovered index (${label}) must be usable`);
+			const odds = [];
+			for await (const record of Recovered.search({ conditions: [{ attribute: 'tag', value: 'odd' }] }))
+				odds.push(record);
+			assert.equal(odds.length, 5, `the recovered backfill (${label}) must index every record`);
+		}
+	});
+
+	it('leaves a build owned by this process incarnation alone', async () => {
+		const tableName = 'IndexAbandonLive';
+		const Seeded = seed(tableName, true);
+		let lastPut;
+		for (let i = 0; i < 10; i++) lastPut = Seeded.put({ id: `k-${i}`, tag: i % 2 ? 'odd' : 'even' });
+		await lastPut;
+		if (Seeded.indexingOperation) await Seeded.indexingOperation;
+		await catalogFlushed(Seeded);
+		const completedBuild = Seeded.indexingOperation;
+
+		// A second thread of this process declaring the same table while the build is genuinely in flight
+		// must not start a duplicate backfill.
+		const key = `${tableName}/tag`;
+		const written = Seeded.dbisDB.put(key, {
+			...Seeded.dbisDB.getSync(key),
+			indexingPID: process.pid,
+			restartNumber: manageThreads.restartNumber ?? 1,
+			indexingIncarnation: manageThreads.processIncarnation,
+			lastIndexedKey: 'k-4',
+		});
+		if (written?.then) await written;
+
+		const Live = seed(tableName, true);
+		assert.equal(Live.indexingOperation, completedBuild, 'a live build in this process must not be re-triggered');
+		assert.equal(Live.indices.tag.isIndexing, true, 'a live build must still read as incomplete');
+	});
+});

--- a/unitTests/resources/indexBuildAbandonment.test.js
+++ b/unitTests/resources/indexBuildAbandonment.test.js
@@ -2,7 +2,9 @@
  * harper#2537 / harper#2536. A backfill can end without running either of runIndexing's own exit paths
  * — the restart-interrupt return inside the loop, and the closed-store return in its catch — leaving a
  * descriptor that claims an armed, in-progress build with no `indexingFailed`, nothing logged above
- * debug, and nothing to re-trigger it. Two guards cover that:
+ * debug, and nothing to re-trigger it. Both reach the same settle handler; the cases below simulate
+ * the closed-store return, which is the one reproducible without a live worker generation. Two guards
+ * cover that:
  *
  *   1. the operation's settle handler persists the failure marker for the exact build it scheduled;
  *   2. the trigger treats a build whose process incarnation is not this process's — including a

--- a/unitTests/resources/indexBuildAbandonment.test.js
+++ b/unitTests/resources/indexBuildAbandonment.test.js
@@ -17,6 +17,9 @@ const { table } = require('#src/resources/databases');
 const manageThreads = require('#js/server/threads/manageThreads');
 const { forComponent } = require('#src/utility/logging/harper_logger');
 
+// resources/Table.ts keys the exclusive schema lock on these bytes
+const UPDATE_ATTRIBUTES_LOCK_KEY = Buffer.from('update-attributes');
+
 describe('an index build that ends without completing is marked and recovered', function () {
 	this.timeout(60000);
 
@@ -96,7 +99,6 @@ describe('an index build that ends without completing is marked and recovered', 
 			`the abandoned build must be reported above debug: ${JSON.stringify(warnings)}`
 		);
 
-		// The marker is what the next load acts on.
 		const Recovered = seed(tableName, true);
 		assert.ok(Recovered.indexingOperation, 'the persisted marker must re-trigger the backfill on the next load');
 		await Recovered.indexingOperation;
@@ -124,14 +126,22 @@ describe('an index build that ends without completing is marked and recovered', 
 		// The settle handler re-reads under the exclusive catalog lock; report a replacement's claim on
 		// that read, which is the window a replacement worker generation actually claims the build in.
 		const dbisDB = Rebuilding.dbisDB;
+		const rootStore = Rebuilding.primaryStore.rootStore;
 		const originalGetSync = dbisDB.getSync.bind(dbisDB);
 		let reads = 0;
+		let heldOnReread = null;
 		dbisDB.getSync = (readKey, ...rest) => {
 			const value = originalGetSync(readKey, ...rest);
-			if (readKey === key && ++reads === 2) return { ...value, indexingBuildId: 'a-replacement-build' };
+			if (readKey === key && ++reads === 2) {
+				// tryLock fails even for the thread already holding it, so this observes the locked section
+				if (typeof rootStore.tryLock === 'function') {
+					heldOnReread = !rootStore.tryLock(UPDATE_ATTRIBUTES_LOCK_KEY);
+					if (!heldOnReread) rootStore.unlock(UPDATE_ATTRIBUTES_LOCK_KEY);
+				}
+				return { ...value, indexingBuildId: 'a-replacement-build' };
+			}
 			return value;
 		};
-		const rootStore = Rebuilding.primaryStore.rootStore;
 		const originalStatus = Object.getOwnPropertyDescriptor(rootStore, 'status');
 		const originalGetRange = Rebuilding.primaryStore.getRange;
 		Rebuilding.primaryStore.getRange = () => {
@@ -148,6 +158,12 @@ describe('an index build that ends without completing is marked and recovered', 
 		}
 
 		assert.ok(reads >= 2, 'the settle handler must re-read the descriptor after its first check');
+		if (typeof rootStore.tryLock === 'function')
+			assert.strictEqual(
+				heldOnReread,
+				true,
+				'the re-read and the write must happen under the exclusive catalog lock the declaration takes'
+			);
 		await catalogFlushed(Rebuilding);
 		assert.strictEqual(
 			originalGetSync(key).indexingFailed,

--- a/unitTests/resources/indexBuildAbandonment.test.js
+++ b/unitTests/resources/indexBuildAbandonment.test.js
@@ -11,7 +11,7 @@
  */
 
 require('../testUtils');
-const assert = require('node:assert/strict');
+const assert = require('node:assert');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const manageThreads = require('#js/server/threads/manageThreads');
@@ -76,13 +76,13 @@ describe('an index build that ends without completing is marked and recovered', 
 
 		await catalogFlushed(Rebuilding);
 		const descriptor = Rebuilding.dbisDB.getSync(`${tableName}/tag`);
-		assert.equal(
+		assert.strictEqual(
 			descriptor.indexingFailed,
 			true,
 			'a backfill that returned without completing must leave a durable failure marker, or nothing re-triggers it'
 		);
 		assert.ok(descriptor.indexingPID, 'the build must still read as incomplete so queries keep refusing');
-		assert.equal(
+		assert.strictEqual(
 			Rebuilding.indices.tag.isIndexing,
 			true,
 			'the index must stay marked as rebuilding after an abandoned build'
@@ -90,48 +90,74 @@ describe('an index build that ends without completing is marked and recovered', 
 		const reported = warnings
 			.map(([message]) => message)
 			.filter((message) => typeof message === 'string' && message.includes(`${tableName}.tag`));
-		assert.equal(reported.length, 1, `the abandoned build must be reported above debug: ${JSON.stringify(warnings)}`);
+		assert.strictEqual(
+			reported.length,
+			1,
+			`the abandoned build must be reported above debug: ${JSON.stringify(warnings)}`
+		);
 
 		// The marker is what the next load acts on.
 		const Recovered = seed(tableName, true);
 		assert.ok(Recovered.indexingOperation, 'the persisted marker must re-trigger the backfill on the next load');
 		await Recovered.indexingOperation;
 		await catalogFlushed(Recovered);
-		assert.equal(
+		assert.strictEqual(
 			Recovered.dbisDB.getSync(`${tableName}/tag`).indexingPID,
 			undefined,
 			'the recovered build must complete and clear the descriptor'
 		);
-		assert.equal(Recovered.indices.tag.isIndexing, false, 'the recovered index must be usable again');
+		assert.strictEqual(Recovered.indices.tag.isIndexing, false, 'the recovered index must be usable again');
 	});
 
-	it('does not mark a build the settle handler no longer owns', async () => {
+	it('does not mark a build a replacement claimed between the settle handler check and its write', async () => {
 		const tableName = 'IndexAbandonNotOwned';
-		const Seeded = seed(tableName, true);
+		const key = `${tableName}/tag`;
+		const Seeded = seed(tableName, false);
 		let lastPut;
 		for (let i = 0; i < 10; i++) lastPut = Seeded.put({ id: `k-${i}`, tag: i % 2 ? 'odd' : 'even' });
 		await lastPut;
-		if (Seeded.indexingOperation) await Seeded.indexingOperation;
-		await catalogFlushed(Seeded);
 
-		// A descriptor re-armed by a later owner, exactly as a replacement worker generation would leave
-		// it: the settled handler must not write a failure marker over a build that is not its own.
-		const key = `${tableName}/tag`;
-		const descriptor = Seeded.dbisDB.getSync(key);
-		const written = Seeded.dbisDB.put(key, {
-			...descriptor,
-			indexingPID: process.pid,
-			restartNumber: (manageThreads.restartNumber ?? 1) + 1,
-			indexingIncarnation: manageThreads.processIncarnation,
-		});
-		if (written?.then) await written;
+		const Rebuilding = seed(tableName, true);
+		const ownBuildId = Rebuilding.dbisDB.getSync(key).indexingBuildId;
+		assert.ok(ownBuildId, 'the trigger must stamp a build id for the settle handler to fence on');
 
-		await Seeded.indexingOperation;
-		await catalogFlushed(Seeded);
-		assert.equal(
-			Seeded.dbisDB.getSync(key).indexingFailed,
+		// The settle handler re-reads under the exclusive catalog lock; report a replacement's claim on
+		// that read, which is the window a replacement worker generation actually claims the build in.
+		const dbisDB = Rebuilding.dbisDB;
+		const originalGetSync = dbisDB.getSync.bind(dbisDB);
+		let reads = 0;
+		dbisDB.getSync = (readKey, ...rest) => {
+			const value = originalGetSync(readKey, ...rest);
+			if (readKey === key && ++reads === 2) return { ...value, indexingBuildId: 'a-replacement-build' };
+			return value;
+		};
+		const rootStore = Rebuilding.primaryStore.rootStore;
+		const originalStatus = Object.getOwnPropertyDescriptor(rootStore, 'status');
+		const originalGetRange = Rebuilding.primaryStore.getRange;
+		Rebuilding.primaryStore.getRange = () => {
+			throw new Error('Database not open');
+		};
+		Object.defineProperty(rootStore, 'status', { value: 'closed', configurable: true, writable: true });
+		try {
+			await Rebuilding.indexingOperation;
+		} finally {
+			Rebuilding.primaryStore.getRange = originalGetRange;
+			if (originalStatus) Object.defineProperty(rootStore, 'status', originalStatus);
+			else delete rootStore.status;
+			dbisDB.getSync = originalGetSync;
+		}
+
+		assert.ok(reads >= 2, 'the settle handler must re-read the descriptor after its first check');
+		await catalogFlushed(Rebuilding);
+		assert.strictEqual(
+			originalGetSync(key).indexingFailed,
 			undefined,
-			'the settle handler marked a build owned by a newer generation as failed'
+			'the settle handler marked a build that a replacement had already claimed'
+		);
+		assert.strictEqual(
+			originalGetSync(key).indexingBuildId,
+			ownBuildId,
+			'the settle handler must not write its own stale descriptor snapshot back over the catalog'
 		);
 	});
 
@@ -165,23 +191,23 @@ describe('an index build that ends without completing is marked and recovered', 
 			if (written?.then) await written;
 
 			const Recovered = seed(tableName, true);
-			assert.notEqual(
+			assert.notStrictEqual(
 				Recovered.indexingOperation,
 				completedBuild,
 				`an armed build ${label} must be re-triggered, not trusted`
 			);
 			await Recovered.indexingOperation;
 			await catalogFlushed(Recovered);
-			assert.equal(
+			assert.strictEqual(
 				Recovered.dbisDB.getSync(key).indexingPID,
 				undefined,
 				`the recovered build (${label}) must complete and clear the descriptor`
 			);
-			assert.equal(Recovered.indices.tag.isIndexing, false, `the recovered index (${label}) must be usable`);
+			assert.strictEqual(Recovered.indices.tag.isIndexing, false, `the recovered index (${label}) must be usable`);
 			const odds = [];
 			for await (const record of Recovered.search({ conditions: [{ attribute: 'tag', value: 'odd' }] }))
 				odds.push(record);
-			assert.equal(odds.length, 5, `the recovered backfill (${label}) must index every record`);
+			assert.strictEqual(odds.length, 5, `the recovered backfill (${label}) must index every record`);
 		}
 	});
 
@@ -208,7 +234,7 @@ describe('an index build that ends without completing is marked and recovered', 
 		if (written?.then) await written;
 
 		const Live = seed(tableName, true);
-		assert.equal(Live.indexingOperation, completedBuild, 'a live build in this process must not be re-triggered');
-		assert.equal(Live.indices.tag.isIndexing, true, 'a live build must still read as incomplete');
+		assert.strictEqual(Live.indexingOperation, completedBuild, 'a live build in this process must not be re-triggered');
+		assert.strictEqual(Live.indices.tag.isIndexing, true, 'a live build must still read as incomplete');
 	});
 });

--- a/unitTests/resources/indexRebuildThreadConsistency-thread.js
+++ b/unitTests/resources/indexRebuildThreadConsistency-thread.js
@@ -51,7 +51,7 @@ async function probe(step) {
 			message.foundById = Boolean(await Table.get(probeId));
 		}
 	} catch (error) {
-		message.failure = error.message;
+		message.failure = error?.message ?? String(error);
 	}
 	parentPort.postMessage(message);
 }

--- a/unitTests/resources/indexRebuildThreadConsistency-thread.js
+++ b/unitTests/resources/indexRebuildThreadConsistency-thread.js
@@ -1,7 +1,8 @@
 const { parentPort, workerData } = require('node:worker_threads');
 const { setupTestDBPath } = require('../testUtils');
 const { resetDatabases } = require('#src/resources/databases');
-const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const manageThreads = require('#js/server/threads/manageThreads');
+const { setMainIsWorker } = manageThreads;
 
 // A thread that never declares the schema: it reaches Table.indices only through the catalog reload
 // (resetDatabases -> initStores), which is what the main and operations threads do in a running node.
@@ -22,7 +23,15 @@ async function run() {
 }
 
 async function probe(step) {
-	const message = { step, loaded: false, isIndexing: null, hits: null, searchError: null, foundById: false };
+	const message = {
+		step,
+		loaded: false,
+		isIndexing: null,
+		hits: null,
+		searchError: null,
+		foundById: false,
+		processIncarnation: manageThreads.processIncarnation,
+	};
 	try {
 		const Table = resetDatabases().test?.[tableName];
 		message.loaded = Boolean(Table);

--- a/unitTests/resources/indexRebuildThreadConsistency-thread.js
+++ b/unitTests/resources/indexRebuildThreadConsistency-thread.js
@@ -1,0 +1,48 @@
+const { parentPort, workerData } = require('worker_threads');
+const { setupTestDBPath } = require('../testUtils');
+const { resetDatabases } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+// A thread that never declares the schema: it reaches Table.indices only through the catalog reload
+// (resetDatabases -> initStores), which is what the main and operations threads do in a running node.
+// Probing is driven by the test with Atomics rather than by an ITC schema event, so the backfill can be
+// held at a known point; the reload it performs is the same one the ITC handler performs.
+const { phase, ack, tableName, attributeName, probeValue, probeId } = workerData ?? {};
+if (phase) run();
+
+async function run() {
+	setupTestDBPath();
+	setMainIsWorker(true);
+	for (let step = 0; step < 3; step++) {
+		Atomics.wait(phase, 0, step);
+		await probe(step + 1);
+		Atomics.store(ack, 0, step + 1);
+		Atomics.notify(ack, 0);
+	}
+}
+
+async function probe(step) {
+	const message = { step, loaded: false, isIndexing: null, hits: null, searchError: null, foundById: false };
+	try {
+		const Table = resetDatabases().test?.[tableName];
+		message.loaded = Boolean(Table);
+		if (Table) {
+			message.isIndexing = Table.indices[attributeName]?.isIndexing ?? null;
+			try {
+				const hits = [];
+				for await (const record of Table.search({
+					allowFullScan: false,
+					conditions: [{ attribute: attributeName, value: probeValue }],
+				}))
+					hits.push(record);
+				message.hits = hits.length;
+			} catch (error) {
+				message.searchError = error.message;
+			}
+			message.foundById = Boolean(await Table.get(probeId));
+		}
+	} catch (error) {
+		message.failure = error.message;
+	}
+	parentPort.postMessage(message);
+}

--- a/unitTests/resources/indexRebuildThreadConsistency-thread.js
+++ b/unitTests/resources/indexRebuildThreadConsistency-thread.js
@@ -46,7 +46,7 @@ async function probe(step) {
 					hits.push(record);
 				message.hits = hits.length;
 			} catch (error) {
-				message.searchError = error.message;
+				message.searchError = error?.message ?? String(error);
 			}
 			message.foundById = Boolean(await Table.get(probeId));
 		}

--- a/unitTests/resources/indexRebuildThreadConsistency-thread.js
+++ b/unitTests/resources/indexRebuildThreadConsistency-thread.js
@@ -1,4 +1,4 @@
-const { parentPort, workerData } = require('worker_threads');
+const { parentPort, workerData } = require('node:worker_threads');
 const { setupTestDBPath } = require('../testUtils');
 const { resetDatabases } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');

--- a/unitTests/resources/indexRebuildThreadConsistency.test.js
+++ b/unitTests/resources/indexRebuildThreadConsistency.test.js
@@ -11,7 +11,7 @@
  */
 
 require('../testUtils');
-const assert = require('node:assert/strict');
+const assert = require('node:assert');
 const { Worker } = require('node:worker_threads');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
@@ -57,28 +57,36 @@ describe('an index being rebuilt is incomplete on every thread (harper#2537)', f
 			]);
 		// every exit from here must terminate the worker, or it stays blocked in Atomics.wait
 		try {
+			// Waits on the acknowledged step rather than on Atomics.wait's return: a reader that acks
+			// before this thread reaches the wait makes it return 'not-equal', which is success, not failure.
 			const release = (step) => {
 				Atomics.store(phase, 0, step);
 				Atomics.notify(phase, 0);
-				return Atomics.wait(ack, 0, step - 1, WAIT_MS);
+				const deadline = Date.now() + WAIT_MS;
+				while (Atomics.load(ack, 0) < step) {
+					const remaining = deadline - Date.now();
+					if (remaining <= 0) return false;
+					Atomics.wait(ack, 0, step - 1, remaining);
+				}
+				return true;
 			};
 
-			assert.equal(release(1), 'ok', 'the reader thread never finished its pre-rebuild load');
+			assert.ok(release(1), 'the reader thread never finished its pre-rebuild load');
 			const before = await probed(1);
 
 			const Table = trigger();
 			assert.ok(Table.indexingOperation, 'the rebuild was not triggered, so nothing is held');
 			// Blocking here keeps the backfill suspended at runIndexing's first await, so the reader
 			// observes an armed descriptor over an index with nothing written to it yet.
-			assert.equal(release(2), 'ok', 'the reader thread never finished its mid-rebuild load');
+			assert.ok(release(2), 'the reader thread never finished its mid-rebuild load');
 			const during = await probed(2);
 
 			await Table.indexingOperation;
-			assert.equal(release(3), 'ok', 'the reader thread never finished its post-rebuild load');
+			assert.ok(release(3), 'the reader thread never finished its post-rebuild load');
 			const after = await probed(3);
 
 			for (const probe of [before, during, after])
-				assert.equal(probe.failure, undefined, `reader thread failed at step ${probe.step}: ${probe.failure}`);
+				assert.strictEqual(probe.failure, undefined, `reader thread failed at step ${probe.step}: ${probe.failure}`);
 			return { before, during, after };
 		} finally {
 			await worker.terminate();
@@ -114,13 +122,13 @@ describe('an index being rebuilt is incomplete on every thread (harper#2537)', f
 		);
 
 		assert.ok(before.loaded, 'the reader thread must have loaded the table before the rebuild');
-		assert.equal(before.isIndexing, null, 'there is no index on the attribute before the rebuild');
+		assert.strictEqual(before.isIndexing, null, 'there is no index on the attribute before the rebuild');
 
 		assert.ok(
 			during.foundById,
 			'the probe record must be readable by primary key while the rebuild is held, or the test proves nothing'
 		);
-		assert.equal(
+		assert.strictEqual(
 			during.isIndexing,
 			true,
 			'a thread that loaded the table before the rebuild was triggered held isIndexing = false and served the partial index'
@@ -131,9 +139,9 @@ describe('an index being rebuilt is incomplete on every thread (harper#2537)', f
 			`a read of a rebuilding index must refuse, not return ${during.hits} rows for a record that exists`
 		);
 
-		assert.equal(after.isIndexing, false, 'the reload after completion must clear isIndexing');
-		assert.equal(after.searchError, null, 'the completed index must serve reads');
-		assert.equal(after.hits, 1, 'the completed index must return the seeded record');
+		assert.strictEqual(after.isIndexing, false, 'the reload after completion must clear isIndexing');
+		assert.strictEqual(after.searchError, null, 'the completed index must serve reads');
+		assert.strictEqual(after.hits, 1, 'the completed index must return the seeded record');
 	});
 
 	it('a handle the reader already holds is re-stamped, not left at its previous state', async () => {
@@ -157,10 +165,10 @@ describe('an index being rebuilt is incomplete on every thread (harper#2537)', f
 			})
 		);
 
-		assert.equal(before.isIndexing, false, 'the completed index must be usable before the rebuild');
-		assert.equal(before.hits, 1, 'the completed index must return the seeded record before the rebuild');
+		assert.strictEqual(before.isIndexing, false, 'the completed index must be usable before the rebuild');
+		assert.strictEqual(before.hits, 1, 'the completed index must return the seeded record before the rebuild');
 
-		assert.equal(
+		assert.strictEqual(
 			during.isIndexing,
 			true,
 			'a handle already open on the reader thread must be re-stamped as rebuilding'
@@ -171,7 +179,11 @@ describe('an index being rebuilt is incomplete on every thread (harper#2537)', f
 			'a reused handle must also refuse reads while rebuilding'
 		);
 
-		assert.equal(after.isIndexing, false, 'the reload after completion must clear isIndexing on the reused handle');
-		assert.equal(after.hits, 1, 'the rebuilt index must return the seeded record');
+		assert.strictEqual(
+			after.isIndexing,
+			false,
+			'the reload after completion must clear isIndexing on the reused handle'
+		);
+		assert.strictEqual(after.hits, 1, 'the rebuilt index must return the seeded record');
 	});
 });

--- a/unitTests/resources/indexRebuildThreadConsistency.test.js
+++ b/unitTests/resources/indexRebuildThreadConsistency.test.js
@@ -12,7 +12,8 @@ const assert = require('node:assert');
 const { Worker } = require('node:worker_threads');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
-const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const manageThreads = require('#js/server/threads/manageThreads');
+const { setMainIsWorker } = manageThreads;
 
 const WAIT_MS = 30000;
 const PROBE_ID = 'seed-3';
@@ -35,7 +36,18 @@ describe('an index being rebuilt is incomplete on every thread (harper#2537)', f
 		const phase = new Int32Array(new SharedArrayBuffer(4));
 		const ack = new Int32Array(new SharedArrayBuffer(4));
 		const worker = new Worker(__dirname + '/indexRebuildThreadConsistency-thread.js', {
-			workerData: { phase, ack, tableName, attributeName, probeValue: PROBE_VALUE, probeId: PROBE_ID, addPorts: [] },
+			workerData: {
+				phase,
+				ack,
+				tableName,
+				attributeName,
+				probeValue: PROBE_VALUE,
+				probeId: PROBE_ID,
+				addPorts: [],
+				// startWorker sends this key with every worker it spawns; the reader must adopt it, not mint
+				// its own, or two live threads would disagree about which builds this process owns
+				processIncarnation: manageThreads.processIncarnation,
+			},
 		});
 		const probes = {};
 		const failure = new Promise((_, reject) => worker.once('error', reject));
@@ -119,6 +131,11 @@ describe('an index being rebuilt is incomplete on every thread (harper#2537)', f
 		);
 
 		assert.ok(before.loaded, 'the reader thread must have loaded the table before the rebuild');
+		assert.strictEqual(
+			before.processIncarnation,
+			manageThreads.processIncarnation,
+			'a worker must adopt the incarnation it was started with, so live threads agree on build ownership'
+		);
 		assert.strictEqual(before.isIndexing, null, 'there is no index on the attribute before the rebuild');
 
 		assert.ok(

--- a/unitTests/resources/indexRebuildThreadConsistency.test.js
+++ b/unitTests/resources/indexRebuildThreadConsistency.test.js
@@ -1,0 +1,177 @@
+/**
+ * harper#2537. `isIndexing` is a per-thread cache of one persisted fact — the attribute descriptor's
+ * `indexingPID`. Only the schema *declare* path (table()) used to write that cache, so a thread that
+ * reaches Table.indices through the schema *load* path (resetDatabases -> initStores) — the main and
+ * operations threads — held `isIndexing === false` for a rebuilding index and served it, returning 200
+ * with rows missing while a primary-key read of the same record returned it.
+ *
+ * The backfill is held by blocking the declaring thread's event loop in `Atomics.wait`: runIndexing is
+ * async and suspends at its first await, so at that point the index is empty and the divergence is
+ * observable with a handful of rows instead of a timing window.
+ */
+
+require('../testUtils');
+const assert = require('node:assert/strict');
+const { Worker } = require('node:worker_threads');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+const WAIT_MS = 30000;
+const PROBE_ID = 'seed-3';
+const PROBE_VALUE = '/p/3';
+
+describe('an index being rebuilt is incomplete on every thread (harper#2537)', function () {
+	this.timeout(60000);
+
+	before(() => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+	});
+
+	/**
+	 * Runs the three-step probe on a second thread: before the rebuild is triggered, while it is held,
+	 * and after it has completed. `trigger` runs on this thread between the first and second probe and
+	 * must return without awaiting the backfill.
+	 */
+	async function withReader(tableName, attributeName, trigger) {
+		const phase = new Int32Array(new SharedArrayBuffer(4));
+		const ack = new Int32Array(new SharedArrayBuffer(4));
+		const worker = new Worker(__dirname + '/indexRebuildThreadConsistency-thread.js', {
+			workerData: { phase, ack, tableName, attributeName, probeValue: PROBE_VALUE, probeId: PROBE_ID, addPorts: [] },
+		});
+		const probes = {};
+		const failure = new Promise((_, reject) => worker.once('error', reject));
+		worker.on('message', (message) => (probes[message.step] = message));
+		const probed = (step) =>
+			Promise.race([
+				failure,
+				new Promise((resolve) => {
+					if (probes[step]) return resolve(probes[step]);
+					worker.on('message', function onMessage(message) {
+						if (message.step !== step) return;
+						worker.off('message', onMessage);
+						resolve(message);
+					});
+				}),
+			]);
+		// every exit from here must terminate the worker, or it stays blocked in Atomics.wait
+		try {
+			const release = (step) => {
+				Atomics.store(phase, 0, step);
+				Atomics.notify(phase, 0);
+				return Atomics.wait(ack, 0, step - 1, WAIT_MS);
+			};
+
+			assert.equal(release(1), 'ok', 'the reader thread never finished its pre-rebuild load');
+			const before = await probed(1);
+
+			const Table = trigger();
+			assert.ok(Table.indexingOperation, 'the rebuild was not triggered, so nothing is held');
+			// Blocking here keeps the backfill suspended at runIndexing's first await, so the reader
+			// observes an armed descriptor over an index with nothing written to it yet.
+			assert.equal(release(2), 'ok', 'the reader thread never finished its mid-rebuild load');
+			const during = await probed(2);
+
+			await Table.indexingOperation;
+			assert.equal(release(3), 'ok', 'the reader thread never finished its post-rebuild load');
+			const after = await probed(3);
+
+			for (const probe of [before, during, after])
+				assert.equal(probe.failure, undefined, `reader thread failed at step ${probe.step}: ${probe.failure}`);
+			return { before, during, after };
+		} finally {
+			await worker.terminate();
+		}
+	}
+
+	function seed(tableName, attributes) {
+		const Table = table({ table: tableName, database: 'test', schemaDefined: true, attributes });
+		let lastPut;
+		for (let i = 0; i < 8; i++) lastPut = Table.put({ id: `seed-${i}`, path: `/p/${i}` });
+		return { Table, lastPut };
+	}
+
+	it('a thread that opened the table before the rebuild must not serve the partial index', async () => {
+		const tableName = 'IndexThreadNewHandle';
+		const { Table, lastPut } = seed(tableName, [
+			{ name: 'id', type: 'ID', isPrimaryKey: true },
+			{ name: 'path', type: 'String' },
+		]);
+		await lastPut;
+		if (Table.indexingOperation) await Table.indexingOperation;
+
+		const { before, during, after } = await withReader(tableName, 'path', () =>
+			table({
+				table: tableName,
+				database: 'test',
+				schemaDefined: true,
+				attributes: [
+					{ name: 'id', type: 'ID', isPrimaryKey: true },
+					{ name: 'path', type: 'String', indexed: true },
+				],
+			})
+		);
+
+		assert.ok(before.loaded, 'the reader thread must have loaded the table before the rebuild');
+		assert.equal(before.isIndexing, null, 'there is no index on the attribute before the rebuild');
+
+		assert.ok(
+			during.foundById,
+			'the probe record must be readable by primary key while the rebuild is held, or the test proves nothing'
+		);
+		assert.equal(
+			during.isIndexing,
+			true,
+			'a thread that loaded the table before the rebuild was triggered held isIndexing = false and served the partial index'
+		);
+		assert.match(
+			during.searchError ?? '',
+			/not indexed yet/,
+			`a read of a rebuilding index must refuse, not return ${during.hits} rows for a record that exists`
+		);
+
+		assert.equal(after.isIndexing, false, 'the reload after completion must clear isIndexing');
+		assert.equal(after.searchError, null, 'the completed index must serve reads');
+		assert.equal(after.hits, 1, 'the completed index must return the seeded record');
+	});
+
+	it('a handle the reader already holds is re-stamped, not left at its previous state', async () => {
+		const tableName = 'IndexThreadReusedHandle';
+		const indexedAttributes = (indexed) => [
+			{ name: 'id', type: 'ID', isPrimaryKey: true },
+			{ name: 'path', type: 'String', indexed },
+		];
+		const { Table, lastPut } = seed(tableName, indexedAttributes(true));
+		await lastPut;
+		if (Table.indexingOperation) await Table.indexingOperation;
+
+		// A structural index-option change re-triggers the backfill over an attribute the reader thread
+		// already holds an open index handle for, so its handle is reused by the reload rather than opened.
+		const { before, during, after } = await withReader(tableName, 'path', () =>
+			table({
+				table: tableName,
+				database: 'test',
+				schemaDefined: true,
+				attributes: indexedAttributes({ indexNulls: false }),
+			})
+		);
+
+		assert.equal(before.isIndexing, false, 'the completed index must be usable before the rebuild');
+		assert.equal(before.hits, 1, 'the completed index must return the seeded record before the rebuild');
+
+		assert.equal(
+			during.isIndexing,
+			true,
+			'a handle already open on the reader thread must be re-stamped as rebuilding'
+		);
+		assert.match(
+			during.searchError ?? '',
+			/not indexed yet/,
+			'a reused handle must also refuse reads while rebuilding'
+		);
+
+		assert.equal(after.isIndexing, false, 'the reload after completion must clear isIndexing on the reused handle');
+		assert.equal(after.hits, 1, 'the rebuilt index must return the seeded record');
+	});
+});

--- a/unitTests/resources/indexRebuildThreadConsistency.test.js
+++ b/unitTests/resources/indexRebuildThreadConsistency.test.js
@@ -1,13 +1,10 @@
 /**
- * harper#2537. `isIndexing` is a per-thread cache of one persisted fact — the attribute descriptor's
- * `indexingPID`. Only the schema *declare* path (table()) used to write that cache, so a thread that
- * reaches Table.indices through the schema *load* path (resetDatabases -> initStores) — the main and
- * operations threads — held `isIndexing === false` for a rebuilding index and served it, returning 200
- * with rows missing while a primary-key read of the same record returned it.
+ * harper#2537: a thread that reaches Table.indices through the schema load path (resetDatabases ->
+ * initStores) rather than by declaring the schema held `isIndexing === false` for a rebuilding index
+ * and served it — 200 with rows missing, while a primary-key read returned the same record.
  *
- * The backfill is held by blocking the declaring thread's event loop in `Atomics.wait`: runIndexing is
- * async and suspends at its first await, so at that point the index is empty and the divergence is
- * observable with a handful of rows instead of a timing window.
+ * The backfill is held by blocking the declaring thread's event loop in `Atomics.wait`: runIndexing
+ * suspends at its first await, so the index is empty there and no timing window is needed.
  */
 
 require('../testUtils');

--- a/unitTests/resources/indexRestartNumber.test.js
+++ b/unitTests/resources/indexRestartNumber.test.js
@@ -272,12 +272,9 @@ describe('indexing crash-recovery: restartNumber re-trigger (#1359)', () => {
 			'a store closed by shutdown must be handled as a benign interruption, not a rejection'
 		);
 
-		// harper#1359 left this early return writing nothing at all, on the grounds that recovery came
-		// from the restartNumber/PID trigger. harper#2536 showed that trigger is unreachable after a
-		// process restart under PID 1, so the marker is what makes the incomplete build recoverable, and
-		// the settle handler in declareTable persists it. The loud failure #1359 removed does not come
-		// back: runIndexing still writes nothing here, and the settle handler logs a failed write at
-		// debug (in a real shutdown the catalog store is closed too, so it simply cannot write).
+		// harper#1359 left this return writing nothing, because recovery came from the restartNumber/PID
+		// trigger; harper#2536 showed that trigger cannot fire after a process restart under PID 1, so
+		// declareTable's settle handler persists the marker instead. runIndexing still writes nothing here.
 		const desc = findDescriptor(Tbl, 'tag');
 		assert.ok(desc, 'tag descriptor should exist after a shutdown-interrupted backfill');
 		assert.equal(

--- a/unitTests/resources/indexRestartNumber.test.js
+++ b/unitTests/resources/indexRestartNumber.test.js
@@ -211,7 +211,7 @@ describe('indexing crash-recovery: restartNumber re-trigger (#1359)', () => {
 		assert.equal(total, N, 'all rows should be indexed after the restartNumber-triggered re-run');
 	});
 
-	it('treats a store closed by worker shutdown as a benign interruption (resolves, no indexingFailed)', async () => {
+	it('treats a store closed by worker shutdown as a benign interruption, and still marks the build (harper#2537)', async () => {
 		const TABLE = 'RN_ShutdownInterrupt';
 		setupTestDBPath();
 		setMainIsWorker(true);
@@ -272,17 +272,19 @@ describe('indexing crash-recovery: restartNumber re-trigger (#1359)', () => {
 			'a store closed by shutdown must be handled as a benign interruption, not a rejection'
 		);
 
-		// The early-return is a pure no-op on persisted state: it must NOT mark the index
-		// indexingFailed (the old path tried to persist that against the closed store, which
-		// both failed loudly and was unnecessary — recovery comes from the restartNumber/PID
-		// trigger, covered by the tests above). Recovery markers, if the trigger set them, are
-		// left untouched because the fix writes nothing.
+		// harper#1359 left this early return writing nothing at all, on the grounds that recovery came
+		// from the restartNumber/PID trigger. harper#2536 showed that trigger is unreachable after a
+		// process restart under PID 1, so the marker is what makes the incomplete build recoverable, and
+		// the settle handler in declareTable persists it. The loud failure #1359 removed does not come
+		// back: runIndexing still writes nothing here, and the settle handler logs a failed write at
+		// debug (in a real shutdown the catalog store is closed too, so it simply cannot write).
 		const desc = findDescriptor(Tbl, 'tag');
 		assert.ok(desc, 'tag descriptor should exist after a shutdown-interrupted backfill');
-		assert.notEqual(
+		assert.equal(
 			desc.value.indexingFailed,
 			true,
-			'a shutdown-interrupted backfill must NOT be marked indexingFailed'
+			'a backfill that returned without completing must be marked, or nothing re-triggers it under PID 1'
 		);
+		assert.ok(desc.value.indexingPID, 'the build must still read as incomplete so queries keep refusing');
 	});
 });

--- a/unitTests/resources/searchPlannerRebuildingIndex.test.js
+++ b/unitTests/resources/searchPlannerRebuildingIndex.test.js
@@ -16,6 +16,7 @@ describe('the query planner treats a rebuilding index as unavailable (harper#253
 	this.timeout(60000);
 
 	let Table;
+	let Parent;
 
 	before(async () => {
 		setupTestDBPath();
@@ -35,6 +36,29 @@ describe('the query planner treats a rebuilding index as unavailable (harper#253
 			lastPut = Table.put({ id: `k-${i}`, rare: i === 7 ? 'needle' : `r-${i}`, common: i < 10 ? 'left' : 'right' });
 		await lastPut;
 		if (Table.indexingOperation) await Table.indexingOperation;
+
+		Parent = table({
+			table: 'PlannerRebuildingParent',
+			database: 'test',
+			schemaDefined: true,
+			schemaRelationshipsDefined: true,
+			attributes: [
+				{ name: 'id', type: 'ID', isPrimaryKey: true },
+				{ name: 'status', type: 'String', indexed: true },
+				{ name: 'childId', type: 'ID', indexed: true },
+				{
+					name: 'child',
+					type: 'PlannerRebuildingIndex',
+					relationship: { from: 'childId' },
+					relationshipReference: { database: 'test', table: 'PlannerRebuildingIndex' },
+					definition: { tableClass: Table },
+				},
+			],
+		});
+		for (let i = 0; i < 20; i++)
+			lastPut = Parent.put({ id: `p-${i}`, status: i < 10 ? 'open' : 'closed', childId: `k-${i}` });
+		await lastPut;
+		if (Parent.indexingOperation) await Parent.indexingOperation;
 	});
 
 	/** Stand in for a build in flight without holding one open for the length of the suite. */
@@ -102,5 +126,42 @@ describe('the query planner treats a rebuilding index as unavailable (harper#253
 				'a search that can only be driven by the rebuilding index must refuse rather than return partial results'
 			);
 		});
+	});
+
+	it('follows a relationship path for every comparator, not only equality', async () => {
+		const estimates = await whileRebuilding('rare', () => {
+			const estimate = estimateCondition(Parent);
+			return {
+				equals: estimate({ attribute: ['child', 'rare'], value: 'needle' }),
+				between: estimate({ attribute: ['child', 'rare'], comparator: 'between', value: ['r-0', 'r-9'] }),
+				starts_with: estimate({ attribute: ['child', 'rare'], comparator: 'starts_with', value: 'r-' }),
+			};
+		});
+		for (const [comparator, estimate] of Object.entries(estimates))
+			assert.strictEqual(
+				estimate,
+				Infinity,
+				`a relationship "${comparator}" whose leaf index is rebuilding must not rank as usable (got ${estimate})`
+			);
+	});
+
+	it('treats a rebuilding local join index as unusable too', () => {
+		Parent.indices.childId.isIndexing = true;
+		try {
+			assert.strictEqual(
+				estimateCondition(Parent)({ attribute: ['child', 'rare'], comparator: 'between', value: ['r-0', 'r-9'] }),
+				Infinity,
+				'the join is driven by the local from-index, so a rebuild of it must rank the condition as unusable'
+			);
+		} finally {
+			Parent.indices.childId.isIndexing = false;
+		}
+	});
+
+	it('still estimates a relationship finitely when every index it needs is complete', () => {
+		assert.ok(
+			estimateCondition(Parent)({ attribute: ['child', 'rare'], value: 'needle' }) < Infinity,
+			'a complete relationship path must still produce a finite estimate'
+		);
 	});
 });

--- a/unitTests/resources/searchPlannerRebuildingIndex.test.js
+++ b/unitTests/resources/searchPlannerRebuildingIndex.test.js
@@ -6,7 +6,7 @@
  */
 
 require('../testUtils');
-const assert = require('node:assert/strict');
+const assert = require('node:assert');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { estimateCondition } = require('#src/resources/search');
@@ -59,7 +59,7 @@ describe('the query planner treats a rebuilding index as unavailable (harper#253
 			};
 		});
 		for (const [comparator, estimate] of Object.entries(estimates))
-			assert.equal(
+			assert.strictEqual(
 				estimate,
 				Infinity,
 				`a "${comparator}" condition on a rebuilding index must not rank as usable (got ${estimate})`
@@ -87,7 +87,7 @@ describe('the query planner treats a rebuilding index as unavailable (harper#253
 				found.push(record);
 			return found;
 		});
-		assert.deepEqual(
+		assert.deepStrictEqual(
 			rows.map((row) => row.id),
 			['k-7'],
 			'the sibling index must lead so the rebuilding attribute is applied as a record filter'

--- a/unitTests/resources/searchPlannerRebuildingIndex.test.js
+++ b/unitTests/resources/searchPlannerRebuildingIndex.test.js
@@ -1,0 +1,106 @@
+/**
+ * harper#2537. `searchByIndex` refuses a rebuilding index with IndexRebuildingError, but the planner
+ * used to rank its condition by the partially-built index's cardinality, so the narrowest-first
+ * ordering could hand the lead to a condition the executor was about to refuse — a 503 for a query a
+ * sibling index could have answered completely. The planner has to see a rebuilding index as absent.
+ */
+
+require('../testUtils');
+const assert = require('node:assert/strict');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { estimateCondition } = require('#src/resources/search');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+describe('the query planner treats a rebuilding index as unavailable (harper#2537)', function () {
+	this.timeout(60000);
+
+	let Table;
+
+	before(async () => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		Table = table({
+			table: 'PlannerRebuildingIndex',
+			database: 'test',
+			schemaDefined: true,
+			attributes: [
+				{ name: 'id', type: 'ID', isPrimaryKey: true },
+				{ name: 'rare', type: 'String', indexed: true },
+				{ name: 'common', type: 'String', indexed: true },
+			],
+		});
+		let lastPut;
+		for (let i = 0; i < 20; i++)
+			lastPut = Table.put({ id: `k-${i}`, rare: i === 7 ? 'needle' : `r-${i}`, common: i < 10 ? 'left' : 'right' });
+		await lastPut;
+		if (Table.indexingOperation) await Table.indexingOperation;
+	});
+
+	/** Stand in for a build in flight without holding one open for the length of the suite. */
+	async function whileRebuilding(attribute, body) {
+		Table.indices[attribute].isIndexing = true;
+		try {
+			return await body();
+		} finally {
+			Table.indices[attribute].isIndexing = false;
+		}
+	}
+
+	it('estimates a rebuilding index at Infinity for every comparator that would otherwise use it', async () => {
+		const estimates = await whileRebuilding('rare', () => {
+			const estimate = estimateCondition(Table);
+			return {
+				equals: estimate({ attribute: 'rare', value: 'needle' }),
+				range: estimate({ attribute: 'rare', comparator: 'starts_with', value: 'r-' }),
+				between: estimate({ attribute: 'rare', comparator: 'between', value: ['r-0', 'r-9'] }),
+				in: estimate({ attribute: 'rare', comparator: 'in', value: ['needle', 'r-1'] }),
+				sort: estimate({ attribute: 'rare', comparator: 'sort' }),
+			};
+		});
+		for (const [comparator, estimate] of Object.entries(estimates))
+			assert.equal(
+				estimate,
+				Infinity,
+				`a "${comparator}" condition on a rebuilding index must not rank as usable (got ${estimate})`
+			);
+	});
+
+	it('still estimates a complete index by its cardinality', () => {
+		const estimate = estimateCondition(Table);
+		assert.ok(
+			estimate({ attribute: 'rare', value: 'needle' }) < Infinity,
+			'a complete index must still produce a finite estimate'
+		);
+	});
+
+	it('leads with the available index and answers the query completely', async () => {
+		const rows = await whileRebuilding('rare', async () => {
+			const found = [];
+			for await (const record of Table.search({
+				allowFullScan: false,
+				conditions: [
+					{ attribute: 'rare', value: 'needle' },
+					{ attribute: 'common', value: 'left' },
+				],
+			}))
+				found.push(record);
+			return found;
+		});
+		assert.deepEqual(
+			rows.map((row) => row.id),
+			['k-7'],
+			'the sibling index must lead so the rebuilding attribute is applied as a record filter'
+		);
+	});
+
+	it('still refuses a query whose only condition is on the rebuilding index', async () => {
+		await whileRebuilding('rare', () => {
+			assert.throws(
+				() => Table.search({ allowFullScan: false, conditions: [{ attribute: 'rare', value: 'needle' }] }),
+				/not indexed yet/,
+				'a search that can only be driven by the rebuilding index must refuse rather than return partial results'
+			);
+		});
+	});
+});

--- a/unitTests/resources/sortAlignedCondition.test.js
+++ b/unitTests/resources/sortAlignedCondition.test.js
@@ -8,7 +8,7 @@
  */
 
 require('../testUtils');
-const assert = require('node:assert/strict');
+const assert = require('node:assert');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
@@ -46,7 +46,7 @@ describe('a sort does not drop a condition on the sorted attribute', function ()
 
 	it('applies a condition on the sort attribute even when another condition leads', async () => {
 		// `rare` matches one row and leads; `common` carries both the sort and a condition that excludes it
-		assert.deepEqual(
+		assert.deepStrictEqual(
 			await ids({
 				conditions: [
 					{ attribute: 'rare', value: 'needle' },
@@ -57,7 +57,7 @@ describe('a sort does not drop a condition on the sorted attribute', function ()
 			[],
 			'the only row matching "rare" has common=left, so a common=right condition must exclude it'
 		);
-		assert.deepEqual(
+		assert.deepStrictEqual(
 			await ids({
 				conditions: [
 					{ attribute: 'rare', value: 'needle' },
@@ -80,6 +80,6 @@ describe('a sort does not drop a condition on the sorted attribute', function ()
 		});
 		assert.ok(ordered.length > 1, 'the fixture must return several rows for the ordering to be observable');
 		const sorted = [...ordered].sort().reverse();
-		assert.deepEqual(ordered, sorted, 'the results must still be ordered by the sort attribute, descending');
+		assert.deepStrictEqual(ordered, sorted, 'the results must still be ordered by the sort attribute, descending');
 	});
 });

--- a/unitTests/resources/sortAlignedCondition.test.js
+++ b/unitTests/resources/sortAlignedCondition.test.js
@@ -1,0 +1,85 @@
+/**
+ * A sort on an attribute that also carries a caller's condition used to drop that condition whenever
+ * the planner did not give it the lead: `orderConditions` reorders narrowest-first, and the branch that
+ * un-does the sort alignment spliced whatever `orderAlignedCondition` pointed at — the caller's
+ * condition, not just the pseudo-condition the planner had added. The query then returned rows the
+ * condition excludes. Reached far more often now that a rebuilding index's condition is ranked last
+ * (harper#2537), which is how it surfaced.
+ */
+
+require('../testUtils');
+const assert = require('node:assert/strict');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+describe('a sort does not drop a condition on the sorted attribute', function () {
+	this.timeout(60000);
+
+	let Table;
+
+	before(async () => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		Table = table({
+			table: 'SortAlignedCondition',
+			database: 'test',
+			schemaDefined: true,
+			attributes: [
+				{ name: 'id', type: 'ID', isPrimaryKey: true },
+				{ name: 'rare', type: 'String', indexed: true },
+				{ name: 'common', type: 'String', indexed: true },
+			],
+		});
+		let lastPut;
+		for (let i = 0; i < 20; i++)
+			lastPut = Table.put({ id: `k-${i}`, rare: i === 7 ? 'needle' : `r-${i}`, common: i < 10 ? 'left' : 'right' });
+		await lastPut;
+		if (Table.indexingOperation) await Table.indexingOperation;
+	});
+
+	async function ids(request) {
+		const found = [];
+		for await (const record of Table.search(request)) found.push(record.id);
+		return found;
+	}
+
+	it('applies a condition on the sort attribute even when another condition leads', async () => {
+		// `rare` matches one row and leads; `common` carries both the sort and a condition that excludes it
+		assert.deepEqual(
+			await ids({
+				conditions: [
+					{ attribute: 'rare', value: 'needle' },
+					{ attribute: 'common', value: 'right' },
+				],
+				sort: { attribute: 'common' },
+			}),
+			[],
+			'the only row matching "rare" has common=left, so a common=right condition must exclude it'
+		);
+		assert.deepEqual(
+			await ids({
+				conditions: [
+					{ attribute: 'rare', value: 'needle' },
+					{ attribute: 'common', value: 'left' },
+				],
+				sort: { attribute: 'common' },
+			}),
+			['k-7'],
+			'a matching condition on the sort attribute must still return the row'
+		);
+	});
+
+	it('still orders by the sort attribute when its condition does not lead', async () => {
+		const ordered = await ids({
+			conditions: [
+				{ attribute: 'common', value: 'right' },
+				{ attribute: 'rare', comparator: 'greater_than', value: 'r-1' },
+			],
+			sort: { attribute: 'rare', descending: true },
+		});
+		assert.ok(ordered.length > 1, 'the fixture must return several rows for the ordering to be observable');
+		const sorted = [...ordered].sort().reverse();
+		assert.deepEqual(ordered, sorted, 'the results must still be ordered by the sort attribute, descending');
+	});
+});


### PR DESCRIPTION
On a live 15-node 5.2.7 cluster, the same table and attribute at the same instant answered a
`search_by_value` with `[]` and a 200 on one thread while a `search_by_hash` for that record returned
it, and threw `IndexRebuildingError` (503) on another. Sampling both reachable inspector threads on
every node gave a uniform split: main and operations threads `isIndexing === false`, worker threads
`true`. That is a thread-role difference, not a race.

`isIndexing` is a per-thread cache of one persisted fact — the attribute descriptor's `indexingPID` —
and only the schema *declare* path wrote it. `table()` stamps it in three places; `initStores()`, the
schema *load* path that every thread runs on boot and on every `resetDatabases()`, read the same
descriptor and never stamped, and for an already-loaded table did not touch the handle at all. A
thread that never declares a schema reaches `Table.indices` only through that path, so it held a
stale `false` and served a partially built index.

## Changes

**The load path assigns readiness from the catalog.** `initStores` now
[assigns `isIndexing` from the descriptor it already read](../pull/2543/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1224),
for handles it opens and handles it reuses. Assignment, not a one-way set: the same reload is what
clears the flag when `runIndexing` finishes and signals. No new read is added — the descriptor is
already in hand, so there is no query-path cost.

**Planner and executor agree on which indexes are usable.** `searchByIndex` refuses a rebuilding
index, but the planner ranked its condition by the partial index's cardinality and could hand it the
lead. `estimateCondition` now
[assigns `Infinity` before comparator dispatch](../pull/2543/changes?w=1#diff-e321acd3b1cfdafa43c8a2aec7d9b2d318880adfe8510b34571460057cc4f003R1302)
— several per-comparator branches otherwise fall back to a finite table-fraction heuristic that can
still beat an available index, so returning `undefined` into those fallbacks would not have been
enough. The condition's driving index is resolved by
[`drivesRebuildingIndex`](../pull/2543/changes?w=1#diff-e321acd3b1cfdafa43c8a2aec7d9b2d318880adfe8510b34571460057cc4f003R1258),
which walks a relationship path comparator-independently: only the equality branch resolves a
relationship, so `child.name between [...]` would otherwise reach the range heuristic and outrank an
available sibling, and both the local `relationship.from` index and the related table's leaf index
have to be checked. Every per-comparator branch resolves its handle through
[`usableIndex`](../pull/2543/changes?w=1#diff-e321acd3b1cfdafa43c8a2aec7d9b2d318880adfe8510b34571460057cc4f003R1249),
and the adaptive filter's
[lazy switch to indexed retrieval](../pull/2543/changes?w=1#diff-e321acd3b1cfdafa43c8a2aec7d9b2d318880adfe8510b34571460057cc4f003R1106)
uses the same rule so it cannot call `searchByIndex` mid-scan on an index that will refuse. A query
combining a rebuilding attribute with an indexed sibling now leads with the sibling and applies the
rebuilding one as a record filter: a complete answer instead of a 503.

**An abandoned build leaves a durable marker.** `runIndexing` has two returns that write nothing —
the restart-interrupt return in its loop and the closed-store return in its catch — leaving a
descriptor claiming an armed build with no `indexingFailed`, nothing logged above `debug`, and
nothing to re-trigger it. The operation's
[settle handler](../pull/2543/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3025)
persists that marker. `runIndexing` is unchanged (harper#2536 owns its resume and yield logic).

**A build no live operation owns is detected rather than trusted.** The existing trigger fires on
`indexingPID !== process.pid` or an older restart generation, and harper#2536 showed neither can fire
after a process restart under PID 1: the PID check is a tautology in a container and the generation
resets to 1 in memory while the persisted one is higher. `manageThreads` now
[mints a process incarnation once and carries it to workers](../pull/2543/changes?w=1#diff-02c28577c2ca63129ed10809ce3db1469c70bef080e04fd273f8cbd510b6521bR180)
through `workerData`, beside `restartNumber` and `ticketKeys` — minted centrally, because a value
each thread derived for itself would disagree between live siblings and one worker would treat
another's live backfill as abandoned.
[`isAbandonedIndexBuild`](../pull/2543/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R458)
centralizes all three predicates and treats a descriptor whose incarnation is not this process's —
including one that has none, which only a binary predating the field could have written, so an
already-stuck node self-heals on upgrade — as abandoned. A thread started without an incarnation of
its own falls back to the PID and generation checks rather than declaring a live build dead.

**The marker is fenced to the exact build it scheduled.** A replacement worker generation can claim
the attribute under the catalog lock before an outgoing build's promise settles, and PID +
generation + incarnation cannot tell two builds of the same generation apart. Every trigger stamps
[`indexingBuildId`](../pull/2543/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R2921),
and
[`markAbandonedIndexBuild`](../pull/2543/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3167)
re-reads and writes under the same exclusive catalog lock the declaration takes, so a claim cannot
land between its check and its write. The three new descriptor fields are additive and optional —
descriptors written by older versions still load — carried through the
[metadata-only branch](../pull/2543/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R2958)
like `restartNumber` and cleared on clean completion. None is in `PEER_REDEFINABLE_FIELDS`, so none
is ever replicated from a peer.

**A sort no longer drops a caller's condition** (second commit).
[`resources/Table.ts`](../pull/2543/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R4141)
aligned a sort to a condition's index scan and, when narrowest-first ordering gave the lead to a
different condition, spliced out whatever `orderAlignedCondition` pointed at — the caller's own
condition whenever one existed, not only the pseudo-condition the planner had added. It was then
neither the lead nor a filter, and the query returned rows it excludes. Only the pseudo-condition is
removed now, which is what the surrounding comment already described. Pre-existing, but ranking a
rebuilding index last makes a sort-aligned caller condition lose the lead far more often, so without
it this PR would have turned a 503 into a silently over-broad result set.

## For the human reviewer

**A step-6 framing verdict was resolved, not cleared.** The planning review returned
`Framing-Verdict: better-alternative-exists`. I adopted its central objection: my design derived the
process identity per thread from `Date.now() - process.uptime() * 1000`, which samples two clocks
independently, so two live workers could round to different values and one would start a second
backfill over the other's. The identity is now minted once and transported, mirroring
`restartNumber`. Four of its other points were adopted (fencing the settle handler, keeping it from
rejecting unobserved, assigning `Infinity` before comparator dispatch instead of returning
`undefined` into a finite fallback, and a real two-thread regression test rather than one that
simulates the second thread by forcing the flag).

**The remaining half of that verdict is a gap I did not close, deliberately.** The reviewer asked for
a build-start barrier: do not begin destructive indexing until every thread has confirmed it reloaded
the armed descriptor. The schema broadcast is best-effort — `manageThreads` resolves it after 30s
with no acknowledgements, and `syncSchemaMetadata` catches and swallows its own errors before the ITC
event is acked (`server/itc/serverHandlers.js:77-85`) — so a thread whose refresh threw keeps a stale
`false` handle while the builder rebuilds. **This PR's guarantee is therefore narrowed to threads
whose catalog refresh succeeds.** That hole is pre-existing and unchanged by this change; closing it
needs a policy for a thread that never acknowledges (block the backfill indefinitely, or proceed
anyway), which is its own design question and not a tight v5.2 backport. Filed as a follow-up.

**An existing test's assertion was inverted.** `indexRestartNumber.test.js` asserted that a
shutdown-interrupted backfill must *not* be marked `indexingFailed`, on harper#1359's stated premise
that "recovery comes from the restartNumber/PID trigger". harper#2536 is the demonstration that this
trigger cannot fire after a process restart under PID 1, so the premise no longer holds and the test
now asserts the marker. The loud failure #1359 removed does not return: `runIndexing` still writes
nothing on that path, and the settle handler logs a failed write at `debug` — in a real shutdown the
catalog store is closed too, so it simply cannot write.

**A rebuilding index still 503s when nothing else can drive the query**, by design: a single
condition on it, an `or`, or an `and` whose only sibling is unindexed all still refuse. `Infinity` is
the existing "treat as absent" convention (`contains`, `ends_with`, negated conditions), and ranking
a rebuilding index *below* an unindexed attribute would need a new tier — turning an honest 503 into
a full table scan, which is not obviously the better answer.

**Three review findings I resolved rather than implemented as asked.** Gemini raised three
high-severity findings across rounds 2 and 3 that do not hold against source and the adjudicator
dropped: `randomBytes` is imported at `server/threads/manageThreads.js:20`, `rootStore` is bound at
`resources/databases.ts:2422` inside `declareTable` (and `npm run typecheck` passes), and
`attribute.key` is set by `Object.defineProperty` at `resources/databases.ts:2723` and already used
by `runIndexing`'s own checkpoint writes. Noting them so a later reviewer does not re-derive them.

**A flake worth knowing about, not caused by this change.**
`longLivedTransactions.test.js` › "names a chain link reachable only through the root under its own
native id" failed twice on this box under full-suite load (asserts `state: active`, observes
`state: source-apply`), passed 50/50 when the file was run alone, and did not recur on the final
full run. It is in transaction reporting, which this PR does not touch.

## Verification

- `npm run test:unit:resources` — 2267 passing, 0 failing on the head of this branch.
- `npm run test:unit:main` — 5462 passing, 1 failing (`configValidator` › domain-socket path-length
  warning, which depends on the length of the checkout path and fails the same way on `main` in this
  worktree).
- `npm run test:integration:all` — 2080 tests, 2056 passing, `fail 0`; the only failing file is
  `integrationTests/server/ollama-backend.test.ts`, which needs a live Ollama instance and fails at
  import time in this environment (`ERR_IMPORT_ATTRIBUTE_MISSING` on `json/systemSchema.json`),
  cancelling its 6 children.
- `npm run typecheck`, `npm run lint` (0 errors), `prettier --check` clean.
- **Fails on base**: with `resources/databases.ts`, `resources/search.ts` and
  `server/threads/manageThreads.js` reverted to `origin/main` and `dist` rebuilt, 6 of the new
  assertions fail — the reader thread's `isIndexing` is never stamped for either a new or a reused
  handle, an `equals` condition on a rebuilding index estimates 1 instead of `Infinity`, the
  two-condition query raises `IndexRebuildingError`, no failure marker is persisted, and an armed
  descriptor with no incarnation is trusted.
- New coverage:
  [`indexRebuildThreadConsistency.test.js`](../pull/2543/changes?w=1#diff-5e1380645663678b7e7377fb1b1ab16bbcbd61559d535122624d385363447c28)
  with its
  [worker](../pull/2543/changes?w=1#diff-0cd6f875de7eede81cd04b9cf7f6686ad062a3016149f56b093e79a8956ba741)
  reproduces the reported divergence on a real second thread — it holds a handle from before the
  rebuild, the declaring thread blocks its event loop in `Atomics.wait` so the backfill stays
  suspended at `runIndexing`'s first await, and the reader must refuse rather than return a 200
  missing a record its primary-key read returns;
  [`indexBuildAbandonment.test.js`](../pull/2543/changes?w=1#diff-2742e93aafa45428dec83b236cf4a6802b94c813e81c51e0eddea799ea2d8639)
  covers the marker, a replacement claim interleaved between the handler's check and its write, both
  shapes of foreign incarnation, and a live build left alone;
  [`searchPlannerRebuildingIndex.test.js`](../pull/2543/changes?w=1#diff-3c89276d9c6db800c2df408aaa29bc29329c73c2c46567aa3a463eb982ac926c)
  and
  [`sortAlignedCondition.test.js`](../pull/2543/changes?w=1#diff-778a4b47acbd35f08108db83a64356e14b6343f1f9c7960beca4077f353773b9)
  cover the planner and the sort fix.
- Still uncovered: the one-line `processIncarnation` spread in `startWorker` itself (the fixture is
  spawned with a raw `Worker`, so it asserts the consume half — that a worker adopts the incarnation
  it was given rather than minting its own — but not that `startWorker` sends it).
- Not observable end-to-end here: an actual process restart under PID 1, ITC delivery of the schema
  event to the main thread (the fixture calls the same reload the handler calls), and the
  worker-startup transport of the incarnation. The 15-node reproduction in harper#2537 is the
  evidence for the thread-role split itself.

Refs #2537

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vjXRgXEmvF5JhHPqGHX9s

Complexity: complicated

<sub>Review-Coverage: authored=codex; ran=gemini,cursor-grok; blocked=claude(exit-1),domain(timeout); declined=cursor-composer; rounds=7 @ 9bd13e1e083a</sub>

<sub>Human-Review-Need: 4 @ 9bd13e1e083a</sub>
