### PR TITLE
test(database): pin the encoder write-path contract for NaN, ±Infinity and -0 (QA-432)

### DIFF
--- a/integrationTests/database/special-float-write-fidelity.test.ts
+++ b/integrationTests/database/special-float-write-fidelity.test.ts
@@ -1,0 +1,271 @@
+/**
+ * QA-432 — content-negotiation WRITE-path fidelity for IEEE-754 special floats.
+ *
+ * A JSON request body cannot represent NaN, ±Infinity or -0, so a JSON write bakes the
+ * JSON-spec coercions in before storage ever sees the value. CBOR and msgpack bodies CAN
+ * represent them, which makes the write path itself observable: PUT a binary body carrying
+ * the special values, then read the record back over all three surfaces (CBOR, msgpack,
+ * JSON). A binary read that recovers the exact value proves storage kept it and only the
+ * JSON serializer flattens it; a binary read that does not proves the value was lost at
+ * ingest, because no read format can resurrect what was never stored.
+ *
+ * The contract this pins (from QA-432):
+ *   - NaN / +Infinity / -Infinity survive a binary write and round-trip exactly on a binary read.
+ *   - A JSON read of those flattens to null, per the JSON spec — read-path, not storage.
+ *   - -0 loses its sign on the binary WRITE path: every read, binary included, returns +0.
+ *     Benign (-0 === 0 for nearly all consumers) but a real asymmetry, so it is pinned
+ *     explicitly rather than left to drift.
+ *   - No special value is ever silently replaced by a WRONG finite number, on any surface.
+ *
+ * Reproduction:
+ *   npm run test:integration -- "integrationTests/database/special-float-write-fidelity.test.ts"
+ */
+import { suite, test, before, after } from 'node:test';
+import { strictEqual, ok, deepStrictEqual } from 'node:assert';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import request from 'supertest';
+import { Encoder } from 'cbor-x';
+import { pack as msgpackPack, unpack as msgpackUnpack } from 'msgpackr';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from '../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'special-float-write-fidelity');
+const skipSuite = process.platform === 'win32';
+const TABLE = 'Doc';
+
+// useToJSON:false so the encoder emits the raw IEEE-754 special values instead of
+// going through a lossy toJSON() path; useRecords:false keeps the wire format simple.
+const cborCodec = new Encoder({ useRecords: false, useToJSON: false });
+
+type Client = ReturnType<typeof createApiClient>;
+
+const FIELDS = {
+	nan: NaN,
+	posInf: Infinity,
+	negInf: -Infinity,
+	negZero: -0,
+	normal: 3.14, // control — must always survive faithfully
+} as const;
+type FieldName = keyof typeof FIELDS;
+
+const READS = [
+	{ label: 'json', accept: 'application/json' },
+	{ label: 'cbor', accept: 'application/cbor' },
+	{ label: 'msgpack', accept: 'application/x-msgpack' },
+] as const;
+
+/** Same-value check that distinguishes NaN and -0 (unlike ===). */
+function sameValue(a: unknown, b: unknown): boolean {
+	return Object.is(a, b);
+}
+
+function fmt(v: unknown): string {
+	if (v === null) return 'null';
+	if (v === undefined) return 'undefined';
+	if (typeof v === 'number') {
+		if (Object.is(v, -0)) return '-0';
+		if (Number.isNaN(v)) return 'NaN';
+		if (!Number.isFinite(v)) return v > 0 ? '+Infinity' : '-Infinity';
+	}
+	return JSON.stringify(v);
+}
+
+interface Cell {
+	status: number;
+	value: unknown;
+}
+// matrix[writeFormat][field][readLabel] = Cell
+const matrix: Record<string, Record<string, Record<string, Cell>>> = {};
+
+function binaryParser(res: any, cb: (err: Error | null, body: Buffer) => void) {
+	const chunks: Buffer[] = [];
+	res.on('data', (c: Buffer) => chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c)));
+	res.on('end', () => cb(null, Buffer.concat(chunks)));
+	res.on('error', (e: Error) => cb(e, Buffer.alloc(0)));
+}
+
+suite(
+	'Content-negotiation write-path fidelity for special floats (QA-432)',
+	{ skip: skipSuite },
+	(ctx: ContextWithHarper) => {
+		let client: Client;
+		let restURL: string;
+		let authHeaders: Record<string, string>;
+
+		before(async () => {
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: {}, env: {} });
+			client = createApiClient(ctx.harper);
+			restURL = (client as any).restURL;
+			authHeaders = { Authorization: client.headers.Authorization, Connection: 'close' };
+
+			// Readiness poll (component pre-installed; do NOT restartHttpWorkers — races per QA-179 notes).
+			const deadline = Date.now() + 30_000;
+			while (Date.now() < deadline) {
+				try {
+					const probe = await client.reqRest(`/${TABLE}/`).timeout(3_000);
+					if (probe.status !== 404) break;
+				} catch {
+					/* not ready */
+				}
+				await sleep(250);
+			}
+		});
+
+		after(async () => {
+			await teardownHarper(ctx);
+			printMatrix();
+		});
+
+		function printMatrix() {
+			console.log('\n══ QA-432 WRITE-PATH FIDELITY MATRIX (per write-format record) ══');
+			for (const writeFormat of Object.keys(matrix)) {
+				console.log(`\n  write=${writeFormat}:`);
+				const fieldRows = matrix[writeFormat];
+				const pad = (s: string, n: number) => (s + ' '.repeat(n)).slice(0, n);
+				console.log('    ' + pad('field', 10) + pad('written', 12) + READS.map((r) => pad(r.label, 12)).join(''));
+				for (const field of Object.keys(fieldRows)) {
+					const written = FIELDS[field as FieldName];
+					const cells = READS.map((r) => {
+						const c = fieldRows[field][r.label];
+						if (!c) return pad('n/a', 12);
+						return pad(c.status >= 300 ? `HTTP${c.status}` : fmt(c.value), 12);
+					});
+					console.log('    ' + pad(field, 10) + pad(fmt(written), 12) + cells.join(''));
+				}
+			}
+			console.log('');
+		}
+
+		/** Write one record (all FIELDS) via CBOR or msgpack body; return write status. */
+		async function writeRecord(id: string, writeFormat: 'cbor' | 'msgpack'): Promise<number> {
+			const record: Record<string, unknown> = { id, ...FIELDS };
+			const body = writeFormat === 'cbor' ? cborCodec.encode(record) : msgpackPack(record);
+			const contentType = writeFormat === 'cbor' ? 'application/cbor' : 'application/x-msgpack';
+			const r = await request(restURL)
+				.put(`/${TABLE}/${id}`)
+				.set(authHeaders)
+				.set('Content-Type', contentType)
+				.send(body)
+				.timeout(20_000);
+			return r.status;
+		}
+
+		/** Read the whole record back in a given Accept encoding, decode with the matching codec. */
+		async function readRecord(
+			id: string,
+			accept: string,
+			readLabel: string
+		): Promise<{ status: number; decoded: any }> {
+			const r = await request(restURL)
+				.get(`/${TABLE}/${id}`)
+				.set(authHeaders)
+				.set('Accept', accept)
+				.buffer(true)
+				.parse(binaryParser)
+				.timeout(20_000);
+			if (r.status >= 300) return { status: r.status, decoded: undefined };
+			const buf = r.body as unknown as Buffer;
+			let decoded: any;
+			if (readLabel === 'json') decoded = JSON.parse(buf.toString('utf8'));
+			else if (readLabel === 'cbor') decoded = cborCodec.decode(buf);
+			else decoded = msgpackUnpack(buf);
+			return { status: r.status, decoded };
+		}
+
+		async function runWriteFormat(writeFormat: 'cbor' | 'msgpack') {
+			const id = `rec-${writeFormat}`;
+			const writeStatus = await writeRecord(id, writeFormat);
+			ok(writeStatus < 300, `${writeFormat} write for ${id} should not be rejected, got ${writeStatus}`);
+
+			matrix[writeFormat] = {};
+			for (const field of Object.keys(FIELDS) as FieldName[]) {
+				matrix[writeFormat][field] = {};
+				for (const { label, accept } of READS) {
+					const { status, decoded } = await readRecord(id, accept, label);
+					matrix[writeFormat][field][label] = { status, value: decoded ? decoded[field] : undefined };
+				}
+			}
+		}
+
+		test('CBOR write: PUT body with NaN/Infinity/-Infinity/-0/control', async () => {
+			await runWriteFormat('cbor');
+		});
+
+		test('msgpack write: PUT body with NaN/Infinity/-Infinity/-0/control', async () => {
+			await runWriteFormat('msgpack');
+		});
+
+		/** Vacuity floor: every analysis arm below reads the matrix the two write arms fill in.
+		 *  Without this, a failed write arm leaves it empty and every loop below iterates zero
+		 *  times — green, having measured nothing. */
+		function writeFormats(): string[] {
+			const formats = Object.keys(matrix);
+			deepStrictEqual(formats.sort(), ['cbor', 'msgpack'], 'both write formats must have produced a record');
+			return formats;
+		}
+
+		test('control float (3.14) is faithful on every write x read combo', () => {
+			for (const writeFormat of writeFormats()) {
+				for (const { label } of READS) {
+					const cell = matrix[writeFormat].normal[label];
+					strictEqual(cell.status, 200, `control read ${writeFormat}->${label} should be 200`);
+					strictEqual(cell.value, 3.14, `control float must round-trip via ${writeFormat}->${label}`);
+				}
+			}
+		});
+
+		test('NaN and +/-Infinity survive a binary write and round-trip on a binary read', () => {
+			const preservedFields: FieldName[] = ['nan', 'posInf', 'negInf'];
+			for (const writeFormat of writeFormats()) {
+				for (const field of preservedFields) {
+					const written = FIELDS[field];
+					for (const readLabel of ['cbor', 'msgpack']) {
+						const got = matrix[writeFormat][field][readLabel].value;
+						ok(
+							sameValue(got, written),
+							`${field} written as ${fmt(written)} over ${writeFormat} must read back exactly over ` +
+								`${readLabel}, got ${fmt(got)} — a binary read cannot resurrect a value storage lost, ` +
+								`so this failing means the write path coerced it`
+						);
+					}
+					const jsonVal = matrix[writeFormat][field].json.value;
+					strictEqual(
+						jsonVal,
+						null,
+						`${field} must flatten to null on a JSON read (via ${writeFormat} write), got ${fmt(jsonVal)}`
+					);
+				}
+			}
+		});
+
+		// D-254: the one write-path coercion. Pinned so a change of behaviour is visible, not
+		// because -0 vs +0 matters to a consumer.
+		test('-0 loses its sign on the write path: every read, binary included, returns +0', () => {
+			for (const writeFormat of writeFormats()) {
+				for (const { label } of READS) {
+					const got = matrix[writeFormat]['negZero'][label].value;
+					ok(sameValue(got, 0), `-0 written over ${writeFormat} must read back as +0 over ${label}, got ${fmt(got)}`);
+				}
+			}
+		});
+
+		test('no special value is silently substituted with a wrong finite number', () => {
+			const specialFields: FieldName[] = ['nan', 'posInf', 'negInf'];
+			for (const writeFormat of writeFormats()) {
+				for (const field of specialFields) {
+					for (const { label } of READS) {
+						const v = matrix[writeFormat][field][label].value;
+						const isAcceptable = v === null || (typeof v === 'number' && (Number.isNaN(v) || !Number.isFinite(v)));
+						ok(
+							isAcceptable,
+							`DEFECT: ${writeFormat} write, field=${field}, read=${label}: expected null or the special ` +
+								`value itself, got ${fmt(v)} — silent numeric corruption`
+						);
+					}
+				}
+			}
+		});
+	}
+);

--- a/integrationTests/database/special-float-write-fidelity.test.ts
+++ b/integrationTests/database/special-float-write-fidelity.test.ts
@@ -284,8 +284,7 @@ suite(
 			ok(open.status < 300, `an undeclared attribute must accept any value, got ${open.status}`);
 		});
 
-		// Characterization, not an endorsement: if Harper starts preserving -0 this arm goes red and
-		// the fix is to invert it, not to restore the coercion.
+		// Characterization, not an endorsement: this pins the complete REST round trip, not storage alone.
 		test('a genuine IEEE-754 -0 on the wire does not survive the round trip', async () => {
 			for (const table of TABLES) {
 				const bodyFor = {

--- a/integrationTests/database/special-float-write-fidelity.test.ts
+++ b/integrationTests/database/special-float-write-fidelity.test.ts
@@ -1,29 +1,39 @@
 /**
- * QA-432 — content-negotiation WRITE-path fidelity for IEEE-754 special floats.
+ * QA-432 — content-negotiation write-path fidelity for IEEE-754 special floats.
  *
  * A JSON request body cannot represent NaN, ±Infinity or -0, so a JSON write bakes the JSON-spec
- * coercions in before storage ever sees the value. A CBOR or msgpack body can carry them, which
- * makes ingest itself observable: PUT a binary body, then read the record back over CBOR, msgpack
- * and JSON. A binary read that recovers the exact value proves storage kept it and only the JSON
- * serializer flattens it; a binary read that does not proves the value was lost at ingest, because
- * no read format can resurrect what was never stored. Reads are not served from a write-side
- * object: PrimaryRocksDatabase sets cachePuts=false and invalidates on put, so the first read
- * decodes stored bytes.
+ * coercions in before storage ever sees the value. A CBOR or msgpack body can carry them, so a
+ * binary write is the only way to put one in front of Harper at all. The record is then read back
+ * over CBOR, msgpack and JSON.
+ *
+ * What a binary read proves, and what it does not. Reads are not served from a write-side object —
+ * PrimaryRocksDatabase sets cachePuts=false and invalidates on put, so the first read decodes
+ * stored bytes — which is why a binary read recovering the exact value shows storage kept it. The
+ * converse does NOT hold: Harper's outbound CBOR/msgpack encoders coerce on the way out too, so a
+ * value that comes back changed may have been lost at ingest OR on response encoding, and this
+ * suite cannot tell which. Every claim below is therefore about the round trip. A red arm here is
+ * not on its own evidence about the write path; check `server/serverHelpers/contentTypes.ts`
+ * response encoding before `resources/Table.ts`.
  *
  * The contract this pins:
- *   - NaN / +Infinity / -Infinity survive a binary write and round-trip exactly on a binary read.
- *   - A JSON read of those flattens to null, per the JSON spec — read-path, not storage.
- *   - A genuine IEEE-754 -0 on the wire does not survive the round trip: every read, binary
- *     included, returns +0. Benign (-0 === 0 for nearly all consumers) but a real asymmetry
- *     against NaN and the infinities, so it is pinned rather than left to drift.
+ *   - NaN / +Infinity / -Infinity round-trip exactly on a binary read, after a binary write, on
+ *     both an open table and one whose attributes are declared Float.
+ *   - A JSON read of those flattens to null, per the JSON spec.
+ *   - A genuine IEEE-754 -0 on the wire does not survive the round trip: every read, binary and
+ *     JSON, returns +0. Benign (-0 === 0 for nearly all consumers) but a real asymmetry against
+ *     NaN and the infinities, so it is pinned rather than left to drift.
  *
  * -0 needs the wire checked, not just the value written. Both encoders take an integer fast path
  * for -0 (`-0 >>> 0 === -0`), so `encode({ x: -0 })` emits unsigned integer 0 and Harper never
  * sees a negative zero — a -0 arm built on the default encoders pins cbor-x/msgpackr behaviour
  * while appearing to pin Harper's. cbor-x emits a real float64 under alwaysUseFloat; msgpackr has
  * no such option, so the msgpack body for that field is assembled by hand. Either way the arm
- * asserts the request bytes carry float64 -0 (0xfb / 0xcb + sign bit) before it reads anything
- * back.
+ * asserts the request bytes carry float64 -0 before it reads anything back.
+ *
+ * TypedDoc exists because the open-table path skips per-attribute validation entirely. A declared
+ * Float goes through the `typeof value !== 'number'` branch in resources/Table.ts, which admits
+ * NaN and the infinities today; running the same contract against it is what would catch a
+ * tightening to a finiteness check.
  *
  * Reproduction:
  *   npm run test:integration -- "integrationTests/database/special-float-write-fidelity.test.ts"
@@ -41,10 +51,10 @@ import { createApiClient } from '../apiTests/utils/client.mjs';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'special-float-write-fidelity');
 const skipSuite = process.platform === 'win32';
-const TABLE = 'Doc';
+const TABLES = ['Doc', 'TypedDoc'] as const;
+type TableName = (typeof TABLES)[number];
 
 const cborCodec = new Encoder({ useRecords: false });
-// The only encoder setting that puts a real float64 -0 on the wire; see the header.
 const cborFloatCodec = new Encoder({ useRecords: false, alwaysUseFloat: true });
 
 const FLOAT64_NEG_ZERO = Buffer.from('8000000000000000', 'hex');
@@ -81,6 +91,7 @@ interface Cell {
 	value: unknown;
 }
 const matrix: Record<string, Record<string, Record<string, Cell>>> = {};
+const rowKey = (table: string, writeFormat: string) => `${table}/${writeFormat}`;
 
 function binaryParser(res: any, cb: (err: Error | null, body: Buffer) => void) {
 	const chunks: Buffer[] = [];
@@ -107,30 +118,33 @@ suite(
 			// breaking early lands the first PUT before the table exists and reports it as a
 			// write-path defect.
 			const deadline = Date.now() + 30_000;
-			let lastStatus: number | string = 'no response';
-			while (Date.now() < deadline) {
-				try {
-					const probe = await client.reqRest(`/${TABLE}/`).timeout(3_000);
-					lastStatus = probe.status;
-					if (probe.status === 200) return;
-				} catch (error) {
-					lastStatus = (error as Error).message;
+			for (const table of TABLES) {
+				let lastStatus: number | string = 'no response';
+				let ready = false;
+				while (!ready && Date.now() < deadline) {
+					try {
+						const probe = await client.reqRest(`/${table}/`).timeout(3_000);
+						lastStatus = probe.status;
+						ready = probe.status === 200;
+					} catch (error) {
+						lastStatus = (error as Error).message;
+					}
+					if (!ready) await sleep(250);
 				}
-				await sleep(250);
+				if (!ready) throw new Error(`${table} route never became ready within 30s; last probe: ${lastStatus}`);
 			}
-			throw new Error(`${TABLE} route never became ready within 30s; last probe: ${lastStatus}`);
 		});
 
 		after(async () => {
-			await teardownHarper(ctx);
 			printMatrix();
+			await teardownHarper(ctx);
 		});
 
 		function printMatrix() {
-			console.log('\n══ QA-432 WRITE-PATH FIDELITY MATRIX (per write-format record) ══');
-			for (const writeFormat of Object.keys(matrix)) {
-				console.log(`\n  write=${writeFormat}:`);
-				const fieldRows = matrix[writeFormat];
+			console.log('\n══ QA-432 ROUND-TRIP MATRIX (one row per table x write format) ══');
+			for (const key of Object.keys(matrix)) {
+				console.log(`\n  ${key}:`);
+				const fieldRows = matrix[key];
 				const pad = (s: string, n: number) => (s + ' '.repeat(n)).slice(0, n);
 				console.log('    ' + pad('field', 10) + pad('written', 12) + READS.map((r) => pad(r.label, 12)).join(''));
 				for (const field of Object.keys(fieldRows)) {
@@ -146,12 +160,12 @@ suite(
 			console.log('');
 		}
 
-		async function writeRecord(id: string, writeFormat: 'cbor' | 'msgpack'): Promise<number> {
+		async function writeRecord(table: TableName, id: string, writeFormat: 'cbor' | 'msgpack'): Promise<number> {
 			const record: Record<string, unknown> = { id, ...FIELDS };
 			const body = writeFormat === 'cbor' ? cborCodec.encode(record) : msgpackPack(record);
 			const contentType = writeFormat === 'cbor' ? 'application/cbor' : 'application/x-msgpack';
 			const r = await request(restURL)
-				.put(`/${TABLE}/${id}`)
+				.put(`/${table}/${id}`)
 				.set(authHeaders)
 				.set('Content-Type', contentType)
 				.send(body)
@@ -160,12 +174,13 @@ suite(
 		}
 
 		async function readRecord(
+			table: TableName,
 			id: string,
 			accept: string,
 			readLabel: string
 		): Promise<{ status: number; decoded: any }> {
 			const r = await request(restURL)
-				.get(`/${TABLE}/${id}`)
+				.get(`/${table}/${id}`)
 				.set(authHeaders)
 				.set('Accept', accept)
 				.buffer(true)
@@ -180,11 +195,11 @@ suite(
 			return { status: r.status, decoded };
 		}
 
-		/** Every cell of a row comes from one response, so a row is one snapshot of the record. */
-		async function readAllFormats(id: string): Promise<Record<string, Record<string, Cell>>> {
+		/** One GET per read format, so every field of a given column comes from one response. */
+		async function readAllFormats(table: TableName, id: string): Promise<Record<string, Record<string, Cell>>> {
 			const row: Record<string, Record<string, Cell>> = {};
 			for (const { label, accept } of READS) {
-				const { status, decoded } = await readRecord(id, accept, label);
+				const { status, decoded } = await readRecord(table, id, accept, label);
 				for (const field of Object.keys(FIELDS)) {
 					(row[field] ??= {})[label] = { status, value: decoded ? decoded[field] : undefined };
 				}
@@ -193,10 +208,12 @@ suite(
 		}
 
 		async function runWriteFormat(writeFormat: 'cbor' | 'msgpack') {
-			const id = `rec-${writeFormat}`;
-			const writeStatus = await writeRecord(id, writeFormat);
-			ok(writeStatus < 300, `${writeFormat} write for ${id} should not be rejected, got ${writeStatus}`);
-			matrix[writeFormat] = await readAllFormats(id);
+			for (const table of TABLES) {
+				const id = `rec-${writeFormat}`;
+				const writeStatus = await writeRecord(table, id, writeFormat);
+				ok(writeStatus < 300, `${writeFormat} write for ${table}/${id} should not be rejected, got ${writeStatus}`);
+				matrix[rowKey(table, writeFormat)] = await readAllFormats(table, id);
+			}
 		}
 
 		test('CBOR write: PUT body with NaN/Infinity/-Infinity/control', async () => {
@@ -209,50 +226,49 @@ suite(
 
 		/** A failed write arm leaves the matrix empty, which would make every loop below iterate
 		 *  zero times and pass having measured nothing. */
-		function writeFormats(): string[] {
-			const formats = Object.keys(matrix);
-			deepStrictEqual(formats.sort(), ['cbor', 'msgpack'], 'both write formats must have produced a record');
-			return formats;
+		function rows(): string[] {
+			const expected = TABLES.flatMap((table) => ['cbor', 'msgpack'].map((f) => rowKey(table, f))).sort();
+			deepStrictEqual(Object.keys(matrix).sort(), expected, 'every table x write format must have produced a record');
+			return expected;
 		}
 
 		test('control float (3.14) is faithful on every write x read combo', () => {
-			for (const writeFormat of writeFormats()) {
+			for (const row of rows()) {
 				for (const { label } of READS) {
-					const cell = matrix[writeFormat].normal[label];
-					strictEqual(cell.status, 200, `control read ${writeFormat}->${label} should be 200`);
-					strictEqual(cell.value, 3.14, `control float must round-trip via ${writeFormat}->${label}`);
+					const cell = matrix[row].normal[label];
+					strictEqual(cell.status, 200, `control read ${row}->${label} should be 200`);
+					strictEqual(cell.value, 3.14, `control float must round-trip via ${row}->${label}`);
 				}
 			}
 		});
 
-		test('NaN and +/-Infinity survive a binary write and round-trip on a binary read', () => {
+		test('NaN and +/-Infinity round-trip exactly on a binary read, and flatten to null on JSON', () => {
 			const preservedFields: FieldName[] = ['nan', 'posInf', 'negInf'];
-			for (const writeFormat of writeFormats()) {
+			for (const row of rows()) {
 				for (const field of preservedFields) {
 					const written = FIELDS[field];
 					for (const readLabel of ['cbor', 'msgpack']) {
-						const got = matrix[writeFormat][field][readLabel].value;
+						const got = matrix[row][field][readLabel].value;
 						ok(
 							Object.is(got, written),
-							`${field} written as ${fmt(written)} over ${writeFormat} must read back exactly over ` +
-								`${readLabel}, got ${fmt(got)} — a binary read cannot resurrect a value storage lost, ` +
-								`so this failing means the write path coerced it`
+							`${field} written as ${fmt(written)} over ${row} must read back exactly over ${readLabel}, got ${fmt(got)}`
 						);
 					}
-					const jsonVal = matrix[writeFormat][field].json.value;
-					strictEqual(
-						jsonVal,
-						null,
-						`${field} must flatten to null on a JSON read (via ${writeFormat} write), got ${fmt(jsonVal)}`
-					);
+					const jsonVal = matrix[row][field].json.value;
+					strictEqual(jsonVal, null, `${field} must flatten to null on a JSON read of ${row}, got ${fmt(jsonVal)}`);
 				}
 			}
 		});
 
-		/** msgpackr has no alwaysUseFloat, so this row of the map is assembled byte by byte:
+		/** msgpackr has no alwaysUseFloat, so this map is assembled byte by byte:
 		 *  fixmap(2), "id" -> id, "negZero" -> float64 -0. */
 		function msgpackBodyWithNegZero(id: string): Buffer {
-			const key = (name: string) => Buffer.concat([Buffer.from([0xa0 | name.length]), Buffer.from(name, 'utf8')]);
+			const key = (name: string) => {
+				const bytes = Buffer.from(name, 'utf8');
+				// fixstr only reaches 31 bytes; past that `0xa0 | length` silently wraps to a shorter string.
+				ok(bytes.length <= 31, `msgpack fixstr cannot encode ${bytes.length} bytes: ${name}`);
+				return Buffer.concat([Buffer.from([0xa0 | bytes.length]), bytes]);
+			};
 			return Buffer.concat([
 				Buffer.from([0x82]),
 				key('id'),
@@ -263,53 +279,51 @@ suite(
 			]);
 		}
 
-		// Where the sign is dropped is not observable from here: Harper's CBOR/msgpack response
-		// encoders take the same integer fast path on the way out, so a faithfully stored -0 and a
-		// coerced one look identical over HTTP. The arm therefore pins the round trip, not the
-		// ingest step.
 		test('a genuine IEEE-754 -0 on the wire does not survive the round trip', async () => {
-			const bodies = {
-				cbor: {
-					contentType: 'application/cbor',
-					body: Buffer.from(cborFloatCodec.encode({ id: 'rec-negzero-cbor', negZero: -0 })),
-					marker: Buffer.concat([Buffer.from([0xfb]), FLOAT64_NEG_ZERO]),
-				},
-				msgpack: {
-					contentType: 'application/x-msgpack',
-					body: msgpackBodyWithNegZero('rec-negzero-msgpack'),
-					marker: Buffer.concat([Buffer.from([0xcb]), FLOAT64_NEG_ZERO]),
-				},
-			};
+			for (const table of TABLES) {
+				const bodyFor = {
+					cbor: {
+						contentType: 'application/cbor',
+						build: (id: string) => Buffer.from(cborFloatCodec.encode({ id, negZero: -0 })),
+						marker: Buffer.concat([Buffer.from([0xfb]), FLOAT64_NEG_ZERO]),
+					},
+					msgpack: {
+						contentType: 'application/x-msgpack',
+						build: msgpackBodyWithNegZero,
+						marker: Buffer.concat([Buffer.from([0xcb]), FLOAT64_NEG_ZERO]),
+					},
+				};
 
-			for (const [writeFormat, { contentType, body, marker }] of Object.entries(bodies)) {
-				const id = `rec-negzero-${writeFormat}`;
-				// Arming check: without it the encoder's integer fast path silently turns this into a
-				// test of cbor-x/msgpackr rather than of Harper.
-				ok(
-					body.includes(marker),
-					`${writeFormat} request body must carry float64 -0 (${marker.toString('hex')}), got ${body.toString('hex')}`
-				);
-
-				const writeStatus = (
-					await request(restURL)
-						.put(`/${TABLE}/${id}`)
-						.set(authHeaders)
-						.set('Content-Type', contentType)
-						.send(body)
-						.timeout(20_000)
-				).status;
-				ok(writeStatus < 300, `${writeFormat} -0 write should not be rejected, got ${writeStatus}`);
-
-				for (const readLabel of ['cbor', 'msgpack']) {
-					const accept = READS.find((r) => r.label === readLabel)!.accept;
-					const { status, decoded } = await readRecord(id, accept, readLabel);
-					strictEqual(status, 200, `${writeFormat} -0 read over ${readLabel} should be 200`);
-					const got = decoded?.negZero;
-					console.log(`  [-0] write=${writeFormat} read=${readLabel} -> ${fmt(got)}`);
+				for (const [writeFormat, { contentType, build, marker }] of Object.entries(bodyFor)) {
+					const id = `rec-negzero-${writeFormat}`;
+					const body = build(id);
+					// Without this the encoder's integer fast path turns the arm into a test of
+					// cbor-x/msgpackr rather than of Harper, and it still passes.
 					ok(
-						Object.is(got, 0),
-						`-0 written over ${writeFormat} must read back as +0 over ${readLabel}, got ${fmt(got)}`
+						body.includes(marker),
+						`${writeFormat} request body must carry float64 -0 (${marker.toString('hex')}), got ${body.toString('hex')}`
 					);
+
+					const writeStatus = (
+						await request(restURL)
+							.put(`/${table}/${id}`)
+							.set(authHeaders)
+							.set('Content-Type', contentType)
+							.send(body)
+							.timeout(20_000)
+					).status;
+					ok(writeStatus < 300, `${table} ${writeFormat} -0 write should not be rejected, got ${writeStatus}`);
+
+					for (const { label, accept } of READS) {
+						const { status, decoded } = await readRecord(table, id, accept, label);
+						strictEqual(status, 200, `${table} ${writeFormat} -0 read over ${label} should be 200`);
+						const got = decoded?.negZero;
+						console.log(`  [-0] ${table} write=${writeFormat} read=${label} -> ${fmt(got)}`);
+						ok(
+							Object.is(got, 0),
+							`-0 written to ${table} over ${writeFormat} must read back as +0 over ${label}, got ${fmt(got)}`
+						);
+					}
 				}
 			}
 		});

--- a/integrationTests/database/special-float-write-fidelity.test.ts
+++ b/integrationTests/database/special-float-write-fidelity.test.ts
@@ -168,6 +168,11 @@ suite(
 				.parse(binaryParser)
 				.timeout(20_000);
 			if (r.status >= 300) return { status: r.status, decoded: undefined };
+			strictEqual(
+				r.headers['content-type']?.split(';', 1)[0],
+				accept,
+				`Accept ${accept} must return the matching Content-Type, got ${r.headers['content-type']}`
+			);
 			const buf = r.body as unknown as Buffer;
 			let decoded: any;
 			if (readLabel === 'json') decoded = JSON.parse(buf.toString('utf8'));
@@ -262,26 +267,25 @@ suite(
 		// Dropping TypedDoc's Float declarations would turn it into a second copy of Doc's
 		// open-attribute path with every arm still green, so the difference is asserted.
 		test('TypedDoc reaches per-type validation and Doc does not', async () => {
-			const send = (table: TableName) =>
+			const send = (table: TableName, field: string) =>
 				request(restURL)
-					.put(`/${table}/arming-probe`)
+					.put(`/${table}/arming-probe-${field}`)
 					.set(authHeaders)
 					.set('Content-Type', 'application/json')
-					.send('{"id":"arming-probe","negZero":"not-a-number"}')
+					.send(JSON.stringify({ id: `arming-probe-${field}`, [field]: 'not-a-number' }))
 					.timeout(20_000);
 
-			const typed = await send('TypedDoc');
-			// Exactly 400: a 5xx from a broken fixture would satisfy a >= 400 check and leave the
-			// declared-Float branch unexercised, which is the false green this arm exists to stop.
-			strictEqual(
-				typed.status,
-				400,
-				`a declared Float must reject a non-numeric value with 400, got ${typed.status} — TypedDoc is not reaching per-type validation`
-			);
+			for (const field of [...Object.keys(FIELDS), 'negZero']) {
+				const typed = await send('TypedDoc', field);
+				strictEqual(
+					typed.status,
+					400,
+					`declared Float ${field} must reject a non-numeric value with 400, got ${typed.status}`
+				);
 
-			const open = await send('Doc');
-			console.log(`  [arming] non-numeric Float: TypedDoc -> ${typed.status}, Doc -> ${open.status}`);
-			ok(open.status < 300, `an undeclared attribute must accept any value, got ${open.status}`);
+				const open = await send('Doc', field);
+				ok(open.status < 300, `undeclared attribute ${field} must accept any value, got ${open.status}`);
+			}
 		});
 
 		// Characterization, not an endorsement: this pins the complete REST round trip, not storage alone.

--- a/integrationTests/database/special-float-write-fidelity.test.ts
+++ b/integrationTests/database/special-float-write-fidelity.test.ts
@@ -1,39 +1,31 @@
 /**
  * QA-432 — content-negotiation write-path fidelity for IEEE-754 special floats.
  *
- * A JSON request body cannot represent NaN, ±Infinity or -0, so a JSON write bakes the JSON-spec
- * coercions in before storage ever sees the value. A CBOR or msgpack body can carry them, so a
- * binary write is the only way to put one in front of Harper at all. The record is then read back
- * over CBOR, msgpack and JSON.
+ * JSON cannot represent NaN or ±Infinity, so a JSON write bakes the JSON-spec coercion in before
+ * storage sees the value and a binary body is the only way to put one in front of Harper. -0 is
+ * the exception: `JSON.parse('{"x":-0}').x` is a genuine negative zero, so all three content
+ * types can deliver it and all three are exercised.
  *
  * What a binary read proves, and what it does not. Reads are not served from a write-side object —
  * PrimaryRocksDatabase sets cachePuts=false and invalidates on put, so the first read decodes
  * stored bytes — which is why a binary read recovering the exact value shows storage kept it. The
- * converse does NOT hold: Harper's outbound CBOR/msgpack encoders coerce on the way out too, so a
- * value that comes back changed may have been lost at ingest OR on response encoding, and this
- * suite cannot tell which. Every claim below is therefore about the round trip. A red arm here is
- * not on its own evidence about the write path; check `server/serverHelpers/contentTypes.ts`
- * response encoding before `resources/Table.ts`.
+ * converse does NOT hold: Harper's outbound encoders coerce on the way out too, so a value that
+ * comes back changed may have been lost at ingest OR on response encoding, and this suite cannot
+ * tell which. Every claim here is about the round trip; a red arm is not on its own evidence about
+ * the write path, so check `server/serverHelpers/contentTypes.ts` response encoding before
+ * `resources/Table.ts`.
  *
- * The contract this pins:
- *   - NaN / +Infinity / -Infinity round-trip exactly on a binary read, after a binary write, on
- *     both an open table and one whose attributes are declared Float.
- *   - A JSON read of those flattens to null, per the JSON spec.
- *   - A genuine IEEE-754 -0 on the wire does not survive the round trip: every read, binary and
- *     JSON, returns +0. Benign (-0 === 0 for nearly all consumers) but a real asymmetry against
- *     NaN and the infinities, so it is pinned rather than left to drift.
+ * -0 needs the wire checked, not just the value written. Both binary encoders take an integer fast
+ * path for -0 (`-0 >>> 0 === -0`), so `encode({ x: -0 })` emits unsigned integer 0 and Harper never
+ * sees a negative zero — an arm built on the default encoders pins cbor-x/msgpackr behaviour while
+ * appearing to pin Harper's. cbor-x emits a real float64 under alwaysUseFloat, msgpackr has no such
+ * option so that map is assembled by hand, and JSON.stringify(-0) is "0" so that body is written
+ * out as text. Each arm asserts its request bytes carry a real -0 before reading anything back.
  *
- * -0 needs the wire checked, not just the value written. Both encoders take an integer fast path
- * for -0 (`-0 >>> 0 === -0`), so `encode({ x: -0 })` emits unsigned integer 0 and Harper never
- * sees a negative zero — a -0 arm built on the default encoders pins cbor-x/msgpackr behaviour
- * while appearing to pin Harper's. cbor-x emits a real float64 under alwaysUseFloat; msgpackr has
- * no such option, so the msgpack body for that field is assembled by hand. Either way the arm
- * asserts the request bytes carry float64 -0 before it reads anything back.
- *
- * TypedDoc exists because the open-table path skips per-attribute validation entirely. A declared
- * Float goes through the `typeof value !== 'number'` branch in resources/Table.ts, which admits
- * NaN and the infinities today; running the same contract against it is what would catch a
- * tightening to a finiteness check.
+ * TypedDoc declares every special-float attribute, so its writes reach the per-type validation in
+ * resources/Table.ts — `case 'Float': if (typeof value !== 'number')`, which admits NaN and the
+ * infinities today. Doc leaves them undeclared and skips that branch entirely; running the same
+ * contract against both is what would catch a tightening to a finiteness check.
  *
  * Reproduction:
  *   npm run test:integration -- "integrationTests/database/special-float-write-fidelity.test.ts"
@@ -41,13 +33,14 @@
 import { suite, test, before, after } from 'node:test';
 import { strictEqual, ok, deepStrictEqual } from 'node:assert';
 import { resolve } from 'node:path';
-import { setTimeout as sleep } from 'node:timers/promises';
 import request from 'supertest';
 import { Encoder } from 'cbor-x';
 import { pack as msgpackPack, unpack as msgpackUnpack } from 'msgpackr';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
 import { createApiClient } from '../apiTests/utils/client.mjs';
+// @ts-expect-error utils/lifecycle.mjs has no type declarations; runtime resolves fine
+import { waitForRouteReady } from '../apiTests/utils/lifecycle.mjs';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'special-float-write-fidelity');
 const skipSuite = process.platform === 'win32';
@@ -114,24 +107,12 @@ suite(
 			restURL = (client as any).restURL;
 			authHeaders = { Authorization: client.headers.Authorization, Connection: 'close' };
 
-			// A half-started server answers this probe non-200, so anything but 200 keeps polling:
-			// breaking early lands the first PUT before the table exists and reports it as a
-			// write-path defect.
-			const deadline = Date.now() + 30_000;
+			// A half-started server answers non-200, and breaking early would land the first PUT
+			// before the table exists and report it as a write-path defect.
 			for (const table of TABLES) {
-				let lastStatus: number | string = 'no response';
-				let ready = false;
-				while (!ready && Date.now() < deadline) {
-					try {
-						const probe = await client.reqRest(`/${table}/`).timeout(3_000);
-						lastStatus = probe.status;
-						ready = probe.status === 200;
-					} catch (error) {
-						lastStatus = (error as Error).message;
-					}
-					if (!ready) await sleep(250);
-				}
-				if (!ready) throw new Error(`${table} route never became ready within 30s; last probe: ${lastStatus}`);
+				await waitForRouteReady(client, `/${table}/`, 30_000, {
+					isReady: (response: { status: number }) => response.status === 200,
+				});
 			}
 		});
 
@@ -279,9 +260,37 @@ suite(
 			]);
 		}
 
+		// Without this, dropping the Float declarations from TypedDoc would silently turn it into a
+		// second copy of Doc's open-attribute path and every arm below would stay green.
+		test('TypedDoc reaches per-type validation and Doc does not', async () => {
+			const send = (table: TableName) =>
+				request(restURL)
+					.put(`/${table}/arming-probe`)
+					.set(authHeaders)
+					.set('Content-Type', 'application/json')
+					.send('{"id":"arming-probe","negZero":"not-a-number"}')
+					.timeout(20_000);
+
+			const typed = await send('TypedDoc');
+			ok(
+				typed.status >= 400,
+				`a declared Float must reject a non-numeric value, got ${typed.status} — TypedDoc is not reaching per-type validation`
+			);
+
+			const open = await send('Doc');
+			console.log(`  [arming] non-numeric Float: TypedDoc -> ${typed.status}, Doc -> ${open.status}`);
+			ok(open.status < 300, `an undeclared attribute must accept any value, got ${open.status}`);
+		});
+
 		test('a genuine IEEE-754 -0 on the wire does not survive the round trip', async () => {
 			for (const table of TABLES) {
 				const bodyFor = {
+					json: {
+						contentType: 'application/json',
+						// JSON.stringify(-0) is "0", so the sign has to be written out as text.
+						build: (id: string) => Buffer.from(`{"id":${JSON.stringify(id)},"negZero":-0}`, 'utf8'),
+						marker: Buffer.from('"negZero":-0', 'utf8'),
+					},
 					cbor: {
 						contentType: 'application/cbor',
 						build: (id: string) => Buffer.from(cborFloatCodec.encode({ id, negZero: -0 })),
@@ -309,7 +318,9 @@ suite(
 							.put(`/${table}/${id}`)
 							.set(authHeaders)
 							.set('Content-Type', contentType)
-							.send(body)
+							// supertest sends a Buffer as binary whatever the header says, so the JSON
+							// body has to go out as text or Harper stores the raw bytes as the record.
+							.send(contentType === 'application/json' ? body.toString('utf8') : body)
 							.timeout(20_000)
 					).status;
 					ok(writeStatus < 300, `${table} ${writeFormat} -0 write should not be rejected, got ${writeStatus}`);

--- a/integrationTests/database/special-float-write-fidelity.test.ts
+++ b/integrationTests/database/special-float-write-fidelity.test.ts
@@ -1,21 +1,29 @@
 /**
  * QA-432 — content-negotiation WRITE-path fidelity for IEEE-754 special floats.
  *
- * A JSON request body cannot represent NaN, ±Infinity or -0, so a JSON write bakes the
- * JSON-spec coercions in before storage ever sees the value. CBOR and msgpack bodies CAN
- * represent them, which makes the write path itself observable: PUT a binary body carrying
- * the special values, then read the record back over all three surfaces (CBOR, msgpack,
- * JSON). A binary read that recovers the exact value proves storage kept it and only the
- * JSON serializer flattens it; a binary read that does not proves the value was lost at
- * ingest, because no read format can resurrect what was never stored.
+ * A JSON request body cannot represent NaN, ±Infinity or -0, so a JSON write bakes the JSON-spec
+ * coercions in before storage ever sees the value. A CBOR or msgpack body can carry them, which
+ * makes ingest itself observable: PUT a binary body, then read the record back over CBOR, msgpack
+ * and JSON. A binary read that recovers the exact value proves storage kept it and only the JSON
+ * serializer flattens it; a binary read that does not proves the value was lost at ingest, because
+ * no read format can resurrect what was never stored. Reads are not served from a write-side
+ * object: PrimaryRocksDatabase sets cachePuts=false and invalidates on put, so the first read
+ * decodes stored bytes.
  *
- * The contract this pins (from QA-432):
+ * The contract this pins:
  *   - NaN / +Infinity / -Infinity survive a binary write and round-trip exactly on a binary read.
  *   - A JSON read of those flattens to null, per the JSON spec — read-path, not storage.
- *   - -0 loses its sign on the binary WRITE path: every read, binary included, returns +0.
- *     Benign (-0 === 0 for nearly all consumers) but a real asymmetry, so it is pinned
- *     explicitly rather than left to drift.
- *   - No special value is ever silently replaced by a WRONG finite number, on any surface.
+ *   - A genuine IEEE-754 -0 on the wire does not survive the round trip: every read, binary
+ *     included, returns +0. Benign (-0 === 0 for nearly all consumers) but a real asymmetry
+ *     against NaN and the infinities, so it is pinned rather than left to drift.
+ *
+ * -0 needs the wire checked, not just the value written. Both encoders take an integer fast path
+ * for -0 (`-0 >>> 0 === -0`), so `encode({ x: -0 })` emits unsigned integer 0 and Harper never
+ * sees a negative zero — a -0 arm built on the default encoders pins cbor-x/msgpackr behaviour
+ * while appearing to pin Harper's. cbor-x emits a real float64 under alwaysUseFloat; msgpackr has
+ * no such option, so the msgpack body for that field is assembled by hand. Either way the arm
+ * asserts the request bytes carry float64 -0 (0xfb / 0xcb + sign bit) before it reads anything
+ * back.
  *
  * Reproduction:
  *   npm run test:integration -- "integrationTests/database/special-float-write-fidelity.test.ts"
@@ -35,9 +43,11 @@ const FIXTURE_PATH = resolve(import.meta.dirname, 'special-float-write-fidelity'
 const skipSuite = process.platform === 'win32';
 const TABLE = 'Doc';
 
-// useToJSON:false so the encoder emits the raw IEEE-754 special values instead of
-// going through a lossy toJSON() path; useRecords:false keeps the wire format simple.
-const cborCodec = new Encoder({ useRecords: false, useToJSON: false });
+const cborCodec = new Encoder({ useRecords: false });
+// The only encoder setting that puts a real float64 -0 on the wire; see the header.
+const cborFloatCodec = new Encoder({ useRecords: false, alwaysUseFloat: true });
+
+const FLOAT64_NEG_ZERO = Buffer.from('8000000000000000', 'hex');
 
 type Client = ReturnType<typeof createApiClient>;
 
@@ -45,8 +55,7 @@ const FIELDS = {
 	nan: NaN,
 	posInf: Infinity,
 	negInf: -Infinity,
-	negZero: -0,
-	normal: 3.14, // control — must always survive faithfully
+	normal: 3.14,
 } as const;
 type FieldName = keyof typeof FIELDS;
 
@@ -55,11 +64,6 @@ const READS = [
 	{ label: 'cbor', accept: 'application/cbor' },
 	{ label: 'msgpack', accept: 'application/x-msgpack' },
 ] as const;
-
-/** Same-value check that distinguishes NaN and -0 (unlike ===). */
-function sameValue(a: unknown, b: unknown): boolean {
-	return Object.is(a, b);
-}
 
 function fmt(v: unknown): string {
 	if (v === null) return 'null';
@@ -76,7 +80,6 @@ interface Cell {
 	status: number;
 	value: unknown;
 }
-// matrix[writeFormat][field][readLabel] = Cell
 const matrix: Record<string, Record<string, Record<string, Cell>>> = {};
 
 function binaryParser(res: any, cb: (err: Error | null, body: Buffer) => void) {
@@ -100,17 +103,22 @@ suite(
 			restURL = (client as any).restURL;
 			authHeaders = { Authorization: client.headers.Authorization, Connection: 'close' };
 
-			// Readiness poll (component pre-installed; do NOT restartHttpWorkers — races per QA-179 notes).
+			// A half-started server answers this probe non-200, so anything but 200 keeps polling:
+			// breaking early lands the first PUT before the table exists and reports it as a
+			// write-path defect.
 			const deadline = Date.now() + 30_000;
+			let lastStatus: number | string = 'no response';
 			while (Date.now() < deadline) {
 				try {
 					const probe = await client.reqRest(`/${TABLE}/`).timeout(3_000);
-					if (probe.status !== 404) break;
-				} catch {
-					/* not ready */
+					lastStatus = probe.status;
+					if (probe.status === 200) return;
+				} catch (error) {
+					lastStatus = (error as Error).message;
 				}
 				await sleep(250);
 			}
+			throw new Error(`${TABLE} route never became ready within 30s; last probe: ${lastStatus}`);
 		});
 
 		after(async () => {
@@ -138,7 +146,6 @@ suite(
 			console.log('');
 		}
 
-		/** Write one record (all FIELDS) via CBOR or msgpack body; return write status. */
 		async function writeRecord(id: string, writeFormat: 'cbor' | 'msgpack'): Promise<number> {
 			const record: Record<string, unknown> = { id, ...FIELDS };
 			const body = writeFormat === 'cbor' ? cborCodec.encode(record) : msgpackPack(record);
@@ -152,7 +159,6 @@ suite(
 			return r.status;
 		}
 
-		/** Read the whole record back in a given Accept encoding, decode with the matching codec. */
 		async function readRecord(
 			id: string,
 			accept: string,
@@ -174,32 +180,35 @@ suite(
 			return { status: r.status, decoded };
 		}
 
+		/** Every cell of a row comes from one response, so a row is one snapshot of the record. */
+		async function readAllFormats(id: string): Promise<Record<string, Record<string, Cell>>> {
+			const row: Record<string, Record<string, Cell>> = {};
+			for (const { label, accept } of READS) {
+				const { status, decoded } = await readRecord(id, accept, label);
+				for (const field of Object.keys(FIELDS)) {
+					(row[field] ??= {})[label] = { status, value: decoded ? decoded[field] : undefined };
+				}
+			}
+			return row;
+		}
+
 		async function runWriteFormat(writeFormat: 'cbor' | 'msgpack') {
 			const id = `rec-${writeFormat}`;
 			const writeStatus = await writeRecord(id, writeFormat);
 			ok(writeStatus < 300, `${writeFormat} write for ${id} should not be rejected, got ${writeStatus}`);
-
-			matrix[writeFormat] = {};
-			for (const field of Object.keys(FIELDS) as FieldName[]) {
-				matrix[writeFormat][field] = {};
-				for (const { label, accept } of READS) {
-					const { status, decoded } = await readRecord(id, accept, label);
-					matrix[writeFormat][field][label] = { status, value: decoded ? decoded[field] : undefined };
-				}
-			}
+			matrix[writeFormat] = await readAllFormats(id);
 		}
 
-		test('CBOR write: PUT body with NaN/Infinity/-Infinity/-0/control', async () => {
+		test('CBOR write: PUT body with NaN/Infinity/-Infinity/control', async () => {
 			await runWriteFormat('cbor');
 		});
 
-		test('msgpack write: PUT body with NaN/Infinity/-Infinity/-0/control', async () => {
+		test('msgpack write: PUT body with NaN/Infinity/-Infinity/control', async () => {
 			await runWriteFormat('msgpack');
 		});
 
-		/** Vacuity floor: every analysis arm below reads the matrix the two write arms fill in.
-		 *  Without this, a failed write arm leaves it empty and every loop below iterates zero
-		 *  times — green, having measured nothing. */
+		/** A failed write arm leaves the matrix empty, which would make every loop below iterate
+		 *  zero times and pass having measured nothing. */
 		function writeFormats(): string[] {
 			const formats = Object.keys(matrix);
 			deepStrictEqual(formats.sort(), ['cbor', 'msgpack'], 'both write formats must have produced a record');
@@ -224,7 +233,7 @@ suite(
 					for (const readLabel of ['cbor', 'msgpack']) {
 						const got = matrix[writeFormat][field][readLabel].value;
 						ok(
-							sameValue(got, written),
+							Object.is(got, written),
 							`${field} written as ${fmt(written)} over ${writeFormat} must read back exactly over ` +
 								`${readLabel}, got ${fmt(got)} — a binary read cannot resurrect a value storage lost, ` +
 								`so this failing means the write path coerced it`
@@ -240,30 +249,67 @@ suite(
 			}
 		});
 
-		// D-254: the one write-path coercion. Pinned so a change of behaviour is visible, not
-		// because -0 vs +0 matters to a consumer.
-		test('-0 loses its sign on the write path: every read, binary included, returns +0', () => {
-			for (const writeFormat of writeFormats()) {
-				for (const { label } of READS) {
-					const got = matrix[writeFormat]['negZero'][label].value;
-					ok(sameValue(got, 0), `-0 written over ${writeFormat} must read back as +0 over ${label}, got ${fmt(got)}`);
-				}
-			}
-		});
+		/** msgpackr has no alwaysUseFloat, so this row of the map is assembled byte by byte:
+		 *  fixmap(2), "id" -> id, "negZero" -> float64 -0. */
+		function msgpackBodyWithNegZero(id: string): Buffer {
+			const key = (name: string) => Buffer.concat([Buffer.from([0xa0 | name.length]), Buffer.from(name, 'utf8')]);
+			return Buffer.concat([
+				Buffer.from([0x82]),
+				key('id'),
+				key(id),
+				key('negZero'),
+				Buffer.from([0xcb]),
+				FLOAT64_NEG_ZERO,
+			]);
+		}
 
-		test('no special value is silently substituted with a wrong finite number', () => {
-			const specialFields: FieldName[] = ['nan', 'posInf', 'negInf'];
-			for (const writeFormat of writeFormats()) {
-				for (const field of specialFields) {
-					for (const { label } of READS) {
-						const v = matrix[writeFormat][field][label].value;
-						const isAcceptable = v === null || (typeof v === 'number' && (Number.isNaN(v) || !Number.isFinite(v)));
-						ok(
-							isAcceptable,
-							`DEFECT: ${writeFormat} write, field=${field}, read=${label}: expected null or the special ` +
-								`value itself, got ${fmt(v)} — silent numeric corruption`
-						);
-					}
+		// Where the sign is dropped is not observable from here: Harper's CBOR/msgpack response
+		// encoders take the same integer fast path on the way out, so a faithfully stored -0 and a
+		// coerced one look identical over HTTP. The arm therefore pins the round trip, not the
+		// ingest step.
+		test('a genuine IEEE-754 -0 on the wire does not survive the round trip', async () => {
+			const bodies = {
+				cbor: {
+					contentType: 'application/cbor',
+					body: Buffer.from(cborFloatCodec.encode({ id: 'rec-negzero-cbor', negZero: -0 })),
+					marker: Buffer.concat([Buffer.from([0xfb]), FLOAT64_NEG_ZERO]),
+				},
+				msgpack: {
+					contentType: 'application/x-msgpack',
+					body: msgpackBodyWithNegZero('rec-negzero-msgpack'),
+					marker: Buffer.concat([Buffer.from([0xcb]), FLOAT64_NEG_ZERO]),
+				},
+			};
+
+			for (const [writeFormat, { contentType, body, marker }] of Object.entries(bodies)) {
+				const id = `rec-negzero-${writeFormat}`;
+				// Arming check: without it the encoder's integer fast path silently turns this into a
+				// test of cbor-x/msgpackr rather than of Harper.
+				ok(
+					body.includes(marker),
+					`${writeFormat} request body must carry float64 -0 (${marker.toString('hex')}), got ${body.toString('hex')}`
+				);
+
+				const writeStatus = (
+					await request(restURL)
+						.put(`/${TABLE}/${id}`)
+						.set(authHeaders)
+						.set('Content-Type', contentType)
+						.send(body)
+						.timeout(20_000)
+				).status;
+				ok(writeStatus < 300, `${writeFormat} -0 write should not be rejected, got ${writeStatus}`);
+
+				for (const readLabel of ['cbor', 'msgpack']) {
+					const accept = READS.find((r) => r.label === readLabel)!.accept;
+					const { status, decoded } = await readRecord(id, accept, readLabel);
+					strictEqual(status, 200, `${writeFormat} -0 read over ${readLabel} should be 200`);
+					const got = decoded?.negZero;
+					console.log(`  [-0] write=${writeFormat} read=${readLabel} -> ${fmt(got)}`);
+					ok(
+						Object.is(got, 0),
+						`-0 written over ${writeFormat} must read back as +0 over ${readLabel}, got ${fmt(got)}`
+					);
 				}
 			}
 		});

--- a/integrationTests/database/special-float-write-fidelity.test.ts
+++ b/integrationTests/database/special-float-write-fidelity.test.ts
@@ -205,8 +205,7 @@ suite(
 			await runWriteFormat('msgpack');
 		});
 
-		/** A failed write arm leaves the matrix empty, which would make every loop below iterate
-		 *  zero times and pass having measured nothing. */
+		/** An empty matrix would make every loop below iterate zero times and pass. */
 		function rows(): string[] {
 			const expected = TABLES.flatMap((table) => ['cbor', 'msgpack'].map((f) => rowKey(table, f))).sort();
 			deepStrictEqual(Object.keys(matrix).sort(), expected, 'every table x write format must have produced a record');
@@ -260,8 +259,8 @@ suite(
 			]);
 		}
 
-		// Without this, dropping the Float declarations from TypedDoc would silently turn it into a
-		// second copy of Doc's open-attribute path and every arm below would stay green.
+		// Dropping TypedDoc's Float declarations would turn it into a second copy of Doc's
+		// open-attribute path with every arm still green, so the difference is asserted.
 		test('TypedDoc reaches per-type validation and Doc does not', async () => {
 			const send = (table: TableName) =>
 				request(restURL)
@@ -272,9 +271,12 @@ suite(
 					.timeout(20_000);
 
 			const typed = await send('TypedDoc');
-			ok(
-				typed.status >= 400,
-				`a declared Float must reject a non-numeric value, got ${typed.status} — TypedDoc is not reaching per-type validation`
+			// Exactly 400: a 5xx from a broken fixture would satisfy a >= 400 check and leave the
+			// declared-Float branch unexercised, which is the false green this arm exists to stop.
+			strictEqual(
+				typed.status,
+				400,
+				`a declared Float must reject a non-numeric value with 400, got ${typed.status} — TypedDoc is not reaching per-type validation`
 			);
 
 			const open = await send('Doc');
@@ -282,6 +284,8 @@ suite(
 			ok(open.status < 300, `an undeclared attribute must accept any value, got ${open.status}`);
 		});
 
+		// Characterization, not an endorsement: if Harper starts preserving -0 this arm goes red and
+		// the fix is to invert it, not to restore the coercion.
 		test('a genuine IEEE-754 -0 on the wire does not survive the round trip', async () => {
 			for (const table of TABLES) {
 				const bodyFor = {
@@ -306,8 +310,8 @@ suite(
 				for (const [writeFormat, { contentType, build, marker }] of Object.entries(bodyFor)) {
 					const id = `rec-negzero-${writeFormat}`;
 					const body = build(id);
-					// Without this the encoder's integer fast path turns the arm into a test of
-					// cbor-x/msgpackr rather than of Harper, and it still passes.
+					// The encoders' integer fast path erases -0 silently, so the wire is checked
+					// rather than the value handed to encode().
 					ok(
 						body.includes(marker),
 						`${writeFormat} request body must carry float64 -0 (${marker.toString('hex')}), got ${body.toString('hex')}`

--- a/integrationTests/database/special-float-write-fidelity/config.yaml
+++ b/integrationTests/database/special-float-write-fidelity/config.yaml
@@ -1,0 +1,3 @@
+graphqlSchema:
+  files: '*.graphql'
+rest: true

--- a/integrationTests/database/special-float-write-fidelity/schema.graphql
+++ b/integrationTests/database/special-float-write-fidelity/schema.graphql
@@ -1,0 +1,4 @@
+# QA-432 — content-negotiation WRITE-path fidelity: open table for special-float records.
+type Doc @table @export {
+  id: ID @primaryKey
+}

--- a/integrationTests/database/special-float-write-fidelity/schema.graphql
+++ b/integrationTests/database/special-float-write-fidelity/schema.graphql
@@ -1,16 +1,16 @@
 # QA-432 — content-negotiation WRITE-path fidelity for special floats.
 
 type Doc @table @export {
-  id: ID @primaryKey
+	id: ID @primaryKey
 }
 
 # Every special-float attribute is declared here, so writes reach Table.ts's per-type
 # validation instead of the open-attribute path Doc takes.
 type TypedDoc @table @export {
-  id: ID @primaryKey
-  nan: Float
-  posInf: Float
-  negInf: Float
-  negZero: Float
-  normal: Float
+	id: ID @primaryKey
+	nan: Float
+	posInf: Float
+	negInf: Float
+	negZero: Float
+	normal: Float
 }

--- a/integrationTests/database/special-float-write-fidelity/schema.graphql
+++ b/integrationTests/database/special-float-write-fidelity/schema.graphql
@@ -1,4 +1,16 @@
-# QA-432 — content-negotiation WRITE-path fidelity: open table for special-float records.
+# QA-432 — content-negotiation WRITE-path fidelity for special floats.
+
+# Undeclared attributes: the open-table path, no per-attribute type validation.
 type Doc @table @export {
   id: ID @primaryKey
+}
+
+# Declared Float attributes: the path that runs Table.ts's per-type validation, which a
+# future finiteness check would tighten.
+type TypedDoc @table @export {
+  id: ID @primaryKey
+  nan: Float
+  posInf: Float
+  negInf: Float
+  normal: Float
 }

--- a/integrationTests/database/special-float-write-fidelity/schema.graphql
+++ b/integrationTests/database/special-float-write-fidelity/schema.graphql
@@ -1,16 +1,16 @@
 # QA-432 — content-negotiation WRITE-path fidelity for special floats.
 
-# Undeclared attributes: the open-table path, no per-attribute type validation.
 type Doc @table @export {
   id: ID @primaryKey
 }
 
-# Declared Float attributes: the path that runs Table.ts's per-type validation, which a
-# future finiteness check would tighten.
+# Every special-float attribute is declared here, so writes reach Table.ts's per-type
+# validation instead of the open-attribute path Doc takes.
 type TypedDoc @table @export {
   id: ID @primaryKey
   nan: Float
   posInf: Float
   negInf: Float
+  negZero: Float
   normal: Float
 }


### PR DESCRIPTION
Promotes one QA-explorer regression anchor (candidate P-463, from QA-432) into `integrationTests/database/`: the content-negotiation write-path contract for IEEE-754 special floats. JSON cannot represent `NaN` or `±Infinity`, so a binary body is the only way to put one in front of Harper; the spec PUTs CBOR and msgpack bodies to an open table and to one whose attributes are [declared `Float`](https://github.com/HarperFast/harper/pull/2544/changes?w=1#diff-9a0dc3a57ed3be0599007e55362d155e6ccd899c916957b20b89a371818937b8R9), reads each record back over CBOR, msgpack and JSON, requires every successful response to [declare the requested Content-Type](https://github.com/HarperFast/harper/pull/2544/changes?w=1#diff-fa813804bb9af3fd668d0e514b53560aef3e7f9ec8c8d4cd9c1443a2f6ced9dcR171), and pins that [`NaN` and `±Infinity` round-trip exactly on a binary read and flatten to `null` over JSON](https://github.com/HarperFast/harper/pull/2544/changes?w=1#diff-fa813804bb9af3fd668d0e514b53560aef3e7f9ec8c8d4cd9c1443a2f6ced9dcR230), and that [a genuine `-0` on the wire never survives the round trip](https://github.com/HarperFast/harper/pull/2544/changes?w=1#diff-fa813804bb9af3fd668d0e514b53560aef3e7f9ec8c8d4cd9c1443a2f6ced9dcR293) on any of the 18 table × write-format × read-format combinations. The fixture is [a REST-exported pair of tables](https://github.com/HarperFast/harper/pull/2544/changes?w=1#diff-12d3d6f73e6c3c62b692ec4fa6998653b4cb5966279ce21d3c8f03af0845de4dR1) — `Doc` open, `TypedDoc` declared — and the [file header](https://github.com/HarperFast/harper/pull/2544/changes?w=1#diff-fa813804bb9af3fd668d0e514b53560aef3e7f9ec8c8d4cd9c1443a2f6ced9dcR1) states what a binary read does and does not prove.

Test-only — no product file is modified.

Known non-blocking diagnostic tradeoffs: the assertion arms consume a matrix populated by the preceding write arms, passing runs print that matrix, and the custom parser relies on normal Node response-stream terminal semantics; these can add secondary diagnostics or log noise but cannot create a false pass.

**This PR carries one of the three specs the task asked for. The other two are not promotable, and the evidence is below rather than in a follow-up.** P-629 (QA-883) is already on main: `integrationTests/resources/subscription-delivery-completeness.test.ts` opens with `QA-883` and landed in #2070, in a form better than the banked snapshot. P-445 (QA-668) cannot be armed on current main — its precondition requires 18 phantom null-keyed index entries and both engines now produce zero, because F-175 is fixed and `integrationTests/database/eviction-index-phantom-null-keys.test.ts` asserts exactly that on every removal path. Making P-445 green would mean deleting its precondition, so it stays out. It was also *not* additive to that file in the way its candidate note claimed: the two were complementary only while phantoms existed.

## For the human reviewer

1. **`-0` loss is pinned as the expected characterization, not filed as a defect.** A genuine IEEE-754 `-0` on the wire comes back `+0` on all 18 combinations, and the suite asserts that. The alternative was to encode desired sign preservation or track the known loss separately. I pinned current observable behavior because the surrounding QA finding classed it benign (`-0 === 0` for nearly every consumer) and an anchor's job is to expose a change. A future fidelity fix will make this arm red until its one expectation is inverted; the arm now explicitly scopes itself to the complete REST round trip, not storage alone.
2. **Pinning `NaN`/`±Infinity` as values a declared `Float` must preserve is a stored-data semantics call.** Today `resources/Table.ts` validates a declared `Float` with `typeof value !== 'number'`, which admits non-finite values. This suite now asserts they survive, so it will block a future tightening to a finiteness check. If that tightening is desirable, this contract is the wrong way round and should be inverted before applications depend on it.
3. **JSON reads flatten non-finite values to `null`.** The alternative is rejection or an alternate representation, either of which would be a different network API contract. This anchor keeps today's interoperable JSON representation visible; changing the choice later can break clients that distinguish a successful `null` field from a rejected response.
4. **The suite uses the immediate REST round trip as its evidence layer.** Outbound CBOR/msgpack encoders can lose a value after storage, so a changed read cannot be attributed to ingest, persistence, or response encoding, and the same-lifetime run does not prove restart durability. A direct storage/restart oracle would localize those layers but is a new test with broader scope; adding one later is moderately costly but does not require rewriting this matrix.
5. **Execution covers the default non-Windows storage path, not Windows or LMDB.** Those arms would catch native-storage or platform-specific regressions, but this database fixture follows the existing non-Windows integration-test boundary and broader coverage adds CI cost. Adding either matrix dimension later is straightforward.

## Changes

**Where to look hardest: [the `-0` arm's wire arming check](https://github.com/HarperFast/harper/pull/2544/changes?w=1#diff-fa813804bb9af3fd668d0e514b53560aef3e7f9ec8c8d4cd9c1443a2f6ced9dcR289).** The banked snapshot's `-0` arm never tested Harper at all — cbor-x and msgpackr both take an integer fast path for `-0` (`-0 >>> 0 === -0`), so `encode({ x: -0 })` emitted unsigned integer `0` and the request carried a positive zero. The arm now asserts its request bytes contain a real float64 `-0` before it reads anything back, which is what stops that class recurring; [the msgpack body is assembled byte by byte](https://github.com/HarperFast/harper/pull/2544/changes?w=1#diff-fa813804bb9af3fd668d0e514b53560aef3e7f9ec8c8d4cd9c1443a2f6ced9dcR247) because msgpackr has no `alwaysUseFloat`, and [the JSON body is written as text](https://github.com/HarperFast/harper/pull/2544/changes?w=1#diff-fa813804bb9af3fd668d0e514b53560aef3e7f9ec8c8d4cd9c1443a2f6ced9dcR294) because `JSON.stringify(-0)` is `"0"`. That JSON arm also has to be [sent as a string](https://github.com/HarperFast/harper/pull/2544/changes?w=1#diff-fa813804bb9af3fd668d0e514b53560aef3e7f9ec8c8d4cd9c1443a2f6ced9dcR320): supertest transmits a `Buffer` as binary whatever the `Content-Type` header says, which stored the raw request bytes as the record until it was fixed.

[`TypedDoc` in the schema](https://github.com/HarperFast/harper/pull/2544/changes?w=1#diff-9a0dc3a57ed3be0599007e55362d155e6ccd899c916957b20b89a371818937b8R9) declares every special-float attribute so writes reach `resources/Table.ts`'s per-type validation — `case 'Float': if (typeof value !== 'number')`, which admits non-finite values today — while `Doc` leaves them undeclared and skips that branch. [An arming arm proves every declaration is active](https://github.com/HarperFast/harper/pull/2544/changes?w=1#diff-fa813804bb9af3fd668d0e514b53560aef3e7f9ec8c8d4cd9c1443a2f6ced9dcR278) by independently requiring a non-numeric value in each of the five fields to be rejected with exactly 400 on `TypedDoc` and accepted on `Doc`; without those probes, removing or misspelling one declaration would silently route that field through the open-attribute path while the fidelity assertions stayed green.

[A vacuity floor](https://github.com/HarperFast/harper/pull/2544/changes?w=1#diff-fa813804bb9af3fd668d0e514b53560aef3e7f9ec8c8d4cd9c1443a2f6ced9dcR208) requires all four table × write-format rows before any analysis arm reads the matrix — an empty matrix would otherwise make every loop iterate zero times and pass having measured nothing. [Readiness](https://github.com/HarperFast/harper/pull/2544/changes?w=1#diff-fa813804bb9af3fd668d0e514b53560aef3e7f9ec8c8d4cd9c1443a2f6ced9dcR111) uses the suite's own `waitForRouteReady` with `isReady` tightened to `status === 200`, per table, so a half-started server cannot let the first PUT land before the table exists and be reported as a write-path defect.

## Verification

Planning gate: `Framing-Verdict: chosen-approach-sound`.

Route: new integration test, run on current branch head `ab8da7720` after `npm run build` (integration tests load `dist`).

```
npm run test:integration -- "integrationTests/database/special-float-write-fidelity.test.ts"
  tests 6 / pass 6 / fail 0   4657ms
```

Fresh merge-ref CI (`1ee1d141`, current `main` parent `4f3dda65`): [Format Check](https://github.com/HarperFast/harper/actions/runs/34610081840), [Unit Test](https://github.com/HarperFast/harper/actions/runs/34610081716) including Node 24, and [all Integration Test matrices](https://github.com/HarperFast/harper/actions/runs/34610081702) passed.

Measured round-trip matrix — identical on the open table and the declared-`Float` one, for both binary write formats:

| field | written | json | cbor | msgpack |
|---|---|---|---|---|
| nan | NaN | null | NaN | NaN |
| posInf | +Infinity | null | +Infinity | +Infinity |
| negInf | -Infinity | null | -Infinity | -Infinity |
| normal | 3.14 | 3.14 | 3.14 | 3.14 |

`-0` is lost on all 18 table × write-format × read-format combinations, JSON ingest included. Every negotiated read returned its requested media type, and all five declared-field arming probes measured `TypedDoc -> 400, Doc -> 204`.

Each assertion was shown capable of failing, by mutation:

| mutation | expected | observed |
|---|---|---|
| drop the msgpack write | vacuity floor fires | `pass 2 / fail 4` |
| expect `-0` to survive | sign arm only | `pass 5 / fail 1` |
| build the `-0` body with the default encoder | wire arming check fires | `AssertionError: … must carry float64 -0 … got …6e65675a65726f00` |
| write only to `Doc` | widened floor fires | `every table x write format must have produced a record` |

Gates: `qa-promote-gate.mjs` 0 hard rejects / 0 warnings; `npm run format:check`, `npm run lint:required`, and `npm run typecheck` clean; `npx oxlint --format stylish --deny-warnings` also clean and confirmed armed on this file by a non-underscore probe (`qaProbeUnusedImport` produced `no-unused-vars`, then reverted).

Not covered, deliberately: restart durability, the replication encoder, and which layer drops the `-0` sign — see the reviewer notes above.

Complexity: medium

<sub>Review-Coverage: authored=codex; ran=claude,gemini; declined=cursor-grok,cursor-composer,domain; rounds=3 @ ab8da77207cf</sub>

<sub>Human-Review-Need: 3 @ ab8da77207cf</sub>
