### PR TITLE
test: promote three QA regression anchors (QA-716 / QA-627 / QA-681)

### DIFF
--- a/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
+++ b/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
@@ -76,6 +76,12 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 	): Promise<MqttClient> {
 		return new Promise((resolvePromise, reject) => {
 			const mqttClient = mqtt.connect(url, opts);
+			// A post-connect 'error' listener is mandatory — an unhandled 'error' on an EventEmitter
+			// throws — but discarding it costs the diagnosis: a broker crash or socket reset would
+			// then surface only as a downstream waitFor timeout. Q4 destroys a transport on purpose,
+			// so this logs rather than fails.
+			const noteLateError = (err: Error) =>
+				console.log(`[QA-681] post-connect mqtt error on ${opts.clientId}: ${err?.message ?? err}`);
 			if (collector) mqttClient.on('message', collector);
 			let timer: ReturnType<typeof setTimeout>;
 			const onError = (err: Error) => {
@@ -87,7 +93,7 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 			const onConnect = () => {
 				clearTimeout(timer);
 				mqttClient.removeListener('error', onError);
-				mqttClient.on('error', () => {});
+				mqttClient.on('error', noteLateError);
 				resolvePromise(mqttClient);
 			};
 			// Remove only this helper's own listeners on timeout. removeAllListeners() would also
@@ -96,7 +102,7 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 			timer = setTimeout(() => {
 				mqttClient.removeListener('error', onError);
 				mqttClient.removeListener('connect', onConnect);
-				mqttClient.on('error', () => {});
+				mqttClient.on('error', noteLateError);
 				mqttClient.end(true);
 				reject(new Error(`mqtt connect timed out for clientId=${opts.clientId}`));
 			}, 10_000);

--- a/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
+++ b/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
@@ -30,6 +30,8 @@ import mqtt, { type IClientOptions, type MqttClient } from 'mqtt';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
 import { createApiClient } from '../apiTests/utils/client.mjs';
+// @ts-expect-error lifecycle.mjs has no type declarations; runtime resolves fine
+import { waitForRouteReady } from '../apiTests/utils/lifecycle.mjs';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'qa681-mqtt-shared-subscriptions');
 
@@ -39,6 +41,7 @@ const skipSuite = process.env.HARPER_RUNTIME === 'bun' || process.platform === '
 
 const STREAM_TOPIC = 'Events/stream';
 const Q3_TOPIC = 'Events/q3stream';
+const Q3_SHARE_TOPIC = `$share/g1/${Q3_TOPIC}`;
 const QOS1_TOPIC = 'Events/qos1stream';
 const SHARE_TOPIC = '$share/g1/Events/stream';
 const SUBACK_TOPIC_FILTER_INVALID = 0x8f; // MQTT v5
@@ -199,21 +202,7 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 		const wsScheme = httpURL.startsWith('https') ? 'wss' : 'ws';
 		mqttURL = `${httpURL.replace(/^https?/, wsScheme)}/mqtt`;
 
-		let ready = false;
-		const deadline = Date.now() + 120_000;
-		while (Date.now() < deadline) {
-			try {
-				const probe = await client.reqRest('/Events/').timeout(3_000);
-				if (probe.status !== 404) {
-					ready = true;
-					break;
-				}
-			} catch {
-				/* not ready yet */
-			}
-			await sleep(250);
-		}
-		ok(ready, 'REST route /Events/ never became available within 120s — the fixture did not install');
+		await waitForRouteReady(client, '/Events/', 120_000);
 
 		try {
 			const probe = await connect(mqttURL, baseOpts({ clientId: 'qa681-probe' }));
@@ -318,7 +307,7 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 				for (let i = 0; i < 4; i++) {
 					const c = await connect(mqttURL, baseOpts({ clientId: `qa681-q3-group-${i}` }));
 					groupClients.push(c);
-					groupSubAcks.push(await subscribe(c, SHARE_TOPIC, 1));
+					groupSubAcks.push(await subscribe(c, Q3_SHARE_TOPIC, 1));
 					groupCollectors.push(collectMessages(c));
 				}
 				await subscribe(ordinary, Q3_TOPIC, 1);
@@ -338,7 +327,6 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 					`[QA-681][Q3] ordinary recv=${ordinarySeqs.length}/${M}; refused-client recv counts=${JSON.stringify(groupCounts)}`
 				);
 
-				// Floor: without it a run that published nothing would satisfy the zeros below.
 				// The zeros must come from a refusal, not from a subscribe that timed out: same zero,
 				// different reason.
 				for (const [i, r] of groupSubAcks.entries())

--- a/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
+++ b/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
@@ -38,6 +38,7 @@ const FIXTURE_PATH = resolve(import.meta.dirname, 'qa681-mqtt-shared-subscriptio
 const skipSuite = process.env.HARPER_RUNTIME === 'bun' || process.platform === 'win32';
 
 const STREAM_TOPIC = 'Events/stream';
+const Q3_TOPIC = 'Events/q3stream';
 const QOS1_TOPIC = 'Events/qos1stream';
 const SHARE_TOPIC = '$share/g1/Events/stream';
 const SUBACK_TOPIC_FILTER_INVALID = 0x8f; // MQTT v5
@@ -320,11 +321,11 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 					groupSubAcks.push(await subscribe(c, SHARE_TOPIC, 1));
 					groupCollectors.push(collectMessages(c));
 				}
-				await subscribe(ordinary, STREAM_TOPIC, 1);
+				await subscribe(ordinary, Q3_TOPIC, 1);
 				const ordinaryObs = collectMessages(ordinary);
 
 				for (let seq = 0; seq < M; seq++) {
-					await publish(pub, STREAM_TOPIC, JSON.stringify({ seq, tag: 'q3' }));
+					await publish(pub, Q3_TOPIC, JSON.stringify({ seq, tag: 'q3' }));
 				}
 				await waitFor(() => ordinaryObs.messages.length >= M, 8_000);
 				await sleep(800); // only elapsed time can evidence the absence asserted below
@@ -391,6 +392,10 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 						// unsubscribe, which is what leaves the durable session with a backlog to resume.
 						(dropClient as any).stream?.destroy?.();
 						dropClient.end(true);
+						// Converge on the socket actually being down before publishing past the drop
+						// point; otherwise seq 15 can still reach the old session and the boundary
+						// assertion below fails on a run that behaved correctly.
+						await waitFor(() => dropClient?.connected !== true, 5_000);
 					}
 				}
 				await waitFor(() => cA.messages.length >= N && cC.messages.length >= N, 12_000);

--- a/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
+++ b/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
@@ -1,0 +1,478 @@
+/**
+ * Promoted from qa-explorer (QA-681 / P-460): pins Harper's MQTT shared-subscription (`$share`)
+ * contract and the ordinary fan-out invariants a client would otherwise reach for it to get.
+ *
+ * Harper implements no `$share` parsing. `SubscriptionsSession.addSubscription()` hands the whole
+ * topic string, literal `$share/<group>/` prefix included, to `resources.getMatch(path, 'mqtt')`;
+ * `$share` is never a table, so the lookup misses, addSubscription() throws a 404, and
+ * server/mqtt.ts maps it to SUBACK reason 0x8f on MQTT v5 and 0x80 on v3.1.1.
+ *
+ * The promotable fact is that the subscription is REFUSED rather than accepted as an inert filter.
+ * If a future change silently accepted `$share`, subscribers would begin receiving the FULL fan-out
+ * where the application expected each message to reach exactly one worker — so both the refusal and
+ * the absence of delivery are asserted, and either drift fails this file.
+ *
+ * On a rejected SUBACK mqtt.js's `granted` callback argument echoes the client's own request rather
+ * than the broker's grant, so the reason code is read from `err.packet.granted`. Reading `granted`
+ * there turns a correct refusal into a fabricated "silently accepted" result.
+ *
+ * Run:
+ *   npm run test:integration -- "integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts"
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import mqtt, { type IClientOptions, type MqttClient } from 'mqtt';
+
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from '../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'qa681-mqtt-shared-subscriptions');
+
+// mqtt.js's WebSocket transport doesn't complete CONNACK on Bun — the same skip the sibling MQTT
+// suites carry.
+const skipSuite = process.env.HARPER_RUNTIME === 'bun' || process.platform === 'win32';
+
+const STREAM_TOPIC = 'Events/stream';
+const QOS1_TOPIC = 'Events/qos1stream';
+const SHARE_TOPIC = '$share/g1/Events/stream';
+const SUBACK_TOPIC_FILTER_INVALID = 0x8f; // MQTT v5
+const SUBACK_UNSPECIFIED_FAILURE = 0x80; // MQTT v3.1.1's only failure code
+
+suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite }, (ctx: ContextWithHarper) => {
+	let client: ReturnType<typeof createApiClient>;
+	let mqttURL = '';
+	let mqttUsable = false;
+	let mqttSkipReason = '';
+
+	function baseOpts(overrides: Partial<IClientOptions> = {}): IClientOptions {
+		return {
+			protocolVersion: 5,
+			reconnectPeriod: 0,
+			connectTimeout: 8_000,
+			clean: true,
+			username: ctx.harper.admin.username,
+			password: ctx.harper.admin.password,
+			...overrides,
+		};
+	}
+
+	/** `collector`, when given, is attached synchronously at client creation — before CONNACK. A
+	 *  resuming durable session replays its backlog the moment the connection is accepted, and
+	 *  mqtt.js delivers and acknowledges those PUBLISHes before the continuation of an awaited
+	 *  connect() could install a listener, so a listener added afterwards silently misses them. */
+	function connect(
+		url: string,
+		opts: IClientOptions,
+		collector?: (topic: string, payload: Buffer) => void
+	): Promise<MqttClient> {
+		return new Promise((resolvePromise, reject) => {
+			const mqttClient = mqtt.connect(url, opts);
+			if (collector) mqttClient.on('message', collector);
+			const onError = (err: Error) => {
+				clearTimeout(timer);
+				mqttClient.removeListener('connect', onConnect);
+				mqttClient.end(true);
+				reject(err);
+			};
+			const onConnect = () => {
+				clearTimeout(timer);
+				mqttClient.removeListener('error', onError);
+				mqttClient.on('error', () => {});
+				resolvePromise(mqttClient);
+			};
+			// Remove only this helper's own listeners on timeout. removeAllListeners() would also
+			// strip mqtt.js's internal socket-teardown handlers, which can leave end(true) stalled
+			// and hang the runner rather than failing it.
+			const timer = setTimeout(() => {
+				mqttClient.removeListener('error', onError);
+				mqttClient.removeListener('connect', onConnect);
+				mqttClient.on('error', () => {});
+				mqttClient.end(true);
+				reject(new Error(`mqtt connect timed out for clientId=${opts.clientId}`));
+			}, 10_000);
+			mqttClient.once('error', onError);
+			mqttClient.once('connect', onConnect);
+		});
+	}
+
+	interface SubAckResult {
+		granted?: any[];
+		err?: string;
+		/** The broker's real reason code. mqtt.js's ack handler computes `err.code` from the wire
+		 *  packet, but the top-level subscribe() callback re-wraps it as an `ErrorWithSubackPacket`
+		 *  which drops `.code` and keeps `.packet` — whose `.granted` holds the reason-code bytes.
+		 *  The callback's own `granted` argument is the client's echoed REQUEST on a rejection, so
+		 *  it must never be the source of this value. */
+		code?: number;
+	}
+	function subscribe(
+		mqttClient: MqttClient,
+		topic: string,
+		qos: 0 | 1 | 2 = 1,
+		timeoutMs = 8_000
+	): Promise<SubAckResult> {
+		return new Promise((resolvePromise, reject) => {
+			const timer = setTimeout(() => reject(new Error(`subscribe timed out for ${topic}`)), timeoutMs);
+			mqttClient.subscribe(topic, { qos }, (err, granted) => {
+				clearTimeout(timer);
+				const rawGranted = (err as any)?.packet?.granted;
+				resolvePromise({
+					granted: granted?.map((g: any) => g.qos ?? g),
+					err: err ? String(err.message ?? err) : undefined,
+					code: (err as any)?.code ?? (Array.isArray(rawGranted) ? rawGranted[0] : undefined),
+				});
+			});
+		});
+	}
+
+	function publish(mqttClient: MqttClient, topic: string, payload: string, opts: object = {}): Promise<void> {
+		return new Promise((resolvePromise, reject) => {
+			mqttClient.publish(topic, payload, { qos: 1, retain: false, ...opts }, (err) =>
+				err ? reject(err) : resolvePromise()
+			);
+		});
+	}
+
+	function endQuiet(mqttClient: MqttClient | undefined): Promise<void> {
+		return new Promise((resolvePromise) => {
+			if (!mqttClient) return resolvePromise();
+			const timer = setTimeout(() => resolvePromise(), 3_000);
+			mqttClient.end(true, {}, () => {
+				clearTimeout(timer);
+				resolvePromise();
+			});
+		});
+	}
+
+	interface CollectedMessage {
+		topic: string;
+		payload: string;
+	}
+	function collectMessages(mqttClient: MqttClient) {
+		const messages: CollectedMessage[] = [];
+		const handler = (topic: string, payload: Buffer) => {
+			messages.push({ topic, payload: payload.toString() });
+		};
+		mqttClient.on('message', handler);
+		return { messages, stop: () => mqttClient.removeListener('message', handler) };
+	}
+
+	async function waitFor(predicate: () => boolean, timeoutMs = 6_000, intervalMs = 30): Promise<boolean> {
+		const deadline = Date.now() + timeoutMs;
+		while (Date.now() < deadline) {
+			if (predicate()) return true;
+			await sleep(intervalMs);
+		}
+		return predicate();
+	}
+
+	function payloadSeq(p: string): number | undefined {
+		try {
+			const parsed = JSON.parse(p);
+			if (parsed && typeof parsed === 'object' && 'seq' in parsed) return (parsed as any).seq;
+		} catch {
+			/* a non-JSON payload is not one of ours; the caller's count assertions catch the shortfall */
+		}
+		return undefined;
+	}
+
+	const seqsOf = (collected: { messages: CollectedMessage[] }): number[] =>
+		collected.messages.map((m) => payloadSeq(m.payload)).filter((v): v is number => typeof v === 'number');
+
+	/** Fail rather than silently skip when the harness could not reach MQTT at all: an arm that
+	 *  reports a green verdict without having run its probes is exactly the vacuous coverage a
+	 *  regression anchor exists to prevent. */
+	function requireMqtt() {
+		ok(mqttUsable, `MQTT is unusable, so this arm proved nothing: ${mqttSkipReason}`);
+	}
+
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: {}, env: {} });
+		client = createApiClient(ctx.harper);
+		const httpURL = ctx.harper.httpURL;
+		const wsScheme = httpURL.startsWith('https') ? 'wss' : 'ws';
+		mqttURL = `${httpURL.replace(/^https?/, wsScheme)}/mqtt`;
+
+		// Pre-installed fixture, so poll for non-404 rather than restarting workers.
+		let ready = false;
+		const deadline = Date.now() + 120_000;
+		while (Date.now() < deadline) {
+			try {
+				const probe = await client.reqRest('/Events/').timeout(3_000);
+				if (probe.status !== 404) {
+					ready = true;
+					break;
+				}
+			} catch {
+				/* not ready yet */
+			}
+			await sleep(250);
+		}
+		ok(ready, 'REST route /Events/ never became available within 120s — the fixture did not install');
+
+		try {
+			const probe = await connect(mqttURL, baseOpts({ clientId: 'qa681-probe' }));
+			mqttUsable = probe.connected === true;
+			if (!mqttUsable) mqttSkipReason = `MQTT client connected=false on ${mqttURL}`;
+			await endQuiet(probe);
+		} catch (err) {
+			mqttUsable = false;
+			mqttSkipReason = `MQTT connect probe failed on ${mqttURL}: ${(err as Error)?.message}`;
+		}
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('Q1 (control): ordinary subscribers get complete, duplicate-free fan-out', { timeout: 30_000 }, async () => {
+		requireMqtt();
+		const M = 20;
+		const pub = await connect(mqttURL, baseOpts({ clientId: 'qa681-q1-pub' }));
+		const subA = await connect(mqttURL, baseOpts({ clientId: 'qa681-q1-a' }));
+		const subB = await connect(mqttURL, baseOpts({ clientId: 'qa681-q1-b' }));
+		try {
+			await subscribe(subA, STREAM_TOPIC, 1);
+			await subscribe(subB, STREAM_TOPIC, 1);
+			const cA = collectMessages(subA);
+			const cB = collectMessages(subB);
+
+			for (let seq = 0; seq < M; seq++) {
+				await publish(pub, STREAM_TOPIC, JSON.stringify({ seq, tag: 'q1' }));
+			}
+			await waitFor(() => cA.messages.length >= M && cB.messages.length >= M, 10_000);
+			await sleep(500); // so a duplicate just behind the Mth message still lands in the count
+			cA.stop();
+			cB.stop();
+
+			const seqsA = seqsOf(cA);
+			const seqsB = seqsOf(cB);
+			console.log(`[QA-681][Q1] ordinary fan-out: A recv=${seqsA.length} B recv=${seqsB.length} (published=${M})`);
+			strictEqual(seqsA.length, M, `ordinary subscriber A should get every one of ${M} messages (true fan-out)`);
+			strictEqual(seqsB.length, M, `ordinary subscriber B should get every one of ${M} messages (true fan-out)`);
+			strictEqual(new Set(seqsA).size, M, 'no duplicates for A');
+			strictEqual(new Set(seqsB).size, M, 'no duplicates for B');
+		} finally {
+			await endQuiet(pub);
+			await endQuiet(subA);
+			await endQuiet(subB);
+		}
+	});
+
+	test('Q2: $share subscriptions are refused with an explicit SUBACK reason code', { timeout: 30_000 }, async () => {
+		requireMqtt();
+
+		const clientsV5: MqttClient[] = [];
+		const resultsV5: SubAckResult[] = [];
+		try {
+			for (let i = 0; i < 4; i++) {
+				const c = await connect(mqttURL, baseOpts({ clientId: `qa681-q2-v5-${i}` }));
+				clientsV5.push(c);
+				resultsV5.push(await subscribe(c, SHARE_TOPIC, 1));
+			}
+		} finally {
+			for (const c of clientsV5) await endQuiet(c);
+		}
+		console.log(`[QA-681][Q2] v5 SUBACK results for ${SHARE_TOPIC} (4 clients): ${JSON.stringify(resultsV5)}`);
+		strictEqual(resultsV5.length, 4, 'all four v5 clients must have produced a SUBACK result');
+		for (const [i, r] of resultsV5.entries()) {
+			strictEqual(
+				r.code,
+				SUBACK_TOPIC_FILTER_INVALID,
+				`client ${i}: expected reason 0x8f (Topic Filter invalid) — $share must be REFUSED, not accepted as an ordinary filter — got ${JSON.stringify(r)}`
+			);
+		}
+
+		const clientV3 = await connect(mqttURL, baseOpts({ clientId: 'qa681-q2-v3', protocolVersion: 4 }));
+		try {
+			const resV3 = await subscribe(clientV3, SHARE_TOPIC, 1);
+			console.log(`[QA-681][Q2] v3.1.1 SUBACK result: ${JSON.stringify(resV3)}`);
+			strictEqual(
+				resV3.code,
+				SUBACK_UNSPECIFIED_FAILURE,
+				`v3.1.1 expected refusal reason 0x80, got ${JSON.stringify(resV3)}`
+			);
+		} finally {
+			await endQuiet(clientV3);
+		}
+	});
+
+	test(
+		'Q3: a refused $share subscriber receives nothing and does not disturb an ordinary one',
+		{ timeout: 30_000 },
+		async () => {
+			requireMqtt();
+			const M = 15;
+			const pub = await connect(mqttURL, baseOpts({ clientId: 'qa681-q3-pub' }));
+			const groupClients: MqttClient[] = [];
+			const groupCollectors: ReturnType<typeof collectMessages>[] = [];
+			const ordinary = await connect(mqttURL, baseOpts({ clientId: 'qa681-q3-ordinary' }));
+			try {
+				// Delivery is deliberately not gated on the SUBACK: this is the fire-and-forget client.
+				const groupSubAcks: SubAckResult[] = [];
+				for (let i = 0; i < 4; i++) {
+					const c = await connect(mqttURL, baseOpts({ clientId: `qa681-q3-group-${i}` }));
+					groupClients.push(c);
+					groupSubAcks.push(await subscribe(c, SHARE_TOPIC, 1));
+					groupCollectors.push(collectMessages(c));
+				}
+				await subscribe(ordinary, STREAM_TOPIC, 1);
+				const ordinaryObs = collectMessages(ordinary);
+
+				for (let seq = 0; seq < M; seq++) {
+					await publish(pub, STREAM_TOPIC, JSON.stringify({ seq, tag: 'q3' }));
+				}
+				await waitFor(() => ordinaryObs.messages.length >= M, 8_000);
+				await sleep(800); // only elapsed time can evidence the absence asserted below
+				ordinaryObs.stop();
+				groupCollectors.forEach((c) => c.stop());
+
+				const ordinarySeqs = seqsOf(ordinaryObs);
+				const groupCounts = groupCollectors.map((c) => c.messages.length);
+				console.log(
+					`[QA-681][Q3] ordinary recv=${ordinarySeqs.length}/${M}; refused-client recv counts=${JSON.stringify(groupCounts)}`
+				);
+
+				// Floor: without it a run that published nothing would satisfy the zeros below.
+				// The zeros must come from a refusal, not from a subscribe that timed out: same zero,
+				// different reason.
+				for (const [i, r] of groupSubAcks.entries())
+					strictEqual(
+						r.code,
+						SUBACK_TOPIC_FILTER_INVALID,
+						`$share client ${i} must have been refused, not merely unsubscribed: ${JSON.stringify(r)}`
+					);
+				strictEqual(ordinarySeqs.length, M, "ordinary subscriber unaffected by neighbours' refused $share subscribes");
+				strictEqual(new Set(ordinarySeqs).size, M, 'ordinary subscriber sees no duplicates');
+				for (const [i, n] of groupCounts.entries())
+					strictEqual(n, 0, `$share client ${i} must receive ZERO messages — neither load-balanced nor fanned out`);
+			} finally {
+				await endQuiet(pub);
+				await endQuiet(ordinary);
+				for (const c of groupClients) await endQuiet(c);
+			}
+		}
+	);
+
+	test(
+		'Q4: QoS1 mid-stream disconnect — no cross-client redistribution, and the durable session loses nothing',
+		{ timeout: 40_000 },
+		async () => {
+			requireMqtt();
+			const N = 30;
+			const dropAt = 15;
+			const dropClientId = `qa681-q4-drop-${randomUUID().slice(0, 6)}`;
+
+			const pub = await connect(mqttURL, baseOpts({ clientId: 'qa681-q4-pub' }));
+			const survivorA = await connect(mqttURL, baseOpts({ clientId: 'qa681-q4-a' }));
+			const survivorC = await connect(mqttURL, baseOpts({ clientId: 'qa681-q4-c' }));
+			let dropClient: MqttClient | undefined;
+			try {
+				await subscribe(survivorA, QOS1_TOPIC, 1);
+				await subscribe(survivorC, QOS1_TOPIC, 1);
+				// clean:false plus a stable clientId, so "lost forever" is distinguishable from
+				// "redelivered to itself" after the resume.
+				dropClient = await connect(mqttURL, baseOpts({ clientId: dropClientId, clean: false }));
+				await subscribe(dropClient, QOS1_TOPIC, 1);
+
+				const cA = collectMessages(survivorA);
+				const cC = collectMessages(survivorC);
+				const beforeDrop = collectMessages(dropClient);
+
+				for (let seq = 0; seq < N; seq++) {
+					await publish(pub, QOS1_TOPIC, JSON.stringify({ seq, tag: 'q4' }), { qos: 1 });
+					if (seq === dropAt - 1) {
+						await sleep(150); // let in-flight qos1 delivery to dropClient settle first
+						// Destroy the transport with no MQTT DISCONNECT: a crashed member, not a clean
+						// unsubscribe, which is what leaves the durable session with a backlog to resume.
+						(dropClient as any).stream?.destroy?.();
+						dropClient.end(true);
+					}
+				}
+				await waitFor(() => cA.messages.length >= N && cC.messages.length >= N, 12_000);
+				await sleep(800); // so a redistributed extra copy would be counted, not missed
+				cA.stop();
+				cC.stop();
+				beforeDrop.stop();
+
+				const seqsA = seqsOf(cA);
+				const seqsC = seqsOf(cC);
+				const deliveredBeforeDrop = new Set(seqsOf(beforeDrop));
+
+				console.log(
+					`[QA-681][Q4] drop after seq=${dropAt - 1}: survivorA recv=${seqsA.length}/${N} ` +
+						`survivorC recv=${seqsC.length}/${N} dropClient recv-before-drop=${deliveredBeforeDrop.size}`
+				);
+				strictEqual(
+					seqsA.length,
+					N,
+					`survivor A should get exactly ${N} (no redistribution of the dropped client's messages)`
+				);
+				strictEqual(
+					seqsC.length,
+					N,
+					`survivor C should get exactly ${N} (no redistribution of the dropped client's messages)`
+				);
+				strictEqual(new Set(seqsA).size, N, 'no duplicates for survivor A');
+				strictEqual(new Set(seqsC).size, N, 'no duplicates for survivor C');
+
+				// The drop must genuinely have cut delivery. Without this, a run where the transport
+				// destroy failed leaves deliveredBeforeDrop holding all N and expectedRecovery at 0, so
+				// the union check below is satisfied before the session ever resumes and a broken
+				// clean:false resume passes. Which messages landed first is scheduler-dependent; that
+				// none published after the drop did is not, and that is what is asserted.
+				ok(
+					[...deliveredBeforeDrop].every((seq) => seq < dropAt),
+					`the dropped client must have received nothing published after the drop, got ${JSON.stringify([...deliveredBeforeDrop].sort((a, b) => a - b))}`
+				);
+
+				// Reconnect the SAME clientId and let the durable session catch up. How many messages
+				// landed before the drop is scheduler-dependent, so the assertion is on the union:
+				// whatever the split, the session as a whole must have lost nothing.
+				const resumedMessages: CollectedMessage[] = [];
+				const resumed = await connect(mqttURL, baseOpts({ clientId: dropClientId, clean: false }), (topic, payload) =>
+					resumedMessages.push({ topic, payload: payload.toString() })
+				);
+				try {
+					const expectedRecovery = N - deliveredBeforeDrop.size;
+					await waitFor(() => resumedMessages.length >= expectedRecovery, 10_000);
+					await sleep(500); // so a straggler just behind the last recovered message still lands
+					const resumedSeqs = seqsOf({ messages: resumedMessages });
+					console.log(
+						`[QA-681][Q4] resumed same-clientId session recv=${resumedSeqs.length} ` +
+							`(expected at least ${expectedRecovery}): ${JSON.stringify(resumedSeqs)}`
+					);
+
+					// A floor, not an exact count: QoS-1 is at-least-once, so a message unacked when the
+					// transport died may legitimately be replayed — possibly more than once.
+					ok(
+						resumedSeqs.length >= expectedRecovery,
+						`the resumed session should recover the ${expectedRecovery} message(s) it missed, got ${JSON.stringify(resumedSeqs)}`
+					);
+					const seen = new Set([...deliveredBeforeDrop, ...resumedSeqs]);
+					const missing = Array.from({ length: N }, (_, seq) => seq).filter((seq) => !seen.has(seq));
+					strictEqual(
+						missing.length,
+						0,
+						`the durable session must lose nothing across the drop; never delivered seq ${JSON.stringify(missing)}`
+					);
+					ok(
+						resumedSeqs.every((seq) => seq >= 0 && seq < N),
+						`the resumed session must only receive this run's messages, got ${JSON.stringify(resumedSeqs)}`
+					);
+				} finally {
+					await endQuiet(resumed);
+				}
+			} finally {
+				await endQuiet(pub);
+				await endQuiet(survivorA);
+				await endQuiet(survivorC);
+			}
+		}
+	);
+});

--- a/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
+++ b/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
@@ -77,6 +77,7 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 		return new Promise((resolvePromise, reject) => {
 			const mqttClient = mqtt.connect(url, opts);
 			if (collector) mqttClient.on('message', collector);
+			let timer: ReturnType<typeof setTimeout>;
 			const onError = (err: Error) => {
 				clearTimeout(timer);
 				mqttClient.removeListener('connect', onConnect);
@@ -92,7 +93,7 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 			// Remove only this helper's own listeners on timeout. removeAllListeners() would also
 			// strip mqtt.js's internal socket-teardown handlers, which can leave end(true) stalled
 			// and hang the runner rather than failing it.
-			const timer = setTimeout(() => {
+			timer = setTimeout(() => {
 				mqttClient.removeListener('error', onError);
 				mqttClient.removeListener('connect', onConnect);
 				mqttClient.on('error', () => {});
@@ -222,10 +223,13 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 	test('Q1 (control): ordinary subscribers get complete, duplicate-free fan-out', { timeout: 30_000 }, async () => {
 		requireMqtt();
 		const M = 20;
-		const pub = await connect(mqttURL, baseOpts({ clientId: 'qa681-q1-pub' }));
-		const subA = await connect(mqttURL, baseOpts({ clientId: 'qa681-q1-a' }));
-		const subB = await connect(mqttURL, baseOpts({ clientId: 'qa681-q1-b' }));
+		let pub: MqttClient | undefined;
+		let subA: MqttClient | undefined;
+		let subB: MqttClient | undefined;
 		try {
+			pub = await connect(mqttURL, baseOpts({ clientId: 'qa681-q1-pub' }));
+			subA = await connect(mqttURL, baseOpts({ clientId: 'qa681-q1-a' }));
+			subB = await connect(mqttURL, baseOpts({ clientId: 'qa681-q1-b' }));
 			await subscribe(subA, STREAM_TOPIC, 1);
 			await subscribe(subB, STREAM_TOPIC, 1);
 			const cA = collectMessages(subA);
@@ -297,11 +301,13 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 		async () => {
 			requireMqtt();
 			const M = 15;
-			const pub = await connect(mqttURL, baseOpts({ clientId: 'qa681-q3-pub' }));
 			const groupClients: MqttClient[] = [];
 			const groupCollectors: ReturnType<typeof collectMessages>[] = [];
-			const ordinary = await connect(mqttURL, baseOpts({ clientId: 'qa681-q3-ordinary' }));
+			let pub: MqttClient | undefined;
+			let ordinary: MqttClient | undefined;
 			try {
+				pub = await connect(mqttURL, baseOpts({ clientId: 'qa681-q3-pub' }));
+				ordinary = await connect(mqttURL, baseOpts({ clientId: 'qa681-q3-ordinary' }));
 				// Delivery is deliberately not gated on the SUBACK: this is the fire-and-forget client.
 				const groupSubAcks: SubAckResult[] = [];
 				for (let i = 0; i < 4; i++) {
@@ -356,11 +362,14 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 			const dropAt = 15;
 			const dropClientId = `qa681-q4-drop-${randomUUID().slice(0, 6)}`;
 
-			const pub = await connect(mqttURL, baseOpts({ clientId: 'qa681-q4-pub' }));
-			const survivorA = await connect(mqttURL, baseOpts({ clientId: 'qa681-q4-a' }));
-			const survivorC = await connect(mqttURL, baseOpts({ clientId: 'qa681-q4-c' }));
+			let pub: MqttClient | undefined;
+			let survivorA: MqttClient | undefined;
+			let survivorC: MqttClient | undefined;
 			let dropClient: MqttClient | undefined;
 			try {
+				pub = await connect(mqttURL, baseOpts({ clientId: 'qa681-q4-pub' }));
+				survivorA = await connect(mqttURL, baseOpts({ clientId: 'qa681-q4-a' }));
+				survivorC = await connect(mqttURL, baseOpts({ clientId: 'qa681-q4-c' }));
 				await subscribe(survivorA, QOS1_TOPIC, 1);
 				await subscribe(survivorC, QOS1_TOPIC, 1);
 				// clean:false plus a stable clientId, so "lost forever" is distinguishable from
@@ -457,6 +466,7 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 				await endQuiet(pub);
 				await endQuiet(survivorA);
 				await endQuiet(survivorC);
+				await endQuiet(dropClient);
 			}
 		}
 	);

--- a/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
+++ b/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
@@ -385,9 +385,8 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 					await publish(pub, QOS1_TOPIC, JSON.stringify({ seq, tag: 'q4' }), { qos: 1 });
 					if (seq === dropAt - 1) {
 						await sleep(150); // let in-flight qos1 delivery to dropClient settle first
-						// Destroy the transport with no MQTT DISCONNECT: a crashed member, not a clean
-						// unsubscribe, which is what leaves the durable session with a backlog to resume.
-						(dropClient as any).stream?.destroy?.();
+						// end(true) closes the socket without sending a DISCONNECT: a crashed member, not a
+						// clean unsubscribe, which is what leaves the durable session a backlog to resume.
 						dropClient.end(true);
 						// Converge on the socket actually being down before publishing past the drop
 						// point; otherwise seq 15 can still reach the old session and the boundary

--- a/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
+++ b/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
@@ -7,10 +7,10 @@
  * `$share` is never a table, so the lookup misses, addSubscription() throws a 404, and
  * server/mqtt.ts maps it to SUBACK reason 0x8f on MQTT v5 and 0x80 on v3.1.1.
  *
- * The promotable fact is that the subscription is REFUSED rather than accepted as an inert filter.
- * If a future change silently accepted `$share`, subscribers would begin receiving the FULL fan-out
- * where the application expected each message to reach exactly one worker — so both the refusal and
- * the absence of delivery are asserted, and either drift fails this file.
+ * The subscription is REFUSED, not accepted as an inert filter. Were `$share` ever silently
+ * accepted, subscribers would begin receiving the FULL fan-out where the application expected each
+ * message to reach exactly one worker; both the refusal and the absence of delivery are asserted,
+ * so either drift fails this file.
  *
  * On a rejected SUBACK mqtt.js's `granted` callback argument echoes the client's own request rather
  * than the broker's grant, so the reason code is read from `err.packet.granted`. Reading `granted`

--- a/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
+++ b/integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts
@@ -198,7 +198,6 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 		const wsScheme = httpURL.startsWith('https') ? 'wss' : 'ws';
 		mqttURL = `${httpURL.replace(/^https?/, wsScheme)}/mqtt`;
 
-		// Pre-installed fixture, so poll for non-404 rather than restarting workers.
 		let ready = false;
 		const deadline = Date.now() + 120_000;
 		while (Date.now() < deadline) {
@@ -422,44 +421,37 @@ suite('QA-681 MQTT shared-subscription ($share) semantics', { skip: skipSuite },
 				strictEqual(new Set(seqsC).size, N, 'no duplicates for survivor C');
 
 				// The drop must genuinely have cut delivery. Without this, a run where the transport
-				// destroy failed leaves deliveredBeforeDrop holding all N and expectedRecovery at 0, so
-				// the union check below is satisfied before the session ever resumes and a broken
-				// clean:false resume passes. Which messages landed first is scheduler-dependent; that
-				// none published after the drop did is not, and that is what is asserted.
+				// destroy failed leaves deliveredBeforeDrop holding all N, and the coverage poll below
+				// is satisfied before the session ever resumes — so a broken clean:false resume would
+				// pass. Which messages landed first is scheduler-dependent; that none published after
+				// the drop did is not, and that is what is asserted.
 				ok(
 					[...deliveredBeforeDrop].every((seq) => seq < dropAt),
 					`the dropped client must have received nothing published after the drop, got ${JSON.stringify([...deliveredBeforeDrop].sort((a, b) => a - b))}`
 				);
 
-				// Reconnect the SAME clientId and let the durable session catch up. How many messages
-				// landed before the drop is scheduler-dependent, so the assertion is on the union:
-				// whatever the split, the session as a whole must have lost nothing.
 				const resumedMessages: CollectedMessage[] = [];
 				const resumed = await connect(mqttURL, baseOpts({ clientId: dropClientId, clean: false }), (topic, payload) =>
 					resumedMessages.push({ topic, payload: payload.toString() })
 				);
 				try {
-					const expectedRecovery = N - deliveredBeforeDrop.size;
-					await waitFor(() => resumedMessages.length >= expectedRecovery, 10_000);
-					await sleep(500); // so a straggler just behind the last recovered message still lands
+					// Poll on COVERAGE, not on a count. QoS-1 is at-least-once, so a resume may replay a
+					// message that was unacked when the transport died; counting deliveries would then
+					// reach the expected total while a later sequence is still in flight, and the run
+					// would fail a session that recovers everything.
+					const allSeqs = Array.from({ length: N }, (_, seq) => seq);
+					const seenSoFar = () => new Set([...deliveredBeforeDrop, ...seqsOf({ messages: resumedMessages })]);
+					const recovered = await waitFor(() => allSeqs.every((seq) => seenSoFar().has(seq)), 10_000);
 					const resumedSeqs = seqsOf({ messages: resumedMessages });
 					console.log(
 						`[QA-681][Q4] resumed same-clientId session recv=${resumedSeqs.length} ` +
-							`(expected at least ${expectedRecovery}): ${JSON.stringify(resumedSeqs)}`
+							`(missed ${N - deliveredBeforeDrop.size}): ${JSON.stringify(resumedSeqs)}`
 					);
 
-					// A floor, not an exact count: QoS-1 is at-least-once, so a message unacked when the
-					// transport died may legitimately be replayed — possibly more than once.
+					const seen = seenSoFar();
 					ok(
-						resumedSeqs.length >= expectedRecovery,
-						`the resumed session should recover the ${expectedRecovery} message(s) it missed, got ${JSON.stringify(resumedSeqs)}`
-					);
-					const seen = new Set([...deliveredBeforeDrop, ...resumedSeqs]);
-					const missing = Array.from({ length: N }, (_, seq) => seq).filter((seq) => !seen.has(seq));
-					strictEqual(
-						missing.length,
-						0,
-						`the durable session must lose nothing across the drop; never delivered seq ${JSON.stringify(missing)}`
+						recovered,
+						`the durable session must lose nothing across the drop; never delivered seq ${JSON.stringify(allSeqs.filter((seq) => !seen.has(seq)))}`
 					);
 					ok(
 						resumedSeqs.every((seq) => seq >= 0 && seq < N),

--- a/integrationTests/mqtt/qa681-mqtt-shared-subscriptions/config.yaml
+++ b/integrationTests/mqtt/qa681-mqtt-shared-subscriptions/config.yaml
@@ -1,0 +1,4 @@
+graphqlSchema:
+  files: '*.graphql'
+rest: true
+mqtt: true

--- a/integrationTests/mqtt/qa681-mqtt-shared-subscriptions/schema.graphql
+++ b/integrationTests/mqtt/qa681-mqtt-shared-subscriptions/schema.graphql
@@ -1,0 +1,7 @@
+# QA-681 fixture schema. Non-retained publishes to Events/* give a transient fan-out stream with
+# no per-key coalescing, which is what makes delivery countable.
+type Events @table @export {
+	id: ID @primaryKey
+	seq: Int
+	tag: String
+}

--- a/integrationTests/resources/qa716-lingering-write-commit.test.ts
+++ b/integrationTests/resources/qa716-lingering-write-commit.test.ts
@@ -160,22 +160,17 @@ suite(`QA-716 lingering-write-commit vs staged writes [${ENGINE}]`, { skip: skip
 		}
 	}
 
-	let q1Bucket: string;
-	let q1FulfilledIds: string[];
-	let q1Sku: string;
-
 	test('Q1 order fulfilled behind an abandoned read iterator is durable and index-consistent immediately', async () => {
-		q1Bucket = 'B1';
-		q1Sku = `SKU-${q1Bucket}`;
-		await seed(q1Bucket, 20);
-		const { fulfilledIds, scanned } = await fulfillPage(q1Bucket, PAGE_SIZE);
-		q1FulfilledIds = fulfilledIds;
+		const bucket = 'B1';
+		const sku = `SKU-${bucket}`;
+		await seed(bucket, 20);
+		const { fulfilledIds, scanned } = await fulfillPage(bucket, PAGE_SIZE);
 		strictEqual(fulfilledIds.length, PAGE_SIZE, `FulfillPage should pick a full page of ${PAGE_SIZE}`);
 		console.log(`[QA-716 Q1 ${ENGINE}] fulfilled=${JSON.stringify(fulfilledIds)} scanned=${scanned}`);
 
 		// Read the TTL'd table before the index round trips below, not after: a slow shard can
 		// otherwise spend the expiry window on unrelated work.
-		const reservations = (await dump('/DumpReservation/')).filter((r: any) => r.sku === q1Sku);
+		const reservations = (await dump('/DumpReservation/')).filter((r: any) => r.sku === sku);
 		strictEqual(
 			reservations.length,
 			PAGE_SIZE,
@@ -184,12 +179,12 @@ suite(`QA-716 lingering-write-commit vs staged writes [${ENGINE}]`, { skip: skip
 
 		await assertOrdersDurablyFulfilled(fulfilledIds);
 
-		const inv = (await dump('/DumpInventory/')).find((r: any) => r.sku === q1Sku);
-		ok(inv, `Inventory/${q1Sku} must exist`);
+		const inv = (await dump('/DumpInventory/')).find((r: any) => r.sku === sku);
+		ok(inv, `Inventory/${sku} must exist`);
 		strictEqual(
 			inv.fulfilledCount,
 			PAGE_SIZE,
-			`Inventory/${q1Sku}.fulfilledCount must reflect all ${PAGE_SIZE} staged writes`
+			`Inventory/${sku}.fulfilledCount must reflect all ${PAGE_SIZE} staged writes`
 		);
 	});
 
@@ -237,7 +232,14 @@ suite(`QA-716 lingering-write-commit vs staged writes [${ENGINE}]`, { skip: skip
 	);
 
 	test('Q3 durability holds past the long-transaction monitor threshold', async () => {
-		strictEqual(q1FulfilledIds?.length, PAGE_SIZE, 'Q1 must have fulfilled a page for this arm to re-check anything');
+		// Its own bucket, like every other arm: sharing Q1's rows made this arm fail on a Q1 failure
+		// and unrunnable in isolation, without testing anything Q1 had not already established.
+		const bucket = 'B3';
+		const sku = `SKU-${bucket}`;
+		await seed(bucket, 20);
+		const { fulfilledIds } = await fulfillPage(bucket, PAGE_SIZE);
+		strictEqual(fulfilledIds.length, PAGE_SIZE, `FulfillPage(${bucket}) should pick a full page`);
+
 		// Elapsed time, not a convergence wait: the claim is that nothing happens to these writes
 		// once the monitor reaches the abandoned transaction, so there is no event to converge on.
 		await sleep(Math.max(6000, MAX_TXN_OPEN_MS * 6));
@@ -249,9 +251,9 @@ suite(`QA-716 lingering-write-commit vs staged writes [${ENGINE}]`, { skip: skip
 		);
 		// Without this the arm is blind: a change that drops the lingering transaction from write
 		// supervision, or renames storage.maxTransactionOpenTime, would leave it sleeping and then
-		// re-reading writes Q1 already proved durable — green having tested only elapsed time. The
-		// line is #1860's release-only branch (resources/DatabaseTransaction.ts), so it is asserted
-		// on RocksDB alone; LMDB never defers a commit and correctly never logs it.
+		// re-reading writes that were already durable. #1860's release-only branch logs this line
+		// (resources/DatabaseTransaction.ts), so it is asserted on RocksDB alone — LMDB never defers
+		// a commit and correctly never logs it.
 		if (ENGINE === 'rocksdb') {
 			ok(
 				releasedLine,
@@ -261,12 +263,12 @@ suite(`QA-716 lingering-write-commit vs staged writes [${ENGINE}]`, { skip: skip
 		// The abort line is not asserted absent: any other transaction in the run may legitimately
 		// cross the deliberately-low threshold and log it.
 
-		await assertOrdersDurablyFulfilled(q1FulfilledIds);
-		const inv = (await dump('/DumpInventory/')).find((r: any) => r.sku === q1Sku);
+		await assertOrdersDurablyFulfilled(fulfilledIds);
+		const inv = (await dump('/DumpInventory/')).find((r: any) => r.sku === sku);
 		strictEqual(
 			inv?.fulfilledCount,
 			PAGE_SIZE,
-			`Inventory/${q1Sku}.fulfilledCount must still reflect all ${PAGE_SIZE} writes post-monitor`
+			`Inventory/${sku}.fulfilledCount must still reflect all ${PAGE_SIZE} writes post-monitor`
 		);
 	});
 

--- a/integrationTests/resources/qa716-lingering-write-commit.test.ts
+++ b/integrationTests/resources/qa716-lingering-write-commit.test.ts
@@ -6,12 +6,11 @@
  * index agrees with the base store — immediately, not eventually — even though the request left a
  * read iterator open past its own commit.
  *
- * Why an integration anchor on top of unitTests/resources/lingeringWriteCommit.test.js, which
- * shipped with the fix: that covers the single-table case against the transaction object in
- * isolation. Here the same mechanism runs through the whole request path with the factors a real
- * fulfillment endpoint combines — writes staged across three tables in one request transaction, a
- * paged secondary-index iterator the handler never drains or closes, TTL eviction racing the
- * deferred commit, and four worker threads.
+ * unitTests/resources/lingeringWriteCommit.test.js shipped with the fix and covers the single-table
+ * case against the transaction object in isolation. This runs the same mechanism through the whole
+ * request path with the factors a real fulfillment endpoint combines: writes staged across three
+ * tables in one request transaction, a paged secondary-index iterator the handler never drains or
+ * closes, TTL eviction racing the deferred commit, and four worker threads.
  *
  * Pre-#1860, commit() saw readTxnsUsed > 0 from the abandoned iterator, set open=LINGERING and
  * returned WITHOUT committing; the writes could only be flushed from doneReadTxn(), which nothing

--- a/integrationTests/resources/qa716-lingering-write-commit.test.ts
+++ b/integrationTests/resources/qa716-lingering-write-commit.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Promoted from qa-explorer (QA-716 / P-493): regression anchor for PR harper#1860
+ * ("fix(txn): don't drop writes staged while read iterators defer the commit").
+ *
+ * Invariant: once a request is acknowledged, every write it staged is durable and its secondary
+ * index agrees with the base store — immediately, not eventually — even though the request left a
+ * read iterator open past its own commit.
+ *
+ * Why an integration anchor on top of unitTests/resources/lingeringWriteCommit.test.js, which
+ * shipped with the fix: that covers the single-table case against the transaction object in
+ * isolation. Here the same mechanism runs through the whole request path with the factors a real
+ * fulfillment endpoint combines — writes staged across three tables in one request transaction, a
+ * paged secondary-index iterator the handler never drains or closes, TTL eviction racing the
+ * deferred commit, and four worker threads.
+ *
+ * Pre-#1860, commit() saw readTxnsUsed > 0 from the abandoned iterator, set open=LINGERING and
+ * returned WITHOUT committing; the writes could only be flushed from doneReadTxn(), which nothing
+ * ever called, and the HTTP response had already resolved 200. That is the loss this pins against.
+ * RocksDB-only in substance: LMDB never defers a commit on open read transactions, so under
+ * HARPER_STORAGE_ENGINE=lmdb the suite is a no-delta control.
+ *
+ * Run:
+ *   npm run test:integration -- "integrationTests/resources/qa716-lingering-write-commit.test.ts"
+ *   (lmdb control: HARPER_STORAGE_ENGINE=lmdb npm run test:integration -- "<same path>")
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { resolve, join } from 'node:path';
+import { readFileSync, existsSync } from 'node:fs';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from '../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'qa716-lingering-write-commit');
+const SCHEMA = 'data';
+const ENGINE = process.env.HARPER_STORAGE_ENGINE === 'lmdb' ? 'lmdb' : 'rocksdb';
+// Low threshold so the long-transaction monitor reaches the abandoned-iterator transaction well
+// inside Q3's wait window (it fires ~2x this value after the last read-txn touch).
+const MAX_TXN_OPEN_MS = 1000;
+const PAGE_SIZE = 5;
+const skipSuite = process.platform === 'win32';
+
+suite(`QA-716 lingering-write-commit vs staged writes [${ENGINE}]`, { skip: skipSuite }, (ctx: ContextWithHarper) => {
+	let client: ReturnType<typeof createApiClient>;
+	let httpURL: string;
+	let procOutput = '';
+
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+			config: {
+				threads: { count: 4 },
+				storage: { maxTransactionOpenTime: MAX_TXN_OPEN_MS, debugLongTransactions: true },
+				// 'warn', not 'error': #1860's release-only monitor branch logs at warn level, and an
+				// 'error' threshold would swallow it and make Q3's diagnostic blind.
+				logging: { console: true, level: 'warn' },
+			},
+			env: {},
+		});
+		client = createApiClient(ctx.harper);
+		httpURL = ctx.harper.httpURL;
+
+		procOutput += ctx.harper.startupOutput?.stdout ?? '';
+		procOutput += ctx.harper.startupOutput?.stderr ?? '';
+		const proc = ctx.harper.process;
+		proc?.stdout?.on('data', (d: Buffer) => (procOutput += d.toString()));
+		proc?.stderr?.on('data', (d: Buffer) => (procOutput += d.toString()));
+
+		// Pre-installed fixture, so poll for non-404 rather than restarting workers.
+		let ready = false;
+		const deadline = Date.now() + 120_000;
+		while (Date.now() < deadline) {
+			try {
+				const probe = await client.reqRest('/Orders/').timeout(2000);
+				if (probe.status !== 404) {
+					ready = true;
+					break;
+				}
+			} catch {
+				/* not ready yet */
+			}
+			await sleep(250);
+		}
+		ok(ready, 'REST route /Orders/ never became available within 120s — the fixture did not install');
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	function postJSON(path: string, body: unknown): Promise<Response> {
+		return fetch(`${httpURL}${path}`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', 'Authorization': client.headers.Authorization },
+			body: JSON.stringify(body),
+		});
+	}
+
+	function fullLog(): string {
+		let logText = '';
+		const logDir = ctx.harper.logDir;
+		if (logDir) {
+			for (const name of ['hdb.log', 'stdout.log', 'stderr.log']) {
+				const p = join(logDir, name);
+				if (existsSync(p)) {
+					try {
+						logText += readFileSync(p, 'utf8');
+					} catch {
+						/* a log file may rotate mid-read; the process capture below still covers it */
+					}
+				}
+			}
+		}
+		return logText + procOutput;
+	}
+
+	async function searchByValue(table: string, attribute: string, value: string): Promise<Set<string>> {
+		const r = await client
+			.req()
+			.send({
+				operation: 'search_by_value',
+				schema: SCHEMA,
+				table,
+				search_attribute: attribute,
+				search_value: value,
+				get_attributes: ['*'],
+			})
+			.timeout(30_000)
+			.expect(200);
+		const rows: any[] = Array.isArray(r.body) ? r.body : [];
+		return new Set(rows.map((row) => String(row.id)));
+	}
+
+	async function getById(table: string, id: string): Promise<any | null> {
+		const r = await client
+			.req()
+			.send({ operation: 'search_by_id', schema: SCHEMA, table, ids: [id], get_attributes: ['*'] })
+			.timeout(30_000)
+			.expect(200);
+		const rows: any[] = Array.isArray(r.body) ? r.body : [];
+		return rows.length ? rows[0] : null;
+	}
+
+	async function dump(path: string): Promise<any[]> {
+		const r = await fetch(`${httpURL}${path}`, { headers: { Authorization: client.headers.Authorization } });
+		strictEqual(r.status, 200, `${path} should return 200`);
+		return (await r.json()) as any[];
+	}
+
+	async function seed(bucket: string, count: number) {
+		const res = await postJSON('/Seed/', { bucket, count });
+		strictEqual(res.status, 200, `seed ${bucket} should succeed`);
+		return res.json();
+	}
+
+	async function fulfillPage(bucket: string, pageSize: number) {
+		const res = await postJSON('/FulfillPage/', { bucket, pageSize });
+		strictEqual(res.status, 200, `FulfillPage(${bucket}) should succeed`);
+		return res.json() as Promise<{ ok: boolean; bucket: string; fulfilledIds: string[]; scanned: number }>;
+	}
+
+	/** Must hold immediately after the ack, not eventually. The two index reads are hoisted out of
+	 *  the loop: per id they would be 2N sequential full-index scans, which is both slow and a
+	 *  widening window for anything in the suite that races a TTL. */
+	async function assertOrdersDurablyFulfilled(ids: string[]) {
+		const fulfilledHits = await searchByValue('Orders', 'status', 'fulfilled');
+		const pendingHits = await searchByValue('Orders', 'status', 'pending');
+		for (const id of ids) {
+			const byId = await getById('Orders', id);
+			ok(byId, `Orders/${id}: base row must exist`);
+			strictEqual(byId?.status, 'fulfilled', `Orders/${id}: base row status must be 'fulfilled'`);
+			ok(fulfilledHits.has(id), `Orders/${id}: must appear in status='fulfilled' index search`);
+			ok(!pendingHits.has(id), `Orders/${id}: must NOT still appear in status='pending' index (stale/phantom entry)`);
+		}
+	}
+
+	let q1Bucket: string;
+	let q1FulfilledIds: string[];
+	let q1Sku: string;
+
+	test('Q1 order fulfilled behind an abandoned read iterator is durable and index-consistent immediately', async () => {
+		q1Bucket = 'B1';
+		q1Sku = `SKU-${q1Bucket}`;
+		await seed(q1Bucket, 20);
+		const { fulfilledIds, scanned } = await fulfillPage(q1Bucket, PAGE_SIZE);
+		q1FulfilledIds = fulfilledIds;
+		strictEqual(fulfilledIds.length, PAGE_SIZE, `FulfillPage should pick a full page of ${PAGE_SIZE}`);
+		console.log(`[QA-716 Q1 ${ENGINE}] fulfilled=${JSON.stringify(fulfilledIds)} scanned=${scanned}`);
+
+		// Read the TTL'd table before the index round trips below, not after: a slow shard can
+		// otherwise spend the expiry window on unrelated work.
+		const reservations = (await dump('/DumpReservation/')).filter((r: any) => r.sku === q1Sku);
+		strictEqual(
+			reservations.length,
+			PAGE_SIZE,
+			'a Reservation row must exist for every fulfilled order (3rd table, same txn)'
+		);
+
+		await assertOrdersDurablyFulfilled(fulfilledIds);
+
+		const inv = (await dump('/DumpInventory/')).find((r: any) => r.sku === q1Sku);
+		ok(inv, `Inventory/${q1Sku} must exist`);
+		strictEqual(
+			inv.fulfilledCount,
+			PAGE_SIZE,
+			`Inventory/${q1Sku}.fulfilledCount must reflect all ${PAGE_SIZE} staged writes`
+		);
+	});
+
+	test(
+		'Q2 TTL: reservations staged behind the lingering commit expire with no orphaned index entries',
+		{ timeout: 60_000 },
+		async () => {
+			// Its own bucket, fulfilled here rather than reused from Q1. Sharing Q1's rows would put
+			// Q1's remaining index reads inside this arm's expiry window, so a slow shard could expire
+			// correctly-committed reservations before the floor below ever looks at them.
+			const bucket = 'B2';
+			const sku = `SKU-${bucket}`;
+			await seed(bucket, 20);
+			const { fulfilledIds } = await fulfillPage(bucket, PAGE_SIZE);
+			strictEqual(fulfilledIds.length, PAGE_SIZE, `FulfillPage(${bucket}) should pick a full page`);
+
+			// Read immediately: search hides a row once expiresAt has passed, independently of the
+			// sweep (resources/Table.ts, `!includeExpired && entry?.expiresAt < Date.now()`), so this
+			// floor is on wall-clock time from the fulfillPage above, not on sweep progress.
+			const preSweep = (await dump('/DumpReservation/')).filter((r: any) => r.sku === sku);
+			// Vacuity floor: with an already-empty table the expiry assertions below are trivially
+			// true, so a run that lost the staged writes upstream would pass while proving nothing.
+			strictEqual(
+				preSweep.length,
+				PAGE_SIZE,
+				`the ${PAGE_SIZE} Reservation rows staged behind the lingering commit must be present for the TTL axis to mean anything`
+			);
+
+			const deadline = Date.now() + 30_000;
+			let remaining = preSweep.length;
+			while (Date.now() < deadline) {
+				remaining = (await dump('/DumpReservation/')).filter((r: any) => r.sku === sku).length;
+				if (remaining === 0) break;
+				await sleep(1000);
+			}
+			strictEqual(remaining, 0, 'no Reservation row for this sku may still be returned once its TTL has elapsed');
+
+			// Index cleanup lags the base-row delete, so poll a bounded settle window. Scope: search_by_value
+			// materializes its hits and drops any whose base record is gone (resources/Table.ts,
+			// `if (record == null) return canSkip ? SKIP : record`), so this proves the index no longer
+			// RESOLVES an evicted reservation. A dangling entry whose base row is already deleted would
+			// need a raw-index read the operations API does not expose.
+			const indexDeadline = Date.now() + 10_000;
+			let indexHits = await searchByValue('Reservation', 'sku', sku);
+			while (indexHits.size > 0 && Date.now() < indexDeadline) {
+				await sleep(500);
+				indexHits = await searchByValue('Reservation', 'sku', sku);
+			}
+			strictEqual(indexHits.size, 0, 'the sku index must resolve no Reservation rows once the TTL sweep has run');
+		}
+	);
+
+	test('Q3 durability holds past the long-transaction monitor threshold', async () => {
+		strictEqual(q1FulfilledIds?.length, PAGE_SIZE, 'Q1 must have fulfilled a page for this arm to re-check anything');
+		// Elapsed time, not a convergence wait: the claim is that nothing happens to these writes
+		// once the monitor reaches the abandoned transaction, so there is no event to converge on.
+		await sleep(Math.max(6000, MAX_TXN_OPEN_MS * 6));
+		const log = fullLog();
+		// Diagnostics. The abort line is not asserted absent: any other transaction in the run may
+		// legitimately cross the deliberately-low threshold and log it.
+		const abortedLine = /Transaction was open too long and has been aborted/i.test(log);
+		const releasedLine = /Read iterators held a committed transaction.s snapshot/i.test(log);
+		console.log(
+			`[QA-716 Q3 ${ENGINE}] monitor lines seen: aborted-with-writes-discarded=${abortedLine} released-handle-only=${releasedLine}`
+		);
+
+		await assertOrdersDurablyFulfilled(q1FulfilledIds);
+		const inv = (await dump('/DumpInventory/')).find((r: any) => r.sku === q1Sku);
+		strictEqual(
+			inv?.fulfilledCount,
+			PAGE_SIZE,
+			`Inventory/${q1Sku}.fulfilledCount must still reflect all ${PAGE_SIZE} writes post-monitor`
+		);
+	});
+
+	test(
+		'Q4 concurrency: 8 concurrent bucket-isolated lingering commits all land correctly',
+		{ timeout: 60_000 },
+		async () => {
+			const buckets = Array.from({ length: 8 }, (_, i) => `C${i + 1}`);
+			await Promise.all(buckets.map((b) => seed(b, 20)));
+			const results = await Promise.all(buckets.map((b) => fulfillPage(b, PAGE_SIZE)));
+
+			for (let i = 0; i < buckets.length; i++) {
+				strictEqual(
+					results[i].fulfilledIds.length,
+					PAGE_SIZE,
+					`${buckets[i]}: should fulfill a full page of ${PAGE_SIZE}`
+				);
+			}
+
+			let totalChecked = 0;
+			for (let i = 0; i < buckets.length; i++) {
+				const sku = `SKU-${buckets[i]}`;
+				await assertOrdersDurablyFulfilled(results[i].fulfilledIds);
+				totalChecked += results[i].fulfilledIds.length;
+				const inv = (await dump('/DumpInventory/')).find((r: any) => r.sku === sku);
+				strictEqual(
+					inv?.fulfilledCount,
+					PAGE_SIZE,
+					`Inventory/${sku}.fulfilledCount must reflect its own bucket's ${PAGE_SIZE} writes only`
+				);
+			}
+			strictEqual(
+				totalChecked,
+				buckets.length * PAGE_SIZE,
+				`every bucket's page must have been verified, not a subset`
+			);
+			console.log(
+				`[QA-716 Q4 ${ENGINE}] concurrently verified ${totalChecked} durably-fulfilled orders across 8 buckets`
+			);
+
+			const allOrders = await dump('/DumpOrders/');
+			for (const bucket of buckets) {
+				const bucketOrders = allOrders.filter((o: any) => o.bucket === bucket);
+				const fulfilled = bucketOrders.filter((o: any) => o.status === 'fulfilled');
+				strictEqual(
+					fulfilled.length,
+					PAGE_SIZE,
+					`${bucket}: exactly ${PAGE_SIZE} base rows should show status='fulfilled'`
+				);
+			}
+		}
+	);
+});

--- a/integrationTests/resources/qa716-lingering-write-commit.test.ts
+++ b/integrationTests/resources/qa716-lingering-write-commit.test.ts
@@ -66,7 +66,6 @@ suite(`QA-716 lingering-write-commit vs staged writes [${ENGINE}]`, { skip: skip
 		proc?.stdout?.on('data', (d: Buffer) => (procOutput += d.toString()));
 		proc?.stderr?.on('data', (d: Buffer) => (procOutput += d.toString()));
 
-		// Pre-installed fixture, so poll for non-404 rather than restarting workers.
 		let ready = false;
 		const deadline = Date.now() + 120_000;
 		while (Date.now() < deadline) {

--- a/integrationTests/resources/qa716-lingering-write-commit.test.ts
+++ b/integrationTests/resources/qa716-lingering-write-commit.test.ts
@@ -31,6 +31,8 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
 import { createApiClient } from '../apiTests/utils/client.mjs';
+// @ts-expect-error lifecycle.mjs has no type declarations; runtime resolves fine
+import { waitForRouteReady } from '../apiTests/utils/lifecycle.mjs';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'qa716-lingering-write-commit');
 const SCHEMA = 'data';
@@ -66,21 +68,7 @@ suite(`QA-716 lingering-write-commit vs staged writes [${ENGINE}]`, { skip: skip
 		proc?.stdout?.on('data', (d: Buffer) => (procOutput += d.toString()));
 		proc?.stderr?.on('data', (d: Buffer) => (procOutput += d.toString()));
 
-		let ready = false;
-		const deadline = Date.now() + 120_000;
-		while (Date.now() < deadline) {
-			try {
-				const probe = await client.reqRest('/Orders/').timeout(2000);
-				if (probe.status !== 404) {
-					ready = true;
-					break;
-				}
-			} catch {
-				/* not ready yet */
-			}
-			await sleep(250);
-		}
-		ok(ready, 'REST route /Orders/ never became available within 120s — the fixture did not install');
+		await waitForRouteReady(client, '/Orders/', 120_000);
 	});
 
 	after(async () => {
@@ -255,13 +243,24 @@ suite(`QA-716 lingering-write-commit vs staged writes [${ENGINE}]`, { skip: skip
 		// once the monitor reaches the abandoned transaction, so there is no event to converge on.
 		await sleep(Math.max(6000, MAX_TXN_OPEN_MS * 6));
 		const log = fullLog();
-		// Diagnostics. The abort line is not asserted absent: any other transaction in the run may
-		// legitimately cross the deliberately-low threshold and log it.
 		const abortedLine = /Transaction was open too long and has been aborted/i.test(log);
 		const releasedLine = /Read iterators held a committed transaction.s snapshot/i.test(log);
 		console.log(
 			`[QA-716 Q3 ${ENGINE}] monitor lines seen: aborted-with-writes-discarded=${abortedLine} released-handle-only=${releasedLine}`
 		);
+		// Without this the arm is blind: a change that drops the lingering transaction from write
+		// supervision, or renames storage.maxTransactionOpenTime, would leave it sleeping and then
+		// re-reading writes Q1 already proved durable — green having tested only elapsed time. The
+		// line is #1860's release-only branch (resources/DatabaseTransaction.ts), so it is asserted
+		// on RocksDB alone; LMDB never defers a commit and correctly never logs it.
+		if (ENGINE === 'rocksdb') {
+			ok(
+				releasedLine,
+				'the long-transaction monitor must have reached the abandoned iterator and released its snapshot'
+			);
+		}
+		// The abort line is not asserted absent: any other transaction in the run may legitimately
+		// cross the deliberately-low threshold and log it.
 
 		await assertOrdersDurablyFulfilled(q1FulfilledIds);
 		const inv = (await dump('/DumpInventory/')).find((r: any) => r.sku === q1Sku);

--- a/integrationTests/resources/qa716-lingering-write-commit.test.ts
+++ b/integrationTests/resources/qa716-lingering-write-commit.test.ts
@@ -207,7 +207,7 @@ suite(`QA-716 lingering-write-commit vs staged writes [${ENGINE}]`, { skip: skip
 	});
 
 	test(
-		'Q2 TTL: reservations staged behind the lingering commit expire with no orphaned index entries',
+		'Q2 TTL: reservations staged behind the lingering commit are present, then expire',
 		{ timeout: 60_000 },
 		async () => {
 			// Its own bucket, fulfilled here rather than reused from Q1. Sharing Q1's rows would put
@@ -240,18 +240,12 @@ suite(`QA-716 lingering-write-commit vs staged writes [${ENGINE}]`, { skip: skip
 			}
 			strictEqual(remaining, 0, 'no Reservation row for this sku may still be returned once its TTL has elapsed');
 
-			// Index cleanup lags the base-row delete, so poll a bounded settle window. Scope: search_by_value
-			// materializes its hits and drops any whose base record is gone (resources/Table.ts,
-			// `if (record == null) return canSkip ? SKIP : record`), so this proves the index no longer
-			// RESOLVES an evicted reservation. A dangling entry whose base row is already deleted would
-			// need a raw-index read the operations API does not expose.
-			const indexDeadline = Date.now() + 10_000;
-			let indexHits = await searchByValue('Reservation', 'sku', sku);
-			while (indexHits.size > 0 && Date.now() < indexDeadline) {
-				await sleep(500);
-				indexHits = await searchByValue('Reservation', 'sku', sku);
-			}
-			strictEqual(indexHits.size, 0, 'the sku index must resolve no Reservation rows once the TTL sweep has run');
+			// No index-level assertion follows deliberately. search_by_value goes through the same
+			// materialization as the dump above — it hides a row once expiresAt has passed and drops
+			// one whose base record is gone (resources/Table.ts) — so once the dump is empty an index
+			// query is empty too, whatever the index actually holds. A check there could not fail, and
+			// pinning sweep-time index cleanup needs a raw-index read the operations API does not
+			// expose.
 		}
 	);
 

--- a/integrationTests/resources/qa716-lingering-write-commit/config.yaml
+++ b/integrationTests/resources/qa716-lingering-write-commit/config.yaml
@@ -1,0 +1,5 @@
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/resources/qa716-lingering-write-commit/resources.js
+++ b/integrationTests/resources/qa716-lingering-write-commit/resources.js
@@ -1,0 +1,86 @@
+// QA-716 fixture. FulfillPage is the shape under test: it pages a status='pending' search, stages
+// writes across Orders + Inventory + Reservation, and returns with the cursor simply dropped —
+// never drained, never .return()'d — so the read handle outlives the request's own commit.
+//
+//   /Seed          { bucket, count }     — insert `count` pending Orders for bucket.
+//   /FulfillPage   { bucket, pageSize }  — the repro.
+//   GET /DumpOrders, /DumpInventory, /DumpReservation — base scans, index-independent.
+
+function pad(n) {
+	return String(n).padStart(6, '0');
+}
+
+export class Seed extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const bucket = b.bucket || 'B';
+		const n = Number(b.count) || 10;
+		const sku = `SKU-${bucket}`;
+		for (let i = 0; i < n; i++) {
+			await tables.Orders.put({ id: `${bucket}-${pad(i)}`, bucket, status: 'pending', sku, seq: i });
+		}
+		await tables.Inventory.put({ sku, fulfilledCount: 0 });
+		return { ok: true, bucket, count: n, sku };
+	}
+}
+
+export class FulfillPage extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const bucket = b.bucket || 'B';
+		const pageSize = Number(b.pageSize) || 5;
+		const sku = `SKU-${bucket}`;
+
+		const iterator = tables.Orders.search({ conditions: [{ attribute: 'status', value: 'pending' }] })[
+			Symbol.asyncIterator
+		]();
+		const picked = [];
+		let scanned = 0;
+		while (picked.length < pageSize && scanned < 20000) {
+			const { value, done } = await iterator.next();
+			if (done) break;
+			scanned++;
+			if (value.bucket === bucket) picked.push(value);
+		}
+
+		let fulfilledCount = (await tables.Inventory.get(sku))?.fulfilledCount ?? 0;
+		for (const order of picked) {
+			await tables.Orders.put({ id: order.id, bucket, status: 'fulfilled', sku, seq: order.seq });
+			fulfilledCount++;
+			await tables.Inventory.put({ sku, fulfilledCount });
+			await tables.Reservation.put({ id: `${order.id}-hold`, sku, qty: 1 });
+		}
+		// NOTE: `iterator` is intentionally left open here — no more `.next()` calls, no `.return()`.
+		return { ok: true, bucket, fulfilledIds: picked.map((o) => o.id), scanned };
+	}
+}
+
+export class DumpOrders extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		const out = [];
+		for await (const r of tables.Orders.search({}))
+			out.push({ id: r.id, bucket: r.bucket, status: r.status, sku: r.sku });
+		return out;
+	}
+}
+
+export class DumpInventory extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		const out = [];
+		for await (const r of tables.Inventory.search({})) out.push({ sku: r.sku, fulfilledCount: r.fulfilledCount });
+		return out;
+	}
+}
+
+export class DumpReservation extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		const out = [];
+		for await (const r of tables.Reservation.search({})) out.push({ id: r.id, sku: r.sku, qty: r.qty });
+		return out;
+	}
+}

--- a/integrationTests/resources/qa716-lingering-write-commit/resources.js
+++ b/integrationTests/resources/qa716-lingering-write-commit/resources.js
@@ -1,10 +1,7 @@
 // QA-716 fixture. FulfillPage is the shape under test: it pages a status='pending' search, stages
 // writes across Orders + Inventory + Reservation, and returns with the cursor simply dropped —
 // never drained, never .return()'d — so the read handle outlives the request's own commit.
-//
-//   /Seed          { bucket, count }     — insert `count` pending Orders for bucket.
-//   /FulfillPage   { bucket, pageSize }  — the repro.
-//   GET /DumpOrders, /DumpInventory, /DumpReservation — base scans, index-independent.
+// The Dump* resources are base scans, deliberately index-independent.
 
 function pad(n) {
 	return String(n).padStart(6, '0');

--- a/integrationTests/resources/qa716-lingering-write-commit/schema.graphql
+++ b/integrationTests/resources/qa716-lingering-write-commit/schema.graphql
@@ -2,9 +2,9 @@
 # staged write on a second table in the same transaction; Reservation adds a third plus a TTL, so
 # its staged write races background eviction while the deferred commit is in flight.
 #
-# expiration 8 rather than 3: the presence assertions sit behind several sequential index reads,
-# and a contended shard can spend a 3s window on those alone, failing a run in which every write
-# actually landed.
+# expiration 8 rather than 3: search stops returning a row the moment expiresAt passes, so the
+# window is wall-clock time from the write, and a contended shard can spend a 3s one on a single
+# round trip.
 type Orders @table @export {
 	id: ID @primaryKey
 	bucket: String

--- a/integrationTests/resources/qa716-lingering-write-commit/schema.graphql
+++ b/integrationTests/resources/qa716-lingering-write-commit/schema.graphql
@@ -1,0 +1,25 @@
+# QA-716 fixture schema. Orders.status is the secondary index under test; Inventory carries a
+# staged write on a second table in the same transaction; Reservation adds a third plus a TTL, so
+# its staged write races background eviction while the deferred commit is in flight.
+#
+# expiration 8 rather than 3: the presence assertions sit behind several sequential index reads,
+# and a contended shard can spend a 3s window on those alone, failing a run in which every write
+# actually landed.
+type Orders @table @export {
+	id: ID @primaryKey
+	bucket: String
+	status: String @indexed
+	sku: String
+	seq: Int
+}
+
+type Inventory @table @export {
+	sku: ID @primaryKey
+	fulfilledCount: Int
+}
+
+type Reservation @table(expiration: 8, scanInterval: 1) @export {
+	id: ID @primaryKey
+	sku: String @indexed
+	qty: Int
+}

--- a/integrationTests/security/qa627-cli-user-auth-separation.test.ts
+++ b/integrationTests/security/qa627-cli-user-auth-separation.test.ts
@@ -89,6 +89,10 @@ suite(
 			// the fallback arms would exchange an OIDC token instead of using the fallback.
 			delete base.ACTIONS_ID_TOKEN_REQUEST_URL;
 			delete base.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+			// A runner that preloads dotenv through NODE_OPTIONS would re-inject HARPER_CLI_* from
+			// DOTENV_CONFIG_PATH after the scrub above, from outside the throwaway cwd.
+			delete base.NODE_OPTIONS;
+			delete base.DOTENV_CONFIG_PATH;
 			try {
 				const { stdout, stderr } = await execFileAsync(process.execPath, [HARPER_BIN, ...args], {
 					// dotenv.config() runs before auth resolution, so a repo-root `.env` would refill

--- a/integrationTests/security/qa627-cli-user-auth-separation.test.ts
+++ b/integrationTests/security/qa627-cli-user-auth-separation.test.ts
@@ -38,8 +38,7 @@
 import { suite, test, before, after } from 'node:test';
 import assert from 'node:assert';
 import { resolve, join } from 'node:path';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { mkdir } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -100,7 +99,12 @@ suite(
 				});
 				return { code: 0, stdout, stderr };
 			} catch (err: any) {
-				return { code: err.code ?? 1, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+				// A spawn failure puts a string in `code` (ENOENT and friends); keep the contract numeric
+				// so an assertion diff reads as an exit status rather than a type mismatch.
+				const code = typeof err.code === 'number' ? err.code : 1;
+				const stderr =
+					typeof err.code === 'string' ? `${err.code}: ${err.message}\n${err.stderr ?? ''}` : (err.stderr ?? '');
+				return { code, stdout: err.stdout ?? '', stderr };
 			}
 		}
 
@@ -126,9 +130,11 @@ suite(
 				env: {},
 			});
 			client = createApiClient(ctx.harper);
-			cliHome = await mkdtemp(join(tmpdir(), 'qa627-cli-home-'));
+			// Under dataRootDir so instance teardown removes it, rather than a tmpdir entry that
+			// leaks if this hook throws before `after` runs.
+			cliHome = join(ctx.harper.dataRootDir, 'qa627-cli-home');
+			await mkdir(cliHome, { recursive: true });
 
-			// Pre-installed fixture, so poll for non-404 rather than restarting workers.
 			let ready = false;
 			const deadline = Date.now() + 120_000;
 			while (Date.now() < deadline) {
@@ -153,7 +159,6 @@ suite(
 
 		after(async () => {
 			await teardownHarper(ctx);
-			if (cliHome) await rm(cliHome, { recursive: true, force: true });
 		});
 
 		test('CONTROL: a no-credentials ops-API call gets a genuine 401 (authorizeLocal bypass disabled)', async () => {

--- a/integrationTests/security/qa627-cli-user-auth-separation.test.ts
+++ b/integrationTests/security/qa627-cli-user-auth-separation.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Promoted from qa-explorer (QA-627 / P-409): regression anchor for harper#1872, fixed by PR
+ * harper#1873 ("fix(cli): separate transport auth from operation payload for add_user/alter_user").
+ *
+ * Invariant: for a networked CLI operation the HTTP Basic identity comes from a configured
+ * credential source, never from the `username=`/`password=` args that are the add_user/alter_user
+ * PAYLOAD. Pre-#1873 those args won the precedence chain, so the CLI authenticated as the user it
+ * was creating — a 401 for add_user (that user does not exist yet) and for alter_user (the request
+ * carried the new password as its credential), which made non-interactive user provisioning against
+ * a deployed instance impossible.
+ *
+ * Pinned here: `auth_username=`/`auth_password=` win the auth leg; env-var credentials and
+ * target-URL userinfo both beat the payload; each source is all-or-nothing, so an incomplete
+ * explicit pair is fatal rather than completed from the next source; and the legacy payload
+ * fallback survives for operations where those args genuinely ARE the credentials.
+ * unitTests/bin/cliOperations.test.js owns the field-stripping half of the fix, which has no
+ * server-observable effect.
+ *
+ * The suite drives dist/bin/harper.js as a child process, pinned via `harperBinPath` because
+ * auto-resolution can pick up an unrelated `harper` package from node_modules.
+ *
+ * AUTHORIZELOCAL: the harness passes `--AUTHENTICATION_AUTHORIZELOCAL=true`, which auto-auths any
+ * loopback caller as super_user and would make every arm here succeed regardless of what the CLI
+ * sent. `config.authentication.authorizeLocal: false` reaches Harper through HARPER_SET_CONFIG and
+ * overrides that CLI arg; the CONTROL test is the gate that proves it, and every other assertion in
+ * this file is void if it fails.
+ *
+ * HERMETICITY: the CLI child runs with a throwaway HOME and cwd and an env scrubbed of
+ * `HARPER_CLI_*`, `CLI_TARGET_*` and the workload-identity variables. Each is a credential source
+ * outranking the legacy payload fallback, so any of them left in place would decide what the
+ * fallback arms resolve to: a developer's saved `harper login` token in ~/.harperdb/credentials.json,
+ * a repo-root `.env` (cliOperations() calls dotenv.config() before resolving auth), the env vars
+ * themselves, and a CI runner's OIDC identity token.
+ *
+ * Run:
+ *   npm run test:integration -- "integrationTests/security/qa627-cli-user-auth-separation.test.ts"
+ */
+import { suite, test, before, after } from 'node:test';
+import assert from 'node:assert';
+import { resolve, join } from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { setTimeout as sleep } from 'node:timers/promises';
+import request from 'supertest';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from '../apiTests/utils/client.mjs';
+
+const execFileAsync = promisify(execFile);
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'qa627-cli-user-auth-separation');
+const HARPER_BIN = resolve(import.meta.dirname, '../../dist/bin/harper.js');
+const skipSuite = process.platform === 'win32';
+
+const ROLE = 'qa627_svc_role';
+const ENV_AUTH_USER = 'qa627_env_created';
+const ENV_AUTH_PW = 'Qa627-Env-Pw!1';
+const ARGS_AUTH_USER = 'qa627_args_created';
+const ARGS_AUTH_PW = 'Qa627-Args-Pw!1';
+const URL_AUTH_USER = 'qa627_url_created';
+const URL_AUTH_PW = 'Qa627-Url-Pw!1';
+const FATAL_USER = 'qa627_never_created';
+const LONE_USER = 'qa627_lone_username';
+const ALTER_USER = 'qa627_alter_target';
+const ALTER_PW_OLD = 'Qa627-Old-Pw!1';
+const ALTER_PW_NEW = 'Qa627-New-Pw!1';
+
+interface CliResult {
+	code: number;
+	stdout: string;
+	stderr: string;
+}
+
+suite(
+	'QA-627 CLI transport auth is separate from the add_user/alter_user payload (harper#1872)',
+	{ skip: skipSuite },
+	(ctx: ContextWithHarper) => {
+		let client: ReturnType<typeof createApiClient>;
+		let cliHome: string;
+
+		/** A child process, never in-process: cliOperations() calls process.exit(). */
+		async function runCli(args: string[], env: Record<string, string> = {}): Promise<CliResult> {
+			const base: Record<string, string | undefined> = { ...process.env };
+			for (const key of Object.keys(base)) {
+				if (key.startsWith('HARPER_CLI_') || key.startsWith('CLI_TARGET_')) delete base[key];
+			}
+			// bin/workloadIdentity.ts: on an Actions runner with `id-token: write` these are set, and
+			// the fallback arms would exchange an OIDC token instead of using the fallback.
+			delete base.ACTIONS_ID_TOKEN_REQUEST_URL;
+			delete base.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+			try {
+				const { stdout, stderr } = await execFileAsync(process.execPath, [HARPER_BIN, ...args], {
+					// dotenv.config() runs before auth resolution, so a repo-root `.env` would refill
+					// what was just deleted.
+					cwd: cliHome,
+					env: { ...base, HOME: cliHome, USERPROFILE: cliHome, ...env },
+					timeout: 20_000,
+				});
+				return { code: 0, stdout, stderr };
+			} catch (err: any) {
+				return { code: err.code ?? 1, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+			}
+		}
+
+		/** `user_info` is a self lookup, so it needs no super_user permission. */
+		async function canAuthenticate(username: string, password: string): Promise<number> {
+			const header = 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
+			const res = await request(ctx.harper.operationsAPIURL)
+				.post('/')
+				.set('Authorization', header)
+				.send({ operation: 'user_info' });
+			return res.status;
+		}
+
+		async function listUsernames(): Promise<Set<string>> {
+			const res = await client.req().send({ operation: 'list_users' }).expect(200);
+			return new Set((res.body as any[]).map((u) => u.username));
+		}
+
+		before(async () => {
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+				harperBinPath: HARPER_BIN,
+				config: { authentication: { authorizeLocal: false } },
+				env: {},
+			});
+			client = createApiClient(ctx.harper);
+			cliHome = await mkdtemp(join(tmpdir(), 'qa627-cli-home-'));
+
+			// Pre-installed fixture, so poll for non-404 rather than restarting workers.
+			let ready = false;
+			const deadline = Date.now() + 120_000;
+			while (Date.now() < deadline) {
+				try {
+					const probe = await client.reqRest('/FirstTable/').timeout(2000);
+					if (probe.status !== 404) {
+						ready = true;
+						break;
+					}
+				} catch {
+					/* not ready yet */
+				}
+				await sleep(250);
+			}
+			assert.ok(ready, 'REST route /FirstTable/ never became available within 120s — the fixture did not install');
+
+			await client
+				.req()
+				.send({ operation: 'add_role', role: ROLE, permission: { super_user: false } })
+				.expect(200);
+		});
+
+		after(async () => {
+			await teardownHarper(ctx);
+			if (cliHome) await rm(cliHome, { recursive: true, force: true });
+		});
+
+		test('CONTROL: a no-credentials ops-API call gets a genuine 401 (authorizeLocal bypass disabled)', async () => {
+			const res = await request(ctx.harper.operationsAPIURL).post('/').send({ operation: 'describe_all' });
+			console.log(`[QA-627][CONTROL] no-creds describe_all => ${res.status}`);
+			assert.strictEqual(
+				res.status,
+				401,
+				`AUTHORIZELOCAL ESCAPE (every assertion in this file is void if this fails): got ${res.status} ${res.text}`
+			);
+		});
+
+		test('env-var credentials authenticate add_user, while username=/password= stay the payload', async () => {
+			const { code, stdout, stderr } = await runCli(
+				[
+					'add_user',
+					`target=${ctx.harper.operationsAPIURL}`,
+					`username=${ENV_AUTH_USER}`,
+					`password=${ENV_AUTH_PW}`,
+					`role=${ROLE}`,
+					'active=true',
+				],
+				{ HARPER_CLI_USERNAME: ctx.harper.admin.username, HARPER_CLI_PASSWORD: ctx.harper.admin.password }
+			);
+			console.log(`[QA-627][env-auth add_user] exit=${code}\nstdout=${stdout}\nstderr=${stderr}`);
+
+			assert.strictEqual(
+				code,
+				0,
+				`CLI add_user should authenticate as the env-var admin. stdout=${stdout} stderr=${stderr}`
+			);
+			assert.ok((await listUsernames()).has(ENV_AUTH_USER), `${ENV_AUTH_USER} should have been created`);
+			// The payload password reached the BODY, not the Authorization header. Pre-#1873 this
+			// arm 401'd before creating anything.
+			assert.strictEqual(
+				await canAuthenticate(ENV_AUTH_USER, ENV_AUTH_PW),
+				200,
+				`${ENV_AUTH_USER} should authenticate with the password passed as the add_user payload`
+			);
+		});
+
+		test('auth_username=/auth_password= win the auth leg over both the payload and env vars', async () => {
+			const { code, stdout, stderr } = await runCli(
+				[
+					'add_user',
+					`target=${ctx.harper.operationsAPIURL}`,
+					`auth_username=${ctx.harper.admin.username}`,
+					`auth_password=${ctx.harper.admin.password}`,
+					`username=${ARGS_AUTH_USER}`,
+					`password=${ARGS_AUTH_PW}`,
+					`role=${ROLE}`,
+					'active=true',
+				],
+				// Wrong on purpose: without the dedicated args outranking them this call would 401.
+				{ HARPER_CLI_USERNAME: 'qa627_not_a_user', HARPER_CLI_PASSWORD: 'Qa627-Wrong-Pw!1' }
+			);
+			console.log(`[QA-627][args-auth add_user] exit=${code}\nstdout=${stdout}\nstderr=${stderr}`);
+
+			assert.strictEqual(code, 0, `auth_* args should have authenticated as admin. stdout=${stdout} stderr=${stderr}`);
+			assert.ok((await listUsernames()).has(ARGS_AUTH_USER), `${ARGS_AUTH_USER} should have been created`);
+			assert.strictEqual(
+				await canAuthenticate(ARGS_AUTH_USER, ARGS_AUTH_PW),
+				200,
+				`${ARGS_AUTH_USER} should authenticate with its own payload password`
+			);
+		});
+
+		test('admin credentials embedded in the target= URL authenticate add_user', async () => {
+			const targetUrl = new URL(ctx.harper.operationsAPIURL);
+			targetUrl.username = ctx.harper.admin.username;
+			targetUrl.password = ctx.harper.admin.password;
+
+			const { code, stdout, stderr } = await runCli([
+				'add_user',
+				`target=${targetUrl.toString()}`,
+				`username=${URL_AUTH_USER}`,
+				`password=${URL_AUTH_PW}`,
+				`role=${ROLE}`,
+				'active=true',
+			]);
+			console.log(`[QA-627][url-auth add_user] exit=${code}\nstdout=${stdout}\nstderr=${stderr}`);
+
+			assert.strictEqual(
+				code,
+				0,
+				`target= userinfo should have authenticated as admin. stdout=${stdout} stderr=${stderr}`
+			);
+			assert.ok((await listUsernames()).has(URL_AUTH_USER), `${URL_AUTH_USER} should have been created`);
+			assert.strictEqual(
+				await canAuthenticate(URL_AUTH_USER, URL_AUTH_PW),
+				200,
+				`${URL_AUTH_USER} should authenticate with its own payload password`
+			);
+		});
+
+		test("alter_user applies the target user's new password instead of authenticating with it", async () => {
+			await client
+				.req()
+				.send({ operation: 'add_user', role: ROLE, username: ALTER_USER, password: ALTER_PW_OLD, active: true })
+				.expect(200);
+			assert.strictEqual(
+				await canAuthenticate(ALTER_USER, ALTER_PW_OLD),
+				200,
+				'the alter target should authenticate with its original password before the CLI runs'
+			);
+
+			const { code, stdout, stderr } = await runCli(
+				['alter_user', `target=${ctx.harper.operationsAPIURL}`, `username=${ALTER_USER}`, `password=${ALTER_PW_NEW}`],
+				{ HARPER_CLI_USERNAME: ctx.harper.admin.username, HARPER_CLI_PASSWORD: ctx.harper.admin.password }
+			);
+			console.log(`[QA-627][env-auth alter_user] exit=${code}\nstdout=${stdout}\nstderr=${stderr}`);
+
+			assert.strictEqual(
+				code,
+				0,
+				`CLI alter_user should authenticate as the env-var admin. stdout=${stdout} stderr=${stderr}`
+			);
+			assert.strictEqual(
+				await canAuthenticate(ALTER_USER, ALTER_PW_NEW),
+				200,
+				'the new password should now authenticate — alter_user must have been applied'
+			);
+			assert.strictEqual(
+				await canAuthenticate(ALTER_USER, ALTER_PW_OLD),
+				401,
+				'the old password must no longer authenticate'
+			);
+		});
+
+		test('an incomplete auth_* pair is a hard error, never completed from another source', async () => {
+			const { code, stdout, stderr } = await runCli(
+				[
+					'add_user',
+					`target=${ctx.harper.operationsAPIURL}`,
+					`auth_username=${ctx.harper.admin.username}`,
+					`username=${FATAL_USER}`,
+					`password=Qa627-Fatal-Pw!1`,
+					`role=${ROLE}`,
+					'active=true',
+				],
+				// Composing across sources would pair auth_username with the env password and succeed.
+				{ HARPER_CLI_USERNAME: ctx.harper.admin.username, HARPER_CLI_PASSWORD: ctx.harper.admin.password }
+			);
+			console.log(`[QA-627][incomplete auth_*] exit=${code}\nstdout=${stdout}\nstderr=${stderr}`);
+
+			assert.notStrictEqual(code, 0, `a lone auth_username= must fail. stdout=${stdout} stderr=${stderr}`);
+			assert.match(
+				stdout + stderr,
+				/incomplete credentials/i,
+				`expected an incomplete-credentials error, got stdout=${stdout} stderr=${stderr}`
+			);
+			assert.ok(!(await listUsernames()).has(FATAL_USER), `${FATAL_USER} must not have been created`);
+		});
+
+		test('the legacy username=/password= fallback still authenticates an operation where they ARE the credentials', async () => {
+			const both = await runCli([
+				'describe_all',
+				`target=${ctx.harper.operationsAPIURL}`,
+				`username=${ctx.harper.admin.username}`,
+				`password=${ctx.harper.admin.password}`,
+			]);
+			console.log(`[QA-627][payload fallback] exit=${both.code}\nstderr=${both.stderr}`);
+			// The compatibility promise, not the collision fix: this passed pre-#1873 too. It fails
+			// only if the fallback is dropped outright.
+			assert.strictEqual(
+				both.code,
+				0,
+				`the legacy username=/password= fallback should still authenticate describe_all. stdout=${both.stdout} stderr=${both.stderr}`
+			);
+		});
+
+		test('a lone username= stays payload, leaving configured credentials in charge of the request', async () => {
+			await client
+				.req()
+				.send({ operation: 'add_user', role: ROLE, username: LONE_USER, password: 'Qa627-Lone-Pw!1', active: true })
+				.expect(200);
+
+			// The env pair is what makes the two polarities distinguishable: pre-#1873 `req.username`
+			// outranked it and the drop 401'd as a passwordless LONE_USER; now the env pair wins and
+			// the drop succeeds as admin. With no credentials at all both polarities 401, so that
+			// shape cannot detect a revert.
+			const { code, stdout, stderr } = await runCli(
+				['drop_user', `target=${ctx.harper.operationsAPIURL}`, `username=${LONE_USER}`],
+				{ HARPER_CLI_USERNAME: ctx.harper.admin.username, HARPER_CLI_PASSWORD: ctx.harper.admin.password }
+			);
+			console.log(`[QA-627][lone username=] exit=${code}\nstdout=${stdout}\nstderr=${stderr}`);
+
+			assert.strictEqual(
+				code,
+				0,
+				`a lone username= must stay payload and leave the env credentials in charge. stdout=${stdout} stderr=${stderr}`
+			);
+			assert.ok(!(await listUsernames()).has(LONE_USER), `${LONE_USER} should have been dropped`);
+		});
+	}
+);

--- a/integrationTests/security/qa627-cli-user-auth-separation.test.ts
+++ b/integrationTests/security/qa627-cli-user-auth-separation.test.ts
@@ -9,10 +9,10 @@
  * carried the new password as its credential), which made non-interactive user provisioning against
  * a deployed instance impossible.
  *
- * Pinned here: `auth_username=`/`auth_password=` win the auth leg; env-var credentials and
- * target-URL userinfo both beat the payload; each source is all-or-nothing, so an incomplete
- * explicit pair is fatal rather than completed from the next source; and the legacy payload
- * fallback survives for operations where those args genuinely ARE the credentials.
+ * `auth_username=`/`auth_password=` win the auth leg; env-var credentials and target-URL userinfo
+ * both beat the payload; each source is all-or-nothing, so an incomplete explicit pair is fatal
+ * rather than completed from the next source; and the legacy payload fallback survives for
+ * operations where those args genuinely ARE the credentials.
  * unitTests/bin/cliOperations.test.js owns the field-stripping half of the fix, which has no
  * server-observable effect.
  *
@@ -59,6 +59,11 @@ const ENV_AUTH_USER = 'qa627_env_created';
 const ENV_AUTH_PW = 'Qa627-Env-Pw!1';
 const ARGS_AUTH_USER = 'qa627_args_created';
 const ARGS_AUTH_PW = 'Qa627-Args-Pw!1';
+const URL_AUTH_ADMIN = 'qa627_url_admin';
+// Deliberately alphanumeric: `new URL()` percent-encodes userinfo while extractTargetCredentials
+// (bin/cliCredentials.ts) returns it undecoded, so `:` `;` `=` `@` in a password all break the
+// target= form. This arm pins auth precedence, not that pre-existing decoding gap.
+const URL_AUTH_ADMIN_PW = 'Qa627UrlAdminPw1';
 const URL_AUTH_USER = 'qa627_url_created';
 const URL_AUTH_PW = 'Qa627-Url-Pw!1';
 const FATAL_USER = 'qa627_never_created';
@@ -79,6 +84,7 @@ suite(
 	(ctx: ContextWithHarper) => {
 		let client: ReturnType<typeof createApiClient>;
 		let cliHome: string;
+		let superUserRole: string;
 
 		/** A child process, never in-process: cliOperations() calls process.exit(). */
 		async function runCli(args: string[], env: Record<string, string> = {}): Promise<CliResult> {
@@ -145,6 +151,11 @@ suite(
 				.req()
 				.send({ operation: 'add_role', role: ROLE, permission: { super_user: false } })
 				.expect(200);
+
+			const users = await client.req().send({ operation: 'list_users' }).expect(200);
+			const admin = (users.body as any[]).find((u) => u.username === ctx.harper.admin.username);
+			assert.ok(admin?.role?.role, `expected to find the harness admin '${ctx.harper.admin.username}' in list_users`);
+			superUserRole = admin.role.role;
 		});
 
 		after(async () => {
@@ -217,19 +228,23 @@ suite(
 		});
 
 		test('admin credentials embedded in the target= URL authenticate add_user', async () => {
-			// Built by hand rather than through URL setters, which percent-encode userinfo while
-			// extractTargetCredentials (bin/cliCredentials.ts) returns url.password UNDECODED — so a
-			// round trip would send `pw%40x` for a password containing `@` and this arm would report a
-			// #1873 regression that did not happen. The guard fails loudly if a future harness default
-			// makes the literal form ambiguous instead of letting it read as a product failure.
-			const { username, password } = ctx.harper.admin;
-			assert.doesNotMatch(
-				`${username}:${password}`,
-				/[@/?#[\]%\s]/,
-				'the harness admin credentials must be literal-safe in URL userinfo for this arm to mean anything'
-			);
+			// A dedicated super_user with a URL-safe password, rather than the harness admin: the
+			// credential travels through `new URL()` inside the CLI, which percent-encodes userinfo
+			// that extractTargetCredentials then returns undecoded, so an ambient password containing
+			// `:` `;` `=` or `@` would fail this arm for a reason that has nothing to do with #1873.
+			await client
+				.req()
+				.send({
+					operation: 'add_user',
+					role: superUserRole,
+					username: URL_AUTH_ADMIN,
+					password: URL_AUTH_ADMIN_PW,
+					active: true,
+				})
+				.expect(200);
+
 			const url = new URL(ctx.harper.operationsAPIURL);
-			const targetUrl = `${url.protocol}//${username}:${password}@${url.host}${url.pathname}`;
+			const targetUrl = `${url.protocol}//${URL_AUTH_ADMIN}:${URL_AUTH_ADMIN_PW}@${url.host}${url.pathname}`;
 
 			const { code, stdout, stderr } = await runCli([
 				'add_user',
@@ -244,7 +259,7 @@ suite(
 			assert.strictEqual(
 				code,
 				0,
-				`target= userinfo should have authenticated as admin. stdout=${stdout} stderr=${stderr}`
+				`target= userinfo should have authenticated as ${URL_AUTH_ADMIN}. stdout=${stdout} stderr=${stderr}`
 			);
 			assert.ok((await listUsernames()).has(URL_AUTH_USER), `${URL_AUTH_USER} should have been created`);
 			assert.strictEqual(

--- a/integrationTests/security/qa627-cli-user-auth-separation.test.ts
+++ b/integrationTests/security/qa627-cli-user-auth-separation.test.ts
@@ -41,11 +41,12 @@ import { resolve, join } from 'node:path';
 import { mkdir } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { setTimeout as sleep } from 'node:timers/promises';
 import request from 'supertest';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
 import { createApiClient } from '../apiTests/utils/client.mjs';
+// @ts-expect-error lifecycle.mjs has no type declarations; runtime resolves fine
+import { waitForRouteReady } from '../apiTests/utils/lifecycle.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -112,7 +113,6 @@ suite(
 			}
 		}
 
-		/** `user_info` is a self lookup, so it needs no super_user permission. */
 		async function canAuthenticate(username: string, password: string): Promise<number> {
 			const header = 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
 			const res = await request(ctx.harper.operationsAPIURL)
@@ -139,21 +139,7 @@ suite(
 			cliHome = join(ctx.harper.dataRootDir, 'qa627-cli-home');
 			await mkdir(cliHome, { recursive: true });
 
-			let ready = false;
-			const deadline = Date.now() + 120_000;
-			while (Date.now() < deadline) {
-				try {
-					const probe = await client.reqRest('/FirstTable/').timeout(2000);
-					if (probe.status !== 404) {
-						ready = true;
-						break;
-					}
-				} catch {
-					/* not ready yet */
-				}
-				await sleep(250);
-			}
-			assert.ok(ready, 'REST route /FirstTable/ never became available within 120s — the fixture did not install');
+			await waitForRouteReady(client, '/FirstTable/', 120_000);
 
 			await client
 				.req()
@@ -231,13 +217,23 @@ suite(
 		});
 
 		test('admin credentials embedded in the target= URL authenticate add_user', async () => {
-			const targetUrl = new URL(ctx.harper.operationsAPIURL);
-			targetUrl.username = ctx.harper.admin.username;
-			targetUrl.password = ctx.harper.admin.password;
+			// Built by hand rather than through URL setters, which percent-encode userinfo while
+			// extractTargetCredentials (bin/cliCredentials.ts) returns url.password UNDECODED — so a
+			// round trip would send `pw%40x` for a password containing `@` and this arm would report a
+			// #1873 regression that did not happen. The guard fails loudly if a future harness default
+			// makes the literal form ambiguous instead of letting it read as a product failure.
+			const { username, password } = ctx.harper.admin;
+			assert.doesNotMatch(
+				`${username}:${password}`,
+				/[@/?#[\]%\s]/,
+				'the harness admin credentials must be literal-safe in URL userinfo for this arm to mean anything'
+			);
+			const url = new URL(ctx.harper.operationsAPIURL);
+			const targetUrl = `${url.protocol}//${username}:${password}@${url.host}${url.pathname}`;
 
 			const { code, stdout, stderr } = await runCli([
 				'add_user',
-				`target=${targetUrl.toString()}`,
+				`target=${targetUrl}`,
 				`username=${URL_AUTH_USER}`,
 				`password=${URL_AUTH_PW}`,
 				`role=${ROLE}`,

--- a/integrationTests/security/qa627-cli-user-auth-separation/config.yaml
+++ b/integrationTests/security/qa627-cli-user-auth-separation/config.yaml
@@ -1,0 +1,3 @@
+rest: true
+graphqlSchema:
+  files: '*.graphql'

--- a/integrationTests/security/qa627-cli-user-auth-separation/schema.graphql
+++ b/integrationTests/security/qa627-cli-user-auth-separation/schema.graphql
@@ -1,0 +1,6 @@
+# QA-627 fixture schema. FirstTable exists only as the REST readiness-probe route; the anchor
+# exercises the operations API through the real CLI binary.
+type FirstTable @table @export {
+	id: ID @primaryKey
+	value: String
+}


### PR DESCRIPTION
## What / why

Three QA regression anchors promoted out of the qa-explorer bank as committed integration suites. Test-only: the diff is ten new files — three suites, their three fixture components, and one fixture resource — and zero modifications to anything tracked.

One line per spec, with the originating QA id:

- **`integrationTests/resources/qa716-lingering-write-commit.test.ts`** (QA-716 / P-493) — pins PR #1860 ("don't drop writes staged while read iterators defer the commit"): writes staged across three tables in one request transaction, behind a paged secondary-index iterator the handler returns without draining or closing, must be durable **and** index-consistent the moment the request is acked — not eventually.
- **`integrationTests/security/qa627-cli-user-auth-separation.test.ts`** (QA-627 / P-409) — pins #1872, fixed by PR #1873: the CLI resolves HTTP Basic credentials separately from the `add_user`/`alter_user` payload, and per source as an atomic pair.
- **`integrationTests/mqtt/qa681-mqtt-shared-subscriptions.test.ts`** (QA-681 / P-460) — pins that MQTT `$share` subscriptions are explicitly **refused** with a SUBACK reason code rather than accepted as an inert filter, that ordinary fan-out beside them stays complete and duplicate-free, and that a durable session loses nothing across an abrupt mid-stream drop.

### Why QA-716 is additive to `unitTests/resources/lingeringWriteCommit.test.js`

That unit test shipped with the #1860 fix and covers the basic **single-table** case against the transaction object in isolation. This anchor drives the same mechanism through the whole request path and combines it with the factors a real fulfillment endpoint hits at once: writes staged across **three** tables in one request transaction, a paged secondary-index iterator the handler never drains or closes, TTL eviction racing the deferred commit, and 4-way worker concurrency. The fixture's [`FulfillPage`](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-05a0a1e9a667bb786eac95b83b93e569f58838cd10fec248eb1d5f6e22d82ed0R52) is where the shape lives — it pulls a page and returns with the cursor simply dropped.

Both are RocksDB-only in substance, since LMDB never defers a commit on open read transactions, so the suite is parameterized on `HARPER_STORAGE_ENGINE` and the LMDB run is a no-delta control. Q3 [asserts that the long-transaction monitor actually reached the abandoned iterator](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-415936d12a5879d396396c6ea1e928d809e0bdefe1735a8e5df7ee0fe339dfb0R257), via #1860's release-only warn line — on RocksDB only, because LMDB correctly never logs it. Without that assertion the arm was blind: dropping the lingering transaction from write supervision, or renaming `storage.maxTransactionOpenTime`, would have left it sleeping and then re-reading writes Q1 had already proved durable.

### QA-627's polarity was inverted, deliberately

The banked candidate asserted the **pre-fix defect** — that the CLI must 401 because it authenticated as the user being created. Re-run as banked on current `main` it fails 2 of 5 arms, both with `expected the CLI to fail (auth collision) but it exited 0`: red there means the fix works. Promoting it as a defect repro would commit a test that only goes green if #1873 is reverted, so the arms assert the shipped contract instead — env-var credentials, `auth_*` args and target-URL userinfo each winning the auth leg over the payload, the atomic-pair rule, and the legacy `username=`/`password=` fallback surviving for operations where those args genuinely are the credentials.

## For the human reviewer

- **One PR across three directories.** The promotion rules ask for one subsystem per PR; QA-716 and QA-627 are both shipped-fix anchors, which is the accepted cross-directory theme, and QA-681 was bundled rather than opening a second PR because the three files share no code and are read independently. Happy to split QA-681 out if you would rather review it separately.
- **QA-681 has no ratifying issue, and that is the judgment call worth your attention.** It is a clean negative pinning behaviour that is real but undocumented: Harper has no `$share` parsing at all, so the literal prefix fails resource resolution and the SUBACK refuses. The promotion gate routes it to the human lane for exactly that reason. **The question is whether refusing `$share` is the contract Harper wants to be held to**, or merely today's behaviour — a test that pins it makes it the former.
- **`describe_all` with plain `username=`/`password=` is a compatibility anchor, not a fix anchor**, and the file says so: that arm passed before #1873 too. It fails only if the legacy fallback is dropped outright.
- **Two claim scopes were narrowed to what the instruments actually prove**, and the code says so at each site. `search` hides a row the moment `expiresAt` passes, independently of the sweep (`resources/Table.ts`), so QA-716's expiry assertion says an expired row is no longer *returned* rather than that a sweep ran.
- **QA-716's TTL arm deliberately makes no index-level claim, and says so where the assertion used to be.** `search_by_value` materializes its hits and drops any whose base record is gone, so once the base dump is empty an index query is empty too, whatever the index actually holds — a check there could not fail. Pinning sweep-time index cleanup needs a raw-index read the operations API does not expose. Worth knowing: the same limit applies to the phantom oracle in the committed `integrationTests/database/eviction-secondary-index.test.ts:310-315`, whose `residual index entries: 0` and `phantom index entries: 0` assertions are incapable of failing for the pure-orphan case they name. That is pre-existing and filed separately, not introduced here.
- **Three fixed grace windows survived on purpose**, in QA-681 Q3/Q4 and QA-716 Q3, and each guards a claim about an *absence* — no message ever reaches a refused subscriber; no write is discarded once the long-transaction monitor has run. There is no positive event to converge on for those, so elapsed time is the instrument. Every positive claim converges instead.
- **Declined from the pre-push review, with reasons:**
  - *"`authorizeLocal` is never disabled, so the CONTROL arm will fail"* (raised as a blocker). Refuted twice over: the harness passes `--AUTHENTICATION_AUTHORIZELOCAL=true` as a CLI **arg**, never as `process.env`, so `security/auth.ts`'s env branch is `undefined` and the `HARPER_SET_CONFIG` value from `config:` decides — and empirically the CONTROL arm returns 401 on every run. That arm exists precisely to catch this if it ever changes.
  - *Add a `close` listener to the MQTT connect handshake.* The 10s cap already converts a silent handshake drop into a clear failure, and a `close` listener risks a false rejection in mqtt.js's normal event ordering — a worse trade for a test that must not flake.
  - *Extract the readiness poll into a shared `awaitFixtureReady()` helper.* Every committed suite in `integrationTests/` inlines its own poll; a promotion PR is the wrong place to introduce a new cross-suite API, and three similar blocks beat a premature abstraction.
  - *Delete the file headers as "PR history".* They are this suite's own convention for promoted anchors — `qa649-mqtt-restart-wedge.test.ts`, `txn-overtime-atomicity.test.ts`, `overtime-multi-write-atomicity.test.ts` and `eviction-secondary-index.test.ts` all carry one — and each records which fix the anchor pins and what the pre-fix failure looked like, which is the "why" the code cannot express. The inline narration flagged alongside them *is* gone.
- **Not covered here:** the field-stripping half of #1873 (auth args never serialized into the request body). It has no server-observable effect — `add_user` ignores an extra `auth_username` field — so asserting it from an integration test would be theatre. `unitTests/bin/cliOperations.test.js` already owns it.

## Verification

Everything below ran in the worktree on current `main` (`ee46a6acf`) after `npm run build` (exit 0), because integration tests run against `dist/`.

| suite | result |
|---|---|
| `qa716-lingering-write-commit.test.ts` | 4 pass / 0 fail |
| `qa716-lingering-write-commit.test.ts` (`HARPER_STORAGE_ENGINE=lmdb`) | 4 pass / 0 fail |
| `qa627-cli-user-auth-separation.test.ts` | 8 pass / 0 fail |
| `qa681-mqtt-shared-subscriptions.test.ts` | 4 pass / 0 fail |
| all three together | 16 pass / 0 fail |

- `npx prettier --check` and `npx oxlint --format stylish --deny-warnings` are clean on all three specs and the fixture resource. oxlint was confirmed **armed** rather than merely silent, using a non-underscore probe (`qaProbeUnusedImport`) that fired as expected and was then removed — oxlint's `no-unused-vars` exempts underscore-prefixed identifiers, so an `_`-named probe proves nothing.
- **CI note:** the `Unit Test (Node.js v22)` leg failed on `unitTests/resources/longLivedTransactions.test.js` — "names a chain link reachable only through the root under its own native id", asserting `/state: [^,]*active/` and getting `state: source-apply`. That is pre-existing and unrelated: this diff adds files only under `integrationTests/`, every unit script globs `unitTests/**`, `Unit Test (Node.js v24)` passed on the same commit, and the identical failure hit main's own CI run for #2473, the commit that introduced the test. The cause is the 10-line-per-pass cap in `reportLongLivedHolder` deferring a holder past the single tick during which `active` is still in the state list, so a loaded suite intermittently reports the next state instead.
- The qa-explorer promotion gate reports **0 hard rejects** across all three: no `vacuous-assert`, `abs-path`, `restart-fixture`, `bare-sleep`, `raw-restart`, `format` or `lint`.

### The three fixtures

Each suite pre-installs its own component, so none of them restarts workers.

- QA-716 needs a custom resource, so its component declares [`jsResource` alongside the schema](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-8bd5d6ebe5115e4b118ab54e7a8001916ee3030089af5dbf1667c41e7becb372R3), and its [schema](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-21c9787da3ad88afbce589935c116439cbad06536a402c989452d947418f3557R13) carries the three tables the staged writes span: `Orders.status` as the indexed attribute under test, `Inventory` as a second table in the same transaction, and `Reservation` as a third with an 8-second TTL — 8 rather than 3 because `search` stops returning a row the moment `expiresAt` passes, so the window is wall-clock time from the write.
- QA-681 is the only one that [enables `mqtt`](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-de5bda5224c4b2e9d73e51c9e2f6366af6526ce1e4ef79b4034b4fdb4df5b34bR4); its [`Events` table](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-83c8c1f3abf8a5d453da1999810a445c41f38201919b861f3a0cb462233bb6e5R4) is a topic namespace, and non-retained publishes to `Events/*` give a transient stream with no per-key coalescing, which is what makes delivery countable.
- QA-627 exercises the operations API through the CLI rather than any table, so its [component](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-6e416d2fdc97d9343d1f58f464c32f7a4716c18315deae9234e78979c7233d3bR1) and [`FirstTable`](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-0bad372f1a40ff042209bdefe1031b8f5eb3007385cb5c82a5deaa6f3e1c7da4R3) exist only to give the readiness probe a GET-able route.

### Repairs made before promoting

The banked snapshots carried five defects that would have shipped as coverage they did not have. They were fixed rather than carried in:

- **QA-716's TTL arm returned green after logging a skip** when no Reservation rows were present — the exact shape where a lost upstream write makes the eviction assertions trivially true over an empty table. It now asserts [a floor](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-415936d12a5879d396396c6ea1e928d809e0bdefe1735a8e5df7ee0fe339dfb0R213), and [seeds its own bucket](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-415936d12a5879d396396c6ea1e928d809e0bdefe1735a8e5df7ee0fe339dfb0R203) so its expiry window is not shared with another arm's network round trips.
- **QA-681's four arms each returned green after logging `SKIPPED (harness)`** if the MQTT probe failed, so a run that never connected reported coverage it had not taken. They [now fail](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-a91202ec4b1e7efef286a22a216b9d116f052c231531aef63c12a74969d8d73bR194). The same applied to all three suites' readiness polls, which proceeded silently after their 120s deadline.
- **QA-681's durable-session catch-up was logged and never asserted**, and could not distinguish "the session recovered its missed messages" from "the drop never cut delivery". It now asserts the drop cut delivery first, then that the union of before-drop and recovered messages covers everything published — the claim that is stable across shard speeds, unlike the exact split.
- **QA-681's recovery collector was attached after `await connect()`.** A resuming durable session replays its QoS-1 backlog immediately after CONNACK and mqtt.js acknowledges those PUBLISHes before the awaited continuation can install a listener, so the new recovery assertion would have been flaky against a perfectly healthy broker. The collector is now [attached synchronously at client creation](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-a91202ec4b1e7efef286a22a216b9d116f052c231531aef63c12a74969d8d73bR79).
- **QA-627's arms were decided by the developer's own machine.** Every credential source the CLI consults outranks the legacy payload fallback, so a saved `harper login` token in `~/.harperdb/credentials.json`, a repo-root `.env` (`cliOperations()` calls `dotenv.config()` before resolving auth), an inherited `HARPER_CLI_USERNAME`, or a CI runner's OIDC identity would each silently decide what the fallback arms resolved to. The child now runs with a throwaway HOME and cwd and [an env scrubbed of all four](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-8d715aebcd95459f76c83e4dd1fb68673f2c205bc4417daf20782e11d96bc9b2R101).
- **QA-627's lone-`username=` check could not detect a revert:** pre-fix the CLI authenticated as a nonexistent user (401) and post-fix it sends no credentials (also 401), so both polarities matched. It [now runs with a complete env pair configured](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-8d715aebcd95459f76c83e4dd1fb68673f2c205bc4417daf20782e11d96bc9b2R348), where the two differ observably.
- **Three arms shared state that made them race each other.** QA-716's TTL arm read rows another arm's network round trips could expire; QA-681's Q3 shared a topic with Q1, whose last row is that topic's *current record* and is yielded to a new subscriber by a detached iterator that can lose the race to SUBACK; and Q4's drop boundary raced the next publish because `end(true)` does not wait for the socket to be down. Each arm now owns its state — Q3 subscribes through [a `$share` filter wrapping its own topic](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-a91202ec4b1e7efef286a22a216b9d116f052c231531aef63c12a74969d8d73bR44) — and [converges on the transition it depends on](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-a91202ec4b1e7efef286a22a216b9d116f052c231531aef63c12a74969d8d73bR422).
- **QA-716's post-eviction index assertion could not fail** once the base dump was empty — both go through the same materialization. It is gone, with a comment explaining why, rather than left reporting coverage it did not have.
- **QA-627's `target=` URL arm depended on the shape of the ambient admin password.** The credential reaches `new URL()` inside `bin/cliCredentials.ts`, which percent-encodes userinfo that `extractTargetCredentials` then returns undecoded, so `@`, `:`, `;` or `=` in `HDB_ADMIN_PASSWORD` would have reported a #1873 regression that never happened. The arm [provisions its own super_user with an alphanumeric password](https://github.com/HarperFast/harper/pull/2545/changes?w=1#diff-8d715aebcd95459f76c83e4dd1fb68673f2c205bc4417daf20782e11d96bc9b2R247) instead. **That decoding gap is a real pre-existing product bug** — a `target=https://user:p%40ss@host` credential cannot work — and is filed separately rather than worked around silently here.
- **QA-681's resumed-session check fought QoS-1's at-least-once contract twice.** It first forbade duplicates while allowing extra deliveries — two assertions two lines apart that contradicted each other — and then, once duplicates were permitted, still *waited* on a delivery count: a resume replaying an unacked seq 14 alongside 15–28 reaches the expected total while seq 29 is still in flight, so the poll exits early and the run fails a session that recovered everything. The wait is now on sequence **coverage**, which is duplicate-tolerant by construction. The survivors keep their exact-count assertion — that one is the anti-redistribution claim, and it is safe because they never reconnect.

One latent false-green in the banked QA-627 is gone with the inversion: its `NOT-A-WORKAROUND` arm asserted only a non-zero exit, and on current `main` it "passed" because the CLI failed with `User qa627_svc_app already exists` — a 409 left by the previous arm, not an auth collision.

Refs #1860
Refs #1872

Reviewed and authored by Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZPy6UYZtwxhzLgimHWbGD

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=8 @ ca6d3ff5c37c</sub>

<sub>Human-Review-Need: 3 @ ca6d3ff5c37c</sub>
