### PR TITLE
Restore the RocksDB musl lockfile entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2610,6 +2610,25 @@
 				"node": "^22.18.0 || >=24.0.0"
 			}
 		},
+		"node_modules/@harperfast/rocksdb-js-linux-x64-musl": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-2.9.0.tgz",
+			"integrity": "sha512-D/MfsqycP7ijIAAptUcITsMMzn7cnawdL3H1XUqe+h9fgNP7+y0gXk/9KxVA5D6cKPw1TkEDaeLuuBsiI2vFUA==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^22.18.0 || >=24.0.0"
+			}
+		},
 		"node_modules/@harperfast/rocksdb-js-win32-arm64": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-2.9.0.tgz",


### PR DESCRIPTION
Restore the generated [`package-lock.json` musl package record](https://github.com/HarperFast/harper/pull/2555/changes?w=1#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519R2613) for `@harperfast/rocksdb-js-linux-x64-musl@2.9.0`, so `npm ci` can reproduce the complete RocksDB optional-platform graph. This unblocks the `runLinter` workflow and both Node 20 and Node 24 “Next.js adapter integration (against this PR's harper)” jobs; the generated lock entry is the only changed file and the RocksDB version remains 2.9.0—review that generated record most closely.

## For the human reviewer

1. **Scope stops at the reproducible lock graph.** This PR restores the missing package record rather than also adding an Alpine x64 install-and-load smoke test. `npm ci` validates the declared graph immediately and adding platform-container coverage is a separately reversible CI expansion; a decision to require native musl execution proof here would defer the current merge-unblocking repair.

## Verification

- Live package-manager smoke: `npm ci` failed on `origin/main` with the exact missing-musl lockfile error, then completed successfully after regeneration on this branch.
- `npm run build` and `npm run format:check` passed. `npm run lint` exited successfully with 13 existing warnings in unmodified files.
- `npm run test:unit:main` reached 5,462 passing before an unrelated ambient Git credential-variable assertion; `npm run test:unit:resources` reached 2,336 passing before an unrelated long-lived-transaction state assertion. `npm run test:integration:all` exercised the built distribution but failed in unrelated RocksDB scenarios and Node 26 JSON-import-attribute/Ollama setup.
- `v5.2` had the identical missing lock entry; GitHub's release workflow has now cherry-picked this focused fix onto that branch, with no direct release-branch commit from this PR.
- Docker Image Smoke Test intentionally remains red: its exact-vs-caret dependency-pin mismatch belongs to the separately dispatched rocksdb-js fix and is not repairable by this lockfile resync.

Refs #2549

— GPT-5 Codex

🤖 Generated with Codex

Complexity: easy

<sub>Review-Coverage: authored=codex; ran=gemini,cursor-grok; adjudicated=domain; blocked=claude(exit-1); declined=cursor-composer; rounds=1 @ da010736edc7</sub>

<sub>Human-Review-Need: 4 (decisions: musl-proof-level) @ da010736edc7</sub>
