### PR TITLE
Make long-lived chain-link active reporting tests deterministic

### DIFF
--- a/unitTests/resources/longLivedTransactions.test.js
+++ b/unitTests/resources/longLivedTransactions.test.js
@@ -636,15 +636,25 @@ describe('Long-lived transaction reporting (#2471)', () => {
 			if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') this.skip();
 			await withChainLinks(async (links, childLine, childId, refreshChildWrite) => {
 				resetLongLivedTransactionReportsForTests();
-				warnings.length = 0;
-				await refreshChildWrite();
-				await waitFor(() => childLine() !== undefined, 10000);
+				const reportedChildLine = await waitFor(
+					async () => {
+						const trackedTxns = setTxnExpiration(30000);
+						warnings.length = 0;
+						await refreshChildWrite();
+						assert.ok(!trackedTxns.has(links[1]), 'the child must remain reachable only through the root chain');
+						setTxnExpiration(20);
+						await waitFor(() => warningsMatching('Harper transaction has held').length > 0, 2000);
+						setTxnExpiration(30000);
+						return childLine();
+					},
+					{ timeout: 10000, message: 'the child must be reported on the first monitor tick after a write' }
+				);
 				assert.match(
-					childLine(),
+					reportedChildLine,
 					new RegExp(`transaction ${childId}\\b`),
 					'the link must be named under its own native id, which is what the sweep line joins to'
 				);
-				assert.match(childLine(), /state: [^,]*active/);
+				assert.match(reportedChildLine, /state: [^,]*active/);
 			});
 		});
 

--- a/unitTests/resources/longLivedTransactions.test.js
+++ b/unitTests/resources/longLivedTransactions.test.js
@@ -654,7 +654,7 @@ describe('Long-lived transaction reporting (#2471)', () => {
 								).then(
 									() => true,
 									(error) => {
-										if (error.code !== 'ERR_ASSERTION') throw error;
+										if (error?.code !== 'ERR_ASSERTION') throw error;
 										return false;
 									}
 								);
@@ -671,7 +671,7 @@ describe('Long-lived transaction reporting (#2471)', () => {
 						}
 					);
 				} catch (error) {
-					if (error.message === missingActiveReport && lastChildLine)
+					if (error?.message === missingActiveReport && lastChildLine)
 						assert.match(lastChildLine, /state: [^,]*active/, 'the last reported child state must be active');
 					throw error;
 				}

--- a/unitTests/resources/longLivedTransactions.test.js
+++ b/unitTests/resources/longLivedTransactions.test.js
@@ -636,6 +636,7 @@ describe('Long-lived transaction reporting (#2471)', () => {
 			if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') this.skip();
 			await withChainLinks(async (links, childLine, childId, refreshChildWrite) => {
 				resetLongLivedTransactionReportsForTests();
+				const missingActiveReport = 'the child must be reported on the first monitor tick after a write';
 				let lastChildLine;
 				let reportedChildLine;
 				try {
@@ -666,11 +667,11 @@ describe('Long-lived transaction reporting (#2471)', () => {
 						},
 						{
 							timeout: 10000,
-							message: 'the child must be reported on the first monitor tick after a write',
+							message: missingActiveReport,
 						}
 					);
 				} catch (error) {
-					if (error.code === 'ERR_ASSERTION' && lastChildLine)
+					if (error.message === missingActiveReport && lastChildLine)
 						assert.match(lastChildLine, /state: [^,]*active/, 'the last reported child state must be active');
 					throw error;
 				}

--- a/unitTests/resources/longLivedTransactions.test.js
+++ b/unitTests/resources/longLivedTransactions.test.js
@@ -643,9 +643,23 @@ describe('Long-lived transaction reporting (#2471)', () => {
 						await refreshChildWrite();
 						assert.ok(!trackedTxns.has(links[1]), 'the child must remain reachable only through the root chain');
 						setTxnExpiration(20);
-						await waitFor(() => warningsMatching('Harper transaction has held').length > 0, 2000);
-						setTxnExpiration(30000);
-						return childLine();
+						try {
+							const monitorRan = await waitFor(
+								() => warningsMatching('Harper transaction has held').length > 0,
+								2000
+							).then(
+								() => true,
+								(error) => {
+									if (error.code !== 'ERR_ASSERTION') throw error;
+									return false;
+								}
+							);
+							if (!monitorRan) return false;
+							const line = childLine();
+							return /state: [^,]*active/.test(line) && line;
+						} finally {
+							setTxnExpiration(30000);
+						}
 					},
 					{ timeout: 10000, message: 'the child must be reported on the first monitor tick after a write' }
 				);

--- a/unitTests/resources/longLivedTransactions.test.js
+++ b/unitTests/resources/longLivedTransactions.test.js
@@ -632,37 +632,48 @@ describe('Long-lived transaction reporting (#2471)', () => {
 		}
 
 		it('names a chain link reachable only through the root under its own native id', async function () {
-			this.timeout(15000);
+			this.timeout(30000);
 			if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') this.skip();
 			await withChainLinks(async (links, childLine, childId, refreshChildWrite) => {
 				resetLongLivedTransactionReportsForTests();
-				const reportedChildLine = await waitFor(
-					async () => {
-						const trackedTxns = setTxnExpiration(30000);
-						warnings.length = 0;
-						await refreshChildWrite();
-						assert.ok(!trackedTxns.has(links[1]), 'the child must remain reachable only through the root chain');
-						setTxnExpiration(20);
-						try {
-							const monitorRan = await waitFor(
-								() => warningsMatching('Harper transaction has held').length > 0,
-								2000
-							).then(
-								() => true,
-								(error) => {
-									if (error.code !== 'ERR_ASSERTION') throw error;
-									return false;
-								}
-							);
-							if (!monitorRan) return false;
-							const line = childLine();
-							return /state: [^,]*active/.test(line) && line;
-						} finally {
-							setTxnExpiration(30000);
+				let lastChildLine;
+				let reportedChildLine;
+				try {
+					reportedChildLine = await waitFor(
+						async () => {
+							const trackedTxns = setTxnExpiration(30000);
+							warnings.length = 0;
+							await refreshChildWrite();
+							assert.ok(!trackedTxns.has(links[1]), 'the child must remain reachable only through the root chain');
+							setTxnExpiration(20);
+							try {
+								const monitorRan = await waitFor(
+									() => warningsMatching('Harper transaction has held').length > 0,
+									2000
+								).then(
+									() => true,
+									(error) => {
+										if (error.code !== 'ERR_ASSERTION') throw error;
+										return false;
+									}
+								);
+								if (!monitorRan) return false;
+								lastChildLine = childLine();
+								return /state: [^,]*active/.test(lastChildLine) && lastChildLine;
+							} finally {
+								setTxnExpiration(30000);
+							}
+						},
+						{
+							timeout: 10000,
+							message: 'the child must be reported on the first monitor tick after a write',
 						}
-					},
-					{ timeout: 10000, message: 'the child must be reported on the first monitor tick after a write' }
-				);
+					);
+				} catch (error) {
+					if (error.code === 'ERR_ASSERTION' && lastChildLine)
+						assert.match(lastChildLine, /state: [^,]*active/, 'the last reported child state must be active');
+					throw error;
+				}
 				assert.match(
 					reportedChildLine,
 					new RegExp(`transaction ${childId}\\b`),


### PR DESCRIPTION
The intermittent chain-link `active` failure was a test timing defect, not a reporting-logic defect. The test now [observes a first post-write monitor pass and retries when the per-pass reporting budget defers the child](https://github.com/HarperFast/harper/pull/2557/changes?w=1#diff-27b6b8d8f6591d28d485ce8379eab39e98a631cb2a1a4be793f665a0d25e950dR639), while leaving production's tick-based meaning of `active` unchanged.

## For the human reviewer

1. The test continues to use the real interval monitor, pausing it around each refresh write and retrying when another holder consumes the reporting budget. The alternative is an exported synchronous monitor-pass seam; that would be deterministic without timers, but it would also expose a callback that performs shared-process abort, force-commit, and snapshot cleanup. This test-only choice is easy to reverse; rejecting it means adding and reviewing that product seam.
2. Production continues to define `active` as “wrote within the last monitor tick.” An elapsed-time definition was considered and rejected because it changes operator-facing semantics and conflicts with the adjacent decayed-recency coverage. Revisiting this requires a separate product decision, not a test stabilization.

Framing-Verdict: better-alternative-exists (f3f810e6e3c6) — adopted by adding fresh-write retries around the real monitor, which closes both the interleaving race and the per-pass report-cap deferral identified by planning review.

## Changes

`unitTests/resources/longLivedTransactions.test.js` now freezes the monitor before refreshing the child write, [re-arms it for the next pass and verifies the child remains reachable only through the root chain](https://github.com/HarperFast/harper/pull/2557/changes?w=1#diff-27b6b8d8f6591d28d485ce8379eab39e98a631cb2a1a4be793f665a0d25e950dR648), and retries only when a first-pass child line containing `active` was not observed. It retains the last non-active child line for a precise failure and [preserves the native-id and explicit `active` assertions](https://github.com/HarperFast/harper/pull/2557/changes?w=1#diff-27b6b8d8f6591d28d485ce8379eab39e98a631cb2a1a4be793f665a0d25e950dR683).

The sibling `outstandingCommitTracking.test.js` occurrence is not changed: it reads the separate process-global outstanding-commit list and has no dependency on monitor ticks, write recency, report attribution, or warning capture, so it does not share this root cause.

## Verification

- `npm run build` — passed after merging current `origin/main`.
- Focused named test — 100/100 unloaded repetitions during investigation; the implemented retry mechanism then passed 50/50 repetitions pinned to one CPU with two CPU-contention workers, and final HEAD passed another 50/50 repetitions.
- Deliberate report-cap diagnostic — passed with ten older competing holders; the child required a second fresh-write attempt and still reported under its native id with `active`.
- `npm run test:unit:resources` — passed on the final control-flow revision: 2,337 passing, 31 pending.
- `npm run test:unit:main` — 5,461 passing, 196 pending, with two unrelated environment failures: inherited `GIT_CONFIG_GLOBAL` (the affected test passes when unset) and the assigned worktree path exceeding the Unix-socket-length fixture threshold. This command excludes `unitTests/resources`, so the branch adds no main-suite execution path.
- `npm run test:integration:all` — 2,065 passing, 20 skipped, with one unrelated `txnlog-restart-reclaim.test.ts` cleanup-count failure that reproduces alone on current main; the runner cancelled six Ollama cases afterward, which also expose the existing Node 26 JSON-import-attribute incompatibility.
- `npx prettier --check unitTests/resources/longLivedTransactions.test.js` and changed-file `oxlint --deny-warnings` — passed. Full `npm run lint` remains blocked by 13 pre-existing warnings outside the changed file.

Refs #2471

Co-Authored-By: GPT-5 Codex <noreply@openai.com>

🤖 Generated with Codex

Complexity: medium

<sub>Review-Coverage: authored=codex; ran=claude,gemini; declined=cursor-grok,cursor-composer,domain; rounds=5 @ fcaf6dd1bf8f</sub>

<sub>Human-Review-Need: 3 @ fcaf6dd1bf8f</sub>
