### PR TITLE
Keep shrinkwrap guard compatible with hoisted dependencies

### DIFF
--- a/build-tools/check-shrinkwrap-pins.mjs
+++ b/build-tools/check-shrinkwrap-pins.mjs
@@ -256,7 +256,7 @@ function verifyRocksDbDependencyAlignment() {
 			}
 			failed = true;
 		} catch (e) {
-			console.error(`::error::could not resolve the shared ${dep} instance: ${e.message}`);
+			console.error(`::error::could not resolve the shared ${dep} instance: ${e?.message ?? e}`);
 			failed = true;
 		}
 	}

--- a/build-tools/check-shrinkwrap-pins.mjs
+++ b/build-tools/check-shrinkwrap-pins.mjs
@@ -30,7 +30,9 @@
 // Usage: node check-shrinkwrap-pins.mjs <package-root>
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
 
 const CHECKED_DEPS = ['@harperfast/rocksdb-js', 'fastify', '@aws-sdk/client-s3'];
 const ROCKSDB_SINGLE_INSTANCE_DEPS = ['@harperfast/extended-iterable', 'msgpackr'];
@@ -51,6 +53,7 @@ if (packed.lockfileVersion !== 3) {
 	process.exit(1);
 }
 const manifest = JSON.parse(readFileSync(`${pkgRoot}/package.json`, 'utf8'));
+const requireFromRoot = createRequire(realpathSync(resolve(pkgRoot, 'package.json')));
 
 let failed = false;
 const pins = {};
@@ -175,13 +178,18 @@ function verifyCanariesDiscriminate(pins) {
 
 function verifyRocksDbDependencyAlignment() {
 	let rocksdbManifest;
+	let satisfies;
+	let validRange;
+	const rocksdbManifestPath = `${pkgRoot}/node_modules/@harperfast/rocksdb-js/package.json`;
 	try {
-		rocksdbManifest = JSON.parse(readFileSync(`${pkgRoot}/node_modules/@harperfast/rocksdb-js/package.json`, 'utf8'));
+		rocksdbManifest = JSON.parse(readFileSync(rocksdbManifestPath, 'utf8'));
+		({ satisfies, validRange } = requireFromRoot('semver'));
 	} catch (e) {
 		console.error(`::error::could not inspect rocksdb-js dependency alignment: ${e.message}`);
 		failed = true;
 		return;
 	}
+	const requireFromRocksDb = createRequire(realpathSync(rocksdbManifestPath));
 
 	for (const dep of ROCKSDB_SINGLE_INSTANCE_DEPS) {
 		const rootSpec = manifest.dependencies?.[dep];
@@ -193,9 +201,23 @@ function verifyRocksDbDependencyAlignment() {
 			failed = true;
 			continue;
 		}
-		if (rootSpec !== rocksdbSpec) {
+		if (rocksdbSpec == null) {
 			console.error(
-				`::error::the root ${dep} pin ${rootSpec} does not match rocksdb-js ${rocksdbSpec ?? 'missing'} -- update these pins together to preserve one module instance`
+				`::error::rocksdb-js no longer declares ${dep} -- update this check for the new dependency contract before publishing an image`
+			);
+			failed = true;
+			continue;
+		}
+		if (validRange(rocksdbSpec) == null) {
+			console.error(
+				`::error::rocksdb-js declares ${dep} with unsupported range ${rocksdbSpec} -- use a semver range or update this check for the new dependency contract`
+			);
+			failed = true;
+			continue;
+		}
+		if (!satisfies(rootSpec, rocksdbSpec)) {
+			console.error(
+				`::error::the root ${dep} pin ${rootSpec} is outside rocksdb-js ${rocksdbSpec} -- update these specs together to preserve one module instance`
 			);
 			failed = true;
 			continue;
@@ -212,15 +234,28 @@ function verifyRocksDbDependencyAlignment() {
 			failed = true;
 		}
 
-		const nestedManifest = `${pkgRoot}/node_modules/@harperfast/rocksdb-js/node_modules/${dep}/package.json`;
-		if (existsSync(nestedManifest)) {
-			let nestedVersion = 'unknown';
-			try {
-				nestedVersion = JSON.parse(readFileSync(nestedManifest, 'utf8')).version;
-			} catch {}
-			console.error(
-				`::error::rocksdb-js loaded a nested ${dep}@${nestedVersion} -- root and rocksdb-js must share one module instance`
-			);
+		try {
+			const rootResolution = realpathSync(requireFromRoot.resolve(dep));
+			const rocksdbResolution = realpathSync(requireFromRocksDb.resolve(dep));
+			if (rootResolution === rocksdbResolution) continue;
+
+			const nestedManifest = `${pkgRoot}/node_modules/@harperfast/rocksdb-js/node_modules/${dep}/package.json`;
+			if (existsSync(nestedManifest)) {
+				let nestedVersion = 'unknown';
+				try {
+					nestedVersion = JSON.parse(readFileSync(nestedManifest, 'utf8')).version;
+				} catch {}
+				console.error(
+					`::error::rocksdb-js loaded a nested ${dep}@${nestedVersion} -- root and rocksdb-js must share one module instance`
+				);
+			} else {
+				console.error(
+					`::error::rocksdb-js resolves ${dep} from ${rocksdbResolution}, but the root resolves it from ${rootResolution} -- both must share one module instance`
+				);
+			}
+			failed = true;
+		} catch (e) {
+			console.error(`::error::could not resolve the shared ${dep} instance: ${e.message}`);
 			failed = true;
 		}
 	}
@@ -248,9 +283,8 @@ function reportMissingRange(dep, range) {
 	failed = true;
 }
 
-// Numeric major.minor.patch comparison, ignoring any prerelease/build suffix -- sufficient
-// for the stable releases this check compares (avoids depending on a semver-parsing
-// package that may not be resolvable from this script's own location).
+// Numeric major.minor.patch comparison, ignoring prerelease/build suffixes; sufficient for
+// the stable registry versions used by the canary check.
 function compareVersions(a, b) {
 	const partsA = a.split(/[-+]/)[0].split('.').map(Number);
 	const partsB = b.split(/[-+]/)[0].split('.').map(Number);

--- a/build-tools/check-shrinkwrap-pins.mjs
+++ b/build-tools/check-shrinkwrap-pins.mjs
@@ -180,16 +180,17 @@ function verifyRocksDbDependencyAlignment() {
 	let rocksdbManifest;
 	let satisfies;
 	let validRange;
+	let requireFromRocksDb;
 	const rocksdbManifestPath = `${pkgRoot}/node_modules/@harperfast/rocksdb-js/package.json`;
 	try {
 		rocksdbManifest = JSON.parse(readFileSync(rocksdbManifestPath, 'utf8'));
 		({ satisfies, validRange } = requireFromRoot('semver'));
+		requireFromRocksDb = createRequire(realpathSync(rocksdbManifestPath));
 	} catch (e) {
 		console.error(`::error::could not inspect rocksdb-js dependency alignment: ${e.message}`);
 		failed = true;
 		return;
 	}
-	const requireFromRocksDb = createRequire(realpathSync(rocksdbManifestPath));
 
 	for (const dep of ROCKSDB_SINGLE_INSTANCE_DEPS) {
 		const rootSpec = manifest.dependencies?.[dep];
@@ -283,8 +284,6 @@ function reportMissingRange(dep, range) {
 	failed = true;
 }
 
-// Numeric major.minor.patch comparison, ignoring prerelease/build suffixes; sufficient for
-// the stable registry versions used by the canary check.
 function compareVersions(a, b) {
 	const partsA = a.split(/[-+]/)[0].split('.').map(Number);
 	const partsB = b.split(/[-+]/)[0].split('.').map(Number);

--- a/unitTests/build-tools/checkShrinkwrapPins.test.mjs
+++ b/unitTests/build-tools/checkShrinkwrapPins.test.mjs
@@ -25,7 +25,9 @@ describe('shrinkwrap pin canaries', function () {
 		try {
 			rocksdbManifest = JSON.parse(await readFile(rocksdbManifestPath, 'utf8'));
 		} catch (error) {
-			assert.fail(`the installed rocksdb-js manifest is required at ${rocksdbManifestPath}: ${error.message}`);
+			assert.fail(
+				`the installed rocksdb-js manifest is required at ${rocksdbManifestPath}: ${error?.message ?? error}`
+			);
 		}
 		const fixture = await createFixture(manifest.dependencies, {}, false, '', 3, {}, rocksdbManifest.dependencies);
 		try {

--- a/unitTests/build-tools/checkShrinkwrapPins.test.mjs
+++ b/unitTests/build-tools/checkShrinkwrapPins.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { spawnSync } from 'node:child_process';
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -10,13 +10,24 @@ const script = join(root, 'build-tools/check-shrinkwrap-pins.mjs');
 const dependencies = ['@harperfast/rocksdb-js', 'fastify', '@aws-sdk/client-s3'];
 const alignedDependencies = {
 	'@harperfast/extended-iterable': '1.0.3',
-	'msgpackr': '2.0.5',
+	'msgpackr': '2.0.6',
+};
+const rocksdbDependencyRanges = {
+	'@harperfast/extended-iterable': '^1.0.3',
+	'msgpackr': '^2.0.6',
 };
 
 describe('shrinkwrap pin canaries', function () {
 	it('keeps the checked canaries present and ranged in the real manifest', async function () {
 		const manifest = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
-		const fixture = await createFixture(manifest.dependencies);
+		const rocksdbManifestPath = join(root, 'node_modules/@harperfast/rocksdb-js/package.json');
+		let rocksdbManifest;
+		try {
+			rocksdbManifest = JSON.parse(await readFile(rocksdbManifestPath, 'utf8'));
+		} catch (error) {
+			assert.fail(`the installed rocksdb-js manifest is required at ${rocksdbManifestPath}: ${error.message}`);
+		}
+		const fixture = await createFixture(manifest.dependencies, {}, false, '', 3, {}, rocksdbManifest.dependencies);
 		try {
 			const result = runCheck(fixture);
 			assert.strictEqual(result.status, 0, result.stderr);
@@ -25,7 +36,7 @@ describe('shrinkwrap pin canaries', function () {
 		}
 	});
 
-	it('fails when a root encoder pin diverges from rocksdb-js', async function () {
+	it('fails when a root encoder pin is outside the rocksdb-js range', async function () {
 		const fixture = await createFixture({
 			'@harperfast/rocksdb-js': '2.7.1',
 			'fastify': '^5.8.2',
@@ -36,12 +47,56 @@ describe('shrinkwrap pin canaries', function () {
 				join(fixture.packageRoot, 'node_modules/@harperfast/rocksdb-js/package.json'),
 				JSON.stringify({
 					version: '1.0.0',
-					dependencies: { ...alignedDependencies, msgpackr: '2.0.6' },
+					dependencies: { ...rocksdbDependencyRanges, msgpackr: '^3.0.0' },
 				})
 			);
 			const result = runCheck(fixture);
 			assert.strictEqual(result.status, 1);
-			assert.match(result.stderr, /root msgpackr pin 2\.0\.5 does not match rocksdb-js 2\.0\.6/);
+			assert.match(result.stderr, /root msgpackr pin 2\.0\.6 is outside rocksdb-js \^3\.0\.0/);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	it('fails when rocksdb-js no longer declares a guarded dependency', async function () {
+		const fixture = await createFixture({
+			'@harperfast/rocksdb-js': '2.7.1',
+			'fastify': '^5.8.2',
+			'@aws-sdk/client-s3': '^3.1012.0',
+		});
+		try {
+			await writeFile(
+				join(fixture.packageRoot, 'node_modules/@harperfast/rocksdb-js/package.json'),
+				JSON.stringify({
+					version: '1.0.0',
+					dependencies: { '@harperfast/extended-iterable': '^1.0.3' },
+				})
+			);
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 1);
+			assert.match(result.stderr, /rocksdb-js no longer declares msgpackr/);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	it('fails when rocksdb-js uses a non-semver dependency spec', async function () {
+		const fixture = await createFixture({
+			'@harperfast/rocksdb-js': '2.7.1',
+			'fastify': '^5.8.2',
+			'@aws-sdk/client-s3': '^3.1012.0',
+		});
+		try {
+			await writeFile(
+				join(fixture.packageRoot, 'node_modules/@harperfast/rocksdb-js/package.json'),
+				JSON.stringify({
+					version: '1.0.0',
+					dependencies: { ...rocksdbDependencyRanges, msgpackr: 'workspace:*' },
+				})
+			);
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 1);
+			assert.match(result.stderr, /rocksdb-js declares msgpackr with unsupported range workspace:\*/);
 		} finally {
 			await fixture.cleanup();
 		}
@@ -52,30 +107,90 @@ describe('shrinkwrap pin canaries', function () {
 			'@harperfast/rocksdb-js': '2.7.1',
 			'fastify': '^5.8.2',
 			'@aws-sdk/client-s3': '^3.1012.0',
-			'msgpackr': '^2.0.5',
+			'msgpackr': '^2.0.6',
 		});
 		try {
 			const result = runCheck(fixture);
 			assert.strictEqual(result.status, 1);
-			assert.match(result.stderr, /root msgpackr spec must be exact, received \^2\.0\.5/);
+			assert.match(result.stderr, /root msgpackr spec must be exact, received \^2\.0\.6/);
 		} finally {
 			await fixture.cleanup();
 		}
 	});
 
-	it('fails when rocksdb-js installs a nested encoder instance', async function () {
+	for (const [dependency, version] of Object.entries(alignedDependencies)) {
+		it(`fails when rocksdb-js installs a nested ${dependency} instance`, async function () {
+			const fixture = await createFixture({
+				'@harperfast/rocksdb-js': '2.7.1',
+				'fastify': '^5.8.2',
+				'@aws-sdk/client-s3': '^3.1012.0',
+			});
+			try {
+				const nestedDir = join(fixture.packageRoot, 'node_modules/@harperfast/rocksdb-js/node_modules', dependency);
+				await mkdir(nestedDir, { recursive: true });
+				await writeFile(join(nestedDir, 'package.json'), JSON.stringify({ version, main: 'index.js' }));
+				await writeFile(join(nestedDir, 'index.js'), '');
+				const result = runCheck(fixture);
+				assert.strictEqual(result.status, 1);
+				assert(result.stderr.includes(`rocksdb-js loaded a nested ${dependency}@${version}`), result.stderr);
+			} finally {
+				await fixture.cleanup();
+			}
+		});
+	}
+
+	it('follows a linked rocksdb-js package to detect its private dependency instance', async function () {
 		const fixture = await createFixture({
 			'@harperfast/rocksdb-js': '2.7.1',
 			'fastify': '^5.8.2',
 			'@aws-sdk/client-s3': '^3.1012.0',
 		});
 		try {
-			const nestedDir = join(fixture.packageRoot, 'node_modules/@harperfast/rocksdb-js/node_modules/msgpackr');
-			await mkdir(nestedDir, { recursive: true });
-			await writeFile(join(nestedDir, 'package.json'), JSON.stringify({ version: '2.0.5' }));
+			const rocksdbDir = join(fixture.packageRoot, 'node_modules/@harperfast/rocksdb-js');
+			const linkedDir = join(dirname(fixture.packageRoot), 'linked-rocksdb-js');
+			const linkedMsgpackrDir = join(linkedDir, 'node_modules/msgpackr');
+			await mkdir(linkedMsgpackrDir, { recursive: true });
+			await writeFile(
+				join(linkedDir, 'package.json'),
+				JSON.stringify({ version: '1.0.0', dependencies: rocksdbDependencyRanges })
+			);
+			await writeFile(join(linkedMsgpackrDir, 'package.json'), JSON.stringify({ version: '2.0.6', main: 'index.js' }));
+			await writeFile(join(linkedMsgpackrDir, 'index.js'), '');
+			await rm(rocksdbDir, { recursive: true, force: true });
+			await symlink(linkedDir, rocksdbDir, 'junction');
+
 			const result = runCheck(fixture);
 			assert.strictEqual(result.status, 1);
-			assert.match(result.stderr, /rocksdb-js loaded a nested msgpackr@2\.0\.5/);
+			assert.match(result.stderr, /rocksdb-js loaded a nested msgpackr@2\.0\.6/);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	it('reports divergent resolutions outside the classic nested layout', async function () {
+		const fixture = await createFixture({
+			'@harperfast/rocksdb-js': '2.7.1',
+			'fastify': '^5.8.2',
+			'@aws-sdk/client-s3': '^3.1012.0',
+		});
+		try {
+			const rocksdbDir = join(fixture.packageRoot, 'node_modules/@harperfast/rocksdb-js');
+			const linkedDir = join(dirname(fixture.packageRoot), 'linked-rocksdb-js');
+			const siblingMsgpackrDir = join(dirname(linkedDir), 'node_modules/msgpackr');
+			await mkdir(linkedDir, { recursive: true });
+			await mkdir(siblingMsgpackrDir, { recursive: true });
+			await writeFile(
+				join(linkedDir, 'package.json'),
+				JSON.stringify({ version: '1.0.0', dependencies: rocksdbDependencyRanges })
+			);
+			await writeFile(join(siblingMsgpackrDir, 'package.json'), JSON.stringify({ version: '2.0.6', main: 'index.js' }));
+			await writeFile(join(siblingMsgpackrDir, 'index.js'), '');
+			await rm(rocksdbDir, { recursive: true, force: true });
+			await symlink(linkedDir, rocksdbDir, 'junction');
+
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 1);
+			assert.match(result.stderr, /rocksdb-js resolves msgpackr from .* but the root resolves it from /);
 		} finally {
 			await fixture.cleanup();
 		}
@@ -310,7 +425,8 @@ async function createFixture(
 	allRangeVersionsCurrent = false,
 	failedRange = '',
 	failedAttempts = 3,
-	registryResponses = {}
+	registryResponses = {},
+	rocksdbDependencies = rocksdbDependencyRanges
 ) {
 	const tempDir = await mkdtemp(join(tmpdir(), 'harper-shrinkwrap-canary-'));
 	const packageRoot = join(tempDir, 'package');
@@ -318,6 +434,7 @@ async function createFixture(
 	const queryLog = join(tempDir, 'queries.log');
 	await mkdir(packageRoot, { recursive: true });
 	await mkdir(binDir, { recursive: true });
+	await cp(join(root, 'node_modules/semver'), join(packageRoot, 'node_modules/semver'), { recursive: true });
 	await writeFile(queryLog, '');
 	const packageDependencies = { ...alignedDependencies, ...manifestDependencies };
 	await writeFile(join(packageRoot, 'package.json'), JSON.stringify({ dependencies: packageDependencies }));
@@ -339,11 +456,12 @@ async function createFixture(
 				(dependency in alignedDependencies ? packageDependencies[dependency] : '1.0.0'),
 		};
 		if (dependency === '@harperfast/rocksdb-js') {
-			dependencyManifest.dependencies = Object.fromEntries(
-				Object.keys(alignedDependencies).map((dep) => [dep, packageDependencies[dep]])
-			);
+			dependencyManifest.dependencies = rocksdbDependencies;
+		} else if (dependency in alignedDependencies) {
+			dependencyManifest.main = 'index.js';
 		}
 		await writeFile(join(dependencyDir, 'package.json'), JSON.stringify(dependencyManifest));
+		if (dependency in alignedDependencies) await writeFile(join(dependencyDir, 'index.js'), '');
 	}
 	await writeFile(
 		join(binDir, 'npm'),


### PR DESCRIPTION
The Docker shrinkwrap check now validates the installed invariant directly: Harper's exact shared-dependency pins must satisfy rocksdb-js's declared ranges, and both consumers must resolve the same canonical CommonJS module entry. This accepts the intentional caret ranges introduced by [rocksdb-js#803](https://github.com/HarperFast/rocksdb-js/pull/803) without weakening duplicate-instance detection.

## For the human reviewer

The identity check deliberately models CommonJS resolution because Harper consumes rocksdb-js through its CommonJS export, whose bundle requires both guarded dependencies. The review confirmed the design and implementation; its remaining decisions are policy-level and reversible: exact root pins remain required, semver compatibility trusts rocksdb-js's published range, and this PR retains the existing guarded set (`msgpackr` and `@harperfast/extended-iterable`) rather than expanding scope to `ordered-binary`.

Planning review: `Framing-Verdict: chosen-approach-sound`.

## Changes

- Replace raw manifest-spec equality with [exact-pin-in-range validation](https://github.com/HarperFast/harper/pull/2560/changes?w=1#diff-9d256e7934646e71bf4716deae41488d50a743818678a9316bbb7311c00b08ffR219).
- Compare [canonical dependency resolutions](https://github.com/HarperFast/harper/pull/2560/changes?w=1#diff-9d256e7934646e71bf4716deae41488d50a743818678a9316bbb7311c00b08ffR238) from Harper and rocksdb-js, including linked and nonstandard layouts; this is the highest-value invariant to inspect closely.
- Keep [manifest and resolution initialization](https://github.com/HarperFast/harper/pull/2560/changes?w=1#diff-9d256e7934646e71bf4716deae41488d50a743818678a9316bbb7311c00b08ffR185) inside the structured failure boundary, and emit specific diagnostics when rocksdb-js drops a guarded dependency, uses a non-semver contract, or resolves a distinct instance.
- Make fixtures self-contained and [validate the installed rocksdb-js dependency map](https://github.com/HarperFast/harper/pull/2560/changes?w=1#diff-20972f1e6ae948f5b40b51b414cb91c1feb682491c9e8a3545bd84ce62e1e4a6R21).

Deliberately nested fixtures fail with the release-facing diagnostics:

```text
::error::rocksdb-js loaded a nested @harperfast/extended-iterable@1.0.3 -- root and rocksdb-js must share one module instance
::error::rocksdb-js loaded a nested msgpackr@2.0.6 -- root and rocksdb-js must share one module instance
```

## Verification

- `npm run build`
- `npx mocha unitTests/build-tools/checkShrinkwrapPins.test.mjs` — 20 passing; the changed tests prove [nested duplicate rejection](https://github.com/HarperFast/harper/pull/2560/changes?w=1#diff-20972f1e6ae948f5b40b51b414cb91c1feb682491c9e8a3545bd84ce62e1e4a6R121) and [linked/nonstandard resolution handling](https://github.com/HarperFast/harper/pull/2560/changes?w=1#diff-20972f1e6ae948f5b40b51b414cb91c1feb682491c9e8a3545bd84ce62e1e4a6R142)
- `npx oxlint build-tools/check-shrinkwrap-pins.mjs unitTests/build-tools/checkShrinkwrapPins.test.mjs`
- `npx prettier --check build-tools/check-shrinkwrap-pins.mjs unitTests/build-tools/checkShrinkwrapPins.test.mjs`
- Docker checker package-root interface against the current installed tree and packed lock — passing with rocksdb-js 2.9.0
- PR CI — 40 checks passing, including Docker Image Smoke Test, Windows build/unit, Node 22/24/26 unit, and all Node/Bun/uWS/Windows integration matrices
- `npm run test:unit:resources` — 2,353 passing, 31 pending
- `npm run test:unit:main` — 5,462 passing, 196 pending; two unrelated environment/baseline failures in `gitCredentials.test.js` (inherited Git environment) and `configValidator.test.js` (worktree path length)
- `npm run test:integration` — setup reaches an unrelated Node 26.2 `ERR_IMPORT_ATTRIBUTE_MISSING` in the Ollama backend suite; previously owned rocksdb-js 2.9.0 integration failures are cleared on current `main`
- `npm run lint` — repository-wide baseline remains red with 13 unrelated warnings; both changed files pass focused oxlint

Complexity: medium

Refs HarperFast/rocksdb-js#803

Co-Authored-By: GPT-5 Codex <noreply@openai.com>

🤖 Generated with GPT-5 Codex

<sub>Review-Coverage: authored=codex; ran=claude,gemini; declined=cursor-grok,cursor-composer,domain; rounds=5 @ 6c351b5c558e</sub>

<sub>Human-Review-Need: 3 @ 6c351b5c558e</sub>
