### PR TITLE
Wait for every index write a backfill checkpoint covers, so a failed write cannot be skipped

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -411,7 +411,8 @@ When `table()` is called with an attribute newly marked `indexed: true` (or with
 **In-flight state tracking (persisted to `attributesDbi`):**
 
 - `attribute.indexingPID = process.pid` — set at migration start; cleared on clean completion. On restart with a different PID, `indexingPID !== process.pid` triggers a re-migration.
-- `attribute.lastIndexedKey` — updated every 100 records as a resumable checkpoint. Cleared on clean completion; preserved on error so a retry starts from this key.
+- `attribute.lastIndexedKey` — a resumable checkpoint, written at most once per checkpoint period and never before the record floor (`setIndexingCheckpointPeriod`), and only once the index writes it covers have settled and flushed. Cleared on clean completion; preserved on error so a retry starts from this key.
+- `attribute.checkpointCertified` / `attribute.checkpointAlgorithm` — the key the checkpoint was stamped with, and the version of the algorithm that stamped it. A checkpoint resumes only when both match; anything else is rebuilt from scratch, because earlier releases could advance `lastIndexedKey` past a record whose index write failed. The algorithm stamp is also kept on a completed index, so a build made under a version that could skip a record stays distinguishable from one that could not.
 - `attribute.indexingFailed = true` — set if any record's `index.put` errors during the backfill. `table()` checks this flag: a fresh call in the same or a new process re-triggers the backfill from `lastIndexedKey`.
 - `dbi.isIndexing = true` — in-memory flag on the index dbi. Prevents `searchByIndex` from serving partial results (returns 503 "not indexed yet" instead). Cleared only when backfill completes cleanly.
 
@@ -421,8 +422,8 @@ When `signalSchemaChange('schema-change')` fires at the start of `runIndexing`, 
 **Error handling:**
 
 - Per-record sync errors: caught by the inner try-catch. Set `hadIndexingErrors = true`.
-- Per-record async rejections (`index.put` returning a rejected Promise): caught by the `when()` error handler. Set `hadIndexingErrors = true`.
-- The final `await lastResolution` is wrapped in its own try-catch because if the very last put in the loop was rejected, an unguarded `await lastResolution` would throw past the `hadIndexingErrors` check to the outer catch, silently bypassing the error path.
+- Per-record async rejections (`index.put` returning a rejected Promise): every index mutation the build issues — each value's put, the drops for removed indexes, and the LMDB `clearAsync` — is registered in a per-build set that absorbs its own rejection and sets `hadIndexingErrors = true`. A record fans out into one put per indexed value, so tracking only the last one left the earlier puts' failures visible only if they happened to settle in time.
+- A checkpoint drains that set before flushing and refuses to certify if any mutation it covers failed; completion drains it too, so "no errors" means every write settled rather than none had failed yet. The set also bounds how many writes stay in flight (`MAX_OUTSTANDING_INDEXING`).
 - On any error: `indexingFailed = true` is persisted; `indexingPID`, `isIndexing`, and `lastIndexedKey` are kept. This leaves the index in 503 "incomplete" state rather than silently serving partial results.
 
 **`Object.defineProperty(attribute, 'dbi', ...)` must use `configurable: true`:**

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -41,7 +41,6 @@ import { PrimaryRocksDatabase } from './PrimaryRocksDatabase.ts';
 import { replayLogs } from './replayLogs.ts';
 import { totalmem } from 'node:os';
 import { RocksIndexStore } from './RocksIndexStore.ts';
-import { when } from '../utility/when.ts';
 import { resolveRocksMemoryConfig } from '../utility/rocksMemoryConfig.ts';
 import { isProcessRunning } from '../utility/processManagement/processManagement.js';
 import {
@@ -2896,12 +2895,16 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 							const uncertifiedCheckpoint =
 								attributeDescriptor?.lastIndexedKey !== undefined &&
 								(attributeDescriptor.checkpointCertified === undefined ||
+									attributeDescriptor.checkpointAlgorithm !== CHECKPOINT_ALGORITHM ||
 									compareKeys(attributeDescriptor.checkpointCertified, attributeDescriptor.lastIndexedKey) !== 0);
 							attribute.lastIndexedKey =
 								indexOptionsChanged || uncertifiedCheckpoint
 									? undefined
 									: (attributeDescriptor?.lastIndexedKey ?? undefined);
-							if (attribute.lastIndexedKey !== undefined) attribute.checkpointCertified = attribute.lastIndexedKey;
+							if (attribute.lastIndexedKey !== undefined) {
+								attribute.checkpointCertified = attribute.lastIndexedKey;
+								attribute.checkpointAlgorithm = CHECKPOINT_ALGORITHM;
+							}
 							// Explicit reindex is the upgrade path from a legacy (un-versioned) custom-index
 							// object store to the versioned, VT-cacheable format. A full rebuild from scratch
 							// (lastIndexedKey === undefined) clears the store and rewrites every node, so the
@@ -2961,8 +2964,10 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 						// workers / a reload would treat the still-partial index as ready and return incomplete results.
 						attribute.indexingPID = attributeDescriptor.indexingPID;
 						attribute.lastIndexedKey = attributeDescriptor.lastIndexedKey;
-						if (attributeDescriptor.checkpointCertified !== undefined)
+						if (attributeDescriptor.checkpointCertified !== undefined) {
 							attribute.checkpointCertified = attributeDescriptor.checkpointCertified;
+							attribute.checkpointAlgorithm = attributeDescriptor.checkpointAlgorithm;
+						}
 						// Carry the in-progress restart generation too, so persisting this metadata-only
 						// change doesn't drop it and break the crash-recovery trigger for the running backfill.
 						attribute.restartNumber = attributeDescriptor.restartNumber;
@@ -3166,6 +3171,10 @@ export function canonicalizeIndexOptions(value: any): any {
 	}
 	return value;
 }
+// Bumped when a change alters which keys a checkpoint may certify; a descriptor stamped by any other
+// version resumes as uncertified (full rebuild) rather than being trusted. Version 2 is the first that
+// waits for every index mutation a checkpoint covers, not just the last put of each record.
+export const CHECKPOINT_ALGORITHM = 2;
 const MAX_OUTSTANDING_INDEXING = 1000;
 const MIN_OUTSTANDING_INDEXING = 10;
 const INDEXING_YIELD_INTERVAL = 100;
@@ -3272,9 +3281,35 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			new SchemaEventMsg(process.pid, 'schema-change', Table.databaseName, Table.tableName, undefined, branchPath)
 		);
 		let lastResolution;
+		// Every index mutation this build has issued and not yet settled. A record fans out into one put
+		// per indexed value but only the last was ever awaited, so the checkpoint and completion barriers
+		// have to be this whole set: anything still in flight may reject after they read hadIndexingErrors.
+		const pendingMutations = new Set();
+		const track = (result, onRejected) => {
+			if (!result?.then) return result;
+			const tracked = result.then(
+				() => {
+					pendingMutations.delete(tracked);
+					return false;
+				},
+				(error) => {
+					pendingMutations.delete(tracked);
+					onRejected(error);
+					return true;
+				}
+			);
+			pendingMutations.add(tracked);
+			return result;
+		};
+		// Waits on a snapshot of what is in flight now and reports whether any of it failed. The tracked
+		// promises absorb their own rejections, so one failure never abandons its siblings in flight, and
+		// the answer is scoped to the snapshot: a later record failing meanwhile is not this drain's news.
+		const drainMutations = async () => {
+			if (!pendingMutations.size) return false;
+			return (await Promise.all([...pendingMutations])).some(Boolean);
+		};
 		for (const index of indicesToRemove) {
-			lastResolution = index.drop();
-			if (lastResolution?.then) lastResolution.then(undefined, (error) => onIndexPutRejected(index.name, error));
+			track(index.drop(), (error) => onIndexPutRejected(index.name, error));
 		}
 		let interrupted;
 		let indexed = 0;
@@ -3285,25 +3320,30 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			if (start === undefined) {
 				for (const attribute of attributes) {
 					if (attribute.dbi.clearAsync) {
-						// LMDB, note that we don't need to wait for this to complete, just gets enqueued in front of the other writes
-						attribute.dbi.clearAsync();
+						// LMDB: enqueued ahead of the index writes, so the scan need not wait for it, but the
+						// barriers must — a rejected clear otherwise certifies a checkpoint over stale entries.
+						track(attribute.dbi.clearAsync(), (error) => onIndexPutRejected(attribute.name, error));
 					} else {
 						await attribute.dbi.clear();
 					}
 				}
 			}
-			let outstanding = 0;
 			// A resumed scan starts at the checkpoint, so it must only name a key whose every predecessor is
 			// durably indexed: persisted once the writes it covers have settled and flushed, frozen after any
 			// record fails so the retry re-covers it, and stamped with its own key (see the trigger in table()).
 			const persistCheckpoint = async (key) => {
 				if (hadIndexingErrors) return;
 				try {
+					// Everything still in flight was issued for a key at or before this one: the scan has not
+					// moved past it yet. So a failure among them is a failure this checkpoint would cover.
+					const failed = await drainMutations();
+					if (failed) return;
 					await flushIndexStores(Table.primaryStore.rootStore);
 					const puts = [];
 					for (const attribute of attributes) {
 						attribute.lastIndexedKey = key;
 						attribute.checkpointCertified = key;
+						attribute.checkpointAlgorithm = CHECKPOINT_ALGORITHM;
 						puts.push(Table.dbisDB.put(attribute.key, attribute));
 					}
 					await Promise.all(puts);
@@ -3323,9 +3363,8 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 				const atInterval = ++indexed % INDEXING_YIELD_INTERVAL === 0;
 				// TODO: Do we ever need to interrupt due to a schema change that was not a restart?
 				//if (Table.schemaVersion !== schemaVersion) return; // break out if there are any schema changes and let someone else pick it up
-				outstanding++;
-				// Custom indexes (e.g. HNSW) index synchronously and never raise `outstanding`, so the
-				// outstanding-based yield below never fires for them. Track that this row did synchronous
+				// Custom indexes (e.g. HNSW) index synchronously and leave pendingMutations empty, so the
+				// backpressure yield below never fires for them. Track that this row did synchronous
 				// indexing work so we can still yield the event loop after it.
 				let didSynchronousIndexing = false;
 				// every index operation needs to be guarded by the version still be the same. If it has already changed before
@@ -3349,8 +3388,7 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 							const values = getIndexedValues(value, index.indexNulls);
 							if (values) {
 								for (let i = 0, l = values.length; i < l; i++) {
-									lastResolution = index.put(values[i], key);
-									if (lastResolution?.then) lastResolution.then(undefined, onPutRejected);
+									track(index.put(values[i], key), onPutRejected);
 								}
 							}
 						} catch (error) {
@@ -3368,20 +3406,11 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 						}
 					}
 				}
-				when(
-					lastResolution,
-					() => outstanding--,
-					() => outstanding--
-				);
 				if (workerData && workerData.restartNumber !== manageThreads.restartNumber) {
 					interrupted = true;
 				}
 				if (interrupted) {
-					try {
-						await lastResolution;
-					} catch {
-						// already counted and logged by the rejection handler above
-					}
+					await drainMutations();
 					await checkpointing;
 					await persistCheckpoint(key);
 					return;
@@ -3390,29 +3419,19 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 					nextCheckpointAt = performance.now() + indexingCheckpointPeriodMs;
 					nextCheckpointRecord = indexed + indexingCheckpointMinRecords;
 					await checkpointing;
-					checkpointing = when(
-						lastResolution,
-						() => persistCheckpoint(key),
-						() => {}
-					);
+					checkpointing = persistCheckpoint(key);
 				}
-				if (outstanding > MAX_OUTSTANDING_INDEXING) await lastResolution;
-				if (atInterval || didSynchronousIndexing || outstanding > MIN_OUTSTANDING_INDEXING) await yieldEventTurn();
+				// Bound what the tracker retains: the oldest entry settles first, so awaiting it is what
+				// lets the set shrink back under the cap.
+				while (pendingMutations.size > MAX_OUTSTANDING_INDEXING) await pendingMutations.values().next().value;
+				if (atInterval || didSynchronousIndexing || pendingMutations.size > MIN_OUTSTANDING_INDEXING)
+					await yieldEventTurn();
 			}
 		}
 		await checkpointing;
-		// Await the last pending put. If it rejects, that is also an indexing error (already counted by
-		// onIndexPutRejected); catching it here keeps it from escaping to the outer catch.
-		try {
-			await lastResolution;
-		} catch (error) {
-			hadIndexingErrors = true;
-			logger.error(error);
-		}
-		// Yield one more event turn so any queued when() error callbacks (which fire as
-		// microtasks when their tracked promise settles) have a chance to set hadIndexingErrors
-		// before we decide whether to mark indexing as complete.
-		await new Promise((resolve) => setImmediate(resolve));
+		// Completion may only be declared once every mutation this build issued has settled: one that
+		// rejects afterwards has no checkpoint left to freeze and no build left to park.
+		await drainMutations();
 		// the tail since the last checkpoint is not durable until flushed; announcing the index complete
 		// before that would outlive a crash that loses it
 		if (!hadIndexingErrors) {
@@ -3452,6 +3471,7 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			for (const attribute of attributes) {
 				delete attribute.lastIndexedKey;
 				delete attribute.checkpointCertified;
+				delete attribute.checkpointAlgorithm;
 				delete attribute.indexingPID;
 				delete attribute.indexingFailed;
 				delete attribute.restartNumber;

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -2975,6 +2975,10 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 						attribute.indexingBuildId = attributeDescriptor.indexingBuildId;
 						if (attributeDescriptor.indexingFailed) attribute.indexingFailed = attributeDescriptor.indexingFailed;
 					}
+					// The declared attribute never carries the stamp, so any rewrite of a descriptor that has
+					// one would drop it and make a completed index look like a pre-stamp build.
+					if (attribute.checkpointAlgorithm === undefined && attributeDescriptor?.checkpointAlgorithm !== undefined)
+						attribute.checkpointAlgorithm = attributeDescriptor.checkpointAlgorithm;
 					attributesDbi.put(dbiKey, attribute);
 				}
 				// If a migration is in progress (indexingPID set), any newly opened dbi must also
@@ -3281,9 +3285,8 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			new SchemaEventMsg(process.pid, 'schema-change', Table.databaseName, Table.tableName, undefined, branchPath)
 		);
 		let lastResolution;
-		// A record fans out into one put per indexed value and only the last was ever awaited, so the
-		// checkpoint and completion barriers have to cover this whole set: anything still in flight may
-		// reject after they read hadIndexingErrors.
+		// The checkpoint and completion barriers have to cover every mutation still in flight: any of them
+		// may reject after those barriers read hadIndexingErrors.
 		const pendingMutations = new Set();
 		let settleWaiter;
 		const track = (result, onRejected) => {
@@ -3304,14 +3307,12 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			pendingMutations.add(tracked);
 			return result;
 		};
-		// The tracked promises absorb their own rejections, so one failure never abandons its siblings in
-		// flight, and the answer covers only the snapshot taken here.
+		// The tracked promises absorb their own rejections, so one failure never abandons its siblings.
 		const drainMutations = async () => {
 			if (!pendingMutations.size) return false;
 			return (await Promise.all([...pendingMutations])).some(Boolean);
 		};
-		// Resolves on the next settlement of any tracked mutation: waiting on a chosen entry would stall
-		// behind a slow one that the others have already overtaken.
+		// Waiting on a chosen entry would stall behind a slow one the others have already overtaken.
 		const nextSettlement = () =>
 			new Promise((resolve) => {
 				settleWaiter = () => {
@@ -3439,8 +3440,7 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			}
 		}
 		await checkpointing;
-		// A mutation that rejects after completion is declared has no checkpoint left to freeze and no
-		// build left to park.
+		// A mutation that rejects after completion is declared has no build left to park.
 		await drainMutations();
 		// the tail since the last checkpoint is not durable until flushed; announcing the index complete
 		// before that would outlive a crash that loses it

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -3171,9 +3171,9 @@ export function canonicalizeIndexOptions(value: any): any {
 	}
 	return value;
 }
-// Bumped when a change alters which keys a checkpoint may certify; a descriptor stamped by any other
-// version resumes as uncertified (full rebuild) rather than being trusted. Version 2 is the first that
-// waits for every index mutation a checkpoint covers, not just the last put of each record.
+// Bumped when a change alters which keys a checkpoint may certify. A descriptor stamped by any other
+// version resumes as uncertified (full rebuild) rather than being trusted, and a completed index keeps
+// the stamp of the build that wrote it.
 export const CHECKPOINT_ALGORITHM = 2;
 const MAX_OUTSTANDING_INDEXING = 1000;
 const MIN_OUTSTANDING_INDEXING = 10;
@@ -3281,19 +3281,22 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			new SchemaEventMsg(process.pid, 'schema-change', Table.databaseName, Table.tableName, undefined, branchPath)
 		);
 		let lastResolution;
-		// Every index mutation this build has issued and not yet settled. A record fans out into one put
-		// per indexed value but only the last was ever awaited, so the checkpoint and completion barriers
-		// have to be this whole set: anything still in flight may reject after they read hadIndexingErrors.
+		// A record fans out into one put per indexed value and only the last was ever awaited, so the
+		// checkpoint and completion barriers have to cover this whole set: anything still in flight may
+		// reject after they read hadIndexingErrors.
 		const pendingMutations = new Set();
+		let settleWaiter;
 		const track = (result, onRejected) => {
 			if (!result?.then) return result;
 			const tracked = result.then(
 				() => {
 					pendingMutations.delete(tracked);
+					settleWaiter?.();
 					return false;
 				},
 				(error) => {
 					pendingMutations.delete(tracked);
+					settleWaiter?.();
 					onRejected(error);
 					return true;
 				}
@@ -3301,13 +3304,21 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			pendingMutations.add(tracked);
 			return result;
 		};
-		// Waits on a snapshot of what is in flight now and reports whether any of it failed. The tracked
-		// promises absorb their own rejections, so one failure never abandons its siblings in flight, and
-		// the answer is scoped to the snapshot: a later record failing meanwhile is not this drain's news.
+		// The tracked promises absorb their own rejections, so one failure never abandons its siblings in
+		// flight, and the answer covers only the snapshot taken here.
 		const drainMutations = async () => {
 			if (!pendingMutations.size) return false;
 			return (await Promise.all([...pendingMutations])).some(Boolean);
 		};
+		// Resolves on the next settlement of any tracked mutation: waiting on a chosen entry would stall
+		// behind a slow one that the others have already overtaken.
+		const nextSettlement = () =>
+			new Promise((resolve) => {
+				settleWaiter = () => {
+					settleWaiter = undefined;
+					resolve(undefined);
+				};
+			});
 		for (const index of indicesToRemove) {
 			track(index.drop(), (error) => onIndexPutRejected(index.name, error));
 		}
@@ -3320,8 +3331,8 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			if (start === undefined) {
 				for (const attribute of attributes) {
 					if (attribute.dbi.clearAsync) {
-						// LMDB: enqueued ahead of the index writes, so the scan need not wait for it, but the
-						// barriers must — a rejected clear otherwise certifies a checkpoint over stale entries.
+						// LMDB enqueues this ahead of the index writes, so the scan need not wait for it — but the
+						// barriers must, or a rejected clear certifies a checkpoint over stale entries.
 						track(attribute.dbi.clearAsync(), (error) => onIndexPutRejected(attribute.name, error));
 					} else {
 						await attribute.dbi.clear();
@@ -3421,16 +3432,15 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 					await checkpointing;
 					checkpointing = persistCheckpoint(key);
 				}
-				// Bound what the tracker retains: the oldest entry settles first, so awaiting it is what
-				// lets the set shrink back under the cap.
-				while (pendingMutations.size > MAX_OUTSTANDING_INDEXING) await pendingMutations.values().next().value;
+				// Checked once per record, so a record's own fan-out can overshoot before the bound applies.
+				while (pendingMutations.size > MAX_OUTSTANDING_INDEXING) await nextSettlement();
 				if (atInterval || didSynchronousIndexing || pendingMutations.size > MIN_OUTSTANDING_INDEXING)
 					await yieldEventTurn();
 			}
 		}
 		await checkpointing;
-		// Completion may only be declared once every mutation this build issued has settled: one that
-		// rejects afterwards has no checkpoint left to freeze and no build left to park.
+		// A mutation that rejects after completion is declared has no checkpoint left to freeze and no
+		// build left to park.
 		await drainMutations();
 		// the tail since the last checkpoint is not durable until flushed; announcing the index complete
 		// before that would outlive a crash that loses it
@@ -3471,7 +3481,9 @@ async function runIndexing(Table, attributes, indicesToRemove, branchPath?: stri
 			for (const attribute of attributes) {
 				delete attribute.lastIndexedKey;
 				delete attribute.checkpointCertified;
-				delete attribute.checkpointAlgorithm;
+				// Survives completion, unlike the checkpoint fields: without it an index built here is
+				// indistinguishable from one a release that could skip a failed record declared complete.
+				attribute.checkpointAlgorithm = CHECKPOINT_ALGORITHM;
 				delete attribute.indexingPID;
 				delete attribute.indexingFailed;
 				delete attribute.restartNumber;

--- a/unitTests/resources/indexBackfillConvergence.test.js
+++ b/unitTests/resources/indexBackfillConvergence.test.js
@@ -19,6 +19,7 @@ const {
 	closeDatabase,
 	resumeStartKey,
 	setIndexingCheckpointPeriod,
+	CHECKPOINT_ALGORITHM,
 } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 
@@ -333,6 +334,266 @@ describe('index backfill convergence (#2536)', () => {
 		});
 	}
 
+	// A record fans out into one index put per indexed value and only the last was ever awaited, so a
+	// rejection from any earlier one used to be seen only if it happened to settle before the next
+	// checkpoint. These cases release the rejection at a chosen point in the scan instead of on a timer,
+	// so the interleaving is the same on a fast and a slow runner.
+	function deferredPut(release) {
+		let reject;
+		const promise = new Promise((_, r) => (reject = r));
+		promise.catch(() => {}); // the rejection is delivered through runIndexing's own handler
+		release.fire = () => reject(new Error('simulated deferred index put failure'));
+		return promise;
+	}
+
+	it('freezes the checkpoint when an index write rejects only after a later checkpoint was reached', async () => {
+		const TABLE = 'BackfillLateRejection';
+		const N = 600;
+		const FAILING_ID = 'k-' + pad(250);
+		// Past the k-0299 checkpoint the failed record must not reach, and before the next one at k-0399,
+		// so the scan is never waiting on the release.
+		const RELEASE_AT = 'k-' + pad(310);
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + pad(i), tag: ['t-' + (i % 3), 'u-' + (i % 5)] });
+		await last;
+
+		resetDatabases();
+		Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.ok(Tbl.indexingOperation, 'adding an indexed attribute should trigger a backfill');
+		const release = {};
+		const tagIndex = Tbl.indices.tag;
+		const originalPut = tagIndex.put;
+		tagIndex.put = function (indexedValue, primaryKey, options) {
+			// the first of the record's two values, so a resolving put follows it
+			if (primaryKey === FAILING_ID && indexedValue === 't-1') return deferredPut(release);
+			return originalPut.call(this, indexedValue, primaryKey, options);
+		};
+		const observed = observeRange(Tbl, {
+			onKey: (key) => {
+				if (key === RELEASE_AT) release.fire();
+			},
+		});
+		try {
+			await Tbl.indexingOperation;
+		} finally {
+			tagIndex.put = originalPut;
+			observed.restore();
+		}
+
+		const parked = findDescriptor(Tbl, 'tag').value;
+		assert.strictEqual(parked.indexingFailed, true, 'a backfill with a failed record should be parked');
+		const persisted = await settledCheckpoint(Tbl, 'tag');
+		assert.ok(
+			persisted === undefined || persisted < FAILING_ID,
+			`checkpoint ${persisted} must not pass the failed record ${FAILING_ID}`
+		);
+
+		resetDatabases();
+		const Tbl2 = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.ok(Tbl2.indexingOperation, 'a parked backfill should retrigger');
+		const resumed = observeRange(Tbl2);
+		try {
+			await Tbl2.indexingOperation;
+		} finally {
+			resumed.restore();
+		}
+		assert.ok(resumed.keys.includes(FAILING_ID), 'the retry must revisit the record that failed');
+		const viaIndex = await collect(Tbl2.search({ conditions: [{ attribute: 'tag', value: 't-1' }] }));
+		assert.ok(
+			viaIndex.some((row) => row.id === FAILING_ID),
+			'the record whose index write failed must be indexed after the retry'
+		);
+	});
+
+	it('does not declare the index complete while an index write is still in flight', async () => {
+		const TABLE = 'BackfillCompletionRace';
+		const N = 400;
+		const FAILING_ID = 'k-' + pad(250);
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + pad(i), tag: ['t-' + (i % 3), 'u-' + (i % 5)] });
+		await last;
+
+		resetDatabases();
+		Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.ok(Tbl.indexingOperation, 'adding an indexed attribute should trigger a backfill');
+		const release = {};
+		const tagIndex = Tbl.indices.tag;
+		const originalPut = tagIndex.put;
+		tagIndex.put = function (indexedValue, primaryKey, options) {
+			if (primaryKey === FAILING_ID && indexedValue === 't-1') return deferredPut(release);
+			return originalPut.call(this, indexedValue, primaryKey, options);
+		};
+		let settled = false;
+		Tbl.indexingOperation.then(
+			() => (settled = true),
+			() => (settled = true)
+		);
+		// Release as soon as indexing resolves, which is what a build that ignores the unsettled write
+		// does; the deadline only bounds the case where it correctly refuses to resolve. So a slow runner
+		// can only make this test lenient, never make it fail spuriously.
+		const deadline = Date.now() + 2000;
+		while (!settled && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 20));
+		release.fire();
+		try {
+			await Tbl.indexingOperation;
+		} finally {
+			tagIndex.put = originalPut;
+		}
+		assert.strictEqual(
+			findDescriptor(Tbl, 'tag').value.indexingFailed,
+			true,
+			'the build must be parked, not completed, when a write it issued rejected'
+		);
+	});
+
+	it('bounds how many index writes it leaves in flight', async () => {
+		const TABLE = 'BackfillBackpressure';
+		const N = 4000;
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + pad(i), tag: ['t-' + (i % 3), 'u-' + (i % 5)] });
+		await last;
+
+		resetDatabases();
+		Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.ok(Tbl.indexingOperation, 'adding an indexed attribute should trigger a backfill');
+		const tagIndex = Tbl.indices.tag;
+		const originalPut = tagIndex.put;
+		// The first value of each record resolves only after a delay, the second immediately: the shape
+		// that leaves one unsettled write per record behind a per-record counter.
+		let inFlight = 0;
+		let peakInFlight = 0;
+		tagIndex.put = function (indexedValue, primaryKey, options) {
+			const result = originalPut.call(this, indexedValue, primaryKey, options);
+			if (!String(indexedValue).startsWith('t-')) return result;
+			inFlight++;
+			if (inFlight > peakInFlight) peakInFlight = inFlight;
+			return new Promise((resolve) =>
+				setTimeout(() => {
+					inFlight--;
+					resolve(result);
+				}, 400)
+			);
+		};
+		try {
+			await Tbl.indexingOperation;
+		} finally {
+			tagIndex.put = originalPut;
+		}
+		assert.ok(peakInFlight > 0, 'the slow puts should actually have been in flight');
+		// MAX_OUTSTANDING_INDEXING is 1000; the loop checks after issuing a record's writes, so it may
+		// overshoot by that record's fan-out before the bound applies.
+		assert.ok(
+			peakInFlight <= 1100,
+			`the backfill left ${peakInFlight} index writes in flight, past the outstanding bound`
+		);
+	});
+
+	it('rebuilds instead of resuming a checkpoint stamped by an earlier checkpoint algorithm', async () => {
+		const TABLE = 'BackfillLegacyStamp';
+		const N = 400;
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + pad(i), tag: 't-' + (i % 3) });
+		await last;
+
+		resetDatabases();
+		Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		await Tbl.indexingOperation;
+
+		// A checkpoint the pre-fix code left behind: certified and self-consistent, but possibly advanced
+		// past a record whose index write failed, so it must not be resumed from.
+		const { key, value } = findDescriptor(Tbl, 'tag');
+		value.indexingFailed = true;
+		value.lastIndexedKey = 'k-' + pad(200);
+		value.checkpointCertified = value.lastIndexedKey;
+		delete value.checkpointAlgorithm;
+		Tbl.dbisDB.putSync(key, value);
+
+		resetDatabases();
+		const Tbl2 = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.ok(Tbl2.indexingOperation, 'a parked index should retrigger');
+		const resumed = observeRange(Tbl2);
+		try {
+			await Tbl2.indexingOperation;
+		} finally {
+			resumed.restore();
+		}
+		assert.strictEqual(resumed.start, undefined, 'an unversioned checkpoint must force a full rebuild');
+	});
+
 	it('resumes from the minimum of unequal persisted checkpoints, and scans everything when one is absent', async () => {
 		const TABLE = 'BackfillUnequalCheckpoints';
 		const N = 500;
@@ -363,10 +624,14 @@ describe('index backfill convergence (#2536)', () => {
 				const { key, value } = findDescriptor(Tbl, name);
 				value.indexingFailed = true;
 				delete value.checkpointCertified;
+				delete value.checkpointAlgorithm;
 				if (lastIndexedKey === undefined) delete value.lastIndexedKey;
 				else {
 					value.lastIndexedKey = lastIndexedKey;
-					if (certified) value.checkpointCertified = lastIndexedKey;
+					if (certified) {
+						value.checkpointCertified = lastIndexedKey;
+						value.checkpointAlgorithm = CHECKPOINT_ALGORITHM;
+					}
 				}
 				Tbl.dbisDB.putSync(key, value);
 			}

--- a/unitTests/resources/indexBackfillConvergence.test.js
+++ b/unitTests/resources/indexBackfillConvergence.test.js
@@ -342,8 +342,15 @@ describe('index backfill convergence (#2536)', () => {
 		let reject;
 		const promise = new Promise((_, r) => (reject = r));
 		promise.catch(() => {}); // the rejection is delivered through runIndexing's own handler
+		release.issued = true;
 		release.fire = () => reject(new Error('simulated deferred index put failure'));
 		return promise;
+	}
+
+	async function waitFor(condition, what, timeoutMs = 20000) {
+		const deadline = Date.now() + timeoutMs;
+		while (!condition() && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 10));
+		assert.ok(condition(), `timed out waiting for ${what}`);
 	}
 
 	it('freezes the checkpoint when an index write rejects only after a later checkpoint was reached', async () => {
@@ -465,11 +472,15 @@ describe('index backfill convergence (#2536)', () => {
 			() => (settled = true),
 			() => (settled = true)
 		);
+		// The scan has to reach the failing record before there is anything to release; a loaded runner
+		// only makes that slower, never skips it.
+		await waitFor(() => release.issued || settled, 'the failing index write to be issued');
 		// Release as soon as indexing resolves, which is what a build that ignores the unsettled write
 		// does; the deadline only bounds the case where it correctly refuses to resolve. So a slow runner
-		// can only make this test lenient, never make it fail spuriously.
+		// can make this test lenient, never make it fail spuriously.
 		const deadline = Date.now() + 2000;
 		while (!settled && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(release.issued, 'the failing index write should have been issued by now');
 		release.fire();
 		try {
 			await Tbl.indexingOperation;
@@ -480,6 +491,50 @@ describe('index backfill convergence (#2536)', () => {
 			findDescriptor(Tbl, 'tag').value.indexingFailed,
 			true,
 			'the build must be parked, not completed, when a write it issued rejected'
+		);
+	});
+
+	// LMDB only: RocksDB awaits its clear inline, so only the LMDB path enqueues one whose rejection the
+	// barriers have to catch. A full rebuild clears first, so a rejected clear is the one way a checkpoint
+	// could certify over stale index entries with no put ever failing.
+	(LMDB ? it : it.skip)('parks the build when the clear that precedes a full rebuild rejects', async () => {
+		const TABLE = 'BackfillClearRejects';
+		const N = 300;
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + pad(i), tag: 't-' + (i % 3) });
+		await last;
+
+		resetDatabases();
+		Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.ok(Tbl.indexingOperation, 'adding an indexed attribute should trigger a backfill');
+		const tagIndex = Tbl.indices.tag;
+		assert.strictEqual(typeof tagIndex.clearAsync, 'function', 'the LMDB path should clear asynchronously');
+		let cleared = false;
+		tagIndex.clearAsync = () => {
+			cleared = true;
+			return new Promise((_, reject) => setTimeout(() => reject(new Error('simulated clear failure')), 25));
+		};
+		await Tbl.indexingOperation;
+		assert.ok(cleared, 'a full rebuild should have cleared the index first');
+		assert.strictEqual(
+			findDescriptor(Tbl, 'tag').value.indexingFailed,
+			true,
+			'a rejected clear must park the build rather than let it complete'
 		);
 	});
 

--- a/unitTests/resources/indexBackfillConvergence.test.js
+++ b/unitTests/resources/indexBackfillConvergence.test.js
@@ -11,6 +11,7 @@ const path = require('node:path');
 const { readFileSync, rmSync } = require('node:fs');
 const { spawn } = require('node:child_process');
 const { setupTestDBPath } = require('../testUtils');
+const { waitFor } = require('../waitFor.js');
 const env = require('#src/utility/environment/environmentManager');
 const terms = require('#src/utility/hdbTerms');
 const {
@@ -347,12 +348,6 @@ describe('index backfill convergence (#2536)', () => {
 		return promise;
 	}
 
-	async function waitFor(condition, what, timeoutMs = 20000) {
-		const deadline = Date.now() + timeoutMs;
-		while (!condition() && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 10));
-		assert.ok(condition(), `timed out waiting for ${what}`);
-	}
-
 	it('freezes the checkpoint when an index write rejects only after a later checkpoint was reached', async () => {
 		const TABLE = 'BackfillLateRejection';
 		const N = 600;
@@ -474,7 +469,10 @@ describe('index backfill convergence (#2536)', () => {
 		);
 		// The scan has to reach the failing record before there is anything to release; a loaded runner
 		// only makes that slower, never skips it.
-		await waitFor(() => release.issued || settled, 'the failing index write to be issued');
+		await waitFor(() => release.issued || settled, {
+			timeout: 20000,
+			message: 'the failing index write was never issued',
+		});
 		// Release as soon as indexing resolves, which is what a build that ignores the unsettled write
 		// does; the deadline only bounds the case where it correctly refuses to resolve. So a slow runner
 		// can make this test lenient, never make it fail spuriously.
@@ -592,6 +590,57 @@ describe('index backfill convergence (#2536)', () => {
 		assert.ok(
 			peakInFlight <= 1100,
 			`the backfill left ${peakInFlight} index writes in flight, past the outstanding bound`
+		);
+	});
+
+	it('keeps the algorithm stamp on a completed index across a later descriptor rewrite', async () => {
+		const TABLE = 'BackfillCompletedStamp';
+		const N = 200;
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }, { name: 'group' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + pad(i), tag: 't-' + (i % 3), group: 'g-' + (i % 2) });
+		await last;
+
+		resetDatabases();
+		Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag', indexed: true }, { name: 'group' }],
+		});
+		assert.ok(Tbl.indexingOperation, 'adding an indexed attribute should trigger a backfill');
+		await Tbl.indexingOperation;
+		const built = findDescriptor(Tbl, 'tag').value;
+		assert.strictEqual(built.lastIndexedKey, undefined, 'a clean completion clears the checkpoint');
+		assert.strictEqual(
+			built.checkpointAlgorithm,
+			CHECKPOINT_ALGORITHM,
+			'a completed index should record the algorithm that built it'
+		);
+
+		// Indexing a second attribute rewrites every descriptor for the table; the stamp has to survive it,
+		// or a completed index becomes indistinguishable from one an older release built.
+		resetDatabases();
+		const Tbl2 = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+				{ name: 'group', indexed: true },
+			],
+		});
+		if (Tbl2.indexingOperation) await Tbl2.indexingOperation;
+		assert.strictEqual(
+			findDescriptor(Tbl2, 'tag').value.checkpointAlgorithm,
+			CHECKPOINT_ALGORITHM,
+			'the completed index should still carry its stamp after an unrelated descriptor rewrite'
 		);
 	});
 


### PR DESCRIPTION
A secondary-index backfill could persist a resume checkpoint past a record whose index write later failed, or declare the index complete over one, leaving that record silently missing from the index.

`runIndexing` issues one index put per indexed value per record, plus a drop per removed index and a clear per full rebuild, but tracked only the last put in `lastResolution`. Everything else was fire-and-forget: a rejection set `hadIndexingErrors` whenever it happened to settle, while the checkpoint read that flag once on entry and completion waited a single event turn. Whether a failed index write froze the checkpoint was an accident of scheduling. Varying only how long the failing write takes to reject, on one 600-record table whose record at `k-0250` fails:

| rejection delay | checkpoint after the first pass | parked | record indexed after the retry |
|---|---|---|---|
| one event turn | `k-0199`, correct | yes | yes |
| 30 ms | `k-0499`, past the failed record | yes | no |
| 300 ms | cleared, index declared complete | no | no |

Every index mutation the build issues is now registered in a [per-build set](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3290) that absorbs its own rejection, covering the [per-value puts](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3403), the [drops for removed indexes](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3324) and the [LMDB clear](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3337) that a full rebuild runs first. A checkpoint [drains a snapshot of that set and refuses to certify](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3351) when any mutation it covers failed, and [completion drains it](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3444) in place of the one-`setImmediate` heuristic, so "no errors" means every write settled rather than none had failed yet. The set also [bounds what stays in flight](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3437), waiting on the next settlement of any mutation rather than a chosen one, because the drop and clear are inserted before the scan starts and faster writes overtake them.

Checkpoints carry a [`CHECKPOINT_ALGORITHM` stamp](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3181). A descriptor without the current stamp [resumes as uncertified](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R2898) and rebuilds, so a checkpoint the previous code certified past a failed record cannot be resumed from. A [clean completion keeps the stamp](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3486) rather than clearing it with the other checkpoint fields, and it is [carried across a later descriptor rewrite](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R2980); without that, indexing a second attribute on the table dropped the stamp and made the first index indistinguishable from a pre-fix build.

## For the human reviewer

1. **Completed indexes an affected release already built are not repaired, and this PR does not repair them.** `v5.2.10` was tagged 2026-09-10 on `origin/v5.2` and contains the defective code. A build it declared complete over a failed write cleared every marker, so on upgrade its descriptor has no checkpoint and no stamp, `table()` treats it as ready, and the record stays missing from that index. The alternative is forcing one rebuild of every unstamped completed index on upgrade, whose cost depends on how far `v5.2.10` was distributed — a fact I do not have. I chose to make the later decision *possible* instead of making it now: stamping completions means every index built from here on is distinguishable, which is what any remediation has to key on. Changing this later needs another version bump and that same expensive rebuild; leaving it means any already-gapped index stays wrong in the field. **This is the call I most want ruled on.**
2. **The algorithm stamp is compared with `!==`, not `>=`.** A downgrade-then-upgrade cycle therefore forces a full rebuild of any in-flight checkpoint. That is the conservative direction and cheap to change while there is one consumer, but it is a persisted on-disk shape, so changing it later needs its own compatibility story.
3. **Backpressure and the yield hint now share one unit.** `MAX_OUTSTANDING_INDEXING` (1000) and `MIN_OUTSTANDING_INDEXING` (10) were tuned against a per-record counter and now count individual index writes, so a fan-out table reaches both sooner. Two reviewers called this a throughput risk; I measured it rather than argue it, and there is no regression (numbers in Verification). Splitting the yield hint back onto a per-record counter is one line if you disagree with the reading.
4. **The bound is checked once per record, so a single row's fan-out can overshoot it.** A row with a very large indexed array issues all its puts before the cap applies. I left it: it is strictly tighter than the per-record counter it replaces, which allowed that same row's fan-out plus 1000 records' worth beyond it, and moving the check inside the value loop adds a suspension point mid-record for a pathological input.
5. **A checkpoint that fails to persist still only warns.** A sustained catalog write failure leaves `hadIndexingErrors` false and the scan continuing, so progress is under-recorded and a crash rescans further back than necessary. That predates this change; I did not widen it into an indexing error here, because parking a build that is writing correct index data is its own harm.
6. **The barriers are proven at module level with patched mutation promises, not end to end.** Nothing here drives a real engine rejection through the operations API. Adding that later is additive.

I also declined one review suggestion on evidence: re-reading `hadIndexingErrors` after the flush and before writing descriptors. I tried it first, and it made the existing freeze cases checkpoint at `k-0099` instead of `k-0199`, because a failure at a *later* key invalidated a checkpoint whose own records had all succeeded. The drain's scoped result is the correct guard; the global flag is not.

## Changes

[`resources/databases.ts`](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5) carries the mechanism above. Beyond the links in the summary: [`track`](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3292) returns the original result untouched and registers nothing when a put resolves synchronously, so the RocksDB path allocates as it did before; [`drainMutations`](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3311) reports whether any member of its snapshot failed, which is what lets a failure on a later key leave an earlier checkpoint valid; and [`nextSettlement`](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R3316) resolves on the next settlement of anything tracked. The `when()` import is gone with its last use.

[`unitTests/resources/indexBackfillConvergence.test.js`](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-7c2107e8bc4d28f75d46aab61a3e874430788e811bc434a1dd7a7b10d6b930c6) adds five cases; see Verification.

[`DESIGN.md`](https://github.com/HarperFast/harper/pull/2563/changes?w=1#diff-3dc5dd454e080eb849ee5efaf79df2585fbe0a06804d69249b4c81da05a63875) described the removed `when()` error handler, the removed final `await lastResolution` try-catch, and a checkpoint written every 100 records. It now describes the mutation set, the drain barriers, and both checkpoint stamps.

## Verification

Five new cases, each of which fails on a `dist` built from `origin/main`'s `resources/databases.ts`:

| case | on base |
|---|---|
| freezes the checkpoint when an index write rejects only after a later checkpoint was reached | `checkpoint k-0299 must not pass the failed record k-0250` — the nightly symptom, now deterministic |
| does not declare the index complete while an index write is still in flight | index declared complete |
| parks the build when the clear that precedes a full rebuild rejects (LMDB) | build completed over a failed clear |
| bounds how many index writes it leaves in flight | 3900 writes in flight |
| rebuilds instead of resuming a checkpoint stamped by an earlier checkpoint algorithm | resumed at `k-0200` |

A sixth case covers the stamp surviving a descriptor rewrite; it fails on the first two commits of this branch rather than on base, since it guards the stamp those commits introduced.

The rejection in the first two cases is released by an observed scan position, not a timer, so the interleaving is the same on a fast and a slow runner.

```
npx mocha unitTests/resources/indexBackfillConvergence.test.js          19 passing, 1 pending
HARPER_STORAGE_ENGINE=lmdb  (same file)                                 19 passing, 1 pending
npm run test:unit:resources                                             2357 passing
HARPER_STORAGE_ENGINE=lmdb npm run test:unit:resources                  1838 passing
npm run test:unit:main                                                  5466 passing, 2 failing
npm run test:integration:all                                            2058 passing, 0 failing
```

The two `test:unit:main` failures are environmental and reproduce on this box without the diff: a token test that depends on a shared system database, and a config-validator case that asserts on the length of the checkout path. The integration run's only failures are the `ollama-backend` suite, which fails at module load with `ERR_IMPORT_ATTRIBUTE_MISSING` for `systemSchema.json` and needs a live Ollama instance.

Throughput, since this changes what the backpressure thresholds count. 50,000 records, two indexed attributes of two-element arrays, four index writes per record, RocksDB, same box, `dist` built from each side:

| build | backfill |
|---|---|
| `origin/main` | 699 ms, 727 ms |
| this branch | 636 ms, 647 ms |

Refs #2536

Complexity: complicated



🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01892ogD1y5AdZrV42zWpMXb

<sub>Review-Coverage: authored=claude; ran=gemini,codex; declined=cursor-grok,cursor-composer,domain; rounds=3 @ 33dfa286a0cd</sub>

<sub>Human-Review-Need: 4 @ 33dfa286a0cd</sub>
