### PR TITLE
Re-assert @table settings on tables without a declared primary key

### DIFF
--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -2711,41 +2711,38 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 				}
 			}
 		}
-		// TODO: If we have attributes and the schemaDefined flag is not set, turn it on
-		// iterate through the attributes to ensure that we have all the dbis created and indexed
-		for (const attribute of attributes || []) {
-			if (attribute.relationship) {
-				refreshRelationshipAttributes = true;
-				continue;
-			}
-			if (attribute.computed) hasChanges = true;
-			let dbiKey = tableName + '/' + (attribute.name || '');
-			Object.defineProperty(attribute, 'key', { value: dbiKey, configurable: true });
-			let attributeDescriptor = attributesDbi.getSync(dbiKey);
-			if (attribute.isPrimaryKey) {
-				if (deferredPrimaryRow) continue;
-				attributeDescriptor = attributeDescriptor || attributesDbi.getSync((dbiKey = tableName + '/')) || {};
-				// Persist schemaDefined when the explicit live value disagrees with disk. Without this,
-				// a stale `false` (from a v4-era write or replicated event) survives every reload: the
-				// in-memory re-assert in the existing-Table branch only fixes the worker that ran @table,
-				// but other workers' next disk-load re-reads the stale value. The whole settings update is
-				// gated off for cluster-origin callers: their values come from this worker's (possibly
-				// stale) snapshot, so a rewrite could revert a newer local declaration already on disk.
-				const schemaDefinedMismatch = schemaDefinedExplicit && attributeDescriptor.schemaDefined !== schemaDefined;
-				// primary key can't change indexing, but settings can change
-				if (
-					origin !== 'cluster' &&
-					(schemaDefinedMismatch ||
-						(audit !== undefined && audit !== Table.audit) ||
-						(sealed !== undefined && sealed !== Table.sealed) ||
-						(replicate !== undefined && replicate !== Table.replicate) ||
-						(+expiration || undefined) !== (+attributeDescriptor.expiration || undefined) ||
-						(+eviction || undefined) !== (+attributeDescriptor.eviction || undefined) ||
-						attribute.type !== attributeDescriptor.type)
-				) {
-					exclusiveLock();
-					const currentPrimaryAttribute = attributesDbi.getSync(dbiKey);
-					if (!currentPrimaryAttribute || tableIsDropping(currentPrimaryAttribute, dbiKey)) continue;
+		// The settings reconcile runs once per table against the primary catalog row, not per
+		// attribute: a table declared without a primary key has no isPrimaryKey attribute (its
+		// catalog row is keyed at `tableName + '/'` with no name), and it must still pick up
+		// directive changes. Skipped on the create path (deferredPrimaryRow publishes the row
+		// itself), so create and update resolve the same declaration.
+		if (!deferredPrimaryRow) {
+			const declaredPrimaryAttribute = (attributes || []).find((attribute) => attribute.isPrimaryKey);
+			const primaryCatalogKey = primaryDescriptorKey();
+			const primaryDescriptor = attributesDbi.getSync(primaryCatalogKey) || {};
+			// Persist schemaDefined when the explicit live value disagrees with disk. Without this,
+			// a stale `false` (from a v4-era write or replicated event) survives every reload: the
+			// in-memory re-assert in the existing-Table branch only fixes the worker that ran @table,
+			// but other workers' next disk-load re-reads the stale value. The whole settings update is
+			// gated off for cluster-origin callers: their values come from this worker's (possibly
+			// stale) snapshot, so a rewrite could revert a newer local declaration already on disk.
+			const schemaDefinedMismatch = schemaDefinedExplicit && primaryDescriptor.schemaDefined !== schemaDefined;
+			// primary key can't change indexing, but settings can change; compared against the persisted
+			// descriptor (not the live Table) so a stale disk value is corrected too, same class of bug
+			// as the schemaDefined re-assert above
+			if (
+				origin !== 'cluster' &&
+				(schemaDefinedMismatch ||
+					(audit !== undefined && audit !== primaryDescriptor.audit) ||
+					(sealed !== undefined && sealed !== primaryDescriptor.sealed) ||
+					(replicate !== undefined && replicate !== primaryDescriptor.replicate) ||
+					(+expiration || undefined) !== (+primaryDescriptor.expiration || undefined) ||
+					(+eviction || undefined) !== (+primaryDescriptor.eviction || undefined) ||
+					(declaredPrimaryAttribute && declaredPrimaryAttribute.type !== primaryDescriptor.type))
+			) {
+				exclusiveLock();
+				const currentPrimaryAttribute = attributesDbi.getSync(primaryCatalogKey);
+				if (currentPrimaryAttribute && !tableIsDropping(currentPrimaryAttribute, primaryCatalogKey)) {
 					const updatedPrimaryAttribute = { ...currentPrimaryAttribute };
 					if (typeof audit === 'boolean') {
 						if (audit) Table.enableAuditing();
@@ -2755,14 +2752,25 @@ function declareTable<TableResourceType>(target: TableTarget, tableDefinition: T
 					if (eviction) updatedPrimaryAttribute.eviction = +eviction;
 					if (sealed !== undefined) updatedPrimaryAttribute.sealed = sealed;
 					if (replicate !== undefined) updatedPrimaryAttribute.replicate = replicate;
-					if (attribute.type) updatedPrimaryAttribute.type = attribute.type;
+					if (declaredPrimaryAttribute?.type) updatedPrimaryAttribute.type = declaredPrimaryAttribute.type;
 					if (schemaDefinedMismatch) updatedPrimaryAttribute.schemaDefined = schemaDefined;
 					hasChanges = true; // send out notification of the change
-					attributesDbi.put(dbiKey, updatedPrimaryAttribute);
+					attributesDbi.put(primaryCatalogKey, updatedPrimaryAttribute);
 				}
-
+			}
+		}
+		// TODO: If we have attributes and the schemaDefined flag is not set, turn it on
+		// iterate through the attributes to ensure that we have all the dbis created and indexed
+		for (const attribute of attributes || []) {
+			if (attribute.relationship) {
+				refreshRelationshipAttributes = true;
 				continue;
 			}
+			if (attribute.computed) hasChanges = true;
+			const dbiKey = tableName + '/' + (attribute.name || '');
+			Object.defineProperty(attribute, 'key', { value: dbiKey, configurable: true });
+			if (attribute.isPrimaryKey) continue;
+			let attributeDescriptor = attributesDbi.getSync(dbiKey);
 
 			if (attributeDescriptor?.attribute && !attributeDescriptor.name) attributeDescriptor.indexed = true; // legacy descriptor
 

--- a/unitTests/resources/tableSettingsReassert.test.js
+++ b/unitTests/resources/tableSettingsReassert.test.js
@@ -1,0 +1,107 @@
+const assert = require('assert');
+const { setupTestDBPath } = require('../testUtils');
+const { loadGQLSchema } = require('#src/resources/graphql');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+function primaryDescriptor(Table) {
+	return Table.dbisDB.getSync(Table.tableName + '/');
+}
+
+function auditEntriesFor(Table) {
+	const entries = [];
+	for (const entry of Table.auditStore.getRange({ start: 1 })) {
+		if (entry.tableId === Table.tableId) entries.push(entry);
+	}
+	return entries;
+}
+
+describe('@table settings re-assert on existing tables', () => {
+	before(function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+	});
+
+	it('applies an audit change to a table with no declared primary key', async function () {
+		await loadGQLSchema(`
+		type NoPkAudit @table(audit: false) {
+			value: String
+		}`);
+		const Tbl = tables.NoPkAudit;
+		assert.strictEqual(Tbl.audit, false);
+		assert.strictEqual(primaryDescriptor(Tbl).audit, false);
+		await Tbl.put(1, { value: 'one' });
+		await Tbl.put(2, { value: 'two' });
+		assert.strictEqual(auditEntriesFor(Tbl).length, 0);
+
+		await loadGQLSchema(`
+		type NoPkAudit @table(audit: true) {
+			value: String
+		}`);
+		await Tbl.dbisDB.committed;
+		assert.strictEqual(primaryDescriptor(Tbl).audit, true);
+		assert.strictEqual(tables.NoPkAudit.audit, true);
+		await tables.NoPkAudit.put(3, { value: 'three' });
+		assert.strictEqual(auditEntriesFor(tables.NoPkAudit).length, 1);
+	});
+
+	it('applies expiration and eviction changes to a table with no declared primary key', async function () {
+		await loadGQLSchema(`
+		type NoPkTTL @table {
+			value: String
+		}`);
+		const Tbl = tables.NoPkTTL;
+		assert.strictEqual(primaryDescriptor(Tbl).expiration, undefined);
+		assert.strictEqual(primaryDescriptor(Tbl).eviction, undefined);
+
+		await loadGQLSchema(`
+		type NoPkTTL @table(expiration: 3600, eviction: 7200) {
+			value: String
+		}`);
+		await Tbl.dbisDB.committed;
+		assert.strictEqual(primaryDescriptor(Tbl).expiration, 3600);
+		assert.strictEqual(primaryDescriptor(Tbl).eviction, 7200);
+		assert.strictEqual(tables.NoPkTTL.expirationMS, 3600000);
+	});
+
+	it('still applies settings changes to a table with a declared primary key', async function () {
+		await loadGQLSchema(`
+		type PkAudit @table(audit: false) {
+			id: Int @primaryKey
+			value: String
+		}`);
+		const Tbl = tables.PkAudit;
+		assert.strictEqual(Tbl.audit, false);
+		await Tbl.put(1, { value: 'one' });
+		assert.strictEqual(auditEntriesFor(Tbl).length, 0);
+
+		await loadGQLSchema(`
+		type PkAudit @table(audit: true) {
+			id: Int @primaryKey
+			value: String
+		}`);
+		await Tbl.dbisDB.committed;
+		assert.strictEqual(primaryDescriptor(Tbl).audit, true);
+		assert.strictEqual(tables.PkAudit.audit, true);
+		await tables.PkAudit.put(2, { value: 'two' });
+		assert.strictEqual(auditEntriesFor(tables.PkAudit).length, 1);
+	});
+
+	it('does not rewrite the catalog row when the directive is unchanged', async function () {
+		await loadGQLSchema(`
+		type NoPkStable @table(audit: false, expiration: 3600) {
+			value: String
+		}`);
+		const Tbl = tables.NoPkStable;
+		await Tbl.dbisDB.committed;
+		const before = { ...primaryDescriptor(Tbl) };
+		const schemaVersionBefore = Tbl.schemaVersion;
+
+		await loadGQLSchema(`
+		type NoPkStable @table(audit: false, expiration: 3600) {
+			value: String
+		}`);
+		await Tbl.dbisDB.committed;
+		assert.deepStrictEqual({ ...primaryDescriptor(Tbl) }, before);
+		assert.strictEqual(Tbl.schemaVersion, schemaVersionBefore);
+	});
+});


### PR DESCRIPTION
Fixes #2480.

## Problem

On an existing table whose GraphQL type declares no `@primaryKey` field, changing `@table` directive settings (`audit`, `expiration`, `eviction`, `sealed`, `replicate`) had no effect. The only code that re-asserted changed settings on an existing table lived inside the attributes loop in `table()` under `if (attribute.isPrimaryKey)`. A PK-less type yields no `isPrimaryKey` attribute (the graphql loader does not synthesize one), so the comparison never evaluated and the creation-time persisted value won on every reload, silently. Creation honored the same declaration, so create and update disagreed.

## Fix

`resources/databases.ts`, in `table()`:

- The settings reconcile is hoisted out of the per-attribute loop and runs once per table, against the primary catalog row, resolved through the existing `primaryDescriptorKey()` helper (declared primary key name, falling back to the unnamed `tableName + '/'` key, which is exactly where a PK-less table's row lives). The PK branch of the loop now just `continue`s; the reconcile logic itself is the same block, moved.
- All of the block's recent semantics are preserved unchanged: skipped on the create path (`deferredPrimaryRow` publishes the row itself), gated off for cluster-origin callers, and the write happens against a descriptor re-read under the exclusive lock with the `tableIsDropping` check. Create and update resolve the same declaration, and every non-create declare now goes through one comparison regardless of PK-ness, so the paths cannot diverge again.
- `audit` / `sealed` / `replicate` are now compared against the persisted descriptor value instead of the live `Table` statics. The live values can be stale relative to disk in the same way as the `schemaDefined` case documented in the comment above the comparison (the descriptor is what every worker's next disk-load reads), so the descriptor is the value that decides whether a persist is needed. Directive values that are absent (`undefined`) still never trigger a persist; only an explicit changed value does.

Not changed, deliberately:

- The primary-key-change guard earlier in `table()` (declaring a PK on a populated table throws) is untouched and is evaluated before the reconcile; the existing guard test still passes.
- Post-persist semantics are exactly what the PK-declared path already did: `Table.enableAuditing()` when audit turns on, `hasChanges` driving `schemaVersion++` / `updatedAttributes()` / schema-change signalling, and `setTTLExpiration` at the end of `table()` for expiration/eviction. No store is reopened.

## Tests

`unitTests/resources/tableSettingsReassert.test.js`, all driven through `loadGQLSchema` (the real directive path):

1. PK-less table created with `audit: false`, records written (zero audit entries), directive changed to `audit: true`, reloaded: the catalog row and the live table both report `true`, and a subsequent write produces an audit entry. Fails on main, passes here.
2. PK-less table gains `expiration`/`eviction` on reload: persisted to the catalog row and applied (`expirationMS` set). Fails on main, passes here.
3. The same audit flip on a PK-declared table: unchanged behavior, passes on main and here.
4. A PK-less table reloaded with an unchanged directive does not rewrite its catalog row and does not bump `schemaVersion`.

Also run: `unitTests/resources/update-schema.test.js` (includes the populated-table primary-key-change guard test), `databases.test.js`, `auditLog.test.js`, and the full `test:unit:resources` suite.

## Claims from #2480 re-verified against current main

- The settings comparison exists only under `if (attribute.isPrimaryKey)` in the attributes loop (now at databases.ts ~1791, the issue's permalinks are at 0db6cab) and compares `audit`/`sealed`/`replicate` against live `Table` statics: confirmed.
- The graphql loader synthesizes no primary-key attribute for PK-less types (`'id'` appears only as a display fallback): confirmed.
- PK-less tables are created with `primaryKeyAttribute = {}` and their catalog row keyed at `tableName + '/'` with no name: confirmed (the boot loader's "table attribute for a table with no primary key" branch reads that row back as `tableDef.primary`).
- Boot reads audit/expiration/eviction/sealed/replicate from the persisted descriptor, so the creation-time value wins on every worker until the row is rewritten: confirmed.
- The primary-key-change guard throws for a populated table: confirmed by the existing update-schema test.

Lavinia, via Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
