### PR TITLE
Run the Docker image smoke test on release branches, not only main

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -20,7 +20,10 @@ on:
       - utility/processManagement/processManagement.js
       - .github/workflows/docker-smoke.yml
   push:
-    branches: [main]
+    # Release branches too: the image is built from a release branch at publish time, so a branch
+    # that never runs this has no boot coverage for the artifact it actually ships. Same pattern
+    # unit-test.yml uses.
+    branches: [main, 'v[0-9]+.[0-9]+']
     paths:
       - Dockerfile
       - .dockerignore


### PR DESCRIPTION
`docker-smoke.yml`'s push trigger was `branches: [main]`, so **no release branch has ever run it**. That matters because the publish workflow builds the image from a release branch, and this smoke test is the only thing in CI that boots the built image — a `v5.x` branch could carry an image that fails at startup and nothing in its own CI would say so.

Found while verifying `v5.2` for the 5.2 patch. #2560's shrinkwrap single-instance guard was cherry-picked onto `v5.2` precisely so the release branch would prove that root and `@harperfast/rocksdb-js` share one `msgpackr` instance — and the only check that runs that guard could not fire there. The property had to be verified by hand instead:

```
ONE INSTANCE   msgpackr                       v2.0.6
ONE INSTANCE   @harperfast/extended-iterable  v1.0.3
ONE INSTANCE   ordered-binary                 v1.6.1
```

resolved from both the root and from rocksdb-js's own resolution path, plus the checker's own suite 20/20 on `v5.2`. That is the evidence the smoke test would have produced automatically.

Uses the same branch pattern as `unit-test.yml` (`[main, 'v[0-9]+.[0-9]+']`), which already covers both. The `paths:` filter is unchanged, so this only fires on release-branch pushes that actually touch the image inputs.

## Verification

The workflow parses and the trigger resolves as intended:

```
push branches: ['main', 'v[0-9]+.[0-9]+']
jobs: ['smoke']
```

Trigger-only change; there is no behaviour to unit test. The job itself is unchanged and is exercised by this PR's own `pull_request` run.

## Note for whoever merges

Milestone deliberately left unset. Setting it to `v5.2` would cherry-pick this onto the release branch and give `v5.2` real image coverage — but it introduces a new check on a branch that is otherwise green and ready to tag, so that is a release-timing call rather than a code one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)