### PR TITLE
Retry the deploy activation swap through a transient rename lock

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -577,9 +577,10 @@ refuses a rename outright (`EPERM`) while anything holds a handle in the source 
 `deploy_component` hit on the Windows nightly, on the swap itself. The holder was never identified —
 every Harper-held handle on the candidate is closed before the swap, so it is something outside the
 process, but that is inference, not evidence. `renameThroughTransientHolder` retries every rename in
-the activation transaction and its recovery against one five-second deadline with capped exponential
-backoff; a rename it performs from inside a backoff shares that deadline rather than opening its own,
-so the whole activation stays bounded by it.
+the activation transaction and its recovery with capped exponential backoff against a five-second
+deadline. The deadline is per top-level rename, not per activation: a redeploy held up the whole way
+spends up to five seconds each on the move-aside, the swap, and the compensating restore. A rename
+performed from inside a backoff shares its caller's deadline rather than opening a fourth.
 
 The swap's backoff is not a plain sleep: it renames the aside back to the live path, waits there, and
 displaces it again for the next attempt, so the component is missing for one rename rather than for the

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -573,18 +573,25 @@ transaction over two effects: the live tree moves into `.deploy-aside`, then the
 into the live path.
 
 **Both renames wait out a holder, and the wait happens with the previous version in place.** Windows
-refuses a rename outright (`EPERM`) while anything holds a handle in the source tree, and a scanner
-reading a dependency tree npm has just written is exactly that — the failure `deploy_component` hit on
-the Windows nightly, on the swap itself. `renameThroughTransientHolder` retries every rename in the
-activation transaction and its recovery for five seconds with capped exponential backoff. The swap's
-backoff is not a plain sleep: it renames the aside back to the live path, waits there, and displaces it
-again for the next attempt. Retrying where the rename stands would leave the live path absent for the
-whole budget, and `EntryHandler` reports that to its consumers — `unlinkDir`, and the static handler
-drops the component's routes — so the fix for a failed deploy would have been multi-second
-unavailability on the platform that needs it. The retry set is `EPERM`/`EACCES`/`EBUSY` only: a
-destination that exists is structural state nothing here clears between attempts, and
-`settleInterruptedActivation` already fails that case closed rather than guessing which tree is
-current.
+refuses a rename outright (`EPERM`) while anything holds a handle in the source tree, which is what
+`deploy_component` hit on the Windows nightly, on the swap itself. The holder was never identified —
+every Harper-held handle on the candidate is closed before the swap, so it is something outside the
+process, but that is inference, not evidence. `renameThroughTransientHolder` retries every rename in
+the activation transaction and its recovery against one five-second deadline with capped exponential
+backoff; a rename it performs from inside a backoff shares that deadline rather than opening its own,
+so the whole activation stays bounded by it.
+
+The swap's backoff is not a plain sleep: it renames the aside back to the live path, waits there, and
+displaces it again for the next attempt, so the component is missing for one rename rather than for the
+budget. Note what that does and does not buy. Watchers are NOT the beneficiary — `Scope` pauses every
+`EntryHandler` for the duration of a deploy, so an absent tree is never reported as `unlinkDir`, and
+the post-deploy resume diffs against the finished tree. What the put-back protects is everything that
+reads the live path directly: a component reading its own files, a lazily imported module, a concurrent
+scan of the components root, and any thread whose pause the best-effort deploy broadcast did not reach.
+
+The retry set is `EPERM`/`EACCES`/`EBUSY` only: a destination that exists is structural state nothing
+here clears between attempts, and `settleInterruptedActivation` already fails that case closed rather
+than guessing which tree is current.
 
 The ordering is the design. Two things used to be wrong in a way each other hid:
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -572,6 +572,20 @@ load validation against _that_ tree, and only then activates it. Activation is o
 transaction over two effects: the live tree moves into `.deploy-aside`, then the candidate is renamed
 into the live path.
 
+**Both renames wait out a holder, and the wait happens with the previous version in place.** Windows
+refuses a rename outright (`EPERM`) while anything holds a handle in the source tree, and a scanner
+reading a dependency tree npm has just written is exactly that — the failure `deploy_component` hit on
+the Windows nightly, on the swap itself. `renameThroughTransientHolder` retries every rename in the
+activation transaction and its recovery for five seconds with capped exponential backoff. The swap's
+backoff is not a plain sleep: it renames the aside back to the live path, waits there, and displaces it
+again for the next attempt. Retrying where the rename stands would leave the live path absent for the
+whole budget, and `EntryHandler` reports that to its consumers — `unlinkDir`, and the static handler
+drops the component's routes — so the fix for a failed deploy would have been multi-second
+unavailability on the platform that needs it. The retry set is `EPERM`/`EACCES`/`EBUSY` only: a
+destination that exists is structural state nothing here clears between attempts, and
+`settleInterruptedActivation` already fails that case closed rather than guessing which tree is
+current.
+
 The ordering is the design. Two things used to be wrong in a way each other hid:
 
 - **The live tree was moved aside first**, so the component was broken for the whole extract +

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -1073,6 +1073,61 @@ async function syncRenameParents(fromPath: string, toPath: string): Promise<void
 	for (const parent of parents) await syncDirectory(parent);
 }
 
+// A holder that releases on its own: on Windows a rename is refused outright while anything holds a
+// handle in the source tree, which a scanner reading a dependency tree npm has just written does. NOT
+// `EEXIST`/`ENOTEMPTY`/`ENOTDIR`/`EISDIR` — those say the destination exists, which nothing here clears
+// between attempts, so waiting them out would only delay reporting a tree something recreated.
+// `rollbackExtractedDirectory` retries those too because its placeholder logic does repair the
+// destination; that is a different policy, not a copy of this one.
+const TRANSIENT_RENAME_CODES = new Set(['EPERM', 'EACCES', 'EBUSY']);
+const RENAME_RETRY_BUDGET_MS = 5000;
+const RENAME_RETRY_INITIAL_DELAY_MS = 10;
+const RENAME_RETRY_MAX_DELAY_MS = 500;
+
+/**
+ * Rename, waiting out a holder that has not let go yet. `onBackoff` replaces the plain sleep between
+ * attempts, which is how the activation keeps the previous version at the live path while it waits.
+ * A rename that succeeds first time costs one call, no timer and no log.
+ */
+async function renameThroughTransientHolder(
+	fromPath: string,
+	toPath: string,
+	onBackoff?: (delayMs: number) => Promise<void>
+): Promise<void> {
+	const deadline = performance.now() + RENAME_RETRY_BUDGET_MS;
+	let delayMs = RENAME_RETRY_INITIAL_DELAY_MS;
+	for (let attempts = 1; ; attempts++) {
+		try {
+			await rename(fromPath, toPath);
+			if (attempts > 1) {
+				logger.warn(`Renamed ${fromPath} to ${toPath} only on attempt ${attempts}; something was holding it`);
+			}
+			return;
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code ?? '';
+			if (!TRANSIENT_RENAME_CODES.has(code)) throw error;
+			if (performance.now() >= deadline) {
+				// Which side was still there is what separates a holder on the source from a destination
+				// something recreated, and neither survives on the rethrown error.
+				const exists = async (path: string) =>
+					lstat(path).then(
+						() => 'present',
+						() => 'absent'
+					);
+				logger.warn(
+					`Could not rename ${fromPath} to ${toPath}: ${code} after ${attempts} attempts over ` +
+						`${Math.round(RENAME_RETRY_BUDGET_MS + performance.now() - deadline)}ms ` +
+						`(source ${await exists(fromPath)}, destination ${await exists(toPath)})`
+				);
+				throw error;
+			}
+			if (onBackoff) await onBackoff(delayMs);
+			else await delay(delayMs);
+			delayMs = Math.min(delayMs * 2, RENAME_RETRY_MAX_DELAY_MS);
+		}
+	}
+}
+
 /**
  * Write a control file so its final name NEVER exists with partial contents. Opening the final path with
  * `wx` publishes the directory entry before anything is written, so a crash in between leaves a zero-byte
@@ -1816,7 +1871,7 @@ async function settleInterruptedActivation(
 	const asideRecords = await inProgressAsideRecords(asideStagingDir);
 
 	const rollForward = async () => {
-		if (!liveExists) await rename(candidateDirPath, liveDirPath);
+		if (!liveExists) await renameThroughTransientHolder(candidateDirPath, liveDirPath);
 		// Unconditional, not only when THIS pass performed the rename: a crash after normal activation
 		// renamed the candidate but before it repaired the links leaves live present with stale targets, and
 		// gating the repair on the rename would skip exactly that case. Idempotent when there is nothing to
@@ -1831,7 +1886,7 @@ async function settleInterruptedActivation(
 	};
 	const rollBack = async (restoreFrom?: string) => {
 		if (restoreFrom) {
-			await rename(restoreFrom, liveDirPath);
+			await renameThroughTransientHolder(restoreFrom, liveDirPath);
 			await syncRenameParents(restoreFrom, liveDirPath);
 		}
 		for (const record of asideRecords) {
@@ -2109,9 +2164,14 @@ export async function activateCandidateApplication(application: Application, dep
 	// B1 — the live tree moves aside. It stays the rollback source until B4 retires it.
 	let asidePath: string | undefined;
 	let priorAbsentRecordPath: string | undefined;
+	// Whether the previous tree is currently AT the aside path. The swap below puts it back and takes it
+	// away again around every wait, so "an aside path was chosen" and "the live path is empty right now"
+	// stop being the same thing — and compensation has to know which.
+	let liveIsDisplaced = false;
 	if (liveExists) {
 		asidePath = join(asideStagingDir, `${IN_PROGRESS_ASIDE_PREFIX}${Date.now()}-${process.pid}-${randomUUID()}`);
-		await rename(liveDirPath, asidePath);
+		await renameThroughTransientHolder(liveDirPath, asidePath);
+		liveIsDisplaced = true;
 	} else {
 		priorAbsentRecordPath = join(
 			asideStagingDir,
@@ -2120,8 +2180,10 @@ export async function activateCandidateApplication(application: Application, dep
 		await writeFile(priorAbsentRecordPath, '', { flag: 'wx', mode: 0o600 });
 	}
 	const restoreLive = async () => {
-		if (asidePath) await rename(asidePath, liveDirPath);
-		else if (priorAbsentRecordPath) await rm(priorAbsentRecordPath, { force: true });
+		if (liveIsDisplaced) {
+			await renameThroughTransientHolder(asidePath!, liveDirPath);
+			liveIsDisplaced = false;
+		} else if (priorAbsentRecordPath) await rm(priorAbsentRecordPath, { force: true });
 		await syncRenameParents(asidePath ?? priorAbsentRecordPath!, liveDirPath);
 	};
 
@@ -2140,7 +2202,24 @@ export async function activateCandidateApplication(application: Application, dep
 	// because the live path now holds the candidate and renaming the aside back over it cannot succeed. A
 	// compensating step there fails its own rollback and reports a failure for a deploy that is live.
 	try {
-		await rename(candidateDirPath, liveDirPath);
+		await renameThroughTransientHolder(candidateDirPath, liveDirPath, async (delayMs) => {
+			// The previous version serves through the wait. Retrying where the rename stands would leave the
+			// live path absent for the whole budget instead of for one attempt, and a watcher reports that
+			// to its consumers — `EntryHandler` emits `unlinkDir` and the static handler drops the
+			// component's routes — so riding out a five-second holder would cost what harper#2345 exists to
+			// prevent. A first-ever deploy has nothing to put back and retries in place.
+			if (!liveIsDisplaced) return delay(delayMs);
+			// Plain renames, not retrying ones: the deadline above is the whole operation's bound, and either
+			// of these throwing lands in the compensation below with `liveIsDisplaced` saying what it has to
+			// undo.
+			await rename(asidePath!, liveDirPath);
+			liveIsDisplaced = false;
+			await syncRenameParents(asidePath!, liveDirPath);
+			await delay(delayMs);
+			await rename(liveDirPath, asidePath!);
+			liveIsDisplaced = true;
+			await syncRenameParents(liveDirPath, asidePath!);
+		});
 	} catch (error) {
 		await compensate(error, 'move the candidate into place', restoreLive, application);
 		throw error;

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -1107,16 +1107,18 @@ async function renameThroughTransientHolder(
 			const code = (error as NodeJS.ErrnoException).code ?? '';
 			if (!TRANSIENT_RENAME_CODES.has(code)) throw error;
 			if (performance.now() >= deadline) {
-				// Which side was still there is what separates a holder on the source from a destination
-				// something recreated, and neither survives on the rethrown error.
-				const exists = async (path: string) =>
+				// Which side was still there separates a holder on the source from a destination something
+				// recreated, and neither survives on the rethrown error. A failed probe reports its own code:
+				// an `EPERM` reading the destination is itself evidence, and calling it absent would send the
+				// next investigation the wrong way.
+				const state = async (path: string) =>
 					lstat(path).then(
 						() => 'present',
-						() => 'absent'
+						(probeError) => (probeError as NodeJS.ErrnoException)?.code ?? 'unreadable'
 					);
 				logger.warn(
 					`Could not rename ${fromPath} to ${toPath}: ${code} after ${attempts} attempts ` +
-						`(source ${await exists(fromPath)}, destination ${await exists(toPath)})`
+						`(source ${await state(fromPath)}, destination ${await state(toPath)})`
 				);
 				throw error;
 			}

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -1073,28 +1073,28 @@ async function syncRenameParents(fromPath: string, toPath: string): Promise<void
 	for (const parent of parents) await syncDirectory(parent);
 }
 
-// A holder that releases on its own: on Windows a rename is refused outright while anything holds a
-// handle in the source tree, which a scanner reading a dependency tree npm has just written does. NOT
-// `EEXIST`/`ENOTEMPTY`/`ENOTDIR`/`EISDIR` — those say the destination exists, which nothing here clears
-// between attempts, so waiting them out would only delay reporting a tree something recreated.
-// `rollbackExtractedDirectory` retries those too because its placeholder logic does repair the
-// destination; that is a different policy, not a copy of this one.
+// Deliberately NOT `EEXIST`/`ENOTEMPTY`/`ENOTDIR`/`EISDIR`: those say the destination exists, which
+// nothing here clears between attempts, so waiting on them would only delay reporting a tree something
+// recreated — the case `settleInterruptedActivation` fails closed rather than guessing.
+// `rollbackExtractedDirectory` does retry them, because its placeholder logic repairs the destination.
 const TRANSIENT_RENAME_CODES = new Set(['EPERM', 'EACCES', 'EBUSY']);
 const RENAME_RETRY_BUDGET_MS = 5000;
 const RENAME_RETRY_INITIAL_DELAY_MS = 10;
 const RENAME_RETRY_MAX_DELAY_MS = 500;
 
 /**
- * Rename, waiting out a holder that has not let go yet. `onBackoff` replaces the plain sleep between
- * attempts, which is how the activation keeps the previous version at the live path while it waits.
- * A rename that succeeds first time costs one call, no timer and no log.
+ * Rename, waiting out a holder that has not let go yet — on Windows a rename is refused outright while
+ * anything still has a handle in the source tree.
+ *
+ * `onBackoff` replaces the sleep between attempts; `deadline` lets a rename it performs share this
+ * call's budget instead of opening its own.
  */
 async function renameThroughTransientHolder(
 	fromPath: string,
 	toPath: string,
-	onBackoff?: (delayMs: number) => Promise<void>
+	options: { onBackoff?: (delayMs: number, deadline: number) => Promise<void>; deadline?: number } = {}
 ): Promise<void> {
-	const deadline = performance.now() + RENAME_RETRY_BUDGET_MS;
+	const deadline = options.deadline ?? performance.now() + RENAME_RETRY_BUDGET_MS;
 	let delayMs = RENAME_RETRY_INITIAL_DELAY_MS;
 	for (let attempts = 1; ; attempts++) {
 		try {
@@ -1115,13 +1115,12 @@ async function renameThroughTransientHolder(
 						() => 'absent'
 					);
 				logger.warn(
-					`Could not rename ${fromPath} to ${toPath}: ${code} after ${attempts} attempts over ` +
-						`${Math.round(RENAME_RETRY_BUDGET_MS + performance.now() - deadline)}ms ` +
+					`Could not rename ${fromPath} to ${toPath}: ${code} after ${attempts} attempts ` +
 						`(source ${await exists(fromPath)}, destination ${await exists(toPath)})`
 				);
 				throw error;
 			}
-			if (onBackoff) await onBackoff(delayMs);
+			if (options.onBackoff) await options.onBackoff(delayMs, deadline);
 			else await delay(delayMs);
 			delayMs = Math.min(delayMs * 2, RENAME_RETRY_MAX_DELAY_MS);
 		}
@@ -2164,9 +2163,8 @@ export async function activateCandidateApplication(application: Application, dep
 	// B1 — the live tree moves aside. It stays the rollback source until B4 retires it.
 	let asidePath: string | undefined;
 	let priorAbsentRecordPath: string | undefined;
-	// Whether the previous tree is currently AT the aside path. The swap below puts it back and takes it
-	// away again around every wait, so "an aside path was chosen" and "the live path is empty right now"
-	// stop being the same thing — and compensation has to know which.
+	// The swap below moves the previous tree back and forth around every wait, so a chosen aside path no
+	// longer implies the tree is at it — and compensation needs to know which.
 	let liveIsDisplaced = false;
 	if (liveExists) {
 		asidePath = join(asideStagingDir, `${IN_PROGRESS_ASIDE_PREFIX}${Date.now()}-${process.pid}-${randomUUID()}`);
@@ -2202,23 +2200,21 @@ export async function activateCandidateApplication(application: Application, dep
 	// because the live path now holds the candidate and renaming the aside back over it cannot succeed. A
 	// compensating step there fails its own rollback and reports a failure for a deploy that is live.
 	try {
-		await renameThroughTransientHolder(candidateDirPath, liveDirPath, async (delayMs) => {
-			// The previous version serves through the wait. Retrying where the rename stands would leave the
-			// live path absent for the whole budget instead of for one attempt, and a watcher reports that
-			// to its consumers — `EntryHandler` emits `unlinkDir` and the static handler drops the
-			// component's routes — so riding out a five-second holder would cost what harper#2345 exists to
-			// prevent. A first-ever deploy has nothing to put back and retries in place.
-			if (!liveIsDisplaced) return delay(delayMs);
-			// Plain renames, not retrying ones: the deadline above is the whole operation's bound, and either
-			// of these throwing lands in the compensation below with `liveIsDisplaced` saying what it has to
-			// undo.
-			await rename(asidePath!, liveDirPath);
-			liveIsDisplaced = false;
-			await syncRenameParents(asidePath!, liveDirPath);
-			await delay(delayMs);
-			await rename(liveDirPath, asidePath!);
-			liveIsDisplaced = true;
-			await syncRenameParents(liveDirPath, asidePath!);
+		await renameThroughTransientHolder(candidateDirPath, liveDirPath, {
+			// The previous version occupies the live path through the wait rather than the component being
+			// absent for the whole budget: a read of a component file, and any concurrent scan of the
+			// components root, still finds the last committed tree. (Watchers are already paused for the
+			// deploy, so they are not what this protects.) A first-ever deploy has nothing to put back.
+			onBackoff: async (delayMs, deadline) => {
+				if (!liveIsDisplaced) return delay(delayMs);
+				await renameThroughTransientHolder(asidePath!, liveDirPath, { deadline });
+				liveIsDisplaced = false;
+				await syncRenameParents(asidePath!, liveDirPath);
+				await delay(delayMs);
+				await renameThroughTransientHolder(liveDirPath, asidePath!, { deadline });
+				liveIsDisplaced = true;
+				await syncRenameParents(liveDirPath, asidePath!);
+			},
 		});
 	} catch (error) {
 		await compensate(error, 'move the candidate into place', restoreLive, application);

--- a/unitTests/components/deployActivation.test.js
+++ b/unitTests/components/deployActivation.test.js
@@ -7,6 +7,8 @@ const { existsSync } = require('node:fs');
 const os = require('node:os');
 const { Readable } = require('node:stream');
 const { setTimeout: sleep } = require('node:timers/promises');
+const { waitFor } = require('../waitFor.js');
+const harperLogger = require('#src/utility/logging/harper_logger');
 
 const testUtils = require('../testUtils.js');
 testUtils.preTestPrep();
@@ -552,16 +554,6 @@ describe('activation transaction', () => {
 			await body();
 		});
 
-	// Bounded, because an activation that throws before the marker appears would otherwise leave the
-	// release promise pending forever and mocha's `timeout: 0` would hang the run instead of reporting it.
-	async function waitFor(condition, what) {
-		const deadline = Date.now() + 20000;
-		while (!(await condition())) {
-			if (Date.now() >= deadline) throw new Error(`timed out waiting for ${what}`);
-			await sleep(5);
-		}
-	}
-
 	// The activation journal is the last thing written into the deployment directory before the renames
 	// start, and `writeControlFileDurably` removes its temp file right after. Both have to be done before
 	// that directory can be locked, or the lock blocks the journal write instead of the swap.
@@ -571,14 +563,31 @@ describe('activation transaction', () => {
 	};
 
 	/**
-	 * Park the activation in B1's retry (the components root is already locked when it gets there), then
-	 * hand the swap a lock of its own and let B1 through. Deterministic in ORDER rather than in timing:
-	 * B1 retries for five seconds, so arming the second stage cannot arrive too late.
+	 * Park the activation in the move-aside's retry (the components root is locked before it gets there),
+	 * then hand the swap a lock of its own and let the move-aside through. The hold covers the microseconds
+	 * between the journal landing and the first rename; the retry counts the callers assert are what turn a
+	 * miss into a failure rather than a silent pass.
 	 */
 	async function lockSwapWhileB1Retries(root, deploymentDir) {
-		await waitFor(journalSettled(deploymentDir), 'the activation journal');
+		await waitFor(journalSettled(deploymentDir), { timeout: 20000, interval: 5, message: 'no activation journal' });
+		await sleep(150);
 		await fs.chmod(deploymentDir, 0o500);
 		await fs.chmod(root, 0o700);
+	}
+
+	// A retry is only provable by the line the helper logs when one happened; an elapsed-time assertion is
+	// satisfied by a slow runner that never retried at all.
+	async function countingRetries(body) {
+		const retried = [];
+		const originalWarn = harperLogger.warn;
+		harperLogger.warn = (...args) => {
+			if (String(args[0]).includes('only on attempt')) retried.push(String(args[0]));
+		};
+		try {
+			return await body(retried);
+		} finally {
+			harperLogger.warn = originalWarn;
+		}
 	}
 
 	transientRenameTest('retries a transient failure moving the live tree aside', async () => {
@@ -593,24 +602,23 @@ describe('activation transaction', () => {
 		app.dirPath = live;
 
 		await fs.chmod(root, 0o500);
-		const release = (async () => {
-			await waitFor(journalSettled(deployment), 'the activation journal');
-			await sleep(150);
-			await fs.chmod(root, 0o700);
-		})();
-		let elapsed;
-		try {
-			const startedAt = Date.now();
-			await activateCandidateApplication(app, 'd1');
-			elapsed = Date.now() - startedAt;
-		} finally {
-			await release.catch(() => {});
-			await fs.chmod(root, 0o700).catch(() => {});
-		}
+		const retried = await countingRetries(async (retries) => {
+			const release = (async () => {
+				await waitFor(journalSettled(deployment), { timeout: 20000, interval: 5, message: 'no activation journal' });
+				await sleep(150);
+				await fs.chmod(root, 0o700);
+			})();
+			try {
+				await activateCandidateApplication(app, 'd1');
+			} finally {
+				await release.catch(() => {});
+				await fs.chmod(root, 0o700).catch(() => {});
+			}
+			return retries;
+		});
 
 		assert.strictEqual(await readLive(root, 'web'), 'CANDIDATE\n', 'the holder released and the deploy landed');
-		// Measured across the activation alone, so it cannot be satisfied by waiting on the release timer.
-		assert.ok(elapsed >= 150, `B1 retried rather than winning a race with the lock (took ${elapsed}ms)`);
+		assert.strictEqual(retried.length, 1, `exactly the move-aside retried; saw ${JSON.stringify(retried)}`);
 		await fs.rm(root, { recursive: true, force: true });
 	});
 
@@ -626,24 +634,24 @@ describe('activation transaction', () => {
 		app.dirPath = live;
 
 		await fs.chmod(root, 0o500);
-		const release = (async () => {
-			await waitFor(journalSettled(deployment), 'the activation journal');
-			await sleep(150);
-			await fs.chmod(root, 0o700);
-		})();
-		let elapsed;
-		try {
-			const startedAt = Date.now();
-			await activateCandidateApplication(app, 'd1');
-			elapsed = Date.now() - startedAt;
-		} finally {
-			await release.catch(() => {});
-			await fs.chmod(root, 0o700).catch(() => {});
-		}
+		const retried = await countingRetries(async (retries) => {
+			const release = (async () => {
+				await waitFor(journalSettled(deployment), { timeout: 20000, interval: 5, message: 'no activation journal' });
+				await sleep(150);
+				await fs.chmod(root, 0o700);
+			})();
+			try {
+				await activateCandidateApplication(app, 'd1');
+			} finally {
+				await release.catch(() => {});
+				await fs.chmod(root, 0o700).catch(() => {});
+			}
+			return retries;
+		});
 
 		assert.strictEqual(await readLive(root, 'web'), 'CANDIDATE\n');
 		assert.strictEqual(app.isNewComponent, true);
-		assert.ok(elapsed >= 150, `B2 retried rather than winning a race with the lock (took ${elapsed}ms)`);
+		assert.strictEqual(retried.length, 1, `exactly the swap retried; saw ${JSON.stringify(retried)}`);
 		await fs.rm(root, { recursive: true, force: true });
 	});
 
@@ -663,23 +671,25 @@ describe('activation transaction', () => {
 			app.dirPath = live;
 
 			await fs.chmod(root, 0o500);
-			const release = (async () => {
-				await lockSwapWhileB1Retries(root, deployment);
-				await sleep(400);
-				await fs.chmod(deployment, 0o700);
-			})();
-			let elapsed;
-			try {
-				const startedAt = Date.now();
-				await activateCandidateApplication(app, 'd1');
-				elapsed = Date.now() - startedAt;
-			} finally {
-				await release.catch(() => {});
-				await fs.chmod(deployment, 0o700).catch(() => {});
-				await fs.chmod(root, 0o700).catch(() => {});
-			}
+			const retried = await countingRetries(async (retries) => {
+				const release = (async () => {
+					await lockSwapWhileB1Retries(root, deployment);
+					await sleep(400);
+					await fs.chmod(deployment, 0o700);
+				})();
+				try {
+					await activateCandidateApplication(app, 'd1');
+				} finally {
+					await release.catch(() => {});
+					await fs.chmod(deployment, 0o700).catch(() => {});
+					await fs.chmod(root, 0o700).catch(() => {});
+				}
+				return retries;
+			});
 
-			assert.ok(elapsed >= 400, `the swap waited out the lock rather than winning a race (took ${elapsed}ms)`);
+			// Both stages retried: the move-aside against the locked root, then the swap against the locked
+			// deployment directory — the only path that runs the put-back cycle to a successful attempt.
+			assert.strictEqual(retried.length, 2, `move-aside and swap both retried; saw ${JSON.stringify(retried)}`);
 			assert.strictEqual(await readLive(root, 'web'), 'CANDIDATE\n', 'the candidate is live');
 			assert.strictEqual(
 				existsSync(path.join(root, ASIDE_STAGING_DIR, 'web')),
@@ -734,20 +744,19 @@ describe('activation transaction', () => {
 			['LIVE\n'],
 			'a readable live path during the retry is always the previous release, never a partial tree'
 		);
-		// Each attempt still moves the tree aside for the rename itself, so a few misses are expected; the
-		// property under test is that the WAIT happens with the previous version in place.
+		// Each attempt still moves the tree aside for the rename itself, and the directory fsyncs around it
+		// land inside that window, so misses scale with disk latency. The threshold only has to separate
+		// this from retrying in place, which reads zero.
 		assert.ok(
-			readable.length > samples.length * 0.75,
+			readable.length > samples.length * 0.5,
 			`the previous version should be in place for most of the retry window; ${readable.length}/${samples.length} reads found it`
 		);
 		assert.strictEqual(await readLive(root, 'web'), 'LIVE\n', 'and it is what is live once the deploy gives up');
 		await fs.rm(root, { recursive: true, force: true });
 	});
 
-	// The only coverage that runs on the platform this change is for. Opportunistic by construction: it
-	// holds a handle inside the candidate across the swap and releases it, so it passes whether or not
-	// Windows refuses the rename — what it proves is that the activation still completes with a handle
-	// open in the tree it is moving, which nothing else on the Windows gate exercises.
+	// Opportunistic: it passes whether or not Windows refuses a rename with a handle open inside the tree
+	// being moved. What it establishes is that the activation completes either way.
 	it('activates with a file handle open inside the candidate', async function () {
 		if (process.platform !== 'win32') return this.skip();
 		const root = await newRoot('win-handle');

--- a/unitTests/components/deployActivation.test.js
+++ b/unitTests/components/deployActivation.test.js
@@ -543,29 +543,42 @@ describe('activation transaction', () => {
 		await fs.rm(root, { recursive: true, force: true });
 	});
 
-	// The Windows sharing lock these stand in for cannot be produced here, so they use the one portable
-	// way to make a rename fail and then stop failing: the write permission on its parent directory.
-	// POSIX only, and not as root, where permissions are not enforced.
+	// A Windows sharing lock cannot be produced on POSIX, so these use the one portable way to make a
+	// rename fail and then stop failing: the write permission on its parent directory. Not as root, where
+	// permissions are not enforced.
 	const transientRenameTest = (title, body) =>
 		it(title, async function () {
 			if (process.platform === 'win32' || process.getuid?.() === 0) return this.skip();
 			await body();
 		});
 
-	// `.complete` is the last thing written before the activation reaches its first rename, so holding the
-	// lock past it is what makes the block land on the rename under test rather than on the setup ahead of
-	// it — a fixed timer would let a loaded runner finish the setup late and never retry at all.
-	async function unlockAfterFirstAttempt(deploymentDir, unlock, holdMs = 100) {
-		while (!existsSync(path.join(deploymentDir, '.complete'))) await sleep(5);
-		await sleep(holdMs);
-		await unlock();
+	// Bounded, because an activation that throws before the marker appears would otherwise leave the
+	// release promise pending forever and mocha's `timeout: 0` would hang the run instead of reporting it.
+	async function waitFor(condition, what) {
+		const deadline = Date.now() + 20000;
+		while (!(await condition())) {
+			if (Date.now() >= deadline) throw new Error(`timed out waiting for ${what}`);
+			await sleep(5);
+		}
 	}
 
-	// The activation journal lands in the deployment directory after `.complete`, and its temp file is
-	// removed right after; both have to be done before that directory can be locked.
-	async function journalSettled(deploymentDir) {
+	// The activation journal is the last thing written into the deployment directory before the renames
+	// start, and `writeControlFileDurably` removes its temp file right after. Both have to be done before
+	// that directory can be locked, or the lock blocks the journal write instead of the swap.
+	const journalSettled = (deploymentDir) => async () => {
 		const entries = await fs.readdir(deploymentDir).catch(() => []);
 		return entries.includes('.activation.json') && !entries.some((entry) => entry.includes('.partial-'));
+	};
+
+	/**
+	 * Park the activation in B1's retry (the components root is already locked when it gets there), then
+	 * hand the swap a lock of its own and let B1 through. Deterministic in ORDER rather than in timing:
+	 * B1 retries for five seconds, so arming the second stage cannot arrive too late.
+	 */
+	async function lockSwapWhileB1Retries(root, deploymentDir) {
+		await waitFor(journalSettled(deploymentDir), 'the activation journal');
+		await fs.chmod(deploymentDir, 0o500);
+		await fs.chmod(root, 0o700);
 	}
 
 	transientRenameTest('retries a transient failure moving the live tree aside', async () => {
@@ -580,17 +593,24 @@ describe('activation transaction', () => {
 		app.dirPath = live;
 
 		await fs.chmod(root, 0o500);
-		const release = unlockAfterFirstAttempt(deployment, () => fs.chmod(root, 0o700));
-		const startedAt = Date.now();
+		const release = (async () => {
+			await waitFor(journalSettled(deployment), 'the activation journal');
+			await sleep(150);
+			await fs.chmod(root, 0o700);
+		})();
+		let elapsed;
 		try {
+			const startedAt = Date.now();
 			await activateCandidateApplication(app, 'd1');
+			elapsed = Date.now() - startedAt;
 		} finally {
-			await release;
+			await release.catch(() => {});
 			await fs.chmod(root, 0o700).catch(() => {});
 		}
 
 		assert.strictEqual(await readLive(root, 'web'), 'CANDIDATE\n', 'the holder released and the deploy landed');
-		assert.ok(Date.now() - startedAt >= 100, 'and it got there by retrying, not by winning a race with the lock');
+		// Measured across the activation alone, so it cannot be satisfied by waiting on the release timer.
+		assert.ok(elapsed >= 150, `B1 retried rather than winning a race with the lock (took ${elapsed}ms)`);
 		await fs.rm(root, { recursive: true, force: true });
 	});
 
@@ -606,26 +626,32 @@ describe('activation transaction', () => {
 		app.dirPath = live;
 
 		await fs.chmod(root, 0o500);
-		const release = unlockAfterFirstAttempt(deployment, () => fs.chmod(root, 0o700));
-		const startedAt = Date.now();
+		const release = (async () => {
+			await waitFor(journalSettled(deployment), 'the activation journal');
+			await sleep(150);
+			await fs.chmod(root, 0o700);
+		})();
+		let elapsed;
 		try {
+			const startedAt = Date.now();
 			await activateCandidateApplication(app, 'd1');
+			elapsed = Date.now() - startedAt;
 		} finally {
-			await release;
+			await release.catch(() => {});
 			await fs.chmod(root, 0o700).catch(() => {});
 		}
 
 		assert.strictEqual(await readLive(root, 'web'), 'CANDIDATE\n');
 		assert.strictEqual(app.isNewComponent, true);
-		assert.ok(Date.now() - startedAt >= 100, 'reached by retrying B2');
+		assert.ok(elapsed >= 150, `B2 retried rather than winning a race with the lock (took ${elapsed}ms)`);
 		await fs.rm(root, { recursive: true, force: true });
 	});
 
 	transientRenameTest(
 		'completes the swap after putting the previous version back and taking it away again',
 		async () => {
-			// The redeploy case the other tests miss: nothing else drives the put-back cycle to a
-			// successful attempt.
+			// The redeploy case the other tests miss: nothing else drives the put-back cycle to a successful
+			// attempt.
 			const root = await newRoot('b2-cycle');
 			const live = path.join(root, 'web');
 			await writeTree(live, 'LIVE\n');
@@ -636,23 +662,24 @@ describe('activation transaction', () => {
 			const app = new Application({ name: 'web' });
 			app.dirPath = live;
 
-			// Lock the deployment directory — B2's source parent — only once the journal is written, so
-			// nothing ahead of the swap is blocked and every B2 attempt fails until the second unlock.
+			await fs.chmod(root, 0o500);
 			const release = (async () => {
-				while (!(await journalSettled(deployment))) await sleep(5);
-				await fs.chmod(deployment, 0o500);
+				await lockSwapWhileB1Retries(root, deployment);
 				await sleep(400);
 				await fs.chmod(deployment, 0o700);
 			})();
-			const startedAt = Date.now();
+			let elapsed;
 			try {
+				const startedAt = Date.now();
 				await activateCandidateApplication(app, 'd1');
+				elapsed = Date.now() - startedAt;
 			} finally {
-				await release;
+				await release.catch(() => {});
 				await fs.chmod(deployment, 0o700).catch(() => {});
+				await fs.chmod(root, 0o700).catch(() => {});
 			}
 
-			assert.ok(Date.now() - startedAt >= 400, 'the swap waited out the lock rather than winning a race');
+			assert.ok(elapsed >= 400, `the swap waited out the lock rather than winning a race (took ${elapsed}ms)`);
 			assert.strictEqual(await readLive(root, 'web'), 'CANDIDATE\n', 'the candidate is live');
 			assert.strictEqual(
 				existsSync(path.join(root, ASIDE_STAGING_DIR, 'web')),
@@ -674,21 +701,14 @@ describe('activation transaction', () => {
 		const app = new Application({ name: 'web' });
 		app.dirPath = live;
 
-		// Two stages, so the rename that keeps failing is B2 and only B2: the root starts read-only, which
-		// parks B1 in its retry, and the timer then locks B2's source parent and unlocks the root. Sampling
-		// starts with the lock, so it observes only the window B2 is retrying in.
 		await fs.chmod(root, 0o500);
 		const samples = [];
 		let swapLocked = false;
 		let done = false;
-		const lockSwap = setTimeout(() => {
-			void fs
-				.chmod(deployment, 0o500)
-				.then(() => fs.chmod(root, 0o700))
-				.then(() => {
-					swapLocked = true;
-				});
-		}, 150);
+		const release = (async () => {
+			await lockSwapWhileB1Retries(root, deployment);
+			swapLocked = true;
+		})();
 		const sampler = (async () => {
 			while (!swapLocked && !done) await sleep(5);
 			while (!done) {
@@ -700,8 +720,8 @@ describe('activation transaction', () => {
 		try {
 			await assert.rejects(() => activateCandidateApplication(app, 'd1'), { code: 'EACCES' });
 		} finally {
-			clearTimeout(lockSwap);
 			done = true;
+			await release.catch(() => {});
 			await sampler;
 			await fs.chmod(deployment, 0o700).catch(() => {});
 			await fs.chmod(root, 0o700).catch(() => {});
@@ -715,13 +735,38 @@ describe('activation transaction', () => {
 			'a readable live path during the retry is always the previous release, never a partial tree'
 		);
 		// Each attempt still moves the tree aside for the rename itself, so a few misses are expected; the
-		// property under test is that the WAIT happens with the previous version in place. Retrying where
-		// the rename stands would read close to zero here.
+		// property under test is that the WAIT happens with the previous version in place.
 		assert.ok(
 			readable.length > samples.length * 0.75,
 			`the previous version should be in place for most of the retry window; ${readable.length}/${samples.length} reads found it`
 		);
 		assert.strictEqual(await readLive(root, 'web'), 'LIVE\n', 'and it is what is live once the deploy gives up');
+		await fs.rm(root, { recursive: true, force: true });
+	});
+
+	// The only coverage that runs on the platform this change is for. Opportunistic by construction: it
+	// holds a handle inside the candidate across the swap and releases it, so it passes whether or not
+	// Windows refuses the rename — what it proves is that the activation still completes with a handle
+	// open in the tree it is moving, which nothing else on the Windows gate exercises.
+	it('activates with a file handle open inside the candidate', async function () {
+		if (process.platform !== 'win32') return this.skip();
+		const root = await newRoot('win-handle');
+		const live = path.join(root, 'web');
+		await writeTree(live, 'LIVE\n');
+		const candidate = candidateApplicationPath(live, 'd1');
+		await writeTree(candidate, 'CANDIDATE\n');
+		const app = new Application({ name: 'web' });
+		app.dirPath = live;
+
+		const handle = await fs.open(path.join(candidate, 'index.js'), 'r');
+		const release = sleep(200).then(() => handle.close());
+		try {
+			await activateCandidateApplication(app, 'd1');
+		} finally {
+			await release.catch(() => handle.close().catch(() => {}));
+		}
+
+		assert.strictEqual(await readLive(root, 'web'), 'CANDIDATE\n');
 		await fs.rm(root, { recursive: true, force: true });
 	});
 

--- a/unitTests/components/deployActivation.test.js
+++ b/unitTests/components/deployActivation.test.js
@@ -658,8 +658,7 @@ describe('activation transaction', () => {
 	transientRenameTest(
 		'completes the swap after putting the previous version back and taking it away again',
 		async () => {
-			// The redeploy case the other tests miss: nothing else drives the put-back cycle to a successful
-			// attempt.
+			// A redeploy, so the swap's backoff runs the full put-back cycle rather than sleeping in place.
 			const root = await newRoot('b2-cycle');
 			const live = path.join(root, 'web');
 			await writeTree(live, 'LIVE\n');

--- a/unitTests/components/deployActivation.test.js
+++ b/unitTests/components/deployActivation.test.js
@@ -543,19 +543,36 @@ describe('activation transaction', () => {
 		await fs.rm(root, { recursive: true, force: true });
 	});
 
-	// The Windows sharing lock these three stand in for cannot be produced here, so they use the one
-	// portable way to make a rename fail and then stop failing: the write permission on its parent
-	// directory. POSIX only, and not as root, where permissions are not enforced.
+	// The Windows sharing lock these stand in for cannot be produced here, so they use the one portable
+	// way to make a rename fail and then stop failing: the write permission on its parent directory.
+	// POSIX only, and not as root, where permissions are not enforced.
 	const transientRenameTest = (title, body) =>
 		it(title, async function () {
 			if (process.platform === 'win32' || process.getuid?.() === 0) return this.skip();
 			await body();
 		});
 
+	// `.complete` is the last thing written before the activation reaches its first rename, so holding the
+	// lock past it is what makes the block land on the rename under test rather than on the setup ahead of
+	// it — a fixed timer would let a loaded runner finish the setup late and never retry at all.
+	async function unlockAfterFirstAttempt(deploymentDir, unlock, holdMs = 100) {
+		while (!existsSync(path.join(deploymentDir, '.complete'))) await sleep(5);
+		await sleep(holdMs);
+		await unlock();
+	}
+
+	// The activation journal lands in the deployment directory after `.complete`, and its temp file is
+	// removed right after; both have to be done before that directory can be locked.
+	async function journalSettled(deploymentDir) {
+		const entries = await fs.readdir(deploymentDir).catch(() => []);
+		return entries.includes('.activation.json') && !entries.some((entry) => entry.includes('.partial-'));
+	}
+
 	transientRenameTest('retries a transient failure moving the live tree aside', async () => {
 		const root = await newRoot('b1-retry');
 		const live = path.join(root, 'web');
 		await writeTree(live, 'LIVE\n');
+		const deployment = path.dirname(candidateApplicationPath(live, 'd1'));
 		await writeTree(candidateApplicationPath(live, 'd1'), 'CANDIDATE\n');
 		// Pre-created, so a read-only root blocks B1's rename rather than the staging mkdir ahead of it.
 		await fs.mkdir(path.join(root, ASIDE_STAGING_DIR, 'web'), { recursive: true, mode: 0o700 });
@@ -563,15 +580,17 @@ describe('activation transaction', () => {
 		app.dirPath = live;
 
 		await fs.chmod(root, 0o500);
-		const release = setTimeout(() => void fs.chmod(root, 0o700), 200);
+		const release = unlockAfterFirstAttempt(deployment, () => fs.chmod(root, 0o700));
+		const startedAt = Date.now();
 		try {
 			await activateCandidateApplication(app, 'd1');
 		} finally {
-			clearTimeout(release);
+			await release;
 			await fs.chmod(root, 0o700).catch(() => {});
 		}
 
 		assert.strictEqual(await readLive(root, 'web'), 'CANDIDATE\n', 'the holder released and the deploy landed');
+		assert.ok(Date.now() - startedAt >= 100, 'and it got there by retrying, not by winning a race with the lock');
 		await fs.rm(root, { recursive: true, force: true });
 	});
 
@@ -580,24 +599,69 @@ describe('activation transaction', () => {
 		// the one the Windows CI failure names.
 		const root = await newRoot('b2-retry');
 		const live = path.join(root, 'web');
+		const deployment = path.dirname(candidateApplicationPath(live, 'd1'));
 		await writeTree(candidateApplicationPath(live, 'd1'), 'CANDIDATE\n');
 		await fs.mkdir(path.join(root, ASIDE_STAGING_DIR, 'web'), { recursive: true, mode: 0o700 });
 		const app = new Application({ name: 'web' });
 		app.dirPath = live;
 
 		await fs.chmod(root, 0o500);
-		const release = setTimeout(() => void fs.chmod(root, 0o700), 200);
+		const release = unlockAfterFirstAttempt(deployment, () => fs.chmod(root, 0o700));
+		const startedAt = Date.now();
 		try {
 			await activateCandidateApplication(app, 'd1');
 		} finally {
-			clearTimeout(release);
+			await release;
 			await fs.chmod(root, 0o700).catch(() => {});
 		}
 
 		assert.strictEqual(await readLive(root, 'web'), 'CANDIDATE\n');
 		assert.strictEqual(app.isNewComponent, true);
+		assert.ok(Date.now() - startedAt >= 100, 'reached by retrying B2');
 		await fs.rm(root, { recursive: true, force: true });
 	});
+
+	transientRenameTest(
+		'completes the swap after putting the previous version back and taking it away again',
+		async () => {
+			// The redeploy case the other tests miss: nothing else drives the put-back cycle to a
+			// successful attempt.
+			const root = await newRoot('b2-cycle');
+			const live = path.join(root, 'web');
+			await writeTree(live, 'LIVE\n');
+			const candidate = candidateApplicationPath(live, 'd1');
+			await writeTree(candidate, 'CANDIDATE\n');
+			const deployment = path.dirname(candidate);
+			await fs.mkdir(path.join(root, ASIDE_STAGING_DIR, 'web'), { recursive: true, mode: 0o700 });
+			const app = new Application({ name: 'web' });
+			app.dirPath = live;
+
+			// Lock the deployment directory — B2's source parent — only once the journal is written, so
+			// nothing ahead of the swap is blocked and every B2 attempt fails until the second unlock.
+			const release = (async () => {
+				while (!(await journalSettled(deployment))) await sleep(5);
+				await fs.chmod(deployment, 0o500);
+				await sleep(400);
+				await fs.chmod(deployment, 0o700);
+			})();
+			const startedAt = Date.now();
+			try {
+				await activateCandidateApplication(app, 'd1');
+			} finally {
+				await release;
+				await fs.chmod(deployment, 0o700).catch(() => {});
+			}
+
+			assert.ok(Date.now() - startedAt >= 400, 'the swap waited out the lock rather than winning a race');
+			assert.strictEqual(await readLive(root, 'web'), 'CANDIDATE\n', 'the candidate is live');
+			assert.strictEqual(
+				existsSync(path.join(root, ASIDE_STAGING_DIR, 'web')),
+				false,
+				'and the record the put-back cycle kept moving is still the one that gets retired and swept'
+			);
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	);
 
 	transientRenameTest('keeps the previous version in place while it retries the swap', async () => {
 		const root = await newRoot('swap-availability');
@@ -610,10 +674,9 @@ describe('activation transaction', () => {
 		const app = new Application({ name: 'web' });
 		app.dirPath = live;
 
-		// Two stages, so the rename that keeps failing is B2 and only B2. The root starts read-only, which
-		// parks B1 in its retry; the timer then locks the deployment directory — B2's source parent, and
-		// nothing else's — and unlocks the root, so B1's next attempt succeeds and every B2 attempt fails.
-		// Sampling starts with the lock, so it observes only the window B2 is retrying in.
+		// Two stages, so the rename that keeps failing is B2 and only B2: the root starts read-only, which
+		// parks B1 in its retry, and the timer then locks B2's source parent and unlocks the root. Sampling
+		// starts with the lock, so it observes only the window B2 is retrying in.
 		await fs.chmod(root, 0o500);
 		const samples = [];
 		let swapLocked = false;

--- a/unitTests/components/deployActivation.test.js
+++ b/unitTests/components/deployActivation.test.js
@@ -6,6 +6,7 @@ const fs = require('node:fs/promises');
 const { existsSync } = require('node:fs');
 const os = require('node:os');
 const { Readable } = require('node:stream');
+const { setTimeout: sleep } = require('node:timers/promises');
 
 const testUtils = require('../testUtils.js');
 testUtils.preTestPrep();
@@ -539,6 +540,125 @@ describe('activation transaction', () => {
 
 		await assert.rejects(() => activateCandidateApplication(app, 'missing'), /no candidate build/);
 		assert.strictEqual(await readLive(root, 'web'), 'LIVE\n');
+		await fs.rm(root, { recursive: true, force: true });
+	});
+
+	// The Windows sharing lock these three stand in for cannot be produced here, so they use the one
+	// portable way to make a rename fail and then stop failing: the write permission on its parent
+	// directory. POSIX only, and not as root, where permissions are not enforced.
+	const transientRenameTest = (title, body) =>
+		it(title, async function () {
+			if (process.platform === 'win32' || process.getuid?.() === 0) return this.skip();
+			await body();
+		});
+
+	transientRenameTest('retries a transient failure moving the live tree aside', async () => {
+		const root = await newRoot('b1-retry');
+		const live = path.join(root, 'web');
+		await writeTree(live, 'LIVE\n');
+		await writeTree(candidateApplicationPath(live, 'd1'), 'CANDIDATE\n');
+		// Pre-created, so a read-only root blocks B1's rename rather than the staging mkdir ahead of it.
+		await fs.mkdir(path.join(root, ASIDE_STAGING_DIR, 'web'), { recursive: true, mode: 0o700 });
+		const app = new Application({ name: 'web' });
+		app.dirPath = live;
+
+		await fs.chmod(root, 0o500);
+		const release = setTimeout(() => void fs.chmod(root, 0o700), 200);
+		try {
+			await activateCandidateApplication(app, 'd1');
+		} finally {
+			clearTimeout(release);
+			await fs.chmod(root, 0o700).catch(() => {});
+		}
+
+		assert.strictEqual(await readLive(root, 'web'), 'CANDIDATE\n', 'the holder released and the deploy landed');
+		await fs.rm(root, { recursive: true, force: true });
+	});
+
+	transientRenameTest('retries a transient failure moving the candidate into place', async () => {
+		// A first-ever deploy, so B1 writes a record instead of renaming and the blocked rename is B2 —
+		// the one the Windows CI failure names.
+		const root = await newRoot('b2-retry');
+		const live = path.join(root, 'web');
+		await writeTree(candidateApplicationPath(live, 'd1'), 'CANDIDATE\n');
+		await fs.mkdir(path.join(root, ASIDE_STAGING_DIR, 'web'), { recursive: true, mode: 0o700 });
+		const app = new Application({ name: 'web' });
+		app.dirPath = live;
+
+		await fs.chmod(root, 0o500);
+		const release = setTimeout(() => void fs.chmod(root, 0o700), 200);
+		try {
+			await activateCandidateApplication(app, 'd1');
+		} finally {
+			clearTimeout(release);
+			await fs.chmod(root, 0o700).catch(() => {});
+		}
+
+		assert.strictEqual(await readLive(root, 'web'), 'CANDIDATE\n');
+		assert.strictEqual(app.isNewComponent, true);
+		await fs.rm(root, { recursive: true, force: true });
+	});
+
+	transientRenameTest('keeps the previous version in place while it retries the swap', async () => {
+		const root = await newRoot('swap-availability');
+		const live = path.join(root, 'web');
+		await writeTree(live, 'LIVE\n');
+		const candidate = candidateApplicationPath(live, 'd1');
+		await writeTree(candidate, 'CANDIDATE\n');
+		const deployment = path.dirname(candidate);
+		await fs.mkdir(path.join(root, ASIDE_STAGING_DIR, 'web'), { recursive: true, mode: 0o700 });
+		const app = new Application({ name: 'web' });
+		app.dirPath = live;
+
+		// Two stages, so the rename that keeps failing is B2 and only B2. The root starts read-only, which
+		// parks B1 in its retry; the timer then locks the deployment directory — B2's source parent, and
+		// nothing else's — and unlocks the root, so B1's next attempt succeeds and every B2 attempt fails.
+		// Sampling starts with the lock, so it observes only the window B2 is retrying in.
+		await fs.chmod(root, 0o500);
+		const samples = [];
+		let swapLocked = false;
+		let done = false;
+		const lockSwap = setTimeout(() => {
+			void fs
+				.chmod(deployment, 0o500)
+				.then(() => fs.chmod(root, 0o700))
+				.then(() => {
+					swapLocked = true;
+				});
+		}, 150);
+		const sampler = (async () => {
+			while (!swapLocked && !done) await sleep(5);
+			while (!done) {
+				samples.push(await fs.readFile(path.join(live, 'index.js'), 'utf8').catch((error) => error.code));
+				await sleep(25);
+			}
+		})();
+
+		try {
+			await assert.rejects(() => activateCandidateApplication(app, 'd1'), { code: 'EACCES' });
+		} finally {
+			clearTimeout(lockSwap);
+			done = true;
+			await sampler;
+			await fs.chmod(deployment, 0o700).catch(() => {});
+			await fs.chmod(root, 0o700).catch(() => {});
+		}
+
+		const readable = samples.filter((sample) => sample === 'LIVE\n');
+		assert.ok(samples.length > 20, `expected to sample the retry window, got ${samples.length} samples`);
+		assert.deepStrictEqual(
+			[...new Set(samples.filter((sample) => sample !== 'ENOENT'))],
+			['LIVE\n'],
+			'a readable live path during the retry is always the previous release, never a partial tree'
+		);
+		// Each attempt still moves the tree aside for the rename itself, so a few misses are expected; the
+		// property under test is that the WAIT happens with the previous version in place. Retrying where
+		// the rename stands would read close to zero here.
+		assert.ok(
+			readable.length > samples.length * 0.75,
+			`the previous version should be in place for most of the retry window; ${readable.length}/${samples.length} reads found it`
+		);
+		assert.strictEqual(await readLive(root, 'web'), 'LIVE\n', 'and it is what is live once the deploy gives up');
 		await fs.rm(root, { recursive: true, force: true });
 	});
 


### PR DESCRIPTION
`deploy_component` failed on the 2026-09-11 Windows nightly ([run 34572547753](https://github.com/HarperFast/harper/actions/runs/34572547753), Integration Tests 3/6, Node 24) with:

```
EPERM: operation not permitted, rename
  '...\components\.deploy-staging\f1805741-...\redeploy-pure-esm-runtime-app'
  -> '...\components\redeploy-pure-esm-runtime-app'
```

That is the commit-point swap of the build-aside-then-swap activation #2345 introduced — the one rename in the deploy path that did not exist before it. Windows refuses a rename outright while anything still holds a handle in the source tree, and the source here is a dependency tree `npm install` finished writing 330 ms earlier.

Every rename in the activation transaction and its recovery now goes through [`renameThroughTransientHolder`](https://github.com/HarperFast/harper/pull/2570/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R1092): capped exponential backoff (10→500 ms) against a five-second monotonic deadline, retried only on [`TRANSIENT_RENAME_CODES`](https://github.com/HarperFast/harper/pull/2570/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R1080) — `EPERM`/`EACCES`/`EBUSY`. A destination that already exists is structural state nothing here clears between attempts, so `EEXIST`/`ENOTEMPTY` still fail immediately and `settleInterruptedActivation` decides them; `rollbackExtractedDirectory` keeps its own wider set because its placeholder logic does repair the destination.

**The swap's backoff is not a plain sleep.** It [restores the displaced tree to the live path, waits there, and displaces it again](https://github.com/HarperFast/harper/pull/2570/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R2210), so the component is missing for one rename rather than for the whole budget. Those two renames retry as well, sharing the caller's deadline rather than opening their own. [`liveIsDisplaced`](https://github.com/HarperFast/harper/pull/2570/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R2170) is what keeps compensation correct once a chosen aside path no longer implies the tree is sitting at it — [`restoreLive`](https://github.com/HarperFast/harper/pull/2570/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R2182) reads it rather than the path.

Crash safety is unchanged: the loop only moves between two states already in `settleInterruptedActivation`'s matrix. A crash with live restored leaves live + candidate + journal and no aside record, which takes the both-present branch at [`Application.ts:1921`](https://github.com/HarperFast/harper/blob/main/components/Application.ts#L1921) and rolls back — correct, because the swap never committed. A crash with live displaced leaves exactly what today's window leaves, and rolls forward. Recovery's own two renames ([roll-forward](https://github.com/HarperFast/harper/pull/2570/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R1875), [roll-back](https://github.com/HarperFast/harper/pull/2570/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R1890)) retry too; both run only when the live path is already absent, so neither has anything to put back.

[DESIGN.md](https://github.com/HarperFast/harper/pull/2570/changes?w=1#diff-3dc5dd454e080eb849ee5efaf79df2585fbe0a06804d69249b4c81da05a63875R575) records the policy, what the put-back does and does not buy, and that the deadline is per top-level rename — a redeploy blocked the whole way spends up to five seconds each on the move-aside, the swap and the compensating restore.

## For the human reviewer

**Which explanation this landed on: a CI-environment transient, but one that exposed a real gap.** I traced every Harper-held handle on the candidate at the moment of the swap and found none outstanding — the install's process tree is confirmed gone before `installApplication` returns, the extraction pipeline is awaited, every `syncTreeContents` fsync handle is awaited closed, `syncDirectory` cannot even open a directory on Windows, the component watcher is on the live tree and on worker threads, and validation is a no-op on the main thread where this deploy ran. So the holder is outside the process. **That is inference, not evidence** — nothing in this change identifies it, and the code and DESIGN.md say so. The gap it exposed is real and independent of the holder's identity: #2345 introduced a whole-tree rename that the pre-#2345 path did not have (it `mkdir`'d and extracted into the live path), and it is the only Windows-reachable rename in the repo with no retry — `config/configUtils.ts:171`, `bin/copyDb.ts:750` and `rollbackExtractedDirectory` all have one.

**Open decisions, in the order I'd want them challenged:**

1. **The put-back has a cost the plain sleep does not.** Restoring the old tree during each wait lets anything reopen it — a component's own file reads, a cache writer, a scanner on the reappearing tree — and the re-displace can then fail on *that* handle instead. It retries within the same deadline, but a redeploy that a sleep-only backoff would have completed can still fail. Nobody has measured whether these waits actually attract new handles on Windows. Reverting is deleting the `onBackoff` block.
2. **The planning review changed this design, and its stated reason was wrong.** The first plan retried the swap in place; Codex's planning leg raised the availability regression and I adopted it. The justification I then wrote — that `EntryHandler` would emit `unlinkDir` and the static handler would drop routes — does not hold: `Scope` pauses every `EntryHandler` for the duration of a deploy (`components/Scope.ts:305-315`). The domain leg caught that in review. What the put-back actually protects is direct reads of the live path, concurrent scans of the components root, and threads the best-effort deploy broadcast did not reach. The behavior stands on that narrower benefit; if you don't buy it, see (1).
3. **`EPERM`/`EACCES` are retried on every platform, not just win32.** On Linux those are usually permanent permission errors, so a misconfigured deploy now takes 5–15 s and a warning to report instead of failing at once. Platform-gating is a one-line change but would need a different POSIX test stand-in, since the tests inject exactly these codes.
4. **The budget is a fixed 5 s per top-level rename.** A hold longer than that still fails the deploy. Any fixed budget has that edge; it is trivially tunable.

**Coverage gap, stated rather than papered over:** the Windows sharing lock itself is not reproduced. The four POSIX tests use directory permissions, which is a different errno path from a Windows sharing violation, and they skip on win32. The one test that does run there holds a file handle inside the candidate across the swap and is opportunistic by construction — it passes whether or not Windows refuses the rename, so what it establishes is that the path executes and does not regress, not that the lock reproduces. The Windows nightly is the real rollout evidence.

**Declined review findings**, each with the reason: a claimed blocker that a crash during a backoff silently loses the deploy (wrong branch — that state has no aside record, so it rolls back rather than rolling forward, and nothing reports success); `(error as any)?.code` defensive narrowing (the helper is `async`, so a thrown primitive is a rejection callers already handle); removing the backoff's directory fsyncs to widen the retry budget (on Windows `syncDirectory` returns before it creates a handle, so the cost there is near zero); and the `= {}` default plus `performance.now()` on the success path (a handful of calls per deploy, never a request path).

## Changes

- [`components/Application.ts`](https://github.com/HarperFast/harper/pull/2570/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763) — the retry helper, its code set and budget, and the five call sites above. On exhaustion it logs attempts and the state of both paths, reporting a failed `lstat` probe's own error code rather than calling it absent: an `EPERM` reading the destination is itself the evidence.
- [`unitTests/components/deployActivation.test.js`](https://github.com/HarperFast/harper/pull/2570/changes?w=1#diff-e29fa69245a6512c42e4be22185082a8692783c81ef5e626c3ccddd1171c8f5f) — five tests. [`countingRetries`](https://github.com/HarperFast/harper/pull/2570/changes?w=1#diff-e29fa69245a6512c42e4be22185082a8692783c81ef5e626c3ccddd1171c8f5fR580) captures the helper's retry log so each test asserts the retry it targets actually happened; an elapsed-time assertion is satisfied by a slow runner that never retried. [`lockSwapWhileB1Retries`](https://github.com/HarperFast/harper/pull/2570/changes?w=1#diff-e29fa69245a6512c42e4be22185082a8692783c81ef5e626c3ccddd1171c8f5fR571) parks the activation in the move-aside's retry before handing the swap a lock of its own.
- [`DESIGN.md`](https://github.com/HarperFast/harper/pull/2570/changes?w=1#diff-3dc5dd454e080eb849ee5efaf79df2585fbe0a06804d69249b4c81da05a63875R575) — added to the staged-deploy section.

## Verification

**Fails-on-base**, measured on `d6f4efaed` with base sources and a base `dist` build, then restored:

```
1) retries a transient failure moving the live tree aside
   EACCES … rename '<root>/web' -> '<root>/.deploy-aside/web/.in-progress-…'
   at activateCandidateApplication (components/Application.ts:2114)

2) retries a transient failure moving the candidate into place
   EACCES … rename '<root>/.deploy-staging/d1/web' -> '<root>/web'
   at activateCandidateApplication (components/Application.ts:2143)
```

The second reproduces the nightly's shape — `.deploy-staging/<id>/<component>` → `components/<component>` — at the same source line.

| gate | result |
|---|---|
| `test:unit:main` | 5471 passing. One failure, `configValidator › does not warn when a relative rootPath resolves within the limit`, is a cwd-path-length artifact of the long worktree path; that suite is in the Windows gate's own `EXCLUDED` list. |
| `test:unit:resources` | 2353 passing, 0 failing |
| `test:unit:bin` | 252 passing, 0 failing |
| `test:integration:all` | 2082 tests, 2057 passing, 1 failing — `QA-269 SQL UPDATE resets TTL`, a timing-sensitive TTL probe that passes 6/6 when re-run alone. 6 cancelled are the Ollama suite, which needs a live instance. |
| `integrationTests/deploy/**` | 77 tests, 76 passing, 0 failing — includes `stage-swap-availability.test.ts` and `redeploy-runtime-equivalence.test.ts`, the suite that failed on the nightly |
| `test:types`, `prettier --check .`, `oxlint` | clean; 13 pre-existing lint warnings, none in changed files |

`deployActivation.test.js` ran 8 consecutive times while tuning the fault injection; the availability test measured 193–196 of ~202 samples reading the previous release, against a 50% threshold chosen to separate it from retrying in place, which reads zero.

**CI on this PR.** `Integration Tests 3/6 (Windows, Node.js v24)` passes — the exact shard, on the exact platform, whose `redeploy-pure-esm-runtime-app` deploy produced the reported EPERM. All six Windows integration shards pass, as does `Unit Test (Windows, Node.js v24)`, whose `unitTests/components/**` group runs 1380 passing — that is where the win32 test executes, the four POSIX ones being skipped there.

That is not proof the fix works: the nightly failure is one sighting in nine nights and this shard passes on `main` most nights too. It establishes no regression on the target platform. **Nothing reproduces the Windows sharing lock locally**, so the nightly is still the first real test.

The one red check, `Next.js adapter integration (Node 24)`, is an Ubuntu mirror, not this change. Its `Install Playwright browsers` step times out at 10 minutes in `apt-get update` — `Ign: archive.ubuntu.com noble InRelease` stalls ~4m20s, then `noble-backports` another ~4m20s, while `packages.microsoft.com` and `dl.google.com` answer in milliseconds. `Run integration tests` is **skipped**, so no Harper code runs in the failing job; the same step took 25s on this workflow's last passing run earlier the same day. Node 22, on this identical commit, went red then green across re-runs purely on mirror speed, and its passing run did execute the adapter suite against this build.

`Framing-Verdict: better-alternative-exists` — adopted, not overruled; see decision 2 above.

Refs #2345
Refs #2315

Not chased, per the task's scope: a second deploy in the same job failed with `Failed to install dependencies for redeploy-package-metadata-app using custom install command: sh -c "exit 1"`, which is a test-fixture install-command issue, not this bug.



🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rdnm4ptcPWrZ4b2qiDxVRw

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=5 @ ac3ec8f487e2</sub>

<sub>Human-Review-Need: 4 @ ac3ec8f487e2</sub>
