### PR TITLE
Make subscription replay timing-independent

### DIFF
--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -335,7 +335,7 @@ describe('Subscription replay', () => {
 			await RecordTable.put(99, { name: 'pre2' });
 			await delay(10);
 			const subscription = await RecordTable.subscribe({ id: 99, startTime: startTime - 1 });
-			const expectedEventCount = 5;
+			const finalConcurrentValue = 'post4';
 			const events = [];
 			subscription.on('data', (event) => events.push(event));
 			const concurrentWrites = (async () => {
@@ -344,10 +344,16 @@ describe('Subscription replay', () => {
 				}
 			})();
 			await concurrentWrites;
-			await waitFor(() => events.length >= expectedEventCount, { timeout: 5000 }).catch(() => {});
+			await waitFor(() => events.some((event) => event.value?.name === finalConcurrentValue), {
+				timeout: 5000,
+			}).catch(() => {});
+			await delay(100);
 			subscription.return?.();
 
-			assert.ok(events.length >= expectedEventCount, `expected ${expectedEventCount} events, got ${events.length}`);
+			assert.ok(
+				events.some((event) => event.value?.name === finalConcurrentValue),
+				`expected final concurrent update ${finalConcurrentValue}, got ${events.length} events`
+			);
 			const pairs = events.map((e) => `${e.id}:${e.version}`);
 			assert.equal(new Set(pairs).size, pairs.length, 'duplicate (id,version) emitted');
 			// history then concurrent updates should be chronological throughout

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -335,15 +335,19 @@ describe('Subscription replay', () => {
 			await RecordTable.put(99, { name: 'pre2' });
 			await delay(10);
 			const subscription = await RecordTable.subscribe({ id: 99, startTime: startTime - 1 });
+			const expectedEventCount = 5;
+			const events = [];
+			subscription.on('data', (event) => events.push(event));
 			const concurrentWrites = (async () => {
 				for (let i = 0; i < 5; i++) {
 					await RecordTable.put(99, { name: 'post' + i });
 				}
 			})();
-			const events = await collect(subscription, 150);
 			await concurrentWrites;
+			await waitFor(() => events.length >= expectedEventCount, { timeout: 5000 }).catch(() => {});
 			subscription.return?.();
 
+			assert.ok(events.length >= expectedEventCount, `expected ${expectedEventCount} events, got ${events.length}`);
 			const pairs = events.map((e) => `${e.id}:${e.version}`);
 			assert.equal(new Set(pairs).size, pairs.length, 'duplicate (id,version) emitted');
 			// history then concurrent updates should be chronological throughout


### PR DESCRIPTION
Make the concurrent subscription-replay test wait for its final guaranteed same-record update instead of relying on a fixed quiet-time window. The [direct listener](https://github.com/HarperFast/harper/pull/2571/changes?w=1#diff-5bbee047cb24c2c491077195b51dec92b3ccd4c564827396e44c68f8a5e795a3R338) still exercises the real replay path, while the [bounded final-value wait and post-condition settle](https://github.com/HarperFast/harper/pull/2571/changes?w=1#diff-5bbee047cb24c2c491077195b51dec92b3ccd4c564827396e44c68f8a5e795a3R347) preserve duplicate-detection coverage.

## For the human reviewer

1. The completion oracle waits for the final `post4` value rather than every sequential update. The subscription layer intentionally coalesces superseded same-record versions, so a raw event count would be flaky or pass on replay history alone. This is readily reversible, but requiring every intermediate version would conflict with the existing delivery contract; look hardest at the [final-update assertion](https://github.com/HarperFast/harper/pull/2571/changes?w=1#diff-5bbee047cb24c2c491077195b51dec92b3ccd4c564827396e44c68f8a5e795a3R353), which reports the actual number of received events on timeout.

2. Verification stays at the real Table/storage/audit-broadcast/queue unit boundary. This is a test-only timing fix with no user-facing API change; transport and remote-replication coverage are outside the behavior this test exercises.

3. The duplicate-observation settle stays bounded at 100 ms, matching the file’s nearby duplicate tests. Extending it without a condition would reintroduce the wall-clock dependency this change removes; duplicates after the fully drained final event are outside this test’s deterministic observation window.

## Verification

- End-to-end route: not observable end-to-end because this changes only a unit-test collection strategy.
- `npm run build` — passed.
- `npx mocha unitTests/resources/subscriptionReplay.test.js` — 10 consecutive passes, then three parallel full-file runs under load (each: 27 passing, 9 expected pending).
- `npm run test:unit:resources` — passed (2,358 passing, 32 pending).
- `npm run lint` — blocked by 13 pre-existing warnings in unrelated files; the changed file passes direct oxlint and Prettier checks.
- `npm run test:unit:main` — 5,466 passing, 196 pending, with two environment failures: inherited `GIT_CONFIG_GLOBAL`/`GIT_PAGER`, and the 89-byte worktree path exceeding the socket-length fixture’s assumption.
- `npm run test:integration:all` — ran against freshly built `dist` and completed non-zero; the runner deleted its temporary logs before the terminal failure could be recovered. No emitted failure involved the changed test path.
- GitHub Actions — all build, integration, lint, format, coverage, Windows, Node 22, Node 24, and v5.2 cherry-pick checks passed. The Node 26 job failed before tests while `npm install --ignore-scripts` received a registry `E409` for `which`.

Refs #1617

Co-Authored-By: GPT-5 Codex <noreply@openai.com>

Generated with GPT-5 Codex

Complexity: easy

<sub>Review-Coverage: authored=codex; ran=gemini,claude; adjudicated=domain; declined=cursor-grok,cursor-composer; rounds=3 @ 87417eef9288</sub>

<sub>Human-Review-Need: 3 (decisions: completion-oracle, coverage-layer) @ 87417eef9288</sub>
