### PR TITLE
Honor install-script policy in custom component commands

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -725,12 +725,20 @@ Every npm install Harper invokes directly — automatic component installation a
 `install_node_modules` operation alike — composes its arguments in `packageManagerInstallArguments()`,
 which is production-only and adds `--omit=dev --no-audit --no-fund`. `--no-audit` is load-bearing, not
 hygiene: npm 10 puts even a `file:` link into its audit bulk request, and the registry's answer to that
-is unbounded from Harper's side.
+is unbounded from Harper's side. The operation accepts the established `install_allow_scripts`
+spelling (and `allowInstallScripts` for compatibility), defaulting to its historical `true`; false
+reaches the shared builder and adds `--ignore-scripts`.
 `installApplication()` skips the package-manager child entirely when the root manifest declares no
 production dependencies, non-empty workspaces, or enabled install lifecycle. An explicitly selected
 non-npm manager still runs so it can discover workspace configuration outside `package.json`, and it
 retains its own install defaults. A configured `install_command` remains the explicit escape hatch for
-build-time tooling. `readInstalledPackageMetadata()` must use the same automatic-work predicate so a
+build-time tooling, but not for lifecycle-script policy: unless `install_allow_scripts` is true, its
+spawn gets `npm_config_ignore_scripts=true`, which covers npm nested anywhere in the command without
+adding an argument that could break non-npm tooling. The setting uses npm's configuration namespace;
+other package managers that consume `npm_config_*` options can honor it too. When the policy is
+omitted, Harper warns that package lifecycle scripts—including `npm run` pre/post hooks—are suppressed
+and names both the operations-API and root-config opt-ins.
+`readInstalledPackageMetadata()` must use the same automatic-work predicate so a
 dev-only npm manifest does not force a restart on every redeploy for lacking a lockfile while an
 explicit non-npm workspace install still does. Absolute local archives are classified before
 package-protocol detection: a Windows drive letter's colon is path syntax, not an npm protocol. File

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -2986,8 +2986,15 @@ export async function installApplication(application: Application, buildDirPath 
 		// If node_modules doesn't exist, we need to install dependencies
 	}
 
+	const allowInstallScripts = !!application.install?.allowInstallScripts;
+
 	// If custom install command is specified, run it
 	if (application.install?.command) {
+		if (application.install.allowInstallScripts === undefined) {
+			application.logger.warn(
+				`Application ${application.name} uses install_command without install_allow_scripts; package lifecycle scripts are disabled by default for npm and tools that honor npm_config_ignore_scripts, including npm run pre/post hooks. Set install_allow_scripts (or install.allowInstallScripts in root config) to true to opt in`
+			);
+		}
 		const [command, ...args] = application.install.command.split(' ');
 		const customOnLine = application.onInstallLine
 			? (stream: 'stdout' | 'stderr', line: string) => application.onInstallLine!(command, stream, line)
@@ -2999,7 +3006,9 @@ export async function installApplication(application: Application, buildDirPath 
 			buildDirPath,
 			application.install?.timeout,
 			customOnLine,
-			application.npmUserconfigPath
+			application.npmUserconfigPath,
+			undefined,
+			!allowInstallScripts
 		);
 		// if it succeeds, return
 		if (code === 0) {
@@ -3019,7 +3028,6 @@ export async function installApplication(application: Application, buildDirPath 
 		);
 	}
 
-	const allowInstallScripts = !!application.install?.allowInstallScripts;
 	const { packageManager } = packageJSON.devEngines || {};
 	if (dependencyFieldHasWork(packageJSON, 'devDependencies')) {
 		application.logger.warn(
@@ -3856,7 +3864,8 @@ export async function nonInteractiveSpawn(
 	timeoutMs: number = DEFAULT_COMMAND_TIMEOUT_MS,
 	onLine?: (stream: 'stdout' | 'stderr', line: string) => void,
 	npmUserconfigPath?: string,
-	gitCredentialEnv?: Record<string, string>
+	gitCredentialEnv?: Record<string, string>,
+	ignoreNpmScripts = false
 ): Promise<{ stdout: string; stderr: string; code: number }> {
 	const gitSSH = await materializeGitSSH();
 	try {
@@ -3869,7 +3878,8 @@ export async function nonInteractiveSpawn(
 			onLine,
 			npmUserconfigPath,
 			gitSSH?.command,
-			gitCredentialEnv
+			gitCredentialEnv,
+			ignoreNpmScripts
 		);
 	} finally {
 		await gitSSH?.cleanup();
@@ -3885,7 +3895,8 @@ function spawnWithEnv(
 	onLine: ((stream: 'stdout' | 'stderr', line: string) => void) | undefined,
 	npmUserconfigPath: string | undefined,
 	gitSSHCommand: string | undefined,
-	gitCredentialEnv: Record<string, string> | undefined
+	gitCredentialEnv: Record<string, string> | undefined,
+	ignoreNpmScripts: boolean
 ): Promise<{ stdout: string; stderr: string; code: number }> {
 	return new Promise((resolve, reject) => {
 		logger
@@ -3920,6 +3931,12 @@ function spawnWithEnv(
 				if (key.toLowerCase() === 'npm_config_userconfig') delete env[key];
 			}
 			env.npm_config_userconfig = npmUserconfigPath;
+		}
+		if (ignoreNpmScripts) {
+			for (const key of Object.keys(env)) {
+				if (key.toLowerCase() === 'npm_config_ignore_scripts') delete env[key];
+			}
+			env.npm_config_ignore_scripts = 'true';
 		}
 
 		if (process.platform === 'win32' && command === 'npm') {

--- a/unitTests/components/applicationInstall.test.js
+++ b/unitTests/components/applicationInstall.test.js
@@ -24,6 +24,21 @@ async function createApplication(root, name, packageJSON, install) {
 	return application;
 }
 
+async function createLifecycleDependency(root, name, markerPath) {
+	const dependencyName = `${name}-dependency`;
+	const directory = join(root, dependencyName);
+	await mkdir(directory);
+	await writeFile(
+		join(directory, 'install.cjs'),
+		`require('node:fs').writeFileSync(${JSON.stringify(markerPath)}, 'ran');\n`
+	);
+	await writeFile(
+		join(directory, 'package.json'),
+		JSON.stringify({ name: dependencyName, version: '1.0.0', scripts: { install: 'node install.cjs' } })
+	);
+	return { dependencyName, directory };
+}
+
 async function configureInstallCapture(application, root, name) {
 	const capturePath = join(root, `${name}-args.json`);
 	const captureScript = join(root, `${name}-capture.cjs`);
@@ -163,14 +178,63 @@ describe('automatic application installation', () => {
 		const customMarker = join(application.dirPath, 'custom-command-ran');
 		await writeFile(
 			join(application.dirPath, 'custom-install.cjs'),
-			`require('node:fs').writeFileSync(${JSON.stringify(customMarker)}, 'yes');\n`
+			`require('node:fs').writeFileSync(${JSON.stringify(customMarker)}, JSON.stringify(process.argv.slice(2)));\n`
 		);
 
 		await installApplication(application);
 
-		assert.equal(await readFile(customMarker, 'utf8'), 'yes');
+		assert.deepEqual(JSON.parse(await readFile(customMarker, 'utf8')), []);
 		await assert.rejects(access(automaticCapture), (error) => error.code === 'ENOENT');
 		assert.equal(application.installationIsOpaque, true);
+	});
+
+	it('applies the lifecycle-script policy to custom install commands', async function () {
+		this.timeout(60_000);
+		const inheritedPolicies = Object.entries(process.env).filter(
+			([key]) => key.toLowerCase() === 'npm_config_ignore_scripts'
+		);
+		for (const [key] of inheritedPolicies) delete process.env[key];
+		process.env.npm_config_ignore_scripts = 'false';
+		try {
+			for (const allowInstallScripts of [undefined, false, true]) {
+				const name =
+					allowInstallScripts === undefined
+						? 'custom-scripts-default'
+						: allowInstallScripts
+							? 'custom-scripts-allowed'
+							: 'custom-scripts-blocked';
+				const markerPath = join(this.root, `${name}-marker`);
+				const dependency = await createLifecycleDependency(this.root, name, markerPath);
+				const install = { command: 'npm install --no-audit --no-fund && node -e "process.exit(0)"' };
+				if (allowInstallScripts !== undefined) install.allowInstallScripts = allowInstallScripts;
+				const application = await createApplication(
+					this.root,
+					name,
+					{ dependencies: { [dependency.dependencyName]: `file:${dependency.directory}` } },
+					install
+				);
+				const warnings = [];
+				application.logger.warn = (message) => warnings.push(message);
+
+				await installApplication(application);
+
+				await access(join(application.dirPath, 'node_modules', dependency.dependencyName, 'package.json'));
+				assert.equal(
+					await access(markerPath).then(
+						() => true,
+						() => false
+					),
+					allowInstallScripts === true
+				);
+				assert.equal(warnings.length, allowInstallScripts === undefined ? 1 : 0);
+				if (warnings.length) assert.match(warnings[0], /install\.allowInstallScripts/);
+			}
+		} finally {
+			for (const key of Object.keys(process.env)) {
+				if (key.toLowerCase() === 'npm_config_ignore_scripts') delete process.env[key];
+			}
+			Object.assign(process.env, Object.fromEntries(inheritedPolicies));
+		}
 	});
 
 	it('materializes runtime dependencies while omitting development dependencies', async function () {

--- a/unitTests/utility/npmUtilities.test.js
+++ b/unitTests/utility/npmUtilities.test.js
@@ -16,15 +16,25 @@ describe('install_node_modules', function () {
 	this.timeout(60_000); // .mocharc.json sets `timeout: 0`, and these cases spawn real npm
 
 	let componentsRoot;
+	let lifecycleMarker;
 
 	before(() => {
 		componentsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'harper-install-modules-'));
+		lifecycleMarker = path.join(componentsRoot, 'lifecycle-marker');
 		env.setProperty(CONFIG_PARAMS.COMPONENTSROOT, componentsRoot);
 
 		fs.mkdirSync(path.join(componentsRoot, 'dependency'));
 		fs.writeFileSync(
+			path.join(componentsRoot, 'dependency', 'install.cjs'),
+			`require('node:fs').writeFileSync(${JSON.stringify(lifecycleMarker)}, 'ran');\n`
+		);
+		fs.writeFileSync(
 			path.join(componentsRoot, 'dependency', 'package.json'),
-			JSON.stringify({ name: 'local-dependency', version: '1.0.0' })
+			JSON.stringify({
+				name: 'local-dependency',
+				version: '1.0.0',
+				scripts: { install: 'node install.cjs' },
+			})
 		);
 		fs.mkdirSync(path.join(componentsRoot, 'application'));
 		fs.writeFileSync(
@@ -43,6 +53,7 @@ describe('install_node_modules', function () {
 
 	afterEach(() => {
 		fs.rmSync(path.join(componentsRoot, 'application', 'node_modules'), { recursive: true, force: true });
+		fs.rmSync(lifecycleMarker, { force: true });
 	});
 
 	// npm still reports the dependency it would add under --dry-run, so asserting on that output
@@ -59,6 +70,22 @@ describe('install_node_modules', function () {
 
 	function installedDependencyExists() {
 		return fs.existsSync(path.join(componentsRoot, 'application', 'node_modules', 'local-dependency'));
+	}
+
+	async function withNpmLifecycleScriptsEnabled(callback) {
+		const inheritedPolicies = Object.entries(process.env).filter(
+			([key]) => key.toLowerCase() === 'npm_config_ignore_scripts'
+		);
+		for (const [key] of inheritedPolicies) delete process.env[key];
+		process.env.npm_config_ignore_scripts = 'false';
+		try {
+			return await callback();
+		} finally {
+			for (const key of Object.keys(process.env)) {
+				if (key.toLowerCase() === 'npm_config_ignore_scripts') delete process.env[key];
+			}
+			Object.assign(process.env, Object.fromEntries(inheritedPolicies));
+		}
 	}
 
 	it('honors the documented dry_run field', async () => {
@@ -86,9 +113,38 @@ describe('install_node_modules', function () {
 	});
 
 	it('installs when dry_run is omitted', async () => {
-		const response = await installModules({ projects: ['application'] });
+		const response = await withNpmLifecycleScriptsEnabled(() => installModules({ projects: ['application'] }));
 
 		assertInstalled(response);
+		assert.equal(fs.existsSync(lifecycleMarker), true);
+	});
+
+	it('applies the lifecycle-script policy while preserving the allowed positive control', async () => {
+		await withNpmLifecycleScriptsEnabled(async () => {
+			const blockedResponse = await installModules({ projects: ['application'], allowInstallScripts: false });
+
+			assertInstalled(blockedResponse);
+			assert.equal(fs.existsSync(lifecycleMarker), false);
+			fs.rmSync(path.join(componentsRoot, 'application', 'node_modules'), { recursive: true, force: true });
+
+			const allowedResponse = await installModules({ projects: ['application'], allowInstallScripts: true });
+
+			assertInstalled(allowedResponse);
+			assert.equal(fs.existsSync(lifecycleMarker), true);
+		});
+	});
+
+	it('honors install_allow_scripts and rejects both policy spellings together', async () => {
+		const response = await withNpmLifecycleScriptsEnabled(() =>
+			installModules({ projects: ['application'], install_allow_scripts: false })
+		);
+
+		assertInstalled(response);
+		assert.equal(fs.existsSync(lifecycleMarker), false);
+		await assert.rejects(
+			installModules({ projects: ['application'], install_allow_scripts: false, allowInstallScripts: true }),
+			{ statusCode: 400, message: /install_allow_scripts/ }
+		);
 	});
 
 	it('rejects a request carrying both dry_run spellings', async () => {

--- a/utility/npmUtilities.ts
+++ b/utility/npmUtilities.ts
@@ -31,14 +31,13 @@ export async function installModules(req: any) {
 		throw handleHDBError(validation, validation.message, HTTP_STATUS_CODES.BAD_REQUEST);
 	}
 
-	const { projects, dry_run: dryRun } = validatedRequest;
+	const { projects, dry_run: dryRun, allowInstallScripts } = validatedRequest;
 
 	const componentsRootDirPath = getConfigPath(CONFIG_PARAMS.COMPONENTSROOT);
 
 	const responseObject: any = {};
 
-	// `allowInstallScripts` is true because this operation has always run a project's install lifecycle
-	const args = [...packageManagerInstallArguments('npm', true, true), '--json'];
+	const args = [...packageManagerInstallArguments('npm', allowInstallScripts, true), '--json'];
 	if (dryRun) args.push('--dry-run');
 
 	for (const project of projects) {
@@ -101,7 +100,10 @@ function modulesValidator(req: any) {
 	const funcSchema = Joi.object({
 		projects: Joi.array().min(1).items(Joi.string()).required(),
 		dry_run: Joi.boolean().default(false),
-	}).rename('dryRun', 'dry_run', { ignoreUndefined: true });
+		allowInstallScripts: Joi.boolean().default(true),
+	})
+		.rename('dryRun', 'dry_run', { ignoreUndefined: true })
+		.rename('install_allow_scripts', 'allowInstallScripts', { ignoreUndefined: true });
 
 	return validator.validateAndConvertBySchema(req, funcSchema);
 }


### PR DESCRIPTION
Custom component install commands now [pass Harper's lifecycle-script policy into their spawn](https://github.com/HarperFast/harper/pull/2572/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R3011), and the deprecated `install_node_modules` operation now [passes its validated policy through the shared npm argument builder](https://github.com/HarperFast/harper/pull/2572/changes?w=1#diff-aab51787131300406743175a786a0896ca9bdc7ce9b86458c3d1fdc36cf34aebR40) instead of bypassing it. Custom commands preserve their exact command line, while `install_node_modules` retains its historical scripts-enabled default unless the caller opts out.

## For the human reviewer

1. **Secure default for existing custom commands.** Omitted `install_allow_scripts` now suppresses lifecycle hooks immediately, matching the existing automatic-install policy; the alternative was to preserve legacy custom-command behavior until an explicit `false`. This can break a cold install that previously relied on native-module or generation scripts, so the implementation [emits a server warning naming both opt-in spellings](https://github.com/HarperFast/harper/pull/2572/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R2993); the warning is not streamed to the deploy caller. A “no” means changing the condition to enforce only explicit `false` and staging the secure default for a later release.

2. **Best-effort enforcement for arbitrary commands.** The [child-scoped `npm_config_ignore_scripts=true` approach](https://github.com/HarperFast/harper/pull/2572/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R3935) was chosen after planning review rejected appending `--ignore-scripts`, which fails for shell chains and corrupts non-npm argv. It reaches npm anywhere in the configured shell command, but npm 10 can still run a git dependency's `prepare`, and other package managers vary in whether they consume npm-style configuration; this is the boundary to inspect most closely. A “no” requires a broader design that restricts or parses arbitrary commands; that is outside this issue's instruction to leave the already-equivalent automatic paths unchanged.

3. **Host policy remains authoritative.** Explicit `true` removes Harper's restriction but does not clear an inherited `npm_config_ignore_scripts=true`, matching the existing automatic paths and preserving current infrastructure hardening. The alternative is to force scripts on whenever an application opts in; changing this later is mechanically small but reverses configuration precedence.

4. **Deprecated-operation compatibility.** `install_node_modules` keeps its historical scripts-enabled default, as required by the acceptance criteria, rather than inheriting each component's safer deploy default. The [new validation switch](https://github.com/HarperFast/harper/pull/2572/changes?w=1#diff-aab51787131300406743175a786a0896ca9bdc7ce9b86458c3d1fdc36cf34aebR103) accepts camelCase to match the root configuration vocabulary and snake_case to match the operations API; a request carrying both is rejected rather than resolved ambiguously.

## Changes

- `components/Application.ts` [threads a dedicated lifecycle-policy flag through `nonInteractiveSpawn`](https://github.com/HarperFast/harper/pull/2572/changes?w=1#diff-4a096c65aa8965b002f6b76f448830f942dfda699311e0dd6bfc22587c938763R3868), scrubs case variants before setting the child-only npm configuration, and warns when a custom command relies on the new secure default.
- `utility/npmUtilities.ts` [reads the converted request field](https://github.com/HarperFast/harper/pull/2572/changes?w=1#diff-aab51787131300406743175a786a0896ca9bdc7ce9b86458c3d1fdc36cf34aebR34) and passes it through the shared npm argument builder instead of hard-coding scripts on.
- `DESIGN.md` records the [operation spellings and compatibility default](https://github.com/HarperFast/harper/pull/2572/changes?w=1#diff-3dc5dd454e080eb849ee5efaf79df2585fbe0a06804d69249b4c81da05a63875R728) plus the [environment propagation, package-manager caveats and migration warning](https://github.com/HarperFast/harper/pull/2572/changes?w=1#diff-3dc5dd454e080eb849ee5efaf79df2585fbe0a06804d69249b4c81da05a63875R735).

## Verification

- Selected observable route: the production `installApplication()` and `installModules()` paths spawn real npm against local `file:` dependencies whose lifecycle scripts write filesystem markers. `npx mocha unitTests/components/applicationInstall.test.js unitTests/utility/npmUtilities.test.js` reports 18 passing; the custom-command suite [proves unchanged argv plus undefined/false/true marker and warning behavior](https://github.com/HarperFast/harper/pull/2572/changes?w=1#diff-69076c580eb57840c553ca0bf90b20559673b47a9fe7d58d4b3caaed623f7263R191), while the deprecated-operation suite [proves omitted/true behavior, false suppression, both spellings and conflict rejection](https://github.com/HarperFast/harper/pull/2572/changes?w=1#diff-f0ada45d0d4b92fce70a6e89934360d60e453be2bd36f99b55c6b4a478699c53R115).
- The test fixtures use [real marker-writing component dependencies](https://github.com/HarperFast/harper/pull/2572/changes?w=1#diff-69076c580eb57840c553ca0bf90b20559673b47a9fe7d58d4b3caaed623f7263R27) and [case-insensitive ambient-policy neutralization](https://github.com/HarperFast/harper/pull/2572/changes?w=1#diff-f0ada45d0d4b92fce70a6e89934360d60e453be2bd36f99b55c6b4a478699c53R75) so positive controls cannot depend on the host's npm configuration.
- `npm run build` passes, changed-file Prettier and oxlint checks pass, and `git diff --check` is clean.
- `npm run test:unit:windows` passes all 9 groups and 3,732 tests. `npm run test:unit:resources` reports 2,358 passing / 32 pending.
- `npm run test:unit:main` reports 5,468 passing / 196 pending plus two unrelated environment failures: ambient fleet git variables in `gitCredentials.test.js` and a worktree-depth Unix-socket path in `configValidator.test.js`.
- `npm run test:integration:all` reaches 2,081 passing, 0 assertion failures, 20 skipped and 6 cancelled; the runner exits nonzero on Node 26's existing missing JSON import attribute in `ollama-backend.test.ts`. The component lifecycle integration suite passes.
- Full `npm run lint` remains red on 13 warnings in unrelated files; targeted lint over every changed source and test file passes.
- GitHub reports all 43 applicable main-target CI checks passing with 5 non-applicable jobs skipped. The v5.2 cherry-pick automation reports conflicts and did not run its release-line integration tests; its conflict branch and requested resolution are linked in the workflow comment.

Refs #1978

Complexity: medium

_Generated by GPT-5 Codex._

<sub>Review-Coverage: authored=codex; ran=gemini,claude; adjudicated=domain; declined=cursor-grok,cursor-composer; rounds=4 @ 7f0d5a08ccf1</sub>

<sub>Human-Review-Need: 4 (decisions: default-deny-existing-custom-installs, host-policy-precedence, arbitrary-command-enforcement, deprecated-operation-default) @ 7f0d5a08ccf1</sub>
