### PR TITLE
Fix flaky outstanding-commit tracking unit test under concurrent analytics commits

### DIFF
--- a/unitTests/resources/outstandingCommitTracking.test.js
+++ b/unitTests/resources/outstandingCommitTracking.test.js
@@ -5,10 +5,44 @@ const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { transaction } = require('#src/resources/transaction');
 const { getOutstandingCommits, trackOutstandingCommit } = require('#src/resources/DatabaseTransaction');
+const { waitFor } = require('../waitFor');
 // Outstanding-commit tracking lives on the base DatabaseTransaction (RocksDB path). LMDB writes route
 // through the separate LMDBTransaction overrides (resources/LMDBTransaction.ts), which keep their own
 // unrelated sentinel and do not feed this tracking — matching the carve-outs in transactionQueueDepth.test.js.
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
+
+// getOutstandingCommits() is thread-global, and this thread is never idle: recording any commit's
+// latency arms the analytics reporter, whose main-thread aggregation tick (startScheduledTasks in
+// resources/analytics/write.ts) issues one unawaited hdb_analytics put per metric and per table —
+// 100+ tracked commits in one burst, settling within tens of milliseconds. So an absolute count is
+// only exact inside a synchronous window. The two helpers keep every assertion exact while tolerating
+// such transient foreign work (not arbitrary foreign work: a bystander still pending past the settle
+// deadline fails the assertion too, and then the reported age says so):
+//  - trackedAcross(): the count delta across a synchronous callback. No foreign node can be linked or
+//    unlinked between two reads with no await between them, so the delta is this test's alone.
+//  - settleOutstandingCommits(): waits for the thread to drain to the expected count. A foreign burst
+//    settles in milliseconds; a node left linked never does, so a regression still fails — after the
+//    deadline, reporting the stuck count and its age.
+const SETTLE_TIMEOUT_MS = 5000;
+async function settleOutstandingCommits(expectedCount, message, timeout = SETTLE_TIMEOUT_MS) {
+	let outstanding;
+	try {
+		await waitFor(() => (outstanding = getOutstandingCommits()).count === expectedCount, { timeout, interval: 5 });
+	} catch {
+		assert.fail(`${message}: still ${JSON.stringify(outstanding)} after ${timeout}ms`);
+	}
+	return outstanding;
+}
+async function assertAllUntracked(message) {
+	const outstanding = await settleOutstandingCommits(0, message);
+	assert.deepEqual(outstanding, { count: 0, oldestAgeMs: undefined });
+}
+function trackedAcross(submit) {
+	const before = getOutstandingCommits().count;
+	const result = submit();
+	const outstanding = getOutstandingCommits();
+	return { result, delta: outstanding.count - before, outstanding };
+}
 
 describe('Outstanding commit tracking', () => {
 	let TrackA, TrackB;
@@ -33,11 +67,10 @@ describe('Outstanding commit tracking', () => {
 
 	it('tracks a commit while it is in flight', async function () {
 		if (isLMDB) return;
-		const write = TrackA.put(1, { name: 'in-flight' });
 		// put() returns before the native commit settles, so the commit is outstanding right now.
-		const outstanding = getOutstandingCommits();
+		const { result: write, delta, outstanding } = trackedAcross(() => TrackA.put(1, { name: 'in-flight' }));
 		await write;
-		assert.equal(outstanding.count, 1, 'an in-flight commit should be tracked');
+		assert.equal(delta, 1, 'an in-flight commit should be tracked');
 		assert.equal(typeof outstanding.oldestAgeMs, 'number', 'a tracked commit should report an age');
 		assert.ok(outstanding.oldestAgeMs >= 0, 'a tracked commit should report a non-negative age');
 	});
@@ -48,10 +81,11 @@ describe('Outstanding commit tracking', () => {
 	// unbounded. Concurrent commits must each be tracked, not sampled one at a time.
 	it('tracks every concurrent commit, not just the first', async function () {
 		if (isLMDB) return;
-		const writes = Array.from({ length: 8 }, (unused, index) => TrackA.put(100 + index, { name: `c${index}` }));
-		const outstanding = getOutstandingCommits();
+		const { result: writes, delta } = trackedAcross(() =>
+			Array.from({ length: 8 }, (unused, index) => TrackA.put(100 + index, { name: `c${index}` }))
+		);
 		await Promise.all(writes);
-		assert.equal(outstanding.count, writes.length, 'each concurrent commit should be tracked independently');
+		assert.equal(delta, writes.length, 'each concurrent commit should be tracked independently');
 	});
 
 	// A node left linked after its commit settled would make every write on this thread throw 503
@@ -60,7 +94,7 @@ describe('Outstanding commit tracking', () => {
 	it('untracks a single-table commit once it settles', async function () {
 		if (isLMDB) return;
 		await TrackA.put(2, { name: 'single' });
-		assert.deepEqual(getOutstandingCommits(), { count: 0, oldestAgeMs: undefined });
+		await assertAllUntracked('a settled single-table commit should be untracked');
 	});
 
 	it('untracks every link of a cross-database (chained) transaction', async function () {
@@ -81,7 +115,7 @@ describe('Outstanding commit tracking', () => {
 			chained = !!context.transaction?.next;
 		});
 		assert.ok(chained, 'the two databases should have produced a chained transaction');
-		assert.deepEqual(getOutstandingCommits(), { count: 0, oldestAgeMs: undefined });
+		await assertAllUntracked('every link of a settled chained transaction should be untracked');
 		assert.equal((await TrackA.get(3))?.name, 'chain-a');
 		assert.equal((await TrackB.get(3))?.name, 'chain-b');
 	});
@@ -152,11 +186,13 @@ describe('Outstanding commit tracking', () => {
 				// this file alone alive for ~10s after the result is already known.
 				clearTimeout(timeoutHandle);
 			}
-			// TrackA's node is unlinked before `this.next.commit()` runs (see the comment above), so by
-			// this point count===1 can only be TrackB's held commit — no polling/racing required.
-			const outstanding = getOutstandingCommits();
 			assert.ok(chained, 'the two databases should have produced a chained transaction');
-			assert.equal(outstanding.count, 1, 'the chained second-database commit should be tracked while pending');
+			// TrackA's node is unlinked before `this.next.commit()` runs (see the comment above), so once
+			// any foreign commits drain, count===1 can only be TrackB's held commit.
+			const outstanding = await settleOutstandingCommits(
+				1,
+				'the chained second-database commit should be tracked while pending'
+			);
 			assert.equal(typeof outstanding.oldestAgeMs, 'number', 'the pending chained commit should report an age');
 		} finally {
 			// Always restore the prototype and release the held commit, even if an assertion above threw —
@@ -165,7 +201,7 @@ describe('Outstanding commit tracking', () => {
 			releaseHold();
 			if (done) await done.catch(() => {});
 		}
-		assert.deepEqual(getOutstandingCommits(), { count: 0, oldestAgeMs: undefined });
+		await assertAllUntracked('the released chained commit should be untracked');
 		assert.equal((await TrackA.get(4))?.name, 'chain-a-2');
 		assert.equal((await TrackB.get(4))?.name, 'chain-b-2');
 	});
@@ -180,15 +216,16 @@ describe('Outstanding commit tracking', () => {
 			const promise = new Promise((resolve) => (settle = resolve));
 			return { promise, settle };
 		});
-		for (const { promise } of deferred) trackOutstandingCommit(promise);
-		assert.equal(getOutstandingCommits().count, 5);
+		const { delta } = trackedAcross(() => {
+			for (const { promise } of deferred) trackOutstandingCommit(promise);
+		});
+		assert.equal(delta, 5);
 		for (const index of [2, 0, 4, 1, 3]) {
 			// middle, head, tail, then the remainder
 			deferred[index].settle();
 			await deferred[index].promise;
 		}
-		await new Promise((resolve) => setImmediate(resolve)); // let the last untrack reaction run
-		assert.deepEqual(getOutstandingCommits(), { count: 0, oldestAgeMs: undefined });
+		await assertAllUntracked('every out-of-order settled node should be untracked');
 	});
 
 	it('untracks a commit that rejects', async function () {
@@ -196,30 +233,87 @@ describe('Outstanding commit tracking', () => {
 		const rejected = Promise.reject(new Error('ERR_BUSY'));
 		trackOutstandingCommit(rejected);
 		await rejected.catch(() => {});
-		await new Promise((resolve) => setImmediate(resolve));
-		assert.deepEqual(getOutstandingCommits(), { count: 0, oldestAgeMs: undefined });
+		await assertAllUntracked('a rejected commit should be untracked');
 	});
 
 	it('tracks an already-settled promise and still untracks it', async function () {
 		if (isLMDB) return;
 		const settled = Promise.resolve();
-		trackOutstandingCommit(settled);
 		// The node is linked synchronously; the untrack reaction is queued behind it.
-		assert.equal(getOutstandingCommits().count, 1);
-		await new Promise((resolve) => setImmediate(resolve));
-		assert.deepEqual(getOutstandingCommits(), { count: 0, oldestAgeMs: undefined });
+		const { delta } = trackedAcross(() => trackOutstandingCommit(settled));
+		assert.equal(delta, 1);
+		await assertAllUntracked('an already-settled tracked promise should still be untracked');
 	});
 
 	it('treats the same promise tracked twice as two independent attempts', async function () {
 		if (isLMDB) return;
 		let settle;
 		const shared = new Promise((resolve) => (settle = resolve));
-		trackOutstandingCommit(shared);
-		trackOutstandingCommit(shared);
-		assert.equal(getOutstandingCommits().count, 2);
+		const { delta } = trackedAcross(() => {
+			trackOutstandingCommit(shared);
+			trackOutstandingCommit(shared);
+		});
+		assert.equal(delta, 2);
 		settle();
 		await shared;
-		await new Promise((resolve) => setImmediate(resolve));
-		assert.deepEqual(getOutstandingCommits(), { count: 0, oldestAgeMs: undefined });
+		await assertAllUntracked('both attempts on a shared promise should be untracked');
+	});
+
+	// The CI flake this file used to have: the analytics aggregation tick landed inside the chained
+	// test's ~40ms window and the bare thread-global read returned 130–145 in-flight foreign commits
+	// with a young oldestAgeMs. Reproduce that state deterministically — foreign nodes tracked for
+	// the whole duration of this test's own chained write and released only afterwards — and show
+	// the assertions above stay exact under it rather than counting the bystanders.
+	it('keeps its assertions exact while foreign commits are in flight on the thread', async function () {
+		if (isLMDB) return;
+		let releaseForeign;
+		const foreign = new Promise((resolve) => (releaseForeign = resolve));
+		const FOREIGN_COMMITS = 140;
+		try {
+			const { delta } = trackedAcross(() => {
+				for (let index = 0; index < FOREIGN_COMMITS; index++) trackOutstandingCommit(foreign);
+			});
+			assert.equal(delta, FOREIGN_COMMITS);
+			const context = {};
+			let chained = false;
+			await TrackA.put(5, { name: 'chain-a-3' });
+			await transaction(context, async () => {
+				await TrackA.get(5, context);
+				await TrackB.put(5, { name: 'chain-b-3' }, context);
+				chained = !!context.transaction?.next;
+			});
+			assert.ok(chained, 'the two databases should have produced a chained transaction');
+			// What the old assertion read at this point: the bystanders, not this test's own (already
+			// untracked) links. The chained links are proven untracked only once the foreign burst
+			// settles, below.
+			assert.ok(getOutstandingCommits().count >= FOREIGN_COMMITS, 'the foreign commits are still in flight');
+			const { result: underLoad, delta: ownDelta } = trackedAcross(() => TrackA.put(6, { name: 'under-load' }));
+			assert.equal(ownDelta, 1, 'a synchronous-window delta ignores the in-flight bystanders');
+			await underLoad;
+		} finally {
+			// Never leave the foreign nodes linked: they would age past the overload threshold and 503
+			// every later write on this thread.
+			releaseForeign();
+		}
+		await assertAllUntracked('own links and the released foreign commits should all be untracked');
+		assert.equal((await TrackA.get(5))?.name, 'chain-a-3');
+		assert.equal((await TrackB.get(5))?.name, 'chain-b-3');
+	});
+
+	// Proves the settle helper is still a leak detector: waiting for the count is what lets it tolerate
+	// bystanders, so it must not also wait its way past a node that never unlinks.
+	it('the settle assertion rejects a node that never unlinks, reporting its count and age', async function () {
+		if (isLMDB) return;
+		let releaseStuck;
+		const stuck = new Promise((resolve) => (releaseStuck = resolve));
+		try {
+			trackOutstandingCommit(stuck);
+			await assert.rejects(settleOutstandingCommits(0, 'stuck node', 200), (error) =>
+				/stuck node: still \{"count":[1-9]\d*,"oldestAgeMs":\d{3,}/.test(error.message)
+			);
+		} finally {
+			releaseStuck();
+		}
+		await assertAllUntracked('the released stuck node should be untracked');
 	});
 });

--- a/unitTests/resources/outstandingCommitTracking.test.js
+++ b/unitTests/resources/outstandingCommitTracking.test.js
@@ -4,7 +4,11 @@ const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { transaction } = require('#src/resources/transaction');
-const { getOutstandingCommits, trackOutstandingCommit } = require('#src/resources/DatabaseTransaction');
+const {
+	getOutstandingCommits,
+	trackOutstandingCommit,
+	setMaxOutstandingTxnDuration,
+} = require('#src/resources/DatabaseTransaction');
 const { waitFor } = require('../waitFor');
 // Outstanding-commit tracking lives on the base DatabaseTransaction (RocksDB path). LMDB writes route
 // through the separate LMDBTransaction overrides (resources/LMDBTransaction.ts), which keep their own
@@ -42,7 +46,7 @@ function trackedAcross(submit) {
 	const before = getOutstandingCommits().count;
 	const result = submit();
 	const outstanding = getOutstandingCommits();
-	return { result, delta: outstanding.count - before, outstanding };
+	return { result, before, delta: outstanding.count - before, outstanding };
 }
 
 describe('Outstanding commit tracking', () => {
@@ -69,11 +73,14 @@ describe('Outstanding commit tracking', () => {
 	it('tracks a commit while it is in flight', async function () {
 		if (isLMDB) return;
 		// put() returns before the native commit settles, so the commit is outstanding right now.
-		const { result: write, delta, outstanding } = trackedAcross(() => TrackA.put(1, { name: 'in-flight' }));
+		const { result: write, before, delta, outstanding } = trackedAcross(() => TrackA.put(1, { name: 'in-flight' }));
 		await write;
 		assert.equal(delta, 1, 'an in-flight commit should be tracked');
-		assert.equal(typeof outstanding.oldestAgeMs, 'number', 'a tracked commit should report an age');
-		assert.ok(outstanding.oldestAgeMs >= 0, 'a tracked commit should report a non-negative age');
+		// The oldest age is only this commit's when nothing foreign was already linked.
+		if (before === 0) {
+			assert.equal(typeof outstanding.oldestAgeMs, 'number', 'a tracked commit should report an age');
+			assert.ok(outstanding.oldestAgeMs >= 0, 'a tracked commit should report a non-negative age');
+		}
 	});
 
 	// The defect this guards: tracking used to occupy a single shared slot, claimed by whichever
@@ -271,6 +278,8 @@ describe('Outstanding commit tracking', () => {
 		let releaseForeign;
 		const foreign = new Promise((resolve) => (releaseForeign = resolve));
 		const FOREIGN_COMMITS = 140;
+		// checkOverloaded() sheds on the oldest node's age whoever owns it, and the threshold is config-derived.
+		const restoreDuration = setMaxOutstandingTxnDuration(60000);
 		try {
 			const { delta } = trackedAcross(() => {
 				for (let index = 0; index < FOREIGN_COMMITS; index++) trackOutstandingCommit(foreign);
@@ -292,6 +301,7 @@ describe('Outstanding commit tracking', () => {
 		} finally {
 			// Left linked, they would age past the overload threshold and 503 every later write on this thread.
 			releaseForeign();
+			setMaxOutstandingTxnDuration(restoreDuration);
 		}
 		await assertAllUntracked('own links and the released foreign commits should all be untracked');
 		assert.equal((await TrackA.get(5))?.name, 'chain-a-3');

--- a/unitTests/resources/outstandingCommitTracking.test.js
+++ b/unitTests/resources/outstandingCommitTracking.test.js
@@ -133,8 +133,9 @@ describe('Outstanding commit tracking', () => {
 	// incremented in the first place. Hold the second (chained) link's native commit open through a
 	// narrow test seam (patching Transaction.prototype.commit, scoped to TrackB's store, the same
 	// idiom lingeringWriteCommit.test.js uses) and measure the count delta across the synchronous
-	// block that submits it: commit() links the tracking node right after the native commit returns,
-	// with no await between, so a microtask queued from inside the seam observes exactly that link.
+	// block that submits it. trackOutstandingCommit subscribes to the commit promise (`.then(untrack,
+	// untrack)`) right after linking its node, in that same block, so the returned promise's own `then`
+	// is where the count can be read with no await — and so no foreign link or unlink — in between.
 	it('tracks the second (chained) commit while it is pending, not just the first', async function () {
 		if (isLMDB) return;
 		this.timeout(20000);
@@ -149,20 +150,22 @@ describe('Outstanding commit tracking', () => {
 		// Settles only once TrackB's (patched) commit has been invoked AND its tracking node linked, so
 		// the assertions below cannot run early against TrackA's own transient node.
 		const secondCommitStarted = new Promise((resolve) => (signalSecondCommitStarted = resolve));
-		let secondCommitDelta;
-		let outstandingDuringHold;
+		let before;
+		const deltasAtSubscription = [];
+		let outstandingAtTracking;
 		Transaction.prototype.commit = function (...args) {
 			if (this.store?.db !== targetDb) return originalCommit.apply(this, args);
-			const before = getOutstandingCommits().count;
+			before = getOutstandingCommits().count;
 			const realCommit = originalCommit.apply(this, args);
-			// Runs after the caller's synchronous block has linked this commit's node and before any other
-			// commit's completion can be delivered (each arrives in its own macrotask).
-			queueMicrotask(() => {
-				outstandingDuringHold = getOutstandingCommits();
-				secondCommitDelta = outstandingDuringHold.count - before;
-				signalSecondCommitStarted();
-			});
-			return held.then(() => realCommit);
+			const heldCommit = held.then(() => realCommit);
+			heldCommit.then = function (...thenArgs) {
+				const outstanding = getOutstandingCommits();
+				deltasAtSubscription.push(outstanding.count - before);
+				if (outstanding.count - before === 1) outstandingAtTracking ??= outstanding;
+				return Promise.prototype.then.apply(this, thenArgs);
+			};
+			signalSecondCommitStarted();
+			return heldCommit;
 		};
 		let done;
 		try {
@@ -200,12 +203,19 @@ describe('Outstanding commit tracking', () => {
 				clearTimeout(timeoutHandle);
 			}
 			assert.ok(chained, 'the two databases should have produced a chained transaction');
-			assert.equal(secondCommitDelta, 1, 'the chained second-database commit should be tracked while pending');
 			assert.equal(
-				typeof outstandingDuringHold.oldestAgeMs,
-				'number',
-				'the pending chained commit should report an age'
+				Math.max(...deltasAtSubscription),
+				1,
+				`the chained second-database commit should be tracked, once, while pending (deltas seen at each subscription: ${deltasAtSubscription})`
 			);
+			// The oldest age is only this commit's when nothing foreign was already linked.
+			if (before === 0) {
+				assert.equal(
+					typeof outstandingAtTracking.oldestAgeMs,
+					'number',
+					'the pending chained commit should report an age'
+				);
+			}
 		} finally {
 			// Always restore the prototype and release the held commit, even if an assertion above threw —
 			// otherwise `done`'s chained commit stays pending forever and poisons every later test's count.

--- a/unitTests/resources/outstandingCommitTracking.test.js
+++ b/unitTests/resources/outstandingCommitTracking.test.js
@@ -28,7 +28,8 @@ async function settleOutstandingCommits(expectedCount, message, timeout = SETTLE
 	let outstanding;
 	try {
 		await waitFor(() => (outstanding = getOutstandingCommits()).count === expectedCount, { timeout, interval: 5 });
-	} catch {
+	} catch (error) {
+		if (!(error instanceof assert.AssertionError)) throw error;
 		assert.fail(`${message}: still ${JSON.stringify(outstanding)} after ${timeout}ms`);
 	}
 	return outstanding;
@@ -124,12 +125,12 @@ describe('Outstanding commit tracking', () => {
 	// `this.next.commit()`'s tracking were silently omitted, since the untouched slot was never
 	// incremented in the first place. Hold the second (chained) link's native commit open through a
 	// narrow test seam (patching Transaction.prototype.commit, scoped to TrackB's store, the same
-	// idiom lingeringWriteCommit.test.js uses) so we can observe the count while ONLY that link is
-	// outstanding: TrackA's own commit has already settled and untracked itself by the time
-	// `this.next.commit()` even runs, so a nonzero count here can only come from the second link.
+	// idiom lingeringWriteCommit.test.js uses) and measure the count delta across the synchronous
+	// block that submits it: commit() links the tracking node right after the native commit returns,
+	// with no await between, so a microtask queued from inside the seam observes exactly that link.
 	it('tracks the second (chained) commit while it is pending, not just the first', async function () {
 		if (isLMDB) return;
-		this.timeout(15000);
+		this.timeout(20000);
 		let chained = false;
 		const context = {};
 		const { Transaction } = require('@harperfast/rocksdb-js');
@@ -138,17 +139,22 @@ describe('Outstanding commit tracking', () => {
 		let releaseHold;
 		const held = new Promise((resolve) => (releaseHold = resolve));
 		let signalSecondCommitStarted;
-		// TrackA's own native commit is also tracked (briefly — it settles and untracks itself before
-		// `this.next.commit()` even runs, since `untrack` is attached ahead of the resolve handler that
-		// calls it). Without this signal, the poll loop below could observe THAT transient count>0 and
-		// stop before TrackB's commit is even submitted, letting the assertions pass without ever
-		// actually exercising the re-entrant path this test exists to cover. Only start asserting once
-		// TrackB's (patched) commit has definitely been invoked.
+		// Settles only once TrackB's (patched) commit has been invoked AND its tracking node linked, so
+		// the assertions below cannot run early against TrackA's own transient node.
 		const secondCommitStarted = new Promise((resolve) => (signalSecondCommitStarted = resolve));
+		let secondCommitDelta;
+		let outstandingDuringHold;
 		Transaction.prototype.commit = function (...args) {
 			if (this.store?.db !== targetDb) return originalCommit.apply(this, args);
+			const before = getOutstandingCommits().count;
 			const realCommit = originalCommit.apply(this, args);
-			signalSecondCommitStarted();
+			// Runs after the caller's synchronous block has linked this commit's node and before any other
+			// commit's completion can be delivered (each arrives in its own macrotask).
+			queueMicrotask(() => {
+				outstandingDuringHold = getOutstandingCommits();
+				secondCommitDelta = outstandingDuringHold.count - before;
+				signalSecondCommitStarted();
+			});
 			return held.then(() => realCommit);
 		};
 		let done;
@@ -167,7 +173,7 @@ describe('Outstanding commit tracking', () => {
 			// never invoked, `secondCommitStarted` would otherwise never settle. Mocha's own test timeout
 			// doesn't cancel this still-running async function, so an unbounded await here would hang
 			// forever with `Transaction.prototype.commit` left monkeypatched, breaking every later test
-			// that touches RocksDB. This timeout is comfortably inside the 15s test timeout, so `finally`
+			// that touches RocksDB. This timeout plus the 5s settle deadline fit inside the 20s test timeout, so `finally`
 			// below still gets to run and restore everything before mocha's own timeout would fire.
 			let timeoutHandle;
 			try {
@@ -187,13 +193,12 @@ describe('Outstanding commit tracking', () => {
 				clearTimeout(timeoutHandle);
 			}
 			assert.ok(chained, 'the two databases should have produced a chained transaction');
-			// TrackA's node is unlinked before `this.next.commit()` runs (see the comment above), so once
-			// any foreign commits drain, count===1 can only be TrackB's held commit.
-			const outstanding = await settleOutstandingCommits(
-				1,
-				'the chained second-database commit should be tracked while pending'
+			assert.equal(secondCommitDelta, 1, 'the chained second-database commit should be tracked while pending');
+			assert.equal(
+				typeof outstandingDuringHold.oldestAgeMs,
+				'number',
+				'the pending chained commit should report an age'
 			);
-			assert.equal(typeof outstanding.oldestAgeMs, 'number', 'the pending chained commit should report an age');
 		} finally {
 			// Always restore the prototype and release the held commit, even if an assertion above threw —
 			// otherwise `done`'s chained commit stays pending forever and poisons every later test's count.
@@ -259,11 +264,8 @@ describe('Outstanding commit tracking', () => {
 		await assertAllUntracked('both attempts on a shared promise should be untracked');
 	});
 
-	// The CI flake this file used to have: the analytics aggregation tick landed inside the chained
-	// test's ~40ms window and the bare thread-global read returned 130–145 in-flight foreign commits
-	// with a young oldestAgeMs. Reproduce that state deterministically — foreign nodes tracked for
-	// the whole duration of this test's own chained write and released only afterwards — and show
-	// the assertions above stay exact under it rather than counting the bystanders.
+	// The analytics burst, made deterministic: foreign nodes stay tracked across this test's own chained
+	// write and are released only afterwards.
 	it('keeps its assertions exact while foreign commits are in flight on the thread', async function () {
 		if (isLMDB) return;
 		let releaseForeign;
@@ -283,16 +285,12 @@ describe('Outstanding commit tracking', () => {
 				chained = !!context.transaction?.next;
 			});
 			assert.ok(chained, 'the two databases should have produced a chained transaction');
-			// What the old assertion read at this point: the bystanders, not this test's own (already
-			// untracked) links. The chained links are proven untracked only once the foreign burst
-			// settles, below.
 			assert.ok(getOutstandingCommits().count >= FOREIGN_COMMITS, 'the foreign commits are still in flight');
 			const { result: underLoad, delta: ownDelta } = trackedAcross(() => TrackA.put(6, { name: 'under-load' }));
 			assert.equal(ownDelta, 1, 'a synchronous-window delta ignores the in-flight bystanders');
 			await underLoad;
 		} finally {
-			// Never leave the foreign nodes linked: they would age past the overload threshold and 503
-			// every later write on this thread.
+			// Left linked, they would age past the overload threshold and 503 every later write on this thread.
 			releaseForeign();
 		}
 		await assertAllUntracked('own links and the released foreign commits should all be untracked');
@@ -300,17 +298,21 @@ describe('Outstanding commit tracking', () => {
 		assert.equal((await TrackB.get(5))?.name, 'chain-b-3');
 	});
 
-	// Proves the settle helper is still a leak detector: waiting for the count is what lets it tolerate
-	// bystanders, so it must not also wait its way past a node that never unlinks.
+	// Waiting for the count is what lets the settle helper tolerate bystanders; it must not also wait
+	// its way past a node that never unlinks.
 	it('the settle assertion rejects a node that never unlinks, reporting its count and age', async function () {
 		if (isLMDB) return;
 		let releaseStuck;
 		const stuck = new Promise((resolve) => (releaseStuck = resolve));
+		const timeout = 200;
 		try {
 			trackOutstandingCommit(stuck);
-			await assert.rejects(settleOutstandingCommits(0, 'stuck node', 200), (error) =>
-				/stuck node: still \{"count":[1-9]\d*,"oldestAgeMs":\d{3,}/.test(error.message)
-			);
+			await assert.rejects(settleOutstandingCommits(0, 'stuck node', timeout), (error) => {
+				const reported = JSON.parse(/stuck node: still (\{.*\}) after/.exec(error.message)[1]);
+				assert.ok(reported.count >= 1, `should report the stuck node, got ${error.message}`);
+				assert.ok(reported.oldestAgeMs >= timeout - 10, `should report its age at the deadline, got ${error.message}`);
+				return true;
+			});
 		} finally {
 			releaseStuck();
 		}


### PR DESCRIPTION
Fixes the intermittent main-CI failure of `Outstanding commit tracking > untracks every link of a cross-database (chained) transaction` (`unitTests/resources/outstandingCommitTracking.test.js`), seen on 2026-09-08 (Node 22, `{ count: 130, oldestAgeMs: 112.6 }`) and 2026-09-10 (Node 26, `{ count: 145, oldestAgeMs: 36.4 }`) where `{ count: 0 }` was expected. Test-only change; no product code is touched.

**Determination: over-broad assertion, not a leak.** `getOutstandingCommits()` is thread-global, and the mocha main thread is never idle. Every tracked commit also calls `recordCommitLatency` → `recordAction`, which arms the 1 s `sendAnalytics` timer; on the main thread that calls `recordAnalytics` directly, which starts `startScheduledTasks` — an unref'd 30 s `setInterval` running `aggregation()` (`resources/analytics/write.ts`). One aggregation tick issues one **unawaited** `hdb_analytics` `table.put` per aggregated metric, per database and per table (`storeMetric`, `storeDBSizeMetrics`, `storeRocksDBStatsMetrics`), and each of those is a tracked `DatabaseTransaction.commit`. Late in the resources suite that is 100+ tracked commits submitted within a few milliseconds and settling within tens of milliseconds — exactly the CI signature of a large count with a young `oldestAgeMs`. An instrumented `npm run test:unit:resources` (temporary logging in `trackOutstandingCommit`) recorded that burst three times at a 60 s cadence, reaching count 120 within 16–30 ms, every node `store=system.hdb_analytics`, stack `Timeout._onTimeout → aggregation (write.ts:1208) → storeMetric (write.ts:293) → Resource.applyContext → transaction → DatabaseTransaction.commit → trackOutstandingCommit`. The chained test is hit first because it spans ~40 ms of awaits (the CI log timestamps), the widest window in the file; every exact-count assertion in the file has the same exposure at lower probability. A leak (hypothesis a) is refuted on the same evidence: a leaked node would age without bound, no node aged past its burst, and the unlink in `trackOutstandingCommit` rewires both neighbours and head/tail on every settle path with a double-unlink guard.

**Fix.** Every assertion stays exact but stops assuming an idle thread. Assertions made inside a synchronous window (submit → read, no `await` between) assert the count **delta** across that window via [`trackedAcross()`](https://github.com/HarperFast/harper/pull/2579/changes?w=1#diff-bdc1ab7dcf69280989fb5d848ac0a01a789db1d08f0d1fdccb1bfc0aa4f4f64fR45): no foreign node can be linked or unlinked between two synchronous reads. Assertions made after settlement go through [`settleOutstandingCommits()`](https://github.com/HarperFast/harper/pull/2579/changes?w=1#diff-bdc1ab7dcf69280989fb5d848ac0a01a789db1d08f0d1fdccb1bfc0aa4f4f64fR31) / [`assertAllUntracked()`](https://github.com/HarperFast/harper/pull/2579/changes?w=1#diff-bdc1ab7dcf69280989fb5d848ac0a01a789db1d08f0d1fdccb1bfc0aa4f4f64fR41), which poll (the shared `waitFor`) until the count settles to the expected value within 5 s and then `deepEqual` the observed snapshot. A foreign burst settles in milliseconds, so the poll converges; a node left linked never unlinks, so a regression still fails after the deadline, reporting the stuck count and its age. The [held-chained-commit test](https://github.com/HarperFast/harper/pull/2579/changes?w=1#diff-bdc1ab7dcf69280989fb5d848ac0a01a789db1d08f0d1fdccb1bfc0aa4f4f64fR139) no longer waits for `count === 1` (a lone foreign node in a burst's drain tail could satisfy that); it reads the count inside the `Transaction.prototype.commit` seam before the native commit is issued and again from the [returned promise's own `then`](https://github.com/HarperFast/harper/pull/2579/changes?w=1#diff-bdc1ab7dcf69280989fb5d848ac0a01a789db1d08f0d1fdccb1bfc0aa4f4f64fR161), which `trackOutstandingCommit` calls right after linking its node in the same synchronous block, so the [maximum delta seen at those subscriptions](https://github.com/HarperFast/harper/pull/2579/changes?w=1#diff-bdc1ab7dcf69280989fb5d848ac0a01a789db1d08f0d1fdccb1bfc0aa4f4f64fR207) is exact: 1 tracked once, 0 not tracked, 2 tracked twice. Two new tests pin the fixture: [140 foreign tracked promises held across the chained write](https://github.com/HarperFast/harper/pull/2579/changes?w=1#diff-bdc1ab7dcf69280989fb5d848ac0a01a789db1d08f0d1fdccb1bfc0aa4f4f64fR286), and [a never-unlinking node making the settle assertion reject](https://github.com/HarperFast/harper/pull/2579/changes?w=1#diff-bdc1ab7dcf69280989fb5d848ac0a01a789db1d08f0d1fdccb1bfc0aa4f4f64fR323) with its count and age.

## For the human reviewer

1. **Settle-to-expected instead of identity-scoped counting.** The alternative was a test-only enumeration of tracked nodes by `store` (or a tracking handle returned from `DatabaseTransaction`) so the test counts only its own nodes. Rejected: a node's `store` is a best-effort label for the stuck-commit log (`this.writes[0]?.store`, undefined for nodes driven through the exported `trackOutstandingCommit` seam), so an identity filter can exclude exactly the leaked node it is meant to catch; the settle check catches a leak regardless of label, and the one case that genuinely needed identity (the held chained commit) is now proven by a [synchronous delta inside the commit seam](https://github.com/HarperFast/harper/pull/2579/changes?w=1#diff-bdc1ab7dcf69280989fb5d848ac0a01a789db1d08f0d1fdccb1bfc0aa4f4f64fR161). Cost of a "no": a new production export. Reversible.
2. **Fix in the test rather than quieting the analytics reporter for this suite.** `unitTests/resources/analytics/write.test.js` and `models/analyticsTable.test.js` exercise that pipeline in the same process, and the instrumented run also showed non-analytics bursts of 120+ from other files' fixtures, so an assertion that assumes an idle thread would stay wrong with one producer silenced. Whether the aggregation timer *should* arm in a mocha process at all is noted as a dispatch finding, not decided here.
3. **Two helper-level tests ship.** The foreign-load and stuck-node tests assert about the helpers, not about `DatabaseTransaction`. Kept: they are the permanent guard that the tolerance did not become blindness (the stuck-node one costs 200 ms). Trivially deletable.
4. **Immediacy is no longer asserted.** The old `count: 0` checks ran synchronously after `await put()`, incidentally proving the untrack reaction runs before the put promise resolves. The settle form tolerates a later (but still settling) unlink. `checkOverloaded()` reacts to ages near the 45 s threshold, so millisecond ordering is not a property the product depends on.
5. **One 5 s settle deadline for every drain**, plus the held test's [mocha timeout raised from 15 s to 20 s](https://github.com/HarperFast/harper/pull/2579/changes?w=1#diff-bdc1ab7dcf69280989fb5d848ac0a01a789db1d08f0d1fdccb1bfc0aa4f4f64fR141) so its 10 s start watchdog and a full settle cannot sum past it. A genuine leak surfaces after 5 s; a bystander pending longer than that also fails, and the reported age tells the two apart.

## Verification

- Root cause: instrumented `npm run test:unit:resources` on this branch's base (2490 passing) with a temporary log in `trackOutstandingCommit` at count 20/60/120 — three `hdb_analytics` bursts at 12:27:39, 12:29:09, 12:30:09, each reaching count ≥ 120 (the 12:29:09 one: count 120 at `oldestAgeMs` 29.4 ms), all from the `aggregation` timer stack above.
- Pre-fix assertion under the fixture: a scratch test holding 140 foreign tracked promises across the same chained write and making the old bare `deepEqual(getOutstandingCommits(), { count: 0 })` fails with `{ count: 140, oldestAgeMs: 13.4 }` — the CI failure shape.
- Regression signal preserved: with the chained link's `untrack` deliberately skipped in a throwaway `dist` build, the chained test fails `every link of a settled chained transaction should be untracked: still {"count":1,"oldestAgeMs":5008.4} after 5000ms`, and the six later settle assertions fail the same way (7 failing, 3 passing).
- `npx mocha unitTests/resources/outstandingCommitTracking.test.js` on the fixed file (the [chained-transaction assertion](https://github.com/HarperFast/harper/pull/2579/changes?w=1#diff-bdc1ab7dcf69280989fb5d848ac0a01a789db1d08f0d1fdccb1bfc0aa4f4f64fR126) that flaked on CI, the [in-flight](https://github.com/HarperFast/harper/pull/2579/changes?w=1#diff-bdc1ab7dcf69280989fb5d848ac0a01a789db1d08f0d1fdccb1bfc0aa4f4f64fR76) and [concurrent](https://github.com/HarperFast/harper/pull/2579/changes?w=1#diff-bdc1ab7dcf69280989fb5d848ac0a01a789db1d08f0d1fdccb1bfc0aa4f4f64fR96) delta checks, and the [pinned overload threshold](https://github.com/HarperFast/harper/pull/2579/changes?w=1#diff-bdc1ab7dcf69280989fb5d848ac0a01a789db1d08f0d1fdccb1bfc0aa4f4f64fR292) around the foreign-load fixture): 11 passing, repeated runs (five on the first version, three each after the two follow-up commits).
- `npm run test:unit:resources`: 2493 passing, 33 pending, 0 failing on the final HEAD (and 2492/2493 passing, 0 failing on the two earlier commits). One intermediate run, taken while three focused mocha runs and a review round were also active on the box, had 2 timing failures in untouched files that run before this one alphabetically (`derivedIndexRuntimeNativeBackend.test.js:1516`, `longLivedTransactions.test.js` "the stuck commit must be logged once"); both passed in every other run and the latter passed 50/50 alone.
- `npm run test:unit:main` (compatibility only; it excludes `unitTests/resources/**`): 5520 passing, 197 pending, 1 failing — `getDomainSocketPathLengthWarning › does not warn when a relative rootPath resolves within the limit`, the known local long-worktree-path case, unrelated.
- LMDB carve-out (`if (isLMDB) return;`) and `longLivedTransactions.test.js` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPhhzkDC1XXbPH8u5P9djH

Complexity: medium

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=3; full=1 @ 583512191e95</sub>

<sub>Human-Review-Need: 3 @ 583512191e95</sub>
